### PR TITLE
CA-139888: Changing window size should not change the number of items mi...

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -3087,8 +3087,12 @@ namespace XenAdmin
 
         private void SetSplitterDistance()
         {
-            //CA-71697: chosen min size so the tab contents are visible
-            int chosenPanel2MinSize = splitContainer1.Width/2;
+            //CA-71697: chosen min size for Panel2 so the tab contents are visible, 
+            //but limit it so it can still fit in the main window when this is restored at minimum size (CA-139888)
+            int borderWidth = Width - splitContainer1.Width;
+            int lowerLimitForPanel2MinSize = MinimumSize.Width - splitContainer1.Panel1MinSize -
+                                             splitContainer1.SplitterWidth - borderWidth;
+            int chosenPanel2MinSize = Math.Min(splitContainer1.Width / 2, lowerLimitForPanel2MinSize);
             int min = splitContainer1.Panel1MinSize;
             int max = splitContainer1.Width - chosenPanel2MinSize;
 


### PR DESCRIPTION
...nimized in Outlook-style navigation panel

This fixes the following problem:
When the main window is resized, we set the minimum width of the right side panel (Panel2MinSize) to half the size of the window so that the tab contents are visible. This is fine on most situations, but on a higher screen resolution (e.g. 1920x1080) the following problem occurs:
- starting with the main window at minimum size, when the window is maximized, the Panel2MinSize is set to half window's size (e.g. 960)
- when the main window is restored back to the minimum size, the split container is not resized because there is a conflict between Panel2MinSize and the size of the window itself (Panel1MinSize + Panel2MinSize > window's width)
- therefore the navigation panel is not visible and also the content of the tab control may appear out of scale.

To fix this, we don't allow Panel2MinSize to go above a minimum value, calculated so that the right side panel would fit in the window at the window's minimum size.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
