### PR TITLE
CA-115429: Fixed: Deletion of snapshot is successful but XenCenter logs ...

### DIFF
--- a/XenModel/Actions/VM/VMDestroyAction.cs
+++ b/XenModel/Actions/VM/VMDestroyAction.cs
@@ -101,16 +101,6 @@ namespace XenAdmin.Actions.VMActions
                 }
             }
 
-            //CA-115429: XAPI does delete suspend VM VDIs on destroy (from version 1.7/Midnight Ride),
-            //so we should delete them here only when connected to older XS
-            if (!Helper.APIVersionMeets(session, API_Version.API_1_7))
-            {
-                //CA-91072: Delete Suspend image VDI
-                VDI suspendVDI = vm.Connection.Resolve(vm.suspend_VDI);
-                if (suspendVDI != null)
-                    vdiRefs.Add(vm.suspend_VDI);
-            }
-
             XenAPI.VM.destroy(session, vm.opaque_ref);
 
 


### PR DESCRIPTION
...show error.

XAPI (from 1.7) destroy destroys suspend VDIs as well (code is here: xapi: ocaml/xapi/cli_operations.ml). Depending on actual race conditions, this can lead to a situation when we try to destroy a Suspend VDI that has just been deleted.

Signed-off-by: Gabor Apati-Nagy gabor.apati-nagy@citrix.com
