### PR TITLE
CA-140335: Fixed the problems with dismissing alerts

### DIFF
--- a/XenAdmin/TabPages/AlertSummaryPage.Designer.cs
+++ b/XenAdmin/TabPages/AlertSummaryPage.Designer.cs
@@ -32,13 +32,13 @@ namespace XenAdmin.TabPages
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AlertSummaryPage));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle14 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle13 = new System.Windows.Forms.DataGridViewCellStyle();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.LabelCappingEntries = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
@@ -172,7 +172,7 @@ namespace XenAdmin.TabPages
             // 
             this.tsmiDismissSelected.Name = "tsmiDismissSelected";
             resources.ApplyResources(this.tsmiDismissSelected, "tsmiDismissSelected");
-            this.tsmiDismissSelected.Click += new System.EventHandler(this.ToolStripMenuItemDismiss_Click);
+            this.tsmiDismissSelected.Click += new System.EventHandler(this.tsmiDismissSelected_Click);
             // 
             // toolStripLabelFiltersOnOff
             // 
@@ -189,8 +189,8 @@ namespace XenAdmin.TabPages
             // 
             // GridViewAlerts
             // 
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
-            this.GridViewAlerts.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.Window;
+            this.GridViewAlerts.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle8;
             resources.ApplyResources(this.GridViewAlerts, "GridViewAlerts");
             this.GridViewAlerts.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
             this.GridViewAlerts.BackgroundColor = System.Drawing.SystemColors.Window;
@@ -203,31 +203,31 @@ namespace XenAdmin.TabPages
             this.ColumnLocation,
             this.ColumnDate,
             this.ColumnActions});
-            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
-            dataGridViewCellStyle7.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle7.Font = new System.Drawing.Font("Segoe UI", 9F);
-            dataGridViewCellStyle7.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.GridViewAlerts.DefaultCellStyle = dataGridViewCellStyle7;
+            dataGridViewCellStyle14.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
+            dataGridViewCellStyle14.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle14.Font = new System.Drawing.Font("Segoe UI", 9F);
+            dataGridViewCellStyle14.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle14.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle14.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle14.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.GridViewAlerts.DefaultCellStyle = dataGridViewCellStyle14;
             this.GridViewAlerts.GridColor = System.Drawing.SystemColors.ControlDark;
             this.GridViewAlerts.MultiSelect = true;
             this.GridViewAlerts.Name = "GridViewAlerts";
-            this.GridViewAlerts.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.GridViewAlerts_SortCompare);
+            this.GridViewAlerts.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.GridViewAlerts_CellClick);
             this.GridViewAlerts.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.GridViewAlerts_CellDoubleClick);
             this.GridViewAlerts.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.GridViewAlerts_ColumnHeaderMouseClick);
-            this.GridViewAlerts.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.GridViewAlerts_CellClick);
-            this.GridViewAlerts.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GridViewAlerts_KeyDown);
             this.GridViewAlerts.SelectionChanged += new System.EventHandler(this.GridViewAlerts_SelectionChanged);
+            this.GridViewAlerts.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.GridViewAlerts_SortCompare);
+            this.GridViewAlerts.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GridViewAlerts_KeyDown);
             // 
             // ColumnExpand
             // 
             this.ColumnExpand.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopCenter;
-            dataGridViewCellStyle2.NullValue = null;
-            dataGridViewCellStyle2.Padding = new System.Windows.Forms.Padding(0, 5, 0, 0);
-            this.ColumnExpand.DefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle9.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopCenter;
+            dataGridViewCellStyle9.NullValue = null;
+            dataGridViewCellStyle9.Padding = new System.Windows.Forms.Padding(0, 5, 0, 0);
+            this.ColumnExpand.DefaultCellStyle = dataGridViewCellStyle9;
             resources.ApplyResources(this.ColumnExpand, "ColumnExpand");
             this.ColumnExpand.Name = "ColumnExpand";
             this.ColumnExpand.ReadOnly = true;
@@ -236,10 +236,10 @@ namespace XenAdmin.TabPages
             // ColumnSeverity
             // 
             this.ColumnSeverity.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopCenter;
-            dataGridViewCellStyle3.NullValue = null;
-            dataGridViewCellStyle3.Padding = new System.Windows.Forms.Padding(0, 2, 0, 0);
-            this.ColumnSeverity.DefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopCenter;
+            dataGridViewCellStyle10.NullValue = null;
+            dataGridViewCellStyle10.Padding = new System.Windows.Forms.Padding(0, 2, 0, 0);
+            this.ColumnSeverity.DefaultCellStyle = dataGridViewCellStyle10;
             resources.ApplyResources(this.ColumnSeverity, "ColumnSeverity");
             this.ColumnSeverity.Name = "ColumnSeverity";
             this.ColumnSeverity.ReadOnly = true;
@@ -248,9 +248,9 @@ namespace XenAdmin.TabPages
             // 
             // ColumnMessage
             // 
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
-            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.ColumnMessage.DefaultCellStyle = dataGridViewCellStyle4;
+            dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
+            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.ColumnMessage.DefaultCellStyle = dataGridViewCellStyle11;
             this.ColumnMessage.FillWeight = 200F;
             resources.ApplyResources(this.ColumnMessage, "ColumnMessage");
             this.ColumnMessage.Name = "ColumnMessage";
@@ -258,16 +258,16 @@ namespace XenAdmin.TabPages
             // 
             // ColumnLocation
             // 
-            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
-            this.ColumnLocation.DefaultCellStyle = dataGridViewCellStyle5;
+            dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
+            this.ColumnLocation.DefaultCellStyle = dataGridViewCellStyle12;
             resources.ApplyResources(this.ColumnLocation, "ColumnLocation");
             this.ColumnLocation.Name = "ColumnLocation";
             this.ColumnLocation.ReadOnly = true;
             // 
             // ColumnDate
             // 
-            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
-            this.ColumnDate.DefaultCellStyle = dataGridViewCellStyle6;
+            dataGridViewCellStyle13.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
+            this.ColumnDate.DefaultCellStyle = dataGridViewCellStyle13;
             resources.ApplyResources(this.ColumnDate, "ColumnDate");
             this.ColumnDate.Name = "ColumnDate";
             this.ColumnDate.ReadOnly = true;

--- a/XenAdmin/TabPages/AlertSummaryPage.cs
+++ b/XenAdmin/TabPages/AlertSummaryPage.cs
@@ -475,6 +475,20 @@ namespace XenAdmin.TabPages
 
         private void ToolStripMenuItemDismiss_Click(object sender, EventArgs e)
         {
+            if (GridViewAlerts.SelectedRows.Count != 1)
+                log.DebugFormat("Only 1 alert can be dismissed at a time (Attempted to dismiss {0}). Dismissing the clicked item.", GridViewAlerts.SelectedRows.Count);
+
+            DataGridViewRow clickedRow = FindAlertRow(sender as ToolStripMenuItem);
+            if (clickedRow == null)
+            {
+                log.Debug("Attempted to dismiss alert with no alert selected.");
+                return;
+            }
+
+            Alert alert = (Alert)clickedRow.Tag;
+            if (alert == null)
+                return;
+
             using (var dlog = new ThreeButtonDialog(
                     new ThreeButtonDialog.Details(null, Messages.ALERT_DISMISS_CONFIRM, Messages.XENCENTER),
                     ThreeButtonDialog.ButtonYes,
@@ -484,19 +498,7 @@ namespace XenAdmin.TabPages
                     return;
             }
 
-            DataGridViewRow clickedRow = FindAlertRow(sender as ToolStripMenuItem);
-            if (clickedRow == null)
-                return;
-
-            if (GridViewAlerts.SelectedRows.Count > 1 && GridViewAlerts.SelectedRows.Contains(clickedRow))
-            {
-                var selectedAlerts = from DataGridViewRow row in GridViewAlerts.SelectedRows select row.Tag as Alert;
-                DismissAlerts(selectedAlerts);
-            }
-            else
-            {
-                DismissAlerts(new List<Alert> {(Alert) clickedRow.Tag});
-            }
+            DismissAlerts(new List<Alert> {(Alert) clickedRow.Tag});
         }
 
         private void tsmiDismissAll_Click(object sender, EventArgs e)
@@ -533,6 +535,24 @@ namespace XenAdmin.TabPages
                              : Alert.Alerts;
 
             DismissAlerts(alerts);
+        }
+
+        private void tsmiDismissSelected_Click(object sender, EventArgs e)
+        {
+            using (var dlog = new ThreeButtonDialog(
+                    new ThreeButtonDialog.Details(null, Messages.ALERT_DISMISS_SELECTED_CONFIRM, Messages.XENCENTER),
+                    ThreeButtonDialog.ButtonYes,
+                    ThreeButtonDialog.ButtonNo))
+            {
+                if (dlog.ShowDialog(this) != DialogResult.Yes)
+                    return;
+            }
+
+            if (GridViewAlerts.SelectedRows.Count > 0)
+            {
+                var selectedAlerts = from DataGridViewRow row in GridViewAlerts.SelectedRows select row.Tag as Alert;
+                DismissAlerts(selectedAlerts);
+            }
         }
 
         private void AlertsCollectionChanged(object sender, CollectionChangeEventArgs e)
@@ -652,10 +672,13 @@ namespace XenAdmin.TabPages
             foreach (var g in groups)
             {
                 if (AllowedToDismiss(g.Connection))
+                {
+                    foreach (var alert in g.Alerts)
+                        alert.Dismissing = true;
+                    Rebuild();
                     new DeleteAllAlertsAction(g.Connection, g.Alerts).RunAsync();
+                }
             }
-
-            Rebuild();
         }
 
         #endregion
@@ -799,6 +822,9 @@ namespace XenAdmin.TabPages
 
         private void copyToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            if (GridViewAlerts.SelectedRows.Count != 1)
+                log.DebugFormat("Only 1 alert can be copied at a time (Attempted to copy {0}). Copying the clicked item.", GridViewAlerts.SelectedRows.Count);
+
             DataGridViewRow clickedRow = FindAlertRow(sender as ToolStripMenuItem);
             if (clickedRow == null)
             {
@@ -806,25 +832,13 @@ namespace XenAdmin.TabPages
                 return;
             }
 
-            StringBuilder sb = new StringBuilder();
-            if (GridViewAlerts.SelectedRows.Count > 1 && GridViewAlerts.SelectedRows.Contains(clickedRow))
-            {
-                foreach (DataGridViewRow r in GridViewAlerts.SelectedRows)
-                {
-                    Alert alert = (Alert) r.Tag;
-                    sb.AppendLine(alert.GetAlertDetailsCSVQuotes());
-                }
-            }
-            else
-            {
-                Alert alert = (Alert)clickedRow.Tag;
-                if (alert != null) 
-                    sb.AppendLine(alert.GetUpdateDetailsCSVQuotes());
-            }
+            Alert alert = (Alert)clickedRow.Tag;
+            if (alert == null)
+                return;
 
             try
             {
-                Clipboard.SetText(sb.ToString());
+                Clipboard.SetText(alert.GetUpdateDetailsCSVQuotes());
             }
             catch (Exception ex)
             {

--- a/XenAdmin/TabPages/AlertSummaryPage.resx
+++ b/XenAdmin/TabPages/AlertSummaryPage.resx
@@ -112,16 +112,16 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pictureBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pictureBox1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -140,7 +140,7 @@
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>AutoSize</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
@@ -148,7 +148,7 @@
     <value>pictureBox1</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -184,7 +184,7 @@
     <value>LabelCappingEntries</value>
   </data>
   <data name="&gt;&gt;LabelCappingEntries.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LabelCappingEntries.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -201,7 +201,7 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1, 1</value>
   </metadata>
   <data name="toolStrip1.AutoSize" type="System.Boolean, mscorlib">
@@ -361,7 +361,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -403,7 +403,7 @@
     <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Parent" xml:space="preserve">
     <value>$this</value>
@@ -417,7 +417,7 @@
   <data name="GridViewAlerts.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <metadata name="ColumnExpand.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnExpand.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnExpand.HeaderText" xml:space="preserve">
@@ -429,7 +429,7 @@
   <data name="ColumnExpand.Width" type="System.Int32, mscorlib">
     <value>20</value>
   </data>
-  <metadata name="ColumnSeverity.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnSeverity.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnSeverity.HeaderText" xml:space="preserve">
@@ -441,7 +441,7 @@
   <data name="ColumnSeverity.Width" type="System.Int32, mscorlib">
     <value>30</value>
   </data>
-  <metadata name="ColumnMessage.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnMessage.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnMessage.HeaderText" xml:space="preserve">
@@ -450,7 +450,7 @@
   <data name="ColumnMessage.MinimumWidth" type="System.Int32, mscorlib">
     <value>30</value>
   </data>
-  <metadata name="ColumnLocation.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnLocation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnLocation.HeaderText" xml:space="preserve">
@@ -459,7 +459,7 @@
   <data name="ColumnLocation.MinimumWidth" type="System.Int32, mscorlib">
     <value>30</value>
   </data>
-  <metadata name="ColumnDate.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnDate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnDate.HeaderText" xml:space="preserve">
@@ -468,7 +468,7 @@
   <data name="ColumnDate.MinimumWidth" type="System.Int32, mscorlib">
     <value>30</value>
   </data>
-  <metadata name="ColumnActions.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnActions.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnActions.HeaderText" xml:space="preserve">
@@ -507,7 +507,7 @@
   <data name="&gt;&gt;GridViewAlerts.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -544,90 +544,90 @@
     <value>toolStripSeparator3</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripButtonRefresh.Name" xml:space="preserve">
     <value>toolStripButtonRefresh</value>
   </data>
   <data name="&gt;&gt;toolStripButtonRefresh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
     <value>toolStripSeparator1</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripButtonExportAll.Name" xml:space="preserve">
     <value>toolStripButtonExportAll</value>
   </data>
   <data name="&gt;&gt;toolStripButtonExportAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSplitButtonDismiss.Name" xml:space="preserve">
     <value>toolStripSplitButtonDismiss</value>
   </data>
   <data name="&gt;&gt;toolStripSplitButtonDismiss.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSplitButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripSplitButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tsmiDismissAll.Name" xml:space="preserve">
     <value>tsmiDismissAll</value>
   </data>
   <data name="&gt;&gt;tsmiDismissAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tsmiDismissSelected.Name" xml:space="preserve">
     <value>tsmiDismissSelected</value>
   </data>
   <data name="&gt;&gt;tsmiDismissSelected.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripLabelFiltersOnOff.Name" xml:space="preserve">
     <value>toolStripLabelFiltersOnOff</value>
   </data>
   <data name="&gt;&gt;toolStripLabelFiltersOnOff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripLabel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnExpand.Name" xml:space="preserve">
     <value>ColumnExpand</value>
   </data>
   <data name="&gt;&gt;ColumnExpand.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnSeverity.Name" xml:space="preserve">
     <value>ColumnSeverity</value>
   </data>
   <data name="&gt;&gt;ColumnSeverity.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnMessage.Name" xml:space="preserve">
     <value>ColumnMessage</value>
   </data>
   <data name="&gt;&gt;ColumnMessage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnLocation.Name" xml:space="preserve">
     <value>ColumnLocation</value>
   </data>
   <data name="&gt;&gt;ColumnLocation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnDate.Name" xml:space="preserve">
     <value>ColumnDate</value>
   </data>
   <data name="&gt;&gt;ColumnDate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnActions.Name" xml:space="preserve">
     <value>ColumnActions</value>
   </data>
   <data name="&gt;&gt;ColumnActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>AlertSummaryPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -1240,7 +1240,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Removing all client alerts.
+        ///   Looks up a localized string similar to Removing {0} client alerts.
         /// </summary>
         public static string ACTION_REMOVE_ALERTS_ON_CLIENT_TITLE {
             get {
@@ -1249,11 +1249,29 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Removing all alerts on &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Removing client alert.
+        /// </summary>
+        public static string ACTION_REMOVE_ALERTS_ON_CLIENT_TITLE_ONE {
+            get {
+                return ResourceManager.GetString("ACTION_REMOVE_ALERTS_ON_CLIENT_TITLE_ONE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removing {0} alerts on &apos;{1}&apos;.
         /// </summary>
         public static string ACTION_REMOVE_ALERTS_ON_CONNECTION_TITLE {
             get {
                 return ResourceManager.GetString("ACTION_REMOVE_ALERTS_ON_CONNECTION_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removing alert on &apos;{0}&apos;.
+        /// </summary>
+        public static string ACTION_REMOVE_ALERTS_ON_CONNECTION_TITLE_ONE {
+            get {
+                return ResourceManager.GetString("ACTION_REMOVE_ALERTS_ON_CONNECTION_TITLE_ONE", resourceCulture);
             }
         }
         
@@ -3975,6 +3993,17 @@ namespace XenAdmin {
         public static string ALERT_DISMISS_CONFIRM {
             get {
                 return ResourceManager.GetString("ALERT_DISMISS_CONFIRM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This operation will remove the selected alerts from the servers permanently. Do you wish to continue?
+        ///
+        ///Note that if RBAC is enabled, only alerts which you have privileges to dismiss will be affected..
+        /// </summary>
+        public static string ALERT_DISMISS_SELECTED_CONFIRM {
+            get {
+                return ResourceManager.GetString("ALERT_DISMISS_SELECTED_CONFIRM", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -511,10 +511,16 @@
     <value>Removed 1 alert</value>
   </data>
   <data name="ACTION_REMOVE_ALERTS_ON_CLIENT_TITLE" xml:space="preserve">
-    <value>Removing all client alerts</value>
+    <value>Removing {0} client alerts</value>
+  </data>
+  <data name="ACTION_REMOVE_ALERTS_ON_CLIENT_TITLE_ONE" xml:space="preserve">
+    <value>Removing client alert</value>
   </data>
   <data name="ACTION_REMOVE_ALERTS_ON_CONNECTION_TITLE" xml:space="preserve">
-    <value>Removing all alerts on '{0}'</value>
+    <value>Removing {0} alerts on '{1}'</value>
+  </data>
+  <data name="ACTION_REMOVE_ALERTS_ON_CONNECTION_TITLE_ONE" xml:space="preserve">
+    <value>Removing alert on '{0}'</value>
   </data>
   <data name="ACTION_REMOVE_ALERTS_PROGRESS_DESCRIPTION" xml:space="preserve">
     <value>Removing alert {0} of {1}...</value>
@@ -1481,6 +1487,11 @@ Note that if RBAC is enabled, only alerts which you have privileges to dismiss w
   </data>
   <data name="ALERT_DISMISS_CONFIRM" xml:space="preserve">
     <value>Once a system alert is dismissed it will be removed from the server permanently. Do you wish to continue?</value>
+  </data>
+  <data name="ALERT_DISMISS_SELECTED_CONFIRM" xml:space="preserve">
+    <value>This operation will remove the selected alerts from the servers permanently. Do you wish to continue?
+
+Note that if RBAC is enabled, only alerts which you have privileges to dismiss will be affected.</value>
   </data>
   <data name="ALERT_EXPORT_ALL_BUTTON" xml:space="preserve">
     <value>Export &amp;all</value>


### PR DESCRIPTION
Changes to the DeleteAllAlertsAction:
- when the dismiss operation fails with INVALID_HANDLE we need to remove the alert from our alert list (XenCenterAlerts) and trigger the CollectionChanged event so that the alert count gets updated.
- the action title now says "Removing <n> alerts" when dismissing all/selected alerts and "Removing alert" when dismissing single alert (instead of "Removing all alerts" in all cases)
- move the initialization of Dismissing flag outside the action (see below)

This fix also includes changes so that the Dismissing flag works as intended: to be able to hide the dismissing alerts in the Alerts view immediately, rather than one by one when they were actually deleted, causing a large number of refreshes.
On dismissing alerts we do:
1. set dismissing to true for all alerts
2. rebuild alert list (this will filter out the dismissing alerts)
3. dismiss alerts - run the DismissAllAlerts action

Also, the action buttons on each row should only apply to the clicked row (not multiselect).

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
