### PR TITLE
CA-140330: Use originator in session.login_with_password

### DIFF
--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -320,7 +320,7 @@ namespace XenAdmin.Network
 
             try
             {
-                session.login_with_password(user, password, API_Version.LATEST);
+                session.login_with_password(user, password, Helper.APIVersionString(API_Version.LATEST), Session.UserAgent);
 
                 // this is required so connection.IsConnected returns true in the unit tests.
                 connectTask = new ConnectTask("test", 0);
@@ -486,7 +486,7 @@ namespace XenAdmin.Network
                     session.IsElevatedSession = true;
                 try
                 {
-                    session.login_with_password(uname, pwd, !string.IsNullOrEmpty(Version) ? Version : Helper.APIVersionString(API_Version.LATEST));
+                    session.login_with_password(uname, pwd, !string.IsNullOrEmpty(Version) ? Version : Helper.APIVersionString(API_Version.LATEST), Session.UserAgent);
                     return session;
                 }
                 catch (Failure f)


### PR DESCRIPTION
-Calling new overload of the session.login_with_password() XAPI function (+originator field). This lets XenServer to group all sessions from a given XenCenter instance.

Signed-off-by: Gabor Apati-Nagy gabor.apati-nagy@citrix.com
