### PR TITLE
CA-138822: Improvements to the Host/Pool Storage tab, following on from ...

### DIFF
--- a/XenAdmin/Commands/Controls/CommandButton.cs
+++ b/XenAdmin/Commands/Controls/CommandButton.cs
@@ -35,6 +35,7 @@ using System.Text;
 using System.Windows.Forms;
 using System.ComponentModel;
 using System.Drawing.Design;
+using XenAdmin.Controls;
 
 namespace XenAdmin.Commands
 {
@@ -93,6 +94,9 @@ namespace XenAdmin.Commands
                 {
                     Text = _command.ButtonText;
                 }
+
+                if (Parent is ToolTipContainer)
+                    (Parent as ToolTipContainer).SetToolTip(_command.ToolTipText);
             }
         }
 

--- a/XenAdmin/TabPages/PhysicalStoragePage.Designer.cs
+++ b/XenAdmin/TabPages/PhysicalStoragePage.Designer.cs
@@ -16,9 +16,12 @@ namespace XenAdmin.TabPages
             Host = null;
             Connection = null;
 
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                if (selectionManager != null)
+                    selectionManager.Dispose();
+                if (components != null)
+                    components.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -47,12 +50,14 @@ namespace XenAdmin.TabPages
             this.panel1 = new System.Windows.Forms.Panel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.newSRButton = new XenAdmin.Commands.CommandButton();
-            this.trimButton = new System.Windows.Forms.Button();
+            this.trimButtonContainer = new XenAdmin.Controls.ToolTipContainer();
+            this.trimButton = new XenAdmin.Commands.CommandButton();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.buttonProperties = new System.Windows.Forms.Button();
             this.pageContainerPanel.SuspendLayout();
             this.panel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
+            this.trimButtonContainer.SuspendLayout();
             this.SuspendLayout();
             // 
             // pageContainerPanel
@@ -80,8 +85,8 @@ namespace XenAdmin.TabPages
             this.columnHeader7});
             this.listViewSrs.ContextMenuStrip = this.contextMenuStrip;
             resources.ApplyResources(this.listViewSrs, "listViewSrs");
+            this.listViewSrs.FullRowSelect = true;
             this.listViewSrs.HideSelection = false;
-            this.listViewSrs.MultiSelect = false;
             this.listViewSrs.Name = "listViewSrs";
             this.listViewSrs.UseCompatibleStateImageBehavior = false;
             this.listViewSrs.View = System.Windows.Forms.View.Details;
@@ -136,7 +141,7 @@ namespace XenAdmin.TabPages
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.Controls.Add(this.newSRButton);
-            this.flowLayoutPanel1.Controls.Add(this.trimButton);
+            this.flowLayoutPanel1.Controls.Add(this.trimButtonContainer);
             this.flowLayoutPanel1.Controls.Add(this.groupBox1);
             this.flowLayoutPanel1.Controls.Add(this.buttonProperties);
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
@@ -149,12 +154,18 @@ namespace XenAdmin.TabPages
             this.newSRButton.Name = "newSRButton";
             this.newSRButton.UseVisualStyleBackColor = true;
             // 
+            // trimButtonContainer
+            // 
+            this.trimButtonContainer.Controls.Add(this.trimButton);
+            resources.ApplyResources(this.trimButtonContainer, "trimButtonContainer");
+            this.trimButtonContainer.Name = "trimButtonContainer";
+            // 
             // trimButton
             // 
+            this.trimButton.Command = new XenAdmin.Commands.TrimSRCommand();
             resources.ApplyResources(this.trimButton, "trimButton");
             this.trimButton.Name = "trimButton";
             this.trimButton.UseVisualStyleBackColor = true;
-            this.trimButton.Click += new System.EventHandler(this.trimButton_Click);
             // 
             // groupBox1
             // 
@@ -181,6 +192,7 @@ namespace XenAdmin.TabPages
             this.pageContainerPanel.PerformLayout();
             this.panel1.ResumeLayout(false);
             this.flowLayoutPanel1.ResumeLayout(false);
+            this.trimButtonContainer.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -203,7 +215,8 @@ namespace XenAdmin.TabPages
         private System.Windows.Forms.Button buttonProperties;
         private System.Windows.Forms.GroupBox groupBox1;
         private XenAdmin.Commands.CommandButton newSRButton;
-        private System.Windows.Forms.Button trimButton;
+        private XenAdmin.Commands.CommandButton trimButton;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private Controls.ToolTipContainer trimButtonContainer;
     }
 }

--- a/XenAdmin/TabPages/PhysicalStoragePage.cs
+++ b/XenAdmin/TabPages/PhysicalStoragePage.cs
@@ -32,10 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
-using System.Drawing.Text;
-using System.Data;
-using System.Text;
+using System.Linq;
 using System.Windows.Forms;
 
 using XenAdmin.Controls;
@@ -55,6 +52,9 @@ namespace XenAdmin.TabPages
 
         private bool NeedBuildList;
         private readonly ListViewColumnSorter lvwColumnSorter = new ListViewColumnSorter();
+
+        private SelectionManager selectionManager;
+        private bool showTrimButton;
 
         public PhysicalStoragePage()
         {
@@ -122,6 +122,7 @@ namespace XenAdmin.TabPages
                         pool.PropertyChanged += pool_PropertyChanged;
                 }
 
+                RefreshTrimButton();
                 BuildList();
             }
         }
@@ -297,6 +298,12 @@ namespace XenAdmin.TabPages
                     listViewSrs.SelectedIndices.Clear();
                     listViewSrs.SelectedIndices.Add(selectedIndex);
                 }
+                else
+                {
+                    // Select first item
+                    if (listViewSrs.Items.Count > 0)
+                        listViewSrs.SelectedIndices.Add(0);
+                }
             }
             finally
             {
@@ -369,36 +376,33 @@ namespace XenAdmin.TabPages
         void listViewSrs_SelectedIndexChanged(object sender, EventArgs e)
         {
             RefreshButtons();
+            if (showTrimButton)
+            {
+                List<SelectedItem> selectedSRs = (from ListViewItem item in listViewSrs.SelectedItems select new SelectedItem((SR)item.Tag)).ToList();
+                selectionManager.SetSelection(selectedSRs);
+            }
         }
 
         private void RefreshButtons()
         {
             buttonProperties.Enabled = listViewSrs.SelectedItems.Count == 1;
-            
-            // Trim button
-            if (listViewSrs.SelectedItems.Count == 1)
+        }
+
+        private void RefreshTrimButton()
+        {
+            showTrimButton = connection != null && Helpers.CreedenceOrGreater(connection);
+            if (showTrimButton)
             {
-                SR sr = (SR)listViewSrs.SelectedItems[0].Tag;
-                TrimSRCommand trimCmd = new TrimSRCommand(Program.MainWindow, sr);
-                trimButton.Visible = trimCmd.CanExecute(); 
+                trimButtonContainer.Visible = true;
+                if (selectionManager == null)
+                    selectionManager = new SelectionManager();
+                selectionManager.BindTo(trimButton, Program.MainWindow);
             }
             else
             {
-                trimButton.Visible = false;
+                trimButtonContainer.Visible = false;
+                trimButton.SelectionBroadcaster = null;
             }
         }
-
-        private void trimButton_Click(object sender, EventArgs e)
-        {
-            if (listViewSrs.SelectedItems.Count != 1)
-                return;
-
-            SR sr = (SR)listViewSrs.SelectedItems[0].Tag;
-            TrimSRCommand trimCmd = new TrimSRCommand(Program.MainWindow, sr);
-            if (trimCmd.CanExecute())
-                trimCmd.Execute();
-
-        }
-
     }
 }

--- a/XenAdmin/TabPages/PhysicalStoragePage.resx
+++ b/XenAdmin/TabPages/PhysicalStoragePage.resx
@@ -228,17 +228,17 @@
   <data name="&gt;&gt;newSRButton.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="trimButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="trimButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="trimButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 5</value>
+    <value>0, 0</value>
   </data>
   <data name="trimButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
   </data>
   <data name="trimButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 23</value>
+    <value>120, 23</value>
   </data>
   <data name="trimButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -250,16 +250,40 @@
     <value>trimButton</value>
   </data>
   <data name="&gt;&gt;trimButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>XenAdmin.Commands.CommandButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;trimButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
+    <value>trimButtonContainer</value>
   </data>
   <data name="&gt;&gt;trimButton.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="trimButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 5</value>
+  </data>
+  <data name="trimButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 3, 0</value>
+  </data>
+  <data name="trimButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 23</value>
+  </data>
+  <data name="trimButtonContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.Name" xml:space="preserve">
+    <value>trimButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>244, 5</value>
+    <value>234, 5</value>
   </data>
   <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
@@ -268,7 +292,7 @@
     <value>2, 20</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>0</value>
@@ -289,7 +313,7 @@
     <value>Top, Right</value>
   </data>
   <data name="buttonProperties.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 5</value>
+    <value>242, 5</value>
   </data>
   <data name="buttonProperties.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
@@ -298,7 +322,7 @@
     <value>102, 23</value>
   </data>
   <data name="buttonProperties.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="buttonProperties.Text" xml:space="preserve">
     <value>P&amp;roperties</value>


### PR DESCRIPTION
...the TRIM work
- Make "Reclaim freed space" a CommandButton (will appear as disabled if the command cannot execute)
- Add tooltip to "Reclaim freed space" button to show the reason it is disabled
- Hide "Reclaim freed space" button on old servers
- Allow multiselect
- "Reclaim freed space" button enabled if at least one SR can be trimmed

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
