### PR TITLE
CA-121385 Allow creation of VLAN 0 in XenCenter.

### DIFF
--- a/XenAdmin/SettingsPanels/EditNetworkPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/EditNetworkPage.Designer.cs
@@ -36,6 +36,7 @@ namespace XenAdmin.SettingsPanels
             this.numUpDownVLAN = new System.Windows.Forms.NumericUpDown();
             this.nicHelpLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.labelVLAN0Info = new System.Windows.Forms.Label();
             this.panelLACPWarning = new System.Windows.Forms.Panel();
             this.label2 = new System.Windows.Forms.Label();
             this.pictureBox2 = new System.Windows.Forms.PictureBox();
@@ -77,12 +78,12 @@ namespace XenAdmin.SettingsPanels
             // autoCheckBox
             // 
             resources.ApplyResources(this.autoCheckBox, "autoCheckBox");
-            this.tableLayoutPanel1.SetColumnSpan(this.autoCheckBox, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.autoCheckBox, 4);
             this.autoCheckBox.Name = "autoCheckBox";
             // 
             // HostPNICList
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.HostPNICList, 2);
+            this.tableLayoutPanel1.SetColumnSpan(this.HostPNICList, 3);
             this.HostPNICList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             resources.ApplyResources(this.HostPNICList, "HostPNICList");
             this.HostPNICList.FormattingEnabled = true;
@@ -114,13 +115,14 @@ namespace XenAdmin.SettingsPanels
             // nicHelpLabel
             // 
             resources.ApplyResources(this.nicHelpLabel, "nicHelpLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.nicHelpLabel, 2);
+            this.tableLayoutPanel1.SetColumnSpan(this.nicHelpLabel, 3);
             this.nicHelpLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.nicHelpLabel.Name = "nicHelpLabel";
             // 
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.labelVLAN0Info, 2, 3);
             this.tableLayoutPanel1.Controls.Add(this.panelLACPWarning, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.labelBlurb, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.numUpDownVLAN, 1, 3);
@@ -137,10 +139,16 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanel1.Controls.Add(this.groupBoxBondMode, 0, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
+            // labelVLAN0Info
+            // 
+            resources.ApplyResources(this.labelVLAN0Info, "labelVLAN0Info");
+            this.tableLayoutPanel1.SetColumnSpan(this.labelVLAN0Info, 2);
+            this.labelVLAN0Info.Name = "labelVLAN0Info";
+            // 
             // panelLACPWarning
             // 
             resources.ApplyResources(this.panelLACPWarning, "panelLACPWarning");
-            this.tableLayoutPanel1.SetColumnSpan(this.panelLACPWarning, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.panelLACPWarning, 4);
             this.panelLACPWarning.Controls.Add(this.label2);
             this.panelLACPWarning.Controls.Add(this.pictureBox2);
             this.panelLACPWarning.Name = "panelLACPWarning";
@@ -160,12 +168,12 @@ namespace XenAdmin.SettingsPanels
             // labelBlurb
             // 
             resources.ApplyResources(this.labelBlurb, "labelBlurb");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelBlurb, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.labelBlurb, 4);
             this.labelBlurb.Name = "labelBlurb";
             // 
             // panelDisruptionWarning
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.panelDisruptionWarning, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.panelDisruptionWarning, 4);
             this.panelDisruptionWarning.Controls.Add(this.label1);
             this.panelDisruptionWarning.Controls.Add(this.pictureBox1);
             resources.ApplyResources(this.panelDisruptionWarning, "panelDisruptionWarning");
@@ -197,19 +205,19 @@ namespace XenAdmin.SettingsPanels
             // warningText
             // 
             resources.ApplyResources(this.warningText, "warningText");
-            this.tableLayoutPanel1.SetColumnSpan(this.warningText, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.warningText, 4);
             this.warningText.Name = "warningText";
             // 
             // labelCannotConfigureMTU
             // 
             resources.ApplyResources(this.labelCannotConfigureMTU, "labelCannotConfigureMTU");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelCannotConfigureMTU, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.labelCannotConfigureMTU, 4);
             this.labelCannotConfigureMTU.Name = "labelCannotConfigureMTU";
             // 
             // groupBoxBondMode
             // 
             resources.ApplyResources(this.groupBoxBondMode, "groupBoxBondMode");
-            this.tableLayoutPanel1.SetColumnSpan(this.groupBoxBondMode, 2);
+            this.tableLayoutPanel1.SetColumnSpan(this.groupBoxBondMode, 3);
             this.groupBoxBondMode.Controls.Add(this.tableLayoutPanelBondMode);
             this.groupBoxBondMode.Name = "groupBoxBondMode";
             this.groupBoxBondMode.TabStop = false;
@@ -221,7 +229,6 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanelBondMode.Controls.Add(this.radioButtonBalanceSlb, 0, 0);
             this.tableLayoutPanelBondMode.Controls.Add(this.radioButtonActiveBackup, 0, 1);
             this.tableLayoutPanelBondMode.Controls.Add(this.radioButtonLacpSrcMac, 0, 3);
-            this.tableLayoutPanelBondMode.MinimumSize = new System.Drawing.Size(0, 40);
             this.tableLayoutPanelBondMode.Name = "tableLayoutPanelBondMode";
             // 
             // radioButtonLacpTcpudpPorts
@@ -306,6 +313,7 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.Panel panelLACPWarning;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.PictureBox pictureBox2;
+        private System.Windows.Forms.Label labelVLAN0Info;
 
     }
 }

--- a/XenAdmin/SettingsPanels/EditNetworkPage.cs
+++ b/XenAdmin/SettingsPanels/EditNetworkPage.cs
@@ -102,6 +102,7 @@ namespace XenAdmin.SettingsPanels
             SetNetSettingsEnablement();
             panelDisruptionWarning.Visible = WillDisrupt();
             ShowHideLacpWarning();
+            labelVLAN0Info.Visible = numUpDownVLAN.Enabled && numUpDownVLAN.Value == 0;
         }
 
         private bool VLANEnabled
@@ -301,6 +302,9 @@ namespace XenAdmin.SettingsPanels
             nolicenseRestriction = host != null && !host.RestrictVLAN;
 
             populateHostNicList();
+
+            //set minimum value for VLAN
+            numUpDownVLAN.Minimum = Helpers.VLAN0Allowed(network.Connection) ? 0 : 1;
 
             PIF pif = GetNetworksPIF();
 

--- a/XenAdmin/SettingsPanels/EditNetworkPage.resx
+++ b/XenAdmin/SettingsPanels/EditNetworkPage.resx
@@ -112,23 +112,23 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="HostNicLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="HostNicLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="HostNicLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="HostNicLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 41</value>
   </data>
@@ -151,13 +151,13 @@
     <value>HostNicLabel</value>
   </data>
   <data name="&gt;&gt;HostNicLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;HostNicLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;HostNicLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="HostVLanLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -187,55 +187,64 @@
     <value>HostVLanLabel</value>
   </data>
   <data name="&gt;&gt;HostVLanLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;HostVLanLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;HostVLanLabel.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="autoCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
+  </data>
+  <data name="labelVLAN0Info.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelVLAN0Info.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelVLAN0Info.Location" type="System.Drawing.Point, System.Drawing">
+    <value>133, 92</value>
+  </data>
+  <data name="labelVLAN0Info.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 11, 0, 0</value>
+  </data>
+  <data name="labelVLAN0Info.Size" type="System.Drawing.Size, System.Drawing">
+    <value>252, 13</value>
+  </data>
+  <data name="labelVLAN0Info.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="labelVLAN0Info.Text" xml:space="preserve">
+    <value>VLAN 0 will receive all traffic not on any other VLAN</value>
+  </data>
+  <data name="labelVLAN0Info.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.Name" xml:space="preserve">
+    <value>labelVLAN0Info</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="panelLACPWarning.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 0</value>
-  </data>
-  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="label2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 2, 0, 0</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>244, 15</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>LACP must also be configured on the switch ports</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>panelLACPWarning</value>
@@ -243,29 +252,11 @@
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="pictureBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="pictureBox2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="pictureBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="pictureBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 18</value>
-  </data>
-  <data name="pictureBox2.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>AutoSize</value>
-  </data>
-  <data name="pictureBox2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
   <data name="&gt;&gt;pictureBox2.Name" xml:space="preserve">
     <value>pictureBox2</value>
   </data>
   <data name="&gt;&gt;pictureBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBox2.Parent" xml:space="preserve">
     <value>panelLACPWarning</value>
@@ -283,7 +274,7 @@
     <value>6, 0, 0, 2</value>
   </data>
   <data name="panelLACPWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>511, 18</value>
+    <value>511, 15</value>
   </data>
   <data name="panelLACPWarning.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -295,13 +286,13 @@
     <value>panelLACPWarning</value>
   </data>
   <data name="&gt;&gt;panelLACPWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panelLACPWarning.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;panelLACPWarning.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="labelBlurb.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -334,13 +325,13 @@
     <value>labelBlurb</value>
   </data>
   <data name="&gt;&gt;labelBlurb.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelBlurb.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelBlurb.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="numUpDownVLAN.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
@@ -361,13 +352,13 @@
     <value>numUpDownVLAN</value>
   </data>
   <data name="&gt;&gt;numUpDownVLAN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;numUpDownVLAN.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;numUpDownVLAN.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="nicHelpLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -400,13 +391,13 @@
     <value>nicHelpLabel</value>
   </data>
   <data name="&gt;&gt;nicHelpLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;nicHelpLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;nicHelpLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="HostPNICList.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
@@ -427,13 +418,376 @@
     <value>HostPNICList</value>
   </data>
   <data name="&gt;&gt;HostPNICList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;HostPNICList.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;HostPNICList.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>panelDisruptionWarning</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>panelDisruptionWarning</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelDisruptionWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panelDisruptionWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 348</value>
+  </data>
+  <data name="panelDisruptionWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="panelDisruptionWarning.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 24, 0, 0</value>
+  </data>
+  <data name="panelDisruptionWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>517, 77</value>
+  </data>
+  <data name="panelDisruptionWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="panelDisruptionWarning.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;panelDisruptionWarning.Name" xml:space="preserve">
+    <value>panelDisruptionWarning</value>
+  </data>
+  <data name="&gt;&gt;panelDisruptionWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelDisruptionWarning.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;panelDisruptionWarning.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="numericUpDownMTU.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 252</value>
+  </data>
+  <data name="numericUpDownMTU.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="numericUpDownMTU.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 20</value>
+  </data>
+  <data name="numericUpDownMTU.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;numericUpDownMTU.Name" xml:space="preserve">
+    <value>numericUpDownMTU</value>
+  </data>
+  <data name="&gt;&gt;numericUpDownMTU.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;numericUpDownMTU.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;numericUpDownMTU.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="labelMTU.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelMTU.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="labelMTU.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 255</value>
+  </data>
+  <data name="labelMTU.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 6, 3, 7</value>
+  </data>
+  <data name="labelMTU.Size" type="System.Drawing.Size, System.Drawing">
+    <value>38, 13</value>
+  </data>
+  <data name="labelMTU.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="labelMTU.Text" xml:space="preserve">
+    <value>&amp;MTU:</value>
+  </data>
+  <data name="&gt;&gt;labelMTU.Name" xml:space="preserve">
+    <value>labelMTU</value>
+  </data>
+  <data name="&gt;&gt;labelMTU.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelMTU.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelMTU.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="warningText.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="warningText.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="warningText.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="warningText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 310</value>
+  </data>
+  <data name="warningText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 12, 0, 0</value>
+  </data>
+  <data name="warningText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>517, 13</value>
+  </data>
+  <data name="warningText.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="warningText.Text" xml:space="preserve">
+    <value>(The network's NIC and VLAN cannot be changed as there are active VMs attached)</value>
+  </data>
+  <data name="&gt;&gt;warningText.Name" xml:space="preserve">
+    <value>warningText</value>
+  </data>
+  <data name="&gt;&gt;warningText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningText.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;warningText.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="labelCannotConfigureMTU.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelCannotConfigureMTU.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="labelCannotConfigureMTU.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelCannotConfigureMTU.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 335</value>
+  </data>
+  <data name="labelCannotConfigureMTU.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 12, 0, 0</value>
+  </data>
+  <data name="labelCannotConfigureMTU.Size" type="System.Drawing.Size, System.Drawing">
+    <value>517, 13</value>
+  </data>
+  <data name="labelCannotConfigureMTU.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="labelCannotConfigureMTU.Text" xml:space="preserve">
+    <value>(The network's MTU cannot be changed as there are active VMs attached without tools installed)</value>
+  </data>
+  <data name="&gt;&gt;labelCannotConfigureMTU.Name" xml:space="preserve">
+    <value>labelCannotConfigureMTU</value>
+  </data>
+  <data name="&gt;&gt;labelCannotConfigureMTU.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelCannotConfigureMTU.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelCannotConfigureMTU.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="groupBoxBondMode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="groupBoxBondMode.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.Name" xml:space="preserve">
+    <value>tableLayoutPanelBondMode</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.Parent" xml:space="preserve">
+    <value>groupBoxBondMode</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radioButtonLacpTcpudpPorts" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonBalanceSlb" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonActiveBackup" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonLacpSrcMac" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50" /&gt;&lt;Rows Styles="AutoSize,26,Percent,100,AutoSize,20,AutoSize,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="groupBoxBondMode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="groupBoxBondMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 118</value>
+  </data>
+  <data name="groupBoxBondMode.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 10, 3</value>
+  </data>
+  <data name="groupBoxBondMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>384, 111</value>
+  </data>
+  <data name="groupBoxBondMode.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="groupBoxBondMode.Text" xml:space="preserve">
+    <value>Bond mode</value>
+  </data>
+  <data name="&gt;&gt;groupBoxBondMode.Name" xml:space="preserve">
+    <value>groupBoxBondMode</value>
+  </data>
+  <data name="&gt;&gt;groupBoxBondMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxBondMode.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;groupBoxBondMode.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 10</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>517, 425</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelVLAN0Info" Row="3" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="panelLACPWarning" Row="5" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="labelBlurb" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="numUpDownVLAN" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="nicHelpLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="HostVLanLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="HostNicLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="HostPNICList" Row="1" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="panelDisruptionWarning" Row="11" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="numericUpDownMTU" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelMTU" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="autoCheckBox" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="warningText" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="labelCannotConfigureMTU" Row="10" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="groupBoxBondMode" Row="4" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,67.44186,Percent,32.55814" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,89,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,23,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="autoCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 281</value>
+  </data>
+  <data name="autoCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 6, 3, 0</value>
+  </data>
+  <data name="autoCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>286, 17</value>
+  </data>
+  <data name="autoCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="autoCheckBox.Text" xml:space="preserve">
+    <value>A&amp;utomatically add this network to new virtual machines.</value>
+  </data>
+  <data name="&gt;&gt;autoCheckBox.Name" xml:space="preserve">
+    <value>autoCheckBox</value>
+  </data>
+  <data name="&gt;&gt;autoCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;autoCheckBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;autoCheckBox.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 0</value>
+  </data>
+  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="label2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 2, 0, 0</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>244, 15</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>LACP must also be configured on the switch ports</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>panelLACPWarning</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="pictureBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="pictureBox2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="pictureBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 15</value>
+  </data>
+  <data name="pictureBox2.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="pictureBox2.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Name" xml:space="preserve">
+    <value>pictureBox2</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Parent" xml:space="preserve">
+    <value>panelLACPWarning</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -466,7 +820,7 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>panelDisruptionWarning</value>
@@ -484,7 +838,7 @@
     <value>0, 24</value>
   </data>
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 50</value>
+    <value>16, 53</value>
   </data>
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>AutoSize</value>
@@ -496,181 +850,13 @@
     <value>pictureBox1</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
     <value>panelDisruptionWarning</value>
   </data>
   <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="panelDisruptionWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="panelDisruptionWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 351</value>
-  </data>
-  <data name="panelDisruptionWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="panelDisruptionWarning.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 24, 0, 0</value>
-  </data>
-  <data name="panelDisruptionWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>517, 74</value>
-  </data>
-  <data name="panelDisruptionWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="panelDisruptionWarning.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;panelDisruptionWarning.Name" xml:space="preserve">
-    <value>panelDisruptionWarning</value>
-  </data>
-  <data name="&gt;&gt;panelDisruptionWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelDisruptionWarning.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;panelDisruptionWarning.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="numericUpDownMTU.Location" type="System.Drawing.Point, System.Drawing">
-    <value>41, 255</value>
-  </data>
-  <data name="numericUpDownMTU.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
-  </data>
-  <data name="numericUpDownMTU.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 20</value>
-  </data>
-  <data name="numericUpDownMTU.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;numericUpDownMTU.Name" xml:space="preserve">
-    <value>numericUpDownMTU</value>
-  </data>
-  <data name="&gt;&gt;numericUpDownMTU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;numericUpDownMTU.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;numericUpDownMTU.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="labelMTU.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelMTU.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelMTU.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 258</value>
-  </data>
-  <data name="labelMTU.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 6, 3, 7</value>
-  </data>
-  <data name="labelMTU.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
-  </data>
-  <data name="labelMTU.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="labelMTU.Text" xml:space="preserve">
-    <value>&amp;MTU:</value>
-  </data>
-  <data name="&gt;&gt;labelMTU.Name" xml:space="preserve">
-    <value>labelMTU</value>
-  </data>
-  <data name="&gt;&gt;labelMTU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelMTU.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelMTU.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="warningText.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="warningText.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="warningText.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="warningText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 313</value>
-  </data>
-  <data name="warningText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 12, 0, 0</value>
-  </data>
-  <data name="warningText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>517, 13</value>
-  </data>
-  <data name="warningText.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="warningText.Text" xml:space="preserve">
-    <value>(The network's NIC and VLAN cannot be changed as there are active VMs attached)</value>
-  </data>
-  <data name="&gt;&gt;warningText.Name" xml:space="preserve">
-    <value>warningText</value>
-  </data>
-  <data name="&gt;&gt;warningText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;warningText.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;warningText.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="labelCannotConfigureMTU.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelCannotConfigureMTU.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelCannotConfigureMTU.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelCannotConfigureMTU.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 338</value>
-  </data>
-  <data name="labelCannotConfigureMTU.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 12, 0, 0</value>
-  </data>
-  <data name="labelCannotConfigureMTU.Size" type="System.Drawing.Size, System.Drawing">
-    <value>517, 13</value>
-  </data>
-  <data name="labelCannotConfigureMTU.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="labelCannotConfigureMTU.Text" xml:space="preserve">
-    <value>(The network's MTU cannot be changed as there are active VMs attached without tools installed)</value>
-  </data>
-  <data name="&gt;&gt;labelCannotConfigureMTU.Name" xml:space="preserve">
-    <value>labelCannotConfigureMTU</value>
-  </data>
-  <data name="&gt;&gt;labelCannotConfigureMTU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelCannotConfigureMTU.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelCannotConfigureMTU.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="groupBoxBondMode.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="groupBoxBondMode.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
   </data>
   <data name="tableLayoutPanelBondMode.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -680,6 +866,90 @@
   </data>
   <data name="tableLayoutPanelBondMode.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpTcpudpPorts.Name" xml:space="preserve">
+    <value>radioButtonLacpTcpudpPorts</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpTcpudpPorts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpTcpudpPorts.Parent" xml:space="preserve">
+    <value>tableLayoutPanelBondMode</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpTcpudpPorts.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;radioButtonBalanceSlb.Name" xml:space="preserve">
+    <value>radioButtonBalanceSlb</value>
+  </data>
+  <data name="&gt;&gt;radioButtonBalanceSlb.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonBalanceSlb.Parent" xml:space="preserve">
+    <value>tableLayoutPanelBondMode</value>
+  </data>
+  <data name="&gt;&gt;radioButtonBalanceSlb.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;radioButtonActiveBackup.Name" xml:space="preserve">
+    <value>radioButtonActiveBackup</value>
+  </data>
+  <data name="&gt;&gt;radioButtonActiveBackup.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonActiveBackup.Parent" xml:space="preserve">
+    <value>tableLayoutPanelBondMode</value>
+  </data>
+  <data name="&gt;&gt;radioButtonActiveBackup.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpSrcMac.Name" xml:space="preserve">
+    <value>radioButtonLacpSrcMac</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpSrcMac.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpSrcMac.Parent" xml:space="preserve">
+    <value>tableLayoutPanelBondMode</value>
+  </data>
+  <data name="&gt;&gt;radioButtonLacpSrcMac.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 40</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.RowCount" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>371, 92</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.Name" xml:space="preserve">
+    <value>tableLayoutPanelBondMode</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.Parent" xml:space="preserve">
+    <value>groupBoxBondMode</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelBondMode.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanelBondMode.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radioButtonLacpTcpudpPorts" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonBalanceSlb" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonActiveBackup" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonLacpSrcMac" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50" /&gt;&lt;Rows Styles="AutoSize,26,Percent,100,AutoSize,20,AutoSize,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="radioButtonLacpTcpudpPorts.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -691,7 +961,7 @@
     <value>3, 49</value>
   </data>
   <data name="radioButtonLacpTcpudpPorts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>370, 17</value>
+    <value>365, 17</value>
   </data>
   <data name="radioButtonLacpTcpudpPorts.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -703,7 +973,7 @@
     <value>radioButtonLacpTcpudpPorts</value>
   </data>
   <data name="&gt;&gt;radioButtonLacpTcpudpPorts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;radioButtonLacpTcpudpPorts.Parent" xml:space="preserve">
     <value>tableLayoutPanelBondMode</value>
@@ -730,7 +1000,7 @@
     <value>radioButtonBalanceSlb</value>
   </data>
   <data name="&gt;&gt;radioButtonBalanceSlb.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;radioButtonBalanceSlb.Parent" xml:space="preserve">
     <value>tableLayoutPanelBondMode</value>
@@ -757,7 +1027,7 @@
     <value>radioButtonActiveBackup</value>
   </data>
   <data name="&gt;&gt;radioButtonActiveBackup.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;radioButtonActiveBackup.Parent" xml:space="preserve">
     <value>tableLayoutPanelBondMode</value>
@@ -787,7 +1057,7 @@
     <value>radioButtonLacpSrcMac</value>
   </data>
   <data name="&gt;&gt;radioButtonLacpSrcMac.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;radioButtonLacpSrcMac.Parent" xml:space="preserve">
     <value>tableLayoutPanelBondMode</value>
@@ -795,133 +1065,7 @@
   <data name="&gt;&gt;radioButtonLacpSrcMac.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tableLayoutPanelBondMode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanelBondMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="tableLayoutPanelBondMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="tableLayoutPanelBondMode.RowCount" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanelBondMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>376, 92</value>
-  </data>
-  <data name="tableLayoutPanelBondMode.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelBondMode.Name" xml:space="preserve">
-    <value>tableLayoutPanelBondMode</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelBondMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelBondMode.Parent" xml:space="preserve">
-    <value>groupBoxBondMode</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelBondMode.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanelBondMode.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radioButtonLacpTcpudpPorts" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonBalanceSlb" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonActiveBackup" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonLacpSrcMac" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50" /&gt;&lt;Rows Styles="AutoSize,26,Percent,100,AutoSize,20,AutoSize,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="groupBoxBondMode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="groupBoxBondMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 118</value>
-  </data>
-  <data name="groupBoxBondMode.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
-  </data>
-  <data name="groupBoxBondMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 111</value>
-  </data>
-  <data name="groupBoxBondMode.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="groupBoxBondMode.Text" xml:space="preserve">
-    <value>Bond mode</value>
-  </data>
-  <data name="&gt;&gt;groupBoxBondMode.Name" xml:space="preserve">
-    <value>groupBoxBondMode</value>
-  </data>
-  <data name="&gt;&gt;groupBoxBondMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxBondMode.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;groupBoxBondMode.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 10</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>517, 425</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="panelLACPWarning" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="labelBlurb" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="numUpDownVLAN" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="nicHelpLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="HostVLanLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="HostNicLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="HostPNICList" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panelDisruptionWarning" Row="11" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="numericUpDownMTU" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelMTU" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="autoCheckBox" Row="8" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="warningText" Row="9" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="labelCannotConfigureMTU" Row="10" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="groupBoxBondMode" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,100,Percent,50" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,89,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="autoCheckBox.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8pt</value>
-  </data>
-  <data name="autoCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="autoCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 284</value>
-  </data>
-  <data name="autoCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 6, 3, 0</value>
-  </data>
-  <data name="autoCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>293, 17</value>
-  </data>
-  <data name="autoCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="autoCheckBox.Text" xml:space="preserve">
-    <value>A&amp;utomatically add this network to new virtual machines.</value>
-  </data>
-  <data name="&gt;&gt;autoCheckBox.Name" xml:space="preserve">
-    <value>autoCheckBox</value>
-  </data>
-  <data name="&gt;&gt;autoCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;autoCheckBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;autoCheckBox.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -940,6 +1084,6 @@
     <value>EditNetworkPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.Designer.cs
+++ b/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.Designer.cs
@@ -34,16 +34,19 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             this.labelNIC = new System.Windows.Forms.Label();
             this.labelVLAN = new System.Windows.Forms.Label();
             this.lblNicHelp = new System.Windows.Forms.Label();
-            this.labelVlanError = new System.Windows.Forms.Label();
             this.numericUpDownVLAN = new System.Windows.Forms.NumericUpDown();
             this.comboBoxNICList = new System.Windows.Forms.ComboBox();
             this.checkBoxAutomatic = new System.Windows.Forms.CheckBox();
             this.labelMTU = new System.Windows.Forms.Label();
             this.numericUpDownMTU = new System.Windows.Forms.NumericUpDown();
+            this.panelVLANInfo = new System.Windows.Forms.Panel();
+            this.labelVlanError = new System.Windows.Forms.Label();
+            this.labelVLAN0Info = new System.Windows.Forms.Label();
             this.panel1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownVLAN)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMTU)).BeginInit();
+            this.panelVLANInfo.SuspendLayout();
             this.SuspendLayout();
             // 
             // panel1
@@ -59,12 +62,12 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             this.tableLayoutPanel1.Controls.Add(this.labelNIC, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.labelVLAN, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.lblNicHelp, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.labelVlanError, 2, 2);
             this.tableLayoutPanel1.Controls.Add(this.numericUpDownVLAN, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxNICList, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.checkBoxAutomatic, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.labelMTU, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.numericUpDownMTU, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.panelVLANInfo, 2, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // labelNIC
@@ -82,13 +85,6 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             resources.ApplyResources(this.lblNicHelp, "lblNicHelp");
             this.tableLayoutPanel1.SetColumnSpan(this.lblNicHelp, 4);
             this.lblNicHelp.Name = "lblNicHelp";
-            // 
-            // labelVlanError
-            // 
-            resources.ApplyResources(this.labelVlanError, "labelVlanError");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelVlanError, 2);
-            this.labelVlanError.ForeColor = System.Drawing.Color.Red;
-            this.labelVlanError.Name = "labelVlanError";
             // 
             // numericUpDownVLAN
             // 
@@ -139,6 +135,26 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             resources.ApplyResources(this.numericUpDownMTU, "numericUpDownMTU");
             this.numericUpDownMTU.Name = "numericUpDownMTU";
             // 
+            // panelVLANInfo
+            // 
+            resources.ApplyResources(this.panelVLANInfo, "panelVLANInfo");
+            this.tableLayoutPanel1.SetColumnSpan(this.panelVLANInfo, 2);
+            this.panelVLANInfo.Controls.Add(this.labelVlanError);
+            this.panelVLANInfo.Controls.Add(this.labelVLAN0Info);
+            this.panelVLANInfo.Name = "panelVLANInfo";
+            // 
+            // labelVlanError
+            // 
+            resources.ApplyResources(this.labelVlanError, "labelVlanError");
+            this.labelVlanError.ForeColor = System.Drawing.Color.Red;
+            this.labelVlanError.Name = "labelVlanError";
+            // 
+            // labelVLAN0Info
+            // 
+            resources.ApplyResources(this.labelVLAN0Info, "labelVLAN0Info");
+            this.labelVLAN0Info.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.labelVLAN0Info.Name = "labelVLAN0Info";
+            // 
             // NetWDetails
             // 
             resources.ApplyResources(this, "$this");
@@ -151,6 +167,8 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownVLAN)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMTU)).EndInit();
+            this.panelVLANInfo.ResumeLayout(false);
+            this.panelVLANInfo.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -168,5 +186,7 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
         private System.Windows.Forms.Label labelVlanError;
         private System.Windows.Forms.Label labelMTU;
         private System.Windows.Forms.NumericUpDown numericUpDownMTU;
+        private System.Windows.Forms.Panel panelVLANInfo;
+        private System.Windows.Forms.Label labelVLAN0Info;
     }
 }

--- a/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.cs
+++ b/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.cs
@@ -76,6 +76,8 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
         {
             PopulateHostNicList(Host, Connection);
             UpdateEnablement(SelectedNetworkType == NetworkTypes.External, Host);
+            //set minimum value for VLAN
+            numericUpDownVLAN.Minimum = Helpers.VLAN0Allowed(Connection) ? 0 : 1; 
         }
 
         private int CurrentVLANValue
@@ -198,7 +200,10 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             //CA-72484: check whether the currently selected VLAN is available and keep it
             int curVlan = CurrentVLANValue;
             if (!vlans.Contains(curVlan))
+            {
+                SetError(null);
                 return;
+            }
 
             int avail_vlan = GetFirstAvailableVLAN(vlans);
 
@@ -225,7 +230,7 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             labelVlanError.Visible = visible;
             if (visible)
                 labelVlanError.Text = error;
-            
+            labelVLAN0Info.Visible = !visible && numericUpDownVLAN.Value == 0;
             if (updatePage)
                 OnPageUpdated();
         }

--- a/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.resx
+++ b/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.resx
@@ -112,16 +112,16 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
@@ -134,7 +134,7 @@
   <data name="labelNIC.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="labelNIC.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 72</value>
   </data>
@@ -157,7 +157,7 @@
     <value>labelNIC</value>
   </data>
   <data name="&gt;&gt;labelNIC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelNIC.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -193,7 +193,7 @@
     <value>labelVLAN</value>
   </data>
   <data name="&gt;&gt;labelVLAN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelVLAN.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -235,58 +235,13 @@ Select the physical interface you would like to use:</value>
     <value>lblNicHelp</value>
   </data>
   <data name="&gt;&gt;lblNicHelp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblNicHelp.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblNicHelp.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="labelVlanError.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelVlanError.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelVlanError.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 8.25pt</value>
-  </data>
-  <data name="labelVlanError.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelVlanError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>161, 108</value>
-  </data>
-  <data name="labelVlanError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 9, 0, 7</value>
-  </data>
-  <data name="labelVlanError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>332, 20</value>
-  </data>
-  <data name="labelVlanError.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="labelVlanError.Text" xml:space="preserve">
-    <value>This VLAN number is already in use</value>
-  </data>
-  <data name="labelVlanError.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="labelVlanError.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;labelVlanError.Name" xml:space="preserve">
-    <value>labelVlanError</value>
-  </data>
-  <data name="&gt;&gt;labelVlanError.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelVlanError.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelVlanError.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="numericUpDownVLAN.Location" type="System.Drawing.Point, System.Drawing">
     <value>41, 108</value>
@@ -304,13 +259,13 @@ Select the physical interface you would like to use:</value>
     <value>numericUpDownVLAN</value>
   </data>
   <data name="&gt;&gt;numericUpDownVLAN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;numericUpDownVLAN.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;numericUpDownVLAN.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="comboBoxNICList.Location" type="System.Drawing.Point, System.Drawing">
     <value>41, 75</value>
@@ -325,13 +280,13 @@ Select the physical interface you would like to use:</value>
     <value>comboBoxNICList</value>
   </data>
   <data name="&gt;&gt;comboBoxNICList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;comboBoxNICList.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxNICList.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="checkBoxAutomatic.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -364,13 +319,13 @@ Select the physical interface you would like to use:</value>
     <value>checkBoxAutomatic</value>
   </data>
   <data name="&gt;&gt;checkBoxAutomatic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;checkBoxAutomatic.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;checkBoxAutomatic.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="labelMTU.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -397,13 +352,13 @@ Select the physical interface you would like to use:</value>
     <value>labelMTU</value>
   </data>
   <data name="&gt;&gt;labelMTU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelMTU.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelMTU.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="numericUpDownMTU.Location" type="System.Drawing.Point, System.Drawing">
     <value>41, 135</value>
@@ -421,12 +376,132 @@ Select the physical interface you would like to use:</value>
     <value>numericUpDownMTU</value>
   </data>
   <data name="&gt;&gt;numericUpDownMTU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;numericUpDownMTU.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;numericUpDownMTU.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="panelVLANInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelVlanError.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelVlanError.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="labelVlanError.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt</value>
+  </data>
+  <data name="labelVlanError.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelVlanError.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="labelVlanError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="labelVlanError.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 13</value>
+  </data>
+  <data name="labelVlanError.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="labelVlanError.Text" xml:space="preserve">
+    <value>This VLAN number is already in use</value>
+  </data>
+  <data name="labelVlanError.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="labelVlanError.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;labelVlanError.Name" xml:space="preserve">
+    <value>labelVlanError</value>
+  </data>
+  <data name="&gt;&gt;labelVlanError.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelVlanError.Parent" xml:space="preserve">
+    <value>panelVLANInfo</value>
+  </data>
+  <data name="&gt;&gt;labelVlanError.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelVLAN0Info.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelVLAN0Info.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="labelVLAN0Info.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt</value>
+  </data>
+  <data name="labelVLAN0Info.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelVLAN0Info.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="labelVLAN0Info.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="labelVLAN0Info.Size" type="System.Drawing.Size, System.Drawing">
+    <value>252, 13</value>
+  </data>
+  <data name="labelVLAN0Info.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="labelVLAN0Info.Text" xml:space="preserve">
+    <value>VLAN 0 will receive all traffic not on any other VLAN</value>
+  </data>
+  <data name="labelVLAN0Info.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="labelVLAN0Info.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.Name" xml:space="preserve">
+    <value>labelVLAN0Info</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.Parent" xml:space="preserve">
+    <value>panelVLANInfo</value>
+  </data>
+  <data name="&gt;&gt;labelVLAN0Info.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelVLANInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panelVLANInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>161, 112</value>
+  </data>
+  <data name="panelVLANInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 13, 0, 0</value>
+  </data>
+  <data name="panelVLANInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>332, 23</value>
+  </data>
+  <data name="panelVLANInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;panelVLANInfo.Name" xml:space="preserve">
+    <value>panelVLANInfo</value>
+  </data>
+  <data name="&gt;&gt;panelVLANInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelVLANInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;panelVLANInfo.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -448,7 +523,7 @@ Select the physical interface you would like to use:</value>
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -457,7 +532,7 @@ Select the physical interface you would like to use:</value>
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelNIC" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelVLAN" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblNicHelp" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="labelVlanError" Row="2" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="numericUpDownVLAN" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxNICList" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="checkBoxAutomatic" Row="4" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="labelMTU" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownMTU" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Absolute,120,Absolute,127,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelNIC" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelVLAN" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblNicHelp" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="numericUpDownVLAN" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxNICList" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="checkBoxAutomatic" Row="4" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="labelMTU" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownMTU" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="panelVLANInfo" Row="2" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Absolute,120,Absolute,127,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
@@ -475,7 +550,7 @@ Select the physical interface you would like to use:</value>
     <value>panel1</value>
   </data>
   <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -483,7 +558,7 @@ Select the physical interface you would like to use:</value>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1911,5 +1911,15 @@ namespace XenAdmin.Core
        {
            return connection != null && connection.Cache.GPU_groups.Any(g => g.PGPUs.Count > 0 && g.supported_VGPU_types.Count > 0);
        }
+
+       /// <summary>
+       /// Whether creation of VLAN 0 is allowed.
+       /// </summary>
+       public static bool VLAN0Allowed(IXenConnection connection)
+       {
+           Host master = GetMaster(connection);
+           // For Creedence or later on the vSwitch backend, we allow creation of VLAN 0
+           return master != null && CreedenceOrGreater(master) && master.vSwitchNetworkBackend;
+       }
     }
 }


### PR DESCRIPTION
This applies to the New Network Wizard and the Network Properties.
- The VLAN can be set to 0 only for Creedence or greater hosts on the vSwitch backend.
- When VLAN 0 is selected, an info is shown next to the control, saying "VLAN 0 will receive all traffic not on any other VLAN"
- Also fixed an error on New Network Wizard, where the "VLAN in use" message was still visible when changing the NIC.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
