### PR TITLE
CA-94466: Log when the heartbeat has come back

### DIFF
--- a/XenModel/Network/Heartbeat.cs
+++ b/XenModel/Network/Heartbeat.cs
@@ -127,6 +127,8 @@ namespace XenAdmin.Network
                 GetServerTime();
 
                 // Now that we've successfully received a heartbeat, reset our 'second chance' for the server to timeout
+                if (retrying)
+                    log.DebugFormat("Heartbeat for {0} has come back", session == null ? "null" : session.Url);
                 retrying = false;
             }
             catch (TargetInvocationException exn)


### PR DESCRIPTION
Note that it was not possible to dev-test this because of CA-132066. However, I did dev-test some equivalent code on very old branches where CA-132066 was not present.
