### PR TITLE
CA-115742: VM name and description change not allowed via XenCenter for ...

### DIFF
--- a/XenAdmin/SettingsPanels/VMAdvancedEditPage.cs
+++ b/XenAdmin/SettingsPanels/VMAdvancedEditPage.cs
@@ -130,25 +130,27 @@ namespace XenAdmin.SettingsPanels
 
         public bool HasChanged
         {
-            get
-            {
-                return ShadowValue != vm.HVM_shadow_multiplier
-                       || ShadowMultiplierTextBox.Text != vm.HVM_shadow_multiplier.ToString();
-            }
+            get { return ShadowValue != vm.HVM_shadow_multiplier; }
         }
 
+        private double _shadowMultiplier;
         private double ShadowValue
         {
             get
             {
-                double v;
-                return double.TryParse(ShadowMultiplierTextBox.Text,  NumberStyles.Any, CultureInfo.InvariantCulture, out v)
-                    ? v 
-                    : SHADOW_MULTIPLIER_GENERAL_USE;
+                if (ShadowMultiplierTextBox.Text != _shadowMultiplier.ToString("N", CultureInfo.InvariantCulture))
+                {
+                    double v;
+                    return double.TryParse(ShadowMultiplierTextBox.Text, NumberStyles.Any, CultureInfo.InvariantCulture, out v)
+                        ? v
+                        : SHADOW_MULTIPLIER_GENERAL_USE;
+                }
+                return _shadowMultiplier;
             }
             set
             {
-                ShadowMultiplierTextBox.Text = value.ToString("N", CultureInfo.InvariantCulture);
+                _shadowMultiplier = value;
+                ShadowMultiplierTextBox.Text = _shadowMultiplier.ToString("N", CultureInfo.InvariantCulture);
             }
         }
 


### PR DESCRIPTION
...VM Admin - FIXED

The error has been caused by the shadow multiplier field on Advanced Settings page: XenCenter thinks that the values has changed, and tries to save it, but this is not allowed for VM Admin users.
