### PR TITLE
CA-123914: Install update wizard: When applying a patch to multiple pool...

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
@@ -168,8 +168,8 @@ namespace XenAdmin.Wizards.PatchingWizard
                         }
                     }
                 }
-                planActions.Add(new UnwindProblemsAction(ProblemsResolvedPreCheck));
             }
+            planActions.Add(new UnwindProblemsAction(ProblemsResolvedPreCheck));
 
             actionsWorker = new BackgroundWorker();
             actionsWorker.DoWork += new DoWorkEventHandler(PatchingWizardAutomaticPatchWork);


### PR DESCRIPTION
...s, the "revert prechecks" action should be executed only once, after the patch is applied to all pools.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
