### PR TITLE
Revert "Enable pushing into creedence/xenadmin-ref.hg"

### DIFF
--- a/mk/archive-push.sh
+++ b/mk/archive-push.sh
@@ -30,7 +30,7 @@
 
 set -eu
 
-#DISABLE_PUSH=1
+DISABLE_PUSH=1
 source "$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/declarations.sh"
 
 if [ ${XS_BRANCH} = "trunk" ]


### PR DESCRIPTION
This reverts commit c72d4ba9d0437e0306efb7e124560cc6a76c0db4.
Unlike other branches creedence will follow the same integration schedule as trunk.
