### PR TITLE
CA-141168: EN: Improvement: Textbox lines seem overlap in "Set Maser Pas...

### DIFF
--- a/XenAdmin/Dialogs/RestoreSession/ChangeMasterPasswordDialog.resx
+++ b/XenAdmin/Dialogs/RestoreSession/ChangeMasterPasswordDialog.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -127,11 +127,11 @@
   <data name="currentLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="currentLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="currentLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -142,7 +142,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="currentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 23</value>
+    <value>142, 29</value>
   </data>
   <data name="currentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -150,11 +150,14 @@
   <data name="currentLabel.Text" xml:space="preserve">
     <value>&amp;Current master password:</value>
   </data>
+  <data name="currentLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
   <data name="&gt;&gt;currentLabel.Name" xml:space="preserve">
     <value>currentLabel</value>
   </data>
   <data name="&gt;&gt;currentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;currentLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -178,7 +181,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="currentPasswordError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 71</value>
+    <value>150, 77</value>
   </data>
   <data name="currentPasswordError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -208,13 +211,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="masterTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 93</value>
-  </data>
-  <data name="masterTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>153, 102</value>
   </data>
   <data name="masterTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 23</value>
+    <value>261, 23</value>
   </data>
   <data name="masterTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -223,7 +223,7 @@
     <value>masterTextBox</value>
   </data>
   <data name="&gt;&gt;masterTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;masterTextBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -241,13 +241,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="masterLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 93</value>
+    <value>8, 99</value>
   </data>
   <data name="masterLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="masterLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 23</value>
+    <value>142, 29</value>
   </data>
   <data name="masterLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -255,11 +255,14 @@
   <data name="masterLabel.Text" xml:space="preserve">
     <value>&amp;New master password:</value>
   </data>
+  <data name="masterLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
   <data name="&gt;&gt;masterLabel.Name" xml:space="preserve">
     <value>masterLabel</value>
   </data>
   <data name="&gt;&gt;masterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;masterLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -274,13 +277,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="reEnterMasterTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 116</value>
-  </data>
-  <data name="reEnterMasterTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>153, 131</value>
   </data>
   <data name="reEnterMasterTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 23</value>
+    <value>261, 23</value>
   </data>
   <data name="reEnterMasterTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -289,7 +289,7 @@
     <value>reEnterMasterTextBox</value>
   </data>
   <data name="&gt;&gt;reEnterMasterTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;reEnterMasterTextBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -307,13 +307,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="reEnterMasterLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 116</value>
+    <value>8, 128</value>
   </data>
   <data name="reEnterMasterLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="reEnterMasterLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 23</value>
+    <value>142, 29</value>
   </data>
   <data name="reEnterMasterLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -321,11 +321,14 @@
   <data name="reEnterMasterLabel.Text" xml:space="preserve">
     <value>&amp;Re-enter new password:</value>
   </data>
+  <data name="reEnterMasterLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
   <data name="&gt;&gt;reEnterMasterLabel.Name" xml:space="preserve">
     <value>reEnterMasterLabel</value>
   </data>
   <data name="&gt;&gt;reEnterMasterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;reEnterMasterLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -340,13 +343,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="currentTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 48</value>
-  </data>
-  <data name="currentTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>153, 51</value>
   </data>
   <data name="currentTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 23</value>
+    <value>261, 23</value>
   </data>
   <data name="currentTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -355,7 +355,7 @@
     <value>currentTextBox</value>
   </data>
   <data name="&gt;&gt;currentTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;currentTextBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -379,7 +379,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="newPasswordError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 139</value>
+    <value>150, 157</value>
   </data>
   <data name="newPasswordError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -412,13 +412,13 @@
     <value>NoControl</value>
   </data>
   <data name="noteLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 161</value>
+    <value>8, 179</value>
   </data>
   <data name="noteLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="noteLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>363, 30</value>
+    <value>363, 15</value>
   </data>
   <data name="noteLabel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -431,7 +431,7 @@
     <value>noteLabel</value>
   </data>
   <data name="&gt;&gt;noteLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;noteLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -467,7 +467,7 @@
     <value>cancelButton</value>
   </data>
   <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -500,7 +500,7 @@
     <value>okButton</value>
   </data>
   <data name="&gt;&gt;okButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -518,13 +518,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 211</value>
+    <value>150, 214</value>
   </data>
   <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 20, 0, 3</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 34</value>
+    <value>267, 31</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -533,7 +533,7 @@
     <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -566,7 +566,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -575,7 +575,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="currentLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="currentPasswordError" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="masterTextBox" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="masterLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="masterBlurbLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="reEnterMasterTextBox" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="reEnterMasterLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="currentTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="newPasswordError" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="noteLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="flowLayoutPanel1" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="currentLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="currentPasswordError" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="masterTextBox" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="masterLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="masterBlurbLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="reEnterMasterTextBox" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="reEnterMasterLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="currentTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="newPasswordError" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="noteLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="flowLayoutPanel1" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="masterBlurbLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -603,7 +603,7 @@ You will need to enter this password at the beginning of each session.</value>
     <value>masterBlurbLabel</value>
   </data>
   <data name="&gt;&gt;masterBlurbLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;masterBlurbLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -611,7 +611,7 @@ You will need to enter this password at the beginning of each session.</value>
   <data name="&gt;&gt;masterBlurbLabel.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">

--- a/XenAdmin/Dialogs/RestoreSession/SetMasterPasswordDialog.Designer.cs
+++ b/XenAdmin/Dialogs/RestoreSession/SetMasterPasswordDialog.Designer.cs
@@ -48,7 +48,6 @@ namespace XenAdmin.Dialogs.RestoreSession
             // 
             resources.ApplyResources(this.noteLabel, "noteLabel");
             this.tableLayoutPanel1.SetColumnSpan(this.noteLabel, 2);
-            this.noteLabel.MaximumSize = new System.Drawing.Size(456, 99999);
             this.noteLabel.Name = "noteLabel";
             // 
             // reEnterMasterLabel
@@ -79,7 +78,6 @@ namespace XenAdmin.Dialogs.RestoreSession
             // 
             resources.ApplyResources(this.masterBlurbLabel, "masterBlurbLabel");
             this.tableLayoutPanel1.SetColumnSpan(this.masterBlurbLabel, 2);
-            this.masterBlurbLabel.MaximumSize = new System.Drawing.Size(456, 99999);
             this.masterBlurbLabel.Name = "masterBlurbLabel";
             // 
             // okButton

--- a/XenAdmin/Dialogs/RestoreSession/SetMasterPasswordDialog.resx
+++ b/XenAdmin/Dialogs/RestoreSession/SetMasterPasswordDialog.resx
@@ -112,19 +112,19 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="noteLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
@@ -137,7 +137,7 @@
   <data name="masterLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="masterLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -148,7 +148,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="masterLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 23</value>
+    <value>108, 29</value>
   </data>
   <data name="masterLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -163,7 +163,7 @@
     <value>masterLabel</value>
   </data>
   <data name="&gt;&gt;masterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;masterLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -184,7 +184,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="newPasswordError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 86</value>
+    <value>108, 98</value>
   </data>
   <data name="newPasswordError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -214,13 +214,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="masterTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 40</value>
-  </data>
-  <data name="masterTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>111, 43</value>
   </data>
   <data name="masterTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>348, 23</value>
+    <value>342, 23</value>
   </data>
   <data name="masterTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -229,7 +226,7 @@
     <value>masterTextBox</value>
   </data>
   <data name="&gt;&gt;masterTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;masterTextBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -244,13 +241,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="reEnterMasterTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 63</value>
-  </data>
-  <data name="reEnterMasterTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>111, 72</value>
   </data>
   <data name="reEnterMasterTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>348, 23</value>
+    <value>342, 23</value>
   </data>
   <data name="reEnterMasterTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -259,7 +253,7 @@
     <value>reEnterMasterTextBox</value>
   </data>
   <data name="&gt;&gt;reEnterMasterTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;reEnterMasterTextBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -277,13 +271,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="reEnterMasterLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 63</value>
+    <value>0, 69</value>
   </data>
   <data name="reEnterMasterLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="reEnterMasterLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 23</value>
+    <value>108, 29</value>
   </data>
   <data name="reEnterMasterLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -298,7 +292,7 @@
     <value>reEnterMasterLabel</value>
   </data>
   <data name="&gt;&gt;reEnterMasterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;reEnterMasterLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -321,6 +315,9 @@
   <data name="masterBlurbLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 10</value>
   </data>
+  <data name="masterBlurbLabel.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>456, 99999</value>
+  </data>
   <data name="masterBlurbLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>456, 30</value>
   </data>
@@ -334,7 +331,7 @@
     <value>masterBlurbLabel</value>
   </data>
   <data name="&gt;&gt;masterBlurbLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;masterBlurbLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -370,7 +367,7 @@
     <value>cancelButton</value>
   </data>
   <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -400,7 +397,7 @@
     <value>okButton</value>
   </data>
   <data name="&gt;&gt;okButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -418,13 +415,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 153</value>
+    <value>108, 165</value>
   </data>
   <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>348, 45</value>
+    <value>348, 33</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -433,7 +430,7 @@
     <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -463,7 +460,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -481,10 +478,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="noteLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 123</value>
+    <value>0, 135</value>
   </data>
   <data name="noteLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 10, 0, 0</value>
+  </data>
+  <data name="noteLabel.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>456, 99999</value>
   </data>
   <data name="noteLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>456, 30</value>
@@ -499,7 +499,7 @@
     <value>noteLabel</value>
   </data>
   <data name="&gt;&gt;noteLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;noteLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -507,7 +507,7 @@
   <data name="&gt;&gt;noteLabel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">


### PR DESCRIPTION
...sword" and "Change Master Password" dialog.

-Fixed margins (of input textboxes) on the Set Master Password dialog and on the Change Master Password dialog
-Fixed alignment of buttons on the Change Master Password dialog

Signed-off-by: Gabor Apati-Nagy gabor.apati-nagy@citrix.com
