### PR TITLE
CA-135563:WLB tab show error message after disconnect WLB by Read-Only user

### DIFF
--- a/XenModel/Actions/WLB/DisableWLBAction.cs
+++ b/XenModel/Actions/WLB/DisableWLBAction.cs
@@ -82,13 +82,13 @@ namespace XenAdmin.Actions.Wlb
                     log.Debug("Success disconnecting Workload Balancing on pool " + Pool.Name);
                     this.Description = Messages.COMPLETED;
 
-                    WlbServerState.SetState(Pool, WlbServerState.ServerState.NotConfigured);
+                    WlbServerState.SetState(this.Session, Pool, WlbServerState.ServerState.NotConfigured);
                 }
                 catch (Exception ex)
                 {
                     //Force disabling of WLB
                     XenAPI.Pool.set_wlb_enabled(this.Session, Pool.opaque_ref, false);
-                    WlbServerState.SetState(Pool, WlbServerState.ServerState.ConnectionError, (Failure)ex);
+                    WlbServerState.SetState(this.Session, Pool, WlbServerState.ServerState.ConnectionError, (Failure)ex);
                     log.Debug(string.Format(Messages.ACTION_WLB_DECONFIGURE_FAILED, Pool.Name, ex.Message));
                     throw new Exception(string.Format(Messages.ACTION_WLB_DECONFIGURE_FAILED, Pool.Name, ex.Message));
                 }
@@ -106,13 +106,13 @@ namespace XenAdmin.Actions.Wlb
                     XenAPI.Pool.set_wlb_enabled(this.Session, Pool.opaque_ref, false); 
                     log.Debug("Success pausing Workload Balancing on pool " + Pool.Name);
                     this.Description = Messages.COMPLETED;
-                    WlbServerState.SetState(Pool, WlbServerState.ServerState.Disabled);
+                    WlbServerState.SetState(this.Session, Pool, WlbServerState.ServerState.Disabled);
                 }
                 catch (Exception ex)
                 {
                     if (ex is Failure)
                     {
-                        WlbServerState.SetState(Pool, WlbServerState.ServerState.ConnectionError, (Failure)ex);
+                        WlbServerState.SetState(this.Session, Pool, WlbServerState.ServerState.ConnectionError, (Failure)ex);
                     }
                     throw ex;
                 }

--- a/XenModel/WLB/WlbServerState.cs
+++ b/XenModel/WLB/WlbServerState.cs
@@ -78,9 +78,8 @@ namespace XenAdmin.Wlb
         /// <param name="state">The current state of the pool's Wlb Server State</param>
         public static void SetState(Pool pool, ServerState state)
         {
-            SetState(pool, state, null);
+            SetState(pool.Connection.Session, pool, state, null);
         }
-
         /// <summary>
         /// Public method for updating the Wlb Server state.  If the state is ConnectionFailure and
         /// a Failure is supplied, it's message is stored in the OtherConfig
@@ -90,6 +89,29 @@ namespace XenAdmin.Wlb
         /// <param name="failure">The Failure (if any) describing the Connection Error</param>
         public static void SetState(Pool pool, ServerState state, Failure failure)
         {
+            SetState(pool.Connection.Session, pool, state, failure);
+        }
+        /// <summary>
+        /// Public method for updating the Wlb Server state when there is no error (Failure) and need specific seesion information.
+        /// This method clears any existing failure message for the connection
+        /// </summary>
+        /// <param name="session">The User session use to do this operation</param>
+        /// <param name="pool">The pool who's Wlb connection state we are updating</param>
+        /// <param name="state">The current state of the pool's Wlb Server State</param>
+        public static void SetState(Session session, Pool pool, ServerState state)
+        {
+            SetState(session, pool, state, null);
+        }
+        /// <summary>
+        /// Public method for updating the Wlb Server state.  If the state is ConnectionFailure and
+        /// a Failure is supplied, it's message is stored in the OtherConfig
+        /// </summary>
+        /// <param name="session">The User session use to do this operation</param>
+        /// <param name="pool">The pool who's Wlb connection state we are updating</param>
+        /// <param name="state">The current state of the pool's Wlb Server State</param>
+        /// <param name="failure">The Failure (if any) describing the Connection Error</param>
+        public static void SetState(Session session, Pool pool, ServerState state, Failure failure)
+        {
             //only update the state if new value if different than current value
             //  this is to cut down on unneeded Pool_PropertiesChanged events
             if (GetState(pool) != state) 
@@ -97,7 +119,7 @@ namespace XenAdmin.Wlb
                 // set a lock so we are setting state one at a time
                 lock (_lockObject)
                 {
-                    Helpers.SetOtherConfig(pool.Connection.Session, pool, WLB_CONNECTION_STATUS, state.ToString());
+                    Helpers.SetOtherConfig(session, pool, WLB_CONNECTION_STATUS, state.ToString());
 
                     if (null != failure && state == ServerState.ConnectionError)
                     {
@@ -110,11 +132,11 @@ namespace XenAdmin.Wlb
                         {
                             error = failure.Message;
                         }
-                        Helpers.SetOtherConfig(pool.Connection.Session, pool, WLB_CONNECTION_ERROR, error);
+                        Helpers.SetOtherConfig(session, pool, WLB_CONNECTION_ERROR, error);
                     }
                     else
                     {
-                        Helpers.SetOtherConfig(pool.Connection.Session, pool, WLB_CONNECTION_ERROR, String.Empty);
+                        Helpers.SetOtherConfig(session, pool, WLB_CONNECTION_ERROR, String.Empty);
                     }
                 }
             }


### PR DESCRIPTION
This error is caused by set WLB status using wrong user session if user input read and write user confidential when disconnect WLB in Read-Only user.
Pass the correct session information will solve this problem.
