### PR TITLE
CA-140636: Creedence XenCenter threw an unexpected error (build 87029)

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/DataPlotNav.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataPlotNav.cs
@@ -506,7 +506,9 @@ namespace XenAdmin.Controls.CustomDataGraph
                 {
                     int setindex = ArchiveMaintainer.Archives[currentwidth].Sets.IndexOf(set);
                     todraw = new List<DataPoint>(ArchiveMaintainer.Archives[currentwidth].Sets[setindex].Points);
-                    set.MergePointCollection(set.BinaryChop(set.Points, new DataTimeRange(ScrollViewLeft.Ticks, todraw[todraw.Count - 1].X, GraphResolution.Ticks)), todraw);
+
+                    if (todraw.Count > 0)
+                        set.MergePointCollection(set.BinaryChop(set.Points, new DataTimeRange(ScrollViewLeft.Ticks, todraw[todraw.Count - 1].X, GraphResolution.Ticks)), todraw);
                 }
 
                 set.RefreshCustomY(everything, todraw);


### PR DESCRIPTION
-According to the call stack this is the place where the exception can come from.  Although I was not able to reproduce the exception, this fix solves a possible argument (index) out of range exception. With this check, point merging is not going to be done if it were unnecessary anyway when there were an empty list to be merged (count==0).

Signed-off-by: Gabor Apati-Nagy gabor.apati-nagy@citrix.com
