### PR TITLE
CA-114985: Fixed the issue where an empty summary page was displayed aft...

### DIFF
--- a/XenAdmin/Wizards/NewSRWizard.cs
+++ b/XenAdmin/Wizards/NewSRWizard.cs
@@ -549,11 +549,6 @@ namespace XenAdmin.Wizards
 
             if (m_srWizardType is SrWizardType_LvmoHba)
             {
-                foreach (var asyncAction in actionList)
-                {
-                    asyncAction.Completed += asyncAction_Completed;
-                }
-
                 ActionProgressDialog closureDialog = dialog;
                 // close dialog even when there's an error for HBA SR type as there will be the Summary page displayed.
                 FinalAction.Completed +=
@@ -564,6 +559,14 @@ namespace XenAdmin.Wizards
                         });
             }
             dialog.ShowDialog(this);
+
+            if (m_srWizardType is SrWizardType_LvmoHba)
+            {
+                foreach (var asyncAction in actionList)
+                {
+                    AddActionToSummary(asyncAction);
+                }
+            }
 
             if (!FinalAction.Succeeded && FinalAction is SrReattachAction && _srToReattach.HasPBDs)
             {
@@ -596,9 +599,8 @@ namespace XenAdmin.Wizards
 
         private Dictionary<AsyncAction, SrDescriptor> actionSrDescriptorDict = new Dictionary<AsyncAction, SrDescriptor>();
 
-        void asyncAction_Completed(ActionBase sender)
+        void AddActionToSummary(AsyncAction action)
         {
-            AsyncAction action = sender as AsyncAction;
             if (action == null)
                 return;
 


### PR DESCRIPTION
...er creating Hardware HBA SR
- The problem was the Summary page was displayed before the lists of succeeded and failed actions have been populated (on the Completed event of each action).
- To fix it, we populate these lists after all the actions are completed, and on the event thread.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
