### PR TITLE
[CA-125183] Fix: XenCenterSetup.exe to install, requires .NET 3.5 rather...

### DIFF
--- a/WixInstaller/XenCenter.l10n.diff
+++ b/WixInstaller/XenCenter.l10n.diff
@@ -170,9 +170,9 @@
 @@ -227,7 +253,7 @@
          <Property Id="ARPPRODUCTICON" Value="XenCenterICO" />
          <MajorUpgrade AllowDowngrades="no" AllowSameVersionUpgrades="yes" DowngradeErrorMessage="!(loc.ErrorNewerProduct)" Schedule="afterInstallInitialize"/>
-         <PropertyRef Id="NETFRAMEWORK35" />
--        <Condition Message=".NET Framework 3.5 is required for this installation."><![CDATA[Installed OR NETFRAMEWORK35]]></Condition>
-+        <Condition Message="!(loc.Required_For_Installation)"><![CDATA[Installed OR NETFRAMEWORK35]]></Condition>
+         <PropertyRef Id="NETFRAMEWORK40FULL" />
+-        <Condition Message=".NET Framework 4 is required for this installation."><![CDATA[Installed OR NETFRAMEWORK40FULL]]></Condition>
++        <Condition Message="!(loc.Required_For_Installation)"><![CDATA[Installed OR NETFRAMEWORK40FULL]]></Condition>
          <Property Id="PERMACHINEINSTALL">
              <RegistrySearch Id="InstallRegistry" Type="raw" Root="HKLM" Key="Software\Citrix\XenCenter" Name="InstallDir" />
          </Property>

--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -226,8 +226,8 @@
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
         <Property Id="ARPPRODUCTICON" Value="XenCenterICO" />
         <MajorUpgrade AllowDowngrades="no" AllowSameVersionUpgrades="yes" DowngradeErrorMessage="!(loc.ErrorNewerProduct)" Schedule="afterInstallInitialize"/>
-        <PropertyRef Id="NETFRAMEWORK35" />
-        <Condition Message=".NET Framework 3.5 is required for this installation."><![CDATA[Installed OR NETFRAMEWORK35]]></Condition>
+        <PropertyRef Id="NETFRAMEWORK40FULL" />
+        <Condition Message=".NET Framework 4 is required for this installation."><![CDATA[Installed OR NETFRAMEWORK40FULL]]></Condition>
         <Property Id="PERMACHINEINSTALL">
             <RegistrySearch Id="InstallRegistry" Type="raw" Root="HKLM" Key="Software\Citrix\XenCenter" Name="InstallDir" />
         </Property>

--- a/WixInstaller/en-us.wxl
+++ b/WixInstaller/en-us.wxl
@@ -11,5 +11,5 @@
     <String Id="XenServer_Update_File">XenServer Update File</String>
     <String Id="XenServer_OEM_Update_File">XenServer OEM Update File</String>
     <String Id="XenCenter_Saved_Search">XenCenter Saved Search</String>
-    <String Id="Required_For_Installation">.NET Framework 3.5 is required for this installation.</String>
+    <String Id="Required_For_Installation">.NET Framework 4 is required for this installation.</String>
 </WixLocalization>

--- a/WixInstaller/ja-jp.wxl
+++ b/WixInstaller/ja-jp.wxl
@@ -11,5 +11,5 @@
     <String Id="XenServer_Update_File">XenServer アップデート ファイル</String>
     <String Id="XenServer_OEM_Update_File">XenServer OEM アップデート ファイル</String>
     <String Id="XenCenter_Saved_Search">XenCenter 保存された検索条件</String>
-    <String Id="Required_For_Installation">この製品をインストールするには、.NET Framework 3.5 が必要です。</String>
+    <String Id="Required_For_Installation">この製品をインストールするには、.NET Framework 4 が必要です。</String>
 </WixLocalization>

--- a/WixInstaller/zh-cn.wxl
+++ b/WixInstaller/zh-cn.wxl
@@ -11,5 +11,5 @@
     <String Id="XenServer_Update_File">XenServer 更新文件</String>
     <String Id="XenServer_OEM_Update_File">XenServer OEM 更新文件</String>
     <String Id="XenCenter_Saved_Search">XenCenter 保存的搜索</String>
-    <String Id="Required_For_Installation">此安装需要 .NET Framework 3.5。</String>
+    <String Id="Required_For_Installation">此安装需要 .NET Framework 4。</String>
 </WixLocalization>


### PR DESCRIPTION
... than .NET 4 on Windows8 x64, WS 2012, WS 2008 SP2 x32

Signed-off-by: Gabor Apati-Nagy gabor.apati-nagy@citrix.com
