### PR TITLE
PhysicalStoragePage: In the sr_PropertyChanged event handler we need to ...

### DIFF
--- a/XenAdmin/TabPages/PhysicalStoragePage.cs
+++ b/XenAdmin/TabPages/PhysicalStoragePage.cs
@@ -182,7 +182,7 @@ namespace XenAdmin.TabPages
             }
             else
             {
-                RefreshRowForSr((SR)sender);
+                Program.Invoke(this, () => RefreshRowForSr((SR)sender));
             }
         }
 


### PR DESCRIPTION
...invoke the refresh function on the UI thread, to avoid cross thread operation exception.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
