### PR TITLE
CA-123013: Cloning from template shouldn't allow progress through the Ne...

### DIFF
--- a/XenAdmin/Controls/AffinityPicker.cs
+++ b/XenAdmin/Controls/AffinityPicker.cs
@@ -49,6 +49,13 @@ namespace XenAdmin.Controls
         private Host SrHost;
         private Host Affinity;
 
+        /// <summary>
+        /// Should always be true if the AffinityPicker is used to create a VM.
+        /// If set to false (e.g. on Edit VM) and Affinity is null, then the "no home server" radio button remains enabled, 
+        /// meaning that the VM already has no affinity and should not try to automatically select one.
+        /// </summary>
+        internal bool AutoSelectAffinity = true;
+
         public event EventHandler SelectedAffinityChanged = new EventHandler(OnSelectedAffinityChanged);
 
         private static void OnSelectedAffinityChanged(object obj, EventArgs e) { }
@@ -96,7 +103,8 @@ namespace XenAdmin.Controls
                 return;
 
             // Update enablement
-            DynamicRadioButton.Enabled = (Helpers.HasFullyConnectedSharedStorage(Connection) && SrHost == null) || Affinity == null;
+            DynamicRadioButton.Enabled = (Helpers.HasFullyConnectedSharedStorage(Connection) && SrHost == null) ||
+                                         (Affinity == null && !AutoSelectAffinity);
             ServersGridView.Enabled = StaticRadioButton.Checked;
             DynamicRadioButton.Text = Helpers.HasFullyConnectedSharedStorage(Connection)
                                           ? Messages.AFFINITY_PICKER_DYNAMIC_SHARED_SR

--- a/XenAdmin/SettingsPanels/HomeServerEditPage.cs
+++ b/XenAdmin/SettingsPanels/HomeServerEditPage.cs
@@ -55,7 +55,7 @@ namespace XenAdmin.SettingsPanels
         {
             InitializeComponent();
             Text = Messages.HOME_SERVER;
-           
+            picker.AutoSelectAffinity = false;
         }
 
         #region IEditPage Members


### PR DESCRIPTION
...w VM wizard without shared SR.

On the affinity picker, the "no home server" radio button is disabled if there is no shared storage, except on editing an existing VM that already has no affinity.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
