### PR TITLE
CA-141389 Log all GET and POST calls

### DIFF
--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -986,7 +986,7 @@ namespace XenAdmin.ConsoleView
                 SessionUUID = activeSession.uuid;
             }
 
-            Stream stream = HTTPHelper.CONNECT(uri, console.Connection, SessionUUID, false);
+            Stream stream = HTTPHelper.CONNECT(uri, console.Connection, SessionUUID, false, true);
 
             InvokeConnection(v, stream, console);
         }

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -299,7 +299,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                 Session session = xenObject.Connection.Session;
                 if (session == null)
                     return;
-                using (Stream httpstream = HTTPHelper.GET(URI(session, host, interval, xenObject), xenObject.Connection, true))
+                using (Stream httpstream = HTTPHelper.GET(URI(session, host, interval, xenObject), xenObject.Connection, true, false))
                 {
                     using (XmlReader reader = XmlReader.Create(httpstream))
                     {

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -245,7 +245,7 @@ namespace XenAdmin.Actions
         protected virtual XmlDocument FetchCheckForUpdatesXml(string location)
         {
             XmlDocument xdoc;
-            using (Stream xmlstream = HTTPHelper.GET(new Uri(location), Connection, false))
+            using (Stream xmlstream = HTTPHelper.GET(new Uri(location), Connection, false, true))
             {
                 xdoc = Helpers.LoadXmlDocument(xmlstream);
             }

--- a/XenModel/Actions/VM/ExportVmAction.cs
+++ b/XenModel/Actions/VM/ExportVmAction.cs
@@ -252,7 +252,7 @@ namespace XenAdmin.Actions
         {
             using (FileStream fs = new FileStream(filename, FileMode.Create, FileAccess.Write))
             {
-                using (Stream http = HTTPHelper.GET(uri, Connection, true))
+                using (Stream http = HTTPHelper.GET(uri, Connection, true, true))
                 {
                     new Export().verify(http, fs, (Export.cancellingCallback)delegate() { return Cancelling; });
                 }

--- a/XenModel/Network/HTTPHelper.cs
+++ b/XenModel/Network/HTTPHelper.cs
@@ -305,18 +305,24 @@ namespace XenAPI
             }
         }
 
-        public static Stream CONNECT(Uri uri, IXenConnection connection, string session, bool timeout)
+        public static Stream CONNECT(Uri uri, IXenConnection connection, string session, bool timeout, bool do_log)
         {
+            if (do_log)
+                log.DebugFormat("HTTP CONNECTING to {0}", uri);
             return HTTP.CONNECT(uri, XenAdminConfigManager.Provider.GetProxyFromSettings(connection), session, XenAdminConfigManager.Provider.GetProxyTimeout(timeout));
         }
 
-        public static Stream PUT(Uri uri, long ContentLength, bool timeout)
+        public static Stream PUT(Uri uri, long ContentLength, bool timeout, bool do_log)
         {
+            if (do_log)
+                log.DebugFormat("HTTP PUTTING file to {0}", uri);
             return HTTP.PUT(uri, XenAdminConfigManager.Provider.GetProxyFromSettings(null), ContentLength, XenAdminConfigManager.Provider.GetProxyTimeout(timeout));
         }
 
-        public static Stream GET(Uri uri, IXenConnection connection, bool timeout)
+        public static Stream GET(Uri uri, IXenConnection connection, bool timeout, bool do_log)
         {
+            if (do_log)
+                log.DebugFormat("HTTP GETTING file from {0}", uri);
             return HTTP.GET(uri, XenAdminConfigManager.Provider.GetProxyFromSettings(connection), XenAdminConfigManager.Provider.GetProxyTimeout(timeout));
         }
     }

--- a/XenModel/ServerDBs/Db.cs
+++ b/XenModel/ServerDBs/Db.cs
@@ -53,7 +53,7 @@ namespace XenAdmin.ServerDBs
         {
             _tables = new TableDictionary(this);
 
-            using (StreamReader stream = url.StartsWith("http") ? new StreamReader(HTTPHelper.GET(new Uri(url), connection, true)) : new StreamReader(url))
+            using (StreamReader stream = url.StartsWith("http") ? new StreamReader(HTTPHelper.GET(new Uri(url), connection, true, true)) : new StreamReader(url))
             {
                 StatusReportXmlDocReader reader = new StatusReportXmlDocReader();
                 XmlDocument doc = new XmlDocument();

--- a/XenModel/WLB/WlbReportAction.cs
+++ b/XenModel/WLB/WlbReportAction.cs
@@ -175,7 +175,7 @@ namespace XenAdmin.Actions.Wlb
             byte[] buf = new byte[BUFSIZE];
             using (MemoryStream ms = new MemoryStream())
             {
-                using (Stream http = HTTPHelper.GET(uri, Connection, false))
+                using (Stream http = HTTPHelper.GET(uri, Connection, false, true))
                 {
                     while (true)
                     {

--- a/XenModel/XenAPI-Extensions/Blob.cs
+++ b/XenModel/XenAPI-Extensions/Blob.cs
@@ -53,7 +53,7 @@ namespace XenAPI
             uri.Query = String.Format("ref={0}&session_id={1}",
                 opaque_ref, Uri.EscapeDataString(session.uuid));
 
-            using (Stream outStream = HTTPHelper.PUT(uri.Uri, inStream.Length, true))
+            using (Stream outStream = HTTPHelper.PUT(uri.Uri, inStream.Length, true, true))
             {
                 HTTP.CopyStream(inStream, outStream, null, delegate() { return XenAdminConfigManager.Provider.ForcedExiting; });
             }
@@ -74,7 +74,7 @@ namespace XenAPI
             uri.Query = String.Format("ref={0}&session_id={1}",
                 opaque_ref, Uri.EscapeDataString(session.uuid));
 
-            return HTTPHelper.GET(uri.Uri, Connection, true);
+            return HTTPHelper.GET(uri.Uri, Connection, true, true);
         }
     }
 }

--- a/XenModel/XenSearch/MetricUpdater.cs
+++ b/XenModel/XenSearch/MetricUpdater.cs
@@ -184,7 +184,7 @@ namespace XenAdmin.XenSearch
             {
                 Session session = host.Connection.Session;
                 if (session != null)
-                    return AllValues(HTTPHelper.GET(GetUri(session, host), host.Connection, true));
+                    return AllValues(HTTPHelper.GET(GetUri(session, host), host.Connection, true, false));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Some paths were already logged in HTTPHelpers.cs, but other paths weren't. I have added logging for the missing ones, except for stats gathering for the performance graphs and search page, which are called too often.

Unfortunately, we don't always have the full URL until we get into HTTP.cs, but that's in the public SDK so the only way to add logs there would be to pass in a logging delegate, and that would break backward compatibility of the SDK (or cause us to carry two copies of every function). I decided that it wasn't that important.
