### PR TITLE
CA-139888: Changing window size should not change the number of items mi...

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -3088,7 +3088,7 @@ namespace XenAdmin
         private void SetSplitterDistance()
         {
             //CA-71697: chosen min size so the tab contents are visible
-            int chosenPanel2MinSize = splitContainer1.Width/2;
+            int chosenPanel2MinSize = MinimumSize.Width / 2;
             int min = splitContainer1.Panel1MinSize;
             int max = splitContainer1.Width - chosenPanel2MinSize;
 


### PR DESCRIPTION
...nimized in Outlook-style navigation panel

This fixes the following problem:
When the main window is resized, we set the minimum width of the right side panel (Panel2MinSize) to half the size of the window so that the tab contents are visible. This is fine on most situations, but on a higher screen resolution (e.g. 1920x1080) the following problem occurs:
- starting with the main window at minimum size, when the window is maximized, the Panel2MinSize is set to half window's size (e.g. 960)
- when the main window is restored back to the minimum size, the split container is not resized because there is a conflict between Panel2MinSize and the size of the window itself (Panel1MinSize + Panel2MinSize > window's width)
- therefore the navigation panel is not visible and also the content of the tab control may appear out of scale.

To fix this, we set the Panel2MinSize to half of the window's minimum width. This way the right side panel will always fit in the window, including when it is restored to minimum size.
This also fixes [CA-137956] - Restoring Maximised XenCenter does not resize the main panel properly.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
