### PR TITLE
CA-140647: Customer is not getting the list of updates when ever they se...

### DIFF
--- a/XenModel/XenAPI/HTTP.cs
+++ b/XenModel/XenAPI/HTTP.cs
@@ -413,13 +413,15 @@ namespace XenAPI
         {
             return DO_HTTP(uri, proxy, false, timeout_ms,
                 string.Format("PUT {0} HTTP/1.0", uri.PathAndQuery),
+                string.Format("Host: {0}", uri.Host),
                 string.Format("Content-Length: {0}", ContentLength));
         }
 
         public static Stream GET(Uri uri, IWebProxy proxy, int timeout_ms)
         {
             return DO_HTTP(uri, proxy, false, timeout_ms,
-                string.Format("GET {0} HTTP/1.0", uri.PathAndQuery));
+                string.Format("GET {0} HTTP/1.0", uri.PathAndQuery),
+                string.Format("Host: {0}", uri.Host));
         }
 
         /// <summary>


### PR DESCRIPTION
...lect the "Check for Updates" option from the tools menu within Xencenter.

-Added 'Host:' to HTTP headers for all the HTTP GET and PUT requests sent by XenCenter.
This change will presumably fix network issues occurring when going through certain corporate firewalls/proxies.

Signed-off-by: Gabor Apati-Nagy gabor.apati-nagy@citrix.com
