### PR TITLE
Avoid throwing an exception when there are no CDs in the New VM wizard d...

### DIFF
--- a/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.cs
@@ -335,7 +335,9 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void AddToolTipToCdDropDownBox_DrawItemEvent(object sender, DrawItemEventArgs e)
         {
-            string selectedText = CdDropDownBox.GetItemText(CdDropDownBox.Items[e.Index]);
+            string selectedText = "";
+            if (e.Index != -1)
+                selectedText = CdDropDownBox.GetItemText(CdDropDownBox.Items[e.Index]);
 
             Font font = (e.Index != -1 && CdDropDownBox.Items[e.Index] is ToStringWrapper<SR>) ? Program.DefaultFontBold : Program.DefaultFont;
 


### PR DESCRIPTION
...ropdown

The rest of the code is robust to there being no CDs (and e.Index = -1)
apart from this bit.

Signed-off-by: David Scott dave.scott@eu.citrix.com
