### PR TITLE
CA-123534: In the Install Update wizard, when hosts are disabled because...

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -137,6 +137,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             if(!host.CanApplyHotfixes)
             {
                 row.Enabled = false;
+                row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED;
                 return;
             }
                 
@@ -154,7 +155,10 @@ namespace XenAdmin.Wizards.PatchingWizard
                     if (host.isOEM)
                         row.Enabled = false;
                     if (Patch.IsAppliedTo(host,ConnectionsManager.XenConnectionsCopy))
+                    {
                         row.Enabled = false;
+                        row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_ALREADY_APPLIED;
+                    }
                     break;
             }
         }
@@ -691,8 +695,11 @@ namespace XenAdmin.Wizards.PatchingWizard
                 else
                     _poolIconHostCheckCell = new DataGridViewCheckBoxCell();
 
+
                 _nameCell = new DataGridViewNameCell();
                 _versionCell = new DataGridViewTextBoxCell();
+
+
 
                 Cells.AddRange(new[] { _expansionCell, _poolCheckBoxCell, _poolIconHostCheckCell, _nameCell, _versionCell });
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -24027,6 +24027,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Subscription Advantage required.
+        /// </summary>
+        public static string PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update already applied.
+        /// </summary>
+        public static string PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_ALREADY_APPLIED {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_ALREADY_APPLIED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select Servers.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_TEXT {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8316,6 +8316,12 @@ It is strongly recommended that you Cancel and apply the latest version of the p
   <data name="PATCHINGWIZARD_SELECTPATCHPAGE_UPDATESEXT" xml:space="preserve">
     <value>XenServer Updates|*.xsupdate;*.xsoem</value>
   </data>
+  <data name="PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED" xml:space="preserve">
+    <value>Subscription Advantage required</value>
+  </data>
+  <data name="PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_ALREADY_APPLIED" xml:space="preserve">
+    <value>Update already applied</value>
+  </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_TEXT" xml:space="preserve">
     <value>Select Servers</value>
   </data>


### PR DESCRIPTION
... the update cannot be applied, display the reason as a tooltip.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
