### PR TITLE
CA-137470: Fixed unhandled exception raised by pressing space key on gri...

### DIFF
--- a/XenAdmin/Controls/CheckableDataGridView/CheckableDataGridView.cs
+++ b/XenAdmin/Controls/CheckableDataGridView/CheckableDataGridView.cs
@@ -43,6 +43,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
     public class CheckableDataGridViewRowEventArgs : EventArgs
     {
         public int RowIndex { get; set; }
+        public bool RefreshGrid { get; set; }
     }
 
     /// <summary>
@@ -340,11 +341,11 @@ namespace XenAdmin.Controls.CheckableDataGridView
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void TriggerRowUpdatedEvent(int rowUpdated)
+        public void TriggerRowUpdatedEvent(int rowUpdated, bool refreshGrid)
         {
             RowUpdatedEvent handler = Events[RowUpdatedEventKey] as RowUpdatedEvent;
             if (handler != null)
-                handler.Invoke(this, new CheckableDataGridViewRowEventArgs { RowIndex = rowUpdated });
+                handler.Invoke(this, new CheckableDataGridViewRowEventArgs { RowIndex = rowUpdated, RefreshGrid = refreshGrid });
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/XenAdmin/Controls/CheckableDataGridView/CheckableDataGridViewController.cs
+++ b/XenAdmin/Controls/CheckableDataGridView/CheckableDataGridViewController.cs
@@ -108,7 +108,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
             CheckableDataGridViewRow row = sender as CheckableDataGridViewRow;
             if(row == null)
                 return;
-            UpdateRow(row);
+            UpdateRow(row, true);
         }
 
         public List<CheckableDataGridViewRow> CheckedRows
@@ -122,7 +122,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
                 return;
             storedRows.ForEach(r=>r.Highlighted = false);
             storedRows[rowIndex].Highlighted = true;
-            UpdateRow(storedRows[rowIndex]);
+            UpdateRow(storedRows[rowIndex], false);
             View.DrawRowAsHighlighted(storedRows[rowIndex].Highlighted, rowIndex);
         }
 
@@ -188,7 +188,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
         /// Pass in the replacement row
         /// </summary>
         /// <param name="toUpdate">Replacement Row</param>
-        private void UpdateRow(CheckableDataGridViewRow toUpdate)
+        private void UpdateRow(CheckableDataGridViewRow toUpdate, bool refreshGrid)
         {
             if (toUpdate == null)
                 return;
@@ -208,7 +208,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
                 View.DrawUpdatedRow(storedRows[indexToUpdate].CellText, storedRows[indexToUpdate].CellDataLoaded,
                                     storedRows[indexToUpdate].Disabled, indexToUpdate);
             }
-            View.TriggerRowUpdatedEvent(indexToUpdate);
+            View.TriggerRowUpdatedEvent(indexToUpdate, refreshGrid);
         }
 
         private int ReplaceStoredRow(CheckableDataGridViewRow toUpdate)
@@ -224,6 +224,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
             if (indexToUpdate >= storedRows.Count || indexToUpdate < 0)
             {
                 log.DebugFormat("Unexpected index in ReplaceStoredRow row '{0}'; Stored rows contain '{1}' items", indexToUpdate, storedRows.Count);
+                return -1;
             }
             storedRows.Remove(storedRows[indexToUpdate]);
             storedRows.Insert(indexToUpdate, toUpdate); 

--- a/XenAdmin/Controls/CheckableDataGridView/ICheckableDataGridViewView.cs
+++ b/XenAdmin/Controls/CheckableDataGridView/ICheckableDataGridViewView.cs
@@ -40,7 +40,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
         void DrawRowAsChecked(bool checkStatus, int rowIndex);
         void DrawRowAsHighlighted(bool highlightStatus, int rowIndex);
         void DrawRowAsDisabled(bool disabledStatus, int rowIndex);
-        void TriggerRowUpdatedEvent(int rowUpdated);
+        void TriggerRowUpdatedEvent(int rowUpdated, bool refreshGrid);
         void TriggerRowCheckedEvent(int rowChecked);
         void DrawUpdatedRow(Queue<object> textToUse, bool cellDataLoaded, bool rowDisabled, int rowIndex);
         void DrawAllRowsAsCleared();

--- a/XenAdmin/Dialogs/LicenseManager/LicenseManager.cs
+++ b/XenAdmin/Dialogs/LicenseManager/LicenseManager.cs
@@ -133,7 +133,8 @@ namespace XenAdmin.Dialogs
                 Controller.SummariseSelectedRow(checkableDataGridView.GetCheckableRow(e.RowIndex));
             }
 
-            senderGrid.SortAndRefresh();
+            if (e.RefreshGrid)
+                senderGrid.SortAndRefresh();
         }
 
         private void checkableDataGridView_SelectionChanged(object sender, EventArgs e)


### PR DESCRIPTION
...dview of License Manager.
- Added a 'refresh grid' parameter to UpdateRow() which indicates if a sort and refresh of the grid is necessary.
- A sort and refresh is not needed when the user selects a server by pressing the space key or by mouse, but it is needed when the information displayed has changed, for example when the license has changed.
- Also solved a possible null reference exception in CheckableDataGridViewController.ReplaceStoredRow(), by returning -1 if the index is not within the rows range.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
