### PR TITLE
CA-136288 Restore application settings after installing a new version of XenCenter

### DIFF
--- a/XenAdmin/Program.cs
+++ b/XenAdmin/Program.cs
@@ -204,7 +204,15 @@ namespace XenAdmin
                 {
                     log.Debug("Upgrading settings...");
                     Properties.Settings.Default.Upgrade();
+
+                    // if program's hash has changed (e.g. by upgrading to .NET 4.0), then Upgrade() doesn't import the previous application settings 
+                    // because it cannot locate a previous user.config file. In this case a new user.config file is created with the default settings.
+                    // We will try and find a config file from a previous installation and update the settings from it
+                    if (Properties.Settings.Default.ApplicationVersion == "" && Properties.Settings.Default.DoUpgrade)
+                        SettingsUpdate.Update();
+                    log.DebugFormat("Settings upgraded from '{0}' to '{1}'", Properties.Settings.Default.ApplicationVersion, appVersionString);
                     Properties.Settings.Default.ApplicationVersion = appVersionString;
+                    Settings.TrySaveSettings();
                 }
             }
             catch (ConfigurationErrorsException ex)

--- a/XenAdmin/SettingsUpdate.cs
+++ b/XenAdmin/SettingsUpdate.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Reflection;
+using XenAdmin;
+using System.IO;
+
+public static class SettingsUpdate
+{
+    private static readonly log4net.ILog log = log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+    // The path of the user.config files looks something like this:
+    // <Profile Directory>\<Company Name>\<App Name>_<Evidence Type>_<Evidence Hash>\<Version>\user.config
+
+    /// <summary>
+    /// Looks for a config file from a previous installation of the application and updates the settings from it.
+    /// </summary>
+    public static void Update()
+    {
+        try
+        {
+            Assembly a = Assembly.GetExecutingAssembly();
+            Version appVersion = a.GetName().Version;
+
+            // get previous config file by enumerating through all the folders in <Profile Directory>\<Company Name> 
+            // to find a previous user.config file
+
+            var currentConfigFolder = new DirectoryInfo(Settings.GetUserConfigPath()).Parent;
+
+            if (currentConfigFolder == null)
+                return;
+
+            var appDomainName = AppDomain.CurrentDomain.FriendlyName;
+            var companyFolder = currentConfigFolder.Parent != null ? currentConfigFolder.Parent.Parent : null;
+
+            if (companyFolder == null)
+                return;
+
+            FileInfo previousConfig = null;
+            Version previousVersion = null;
+
+            foreach (var subDir in companyFolder.GetDirectories("*" + appDomainName + "*", SearchOption.AllDirectories))
+            {
+                foreach (var file in subDir.GetFiles("user.config", SearchOption.AllDirectories))
+                {
+                    var configFolderName = Path.GetFileName(Path.GetDirectoryName(file.FullName));
+                    if (configFolderName != null)
+                    {
+                        var configVersion = new Version(configFolderName);
+
+                        if ((configVersion <= appVersion) && (previousVersion == null || configVersion > previousVersion))
+                        {
+                            previousVersion = configVersion;
+                            previousConfig = file;
+                        }
+                    }
+                }
+            }
+            
+            if (previousConfig != null)
+            {
+                // copy previous config file to current config location
+                var destinationFile = Path.GetDirectoryName(currentConfigFolder.FullName);
+
+                destinationFile = Path.Combine(destinationFile, previousVersion.ToString());
+
+                if (!Directory.Exists(destinationFile))
+                    Directory.CreateDirectory(destinationFile);
+
+                destinationFile = Path.Combine(destinationFile, previousConfig.Name);
+
+                File.Copy(previousConfig.FullName, destinationFile);
+
+                // upgrade settings
+                XenAdmin.Properties.Settings.Default.Upgrade();
+            }
+        }
+        catch (Exception ex)
+        {
+            log.DebugFormat("Exception while updating settings: {0}", ex.Message);
+        }
+    }
+}

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -269,6 +269,7 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="SettingsUpdate.cs" />
     <Compile Include="TabPages\BaseTabPage.cs">
       <SubType>UserControl</SubType>
     </Compile>


### PR DESCRIPTION
When running XenCenter after a new installation, and the program's hash has changed (e.g. by .NET 4.0 upgrade), the previous settings are not automatically restored because they cannot be found (they are there, but in different folder).
We need to try and locate a config file from a previous installation, and if found, update the settings from there.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
