### PR TITLE
CA-140336: Hide the Windows menu item at all times

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1546,8 +1546,6 @@ namespace XenAdmin
                 if (itemAdded && insertIndex != menu.DropDownItems.Count)
                     menu.DropDownItems.Insert(insertIndex, new ToolStripSeparator());
             }
-
-            windowToolStripMenuItem.Visible = windowToolStripMenuItem.DropDownItems.Count > 0;
         }
 
         private void MainMenuBar_MenuActivate(object sender, EventArgs e)

--- a/XenAdmin/MainWindow.resx
+++ b/XenAdmin/MainWindow.resx
@@ -2357,6 +2357,9 @@
   <data name="windowToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Window</value>
   </data>
+  <data name="windowToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="helpTopicsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>192, 22</value>
   </data>

--- a/XenAdminTests/TabsAndMenus/PluginTabsAndMenus.cs
+++ b/XenAdminTests/TabsAndMenus/PluginTabsAndMenus.cs
@@ -195,9 +195,6 @@ namespace XenAdminTests.TabsAndMenus
                 MainWindowWrapper.ToolsMenu.ShowDropDown();
                 Assert.AreEqual("tools_ShellTest1", GetVisibleToolStripItems(MainWindowWrapper.ToolsMenu.DropDownItems)[7].Text);
 
-                MainWindowWrapper.WindowMenu.ShowDropDown();
-                Assert.AreEqual("window_ShellTest1", GetVisibleToolStripItems(MainWindowWrapper.WindowMenu.DropDownItems)[0].Text);
-
                 MainWindowWrapper.HelpMenu.ShowDropDown();
                 Assert.AreEqual("help_ShellTest1", GetVisibleToolStripItems(MainWindowWrapper.HelpMenu.DropDownItems)[8].Text);
             });


### PR DESCRIPTION
- cannot remove completely because of the plugin specification, but it is not be visible even if they were plugins trying to use it

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
