### PR TITLE
CA-108676:  Put the Heartbeat and event.next sessions on their own ConnectionGroups

### DIFF
--- a/XenAdmin/Actions/GUIActions/MeddlingAction.cs
+++ b/XenAdmin/Actions/GUIActions/MeddlingAction.cs
@@ -84,6 +84,9 @@ namespace XenAdmin.Actions.GUIActions
                                                      Description = Messages.COMPLETED;
 
                                                  DestroyUnwantedOperations(task);
+
+                                                 if (deleting)
+                                                     LogoutCancelSession();
                                              });
         }
 

--- a/XenModel/Network/Heartbeat.cs
+++ b/XenModel/Network/Heartbeat.cs
@@ -111,6 +111,8 @@ namespace XenAdmin.Network
             }
         }
 
+        private readonly string heartbeatConnectionGroupName = Guid.NewGuid().ToString(); 
+
         private void DoHeartbeat()
         {
             if (!connection.IsConnected)
@@ -122,6 +124,7 @@ namespace XenAdmin.Network
                 {
                     // Try to get a new session, but only give the server one chance (otherwise we get the default 3x timeout)
                     session = connection.DuplicateSession(connectionTimeout < 5000 ? 5000 : connectionTimeout);
+                    session.ConnectionGroupName = heartbeatConnectionGroupName; // this will force the Heartbeat session onto its own set of TCP streams (see CA-108676)
                 }
 
                 GetServerTime();

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -1208,6 +1208,8 @@ namespace XenAdmin.Network
             }
         }
 
+        private readonly string eventNextConnectionGroupName = Guid.NewGuid().ToString(); 
+
         /// <summary>
         /// The main method for a connection to a XenServer. This method runs until the connection is lost, and
         /// contains a loop that after doing an initial cache fill processes events off the wire when they arrive.
@@ -1236,6 +1238,9 @@ namespace XenAdmin.Network
                     session.APIVersion >= API_Version.API_1_6 ?  // Helpers.GeorgeOrGreater, except we can't use that because the cache isn't populated before we fire the first Event.next.
                     DuplicateSession(EVENT_NEXT_TIMEOUT) :
                     session;
+
+                if (session.APIVersion >= API_Version.API_1_6)
+                    eventNextSession.ConnectionGroupName = eventNextConnectionGroupName; // this will force the eventNextSession onto its own set of TCP streams (see CA-108676)
 
                 bool legacyEventSystem = XenObjectDownloader.LegacyEventSystem(session);
 

--- a/XenModel/XenAPI-Extensions/Session.cs
+++ b/XenModel/XenAPI-Extensions/Session.cs
@@ -257,5 +257,11 @@ namespace XenAPI
                 return roles[0].FriendlyName;
             }
         }
+
+        public string ConnectionGroupName
+        {
+            get { return _proxy.ConnectionGroupName; }
+            set { _proxy.ConnectionGroupName = value; }
+        }
     }
 }


### PR DESCRIPTION
Also make sure that the MeddlingAction's cancel session gets disposed.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
