### PR TITLE
CA-141163: EN: Fail to show Single-Server Private network.

### DIFF
--- a/XenAdmin/Controls/NetworkingTab/NetworkList.cs
+++ b/XenAdmin/Controls/NetworkingTab/NetworkList.cs
@@ -341,8 +341,7 @@ namespace XenAdmin.Controls.NetworkingTab
                     List<NetworkRow> networkRowsToAdd = new List<NetworkRow>();
                     for (int i = 0; i < networks.Length; i++)
                     {
-                        if (!networks[i].Show(XenAdmin.Properties.Settings.Default.ShowHiddenVMs) ||
-                            Helpers.FindPIF(networks[i], XenObject as Host) == null)
+                        if (!networks[i].Show(XenAdmin.Properties.Settings.Default.ShowHiddenVMs))
                             continue;
                         networkRowsToAdd.Add(new NetworkRow(networks[i], XenObject));
                     }
@@ -933,7 +932,7 @@ namespace XenAdmin.Controls.NetworkingTab
                 VlanCell.Value = Helpers.VlanString(Pif);
                 AutoCell.Value = Network.AutoPlug ? Messages.YES : Messages.NO;
                 LinkStatusCell.Value = Xmo is Pool ? Network.LinkStatusString : 
-                    Pif == null ? Messages.SPACED_HYPHEN : Pif.LinkStatusString;
+                    Pif == null ? Messages.NONE : Pif.LinkStatusString;
                 MacCell.Value = Pif != null && Pif.IsPhysical ? Pif.MAC : Messages.SPACED_HYPHEN;
                 MtuCell.Value = Network.CanUseJumboFrames ? Network.MTU.ToString() : Messages.SPACED_HYPHEN;
             }

--- a/XenModel/XenAPI-Extensions/Network.cs
+++ b/XenModel/XenAPI-Extensions/Network.cs
@@ -305,7 +305,7 @@ namespace XenAPI
             get
             {
                 if (PIFs.Count == 0)
-                    return Messages.SPACED_HYPHEN;
+                    return Messages.NONE;
 
                 List<PIF.LinkState> states = new List<PIF.LinkState>();
                 foreach (PIF p in Connection.ResolveAll<PIF>(PIFs))


### PR DESCRIPTION
-Reverted changes of CA-109242, See: #62 
-Network tab: now to show '< None >' instead of '-' as Link Status (for pools: when the network has no PIFs; for hosts: when the network has no PIF )

Signed-off-by: Gabor Apati-Nagy gabor.apati-nagy@citrix.com
