### PR TITLE
CP-8120 Cores-per-socket: When building the topology list ignore the max...

### DIFF
--- a/XenAdmin/Controls/ComboBoxes/CPUTopologyComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/CPUTopologyComboBox.cs
@@ -85,7 +85,7 @@ namespace XenAdmin.Controls
         private static List<TopologyTuple> GetTopologies(long noOfVCPUs, long maxNoOfCoresPerSocket)
         {
             var result = new List<TopologyTuple>();
-            var maxCoresPerSocket = Math.Min(noOfVCPUs, maxNoOfCoresPerSocket);
+            var maxCoresPerSocket = maxNoOfCoresPerSocket > 0 ? Math.Min(noOfVCPUs, maxNoOfCoresPerSocket) : noOfVCPUs;
             for (var cores = 1; cores <= maxCoresPerSocket; cores++)
             {
                 if (noOfVCPUs % cores == 0)


### PR DESCRIPTION
...imum number of cores-per-socket (i.e. number of cores per socket on the underlying server) if this is zero, for example because the socket information is not available on 6.1 servers.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
