### PR TITLE
CA-119177: On Prechecks page of Rolling Pool Upgrade wizard, the error s...

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -376,7 +376,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
 
             bool result = _worker != null && !_worker.IsBusy && !problemsFound;
-            panelErrorsFound.Visible = !result;
+            panelErrorsFound.Visible = problemsFound;
             return result;
         }
 


### PR DESCRIPTION
...hould only be visible when errors are found.

If errors are found the error info at the bottom of the page shows up, however this should not happen while still checking and before any errors have been found.
Same applies for Prechecks page of Install Update Wizard.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
