### PR TITLE
CA-141868: Boot options are deleted by New VM Wizard if Installation Media page skipped - Fixed

### DIFF
--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -225,10 +225,13 @@ namespace XenAdmin.Wizards.NewVMWizard
                 }
 
                 // if custom template has no cd drive (must have been removed via cli) don't add one
-                page_3_InstallationMedia.DisableStep = Helpers.CustomWithNoDVD(selectedTemplate);
+                var noInstallMedia = Helpers.CustomWithNoDVD(selectedTemplate);
 
                 if (selectedTemplate != null && selectedTemplate.DefaultTemplate && string.IsNullOrEmpty(selectedTemplate.InstallMethods))
-                    page_3_InstallationMedia.DisableStep = true;
+                    noInstallMedia = true;
+
+                page_3_InstallationMedia.ShowInstallationMedia = !noInstallMedia;
+                page_3_InstallationMedia.DisableStep = noInstallMedia && !page_3_InstallationMedia.ShowBootParameters;
 
                 // The user cannot set their own affinity, use the one off the template
                 if (BlockAffinitySelection)

--- a/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.Designer.cs
@@ -39,17 +39,18 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.label2 = new System.Windows.Forms.Label();
             this.CdDropDownBox = new XenAdmin.Controls.ISODropDownBox();
             this.UrlTextBox = new System.Windows.Forms.TextBox();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.panelInstallationMethod = new System.Windows.Forms.TableLayoutPanel();
             this.linkLabelAttachNewIsoStore = new System.Windows.Forms.LinkLabel();
             this.comboBoxToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.PvBootBox.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
+            this.panelInstallationMethod.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
+            this.panelInstallationMethod.SetColumnSpan(this.label1, 2);
             this.label1.Name = "label1";
             // 
             // CdRadioButton
@@ -110,15 +111,16 @@ namespace XenAdmin.Wizards.NewVMWizard
             resources.ApplyResources(this.UrlTextBox, "UrlTextBox");
             this.UrlTextBox.Name = "UrlTextBox";
             // 
-            // tableLayoutPanel1
+            // panelInstallationMethod
             // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.CdRadioButton, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.UrlRadioButton, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.CdDropDownBox, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.UrlTextBox, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.linkLabelAttachNewIsoStore, 1, 1);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            resources.ApplyResources(this.panelInstallationMethod, "panelInstallationMethod");
+            this.panelInstallationMethod.Controls.Add(this.CdRadioButton, 0, 1);
+            this.panelInstallationMethod.Controls.Add(this.UrlRadioButton, 0, 3);
+            this.panelInstallationMethod.Controls.Add(this.label1, 0, 0);
+            this.panelInstallationMethod.Controls.Add(this.CdDropDownBox, 0, 2);
+            this.panelInstallationMethod.Controls.Add(this.UrlTextBox, 0, 4);
+            this.panelInstallationMethod.Controls.Add(this.linkLabelAttachNewIsoStore, 1, 2);
+            this.panelInstallationMethod.Name = "panelInstallationMethod";
             // 
             // linkLabelAttachNewIsoStore
             // 
@@ -131,16 +133,15 @@ namespace XenAdmin.Wizards.NewVMWizard
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.panelInstallationMethod);
             this.Controls.Add(this.PvBootBox);
-            this.Controls.Add(this.label1);
             this.Name = "Page_InstallationMedia";
             this.PvBootBox.ResumeLayout(false);
             this.PvBootBox.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
+            this.panelInstallationMethod.ResumeLayout(false);
+            this.panelInstallationMethod.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -155,7 +156,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private System.Windows.Forms.Label label2;
         private XenAdmin.Controls.ISODropDownBox CdDropDownBox;
         private System.Windows.Forms.TextBox UrlTextBox;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.TableLayoutPanel panelInstallationMethod;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.LinkLabel linkLabelAttachNewIsoStore;
         private System.Windows.Forms.ToolTip comboBoxToolTip;

--- a/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.cs
@@ -60,6 +60,10 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         public Host Affinity { private get; set; }
 
+        public bool ShowInstallationMedia { private get; set; }
+
+        public bool ShowBootParameters { get { return !SelectedTemplate.IsHVM; } }
+        
         public override void PageLoaded(PageLoadedDirection direction)
         {
             base.PageLoaded(direction);
@@ -80,8 +84,21 @@ namespace XenAdmin.Wizards.NewVMWizard
              * 
              *  Custom  -> DVD drive (inc empty)
              * 
-             *  Skip this page if the custom template has no DVD drive (except debian etch template)
+             *  Disable Installation method section if the custom template has no DVD drive (except debian etch template)
              */
+
+            PvBootBox.Visible = ShowBootParameters;
+            PvBootTextBox.Text = m_template.PV_args;
+
+            if (!ShowInstallationMedia)
+            {
+                CdRadioButton.Checked = UrlRadioButton.Checked = false;
+                CdDropDownBox.Items.Clear();
+                UrlTextBox.Text = string.Empty;
+                panelInstallationMethod.Enabled = false;
+                return;
+            }
+            panelInstallationMethod.Enabled = true;
 
             defaultTemplate = m_template.DefaultTemplate;
             userTemplate = !defaultTemplate;
@@ -132,9 +149,6 @@ namespace XenAdmin.Wizards.NewVMWizard
                 UrlRadioButton.Checked = true;
                 CdRadioButton.Enabled = false;
             }
-
-            PvBootBox.Visible = !hvm;
-            PvBootTextBox.Text = m_template.PV_args;
 
             LoadCdBox();
 
@@ -188,7 +202,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             get
             {
-                if (this.DisableStep || m_template.DefaultTemplate && String.IsNullOrEmpty(m_template.InstallMethods))
+                if (!ShowInstallationMedia || m_template.DefaultTemplate && String.IsNullOrEmpty(m_template.InstallMethods))
                     return InstallMethod.None;
                 if (CdRadioButton.Checked)
                     return InstallMethod.CD;
@@ -204,7 +218,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             get
             {
-                return PvBootTextBox.Text;
+                return ShowBootParameters ? PvBootTextBox.Text : string.Empty;
             }
         }
 
@@ -212,10 +226,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             get
             {
-                if (CdRadioButton.Checked)
-                    return CdDropDownBox.SelectedCD;
-
-                return null;
+                return ShowInstallationMedia && CdRadioButton.Checked ? CdDropDownBox.SelectedCD : null;
             }
         }
 
@@ -223,7 +234,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             get
             {
-                return UrlRadioButton.Checked ? UrlTextBox.Text : string.Empty;
+                return ShowInstallationMedia && UrlRadioButton.Checked ? UrlTextBox.Text : string.Empty;
             }
         }
 
@@ -231,7 +242,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         public override bool EnableNext()
         {
-            return CdRadioButton.Checked || UrlRadioButton.Checked;
+            return ShowInstallationMedia ? CdRadioButton.Checked || UrlRadioButton.Checked : true;
         }
 
         public override string Text
@@ -354,7 +365,4 @@ namespace XenAdmin.Wizards.NewVMWizard
         }
 
     }
-
-
-    
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.resx
@@ -112,23 +112,122 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="panelInstallationMethod.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;CdRadioButton.Name" xml:space="preserve">
+    <value>CdRadioButton</value>
+  </data>
+  <data name="&gt;&gt;CdRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CdRadioButton.Parent" xml:space="preserve">
+    <value>panelInstallationMethod</value>
+  </data>
+  <data name="&gt;&gt;CdRadioButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;UrlRadioButton.Name" xml:space="preserve">
+    <value>UrlRadioButton</value>
+  </data>
+  <data name="&gt;&gt;UrlRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;UrlRadioButton.Parent" xml:space="preserve">
+    <value>panelInstallationMethod</value>
+  </data>
+  <data name="&gt;&gt;UrlRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;CdDropDownBox.Name" xml:space="preserve">
+    <value>CdDropDownBox</value>
+  </data>
+  <data name="&gt;&gt;CdDropDownBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ISODropDownBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CdDropDownBox.Parent" xml:space="preserve">
+    <value>panelInstallationMethod</value>
+  </data>
+  <data name="&gt;&gt;CdDropDownBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;UrlTextBox.Name" xml:space="preserve">
+    <value>UrlTextBox</value>
+  </data>
+  <data name="&gt;&gt;UrlTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;UrlTextBox.Parent" xml:space="preserve">
+    <value>panelInstallationMethod</value>
+  </data>
+  <data name="&gt;&gt;UrlTextBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;linkLabelAttachNewIsoStore.Name" xml:space="preserve">
+    <value>linkLabelAttachNewIsoStore</value>
+  </data>
+  <data name="&gt;&gt;linkLabelAttachNewIsoStore.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabelAttachNewIsoStore.Parent" xml:space="preserve">
+    <value>panelInstallationMethod</value>
+  </data>
+  <data name="&gt;&gt;linkLabelAttachNewIsoStore.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="panelInstallationMethod.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="panelInstallationMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="panelInstallationMethod.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="panelInstallationMethod.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="panelInstallationMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>548, 176</value>
+  </data>
+  <data name="panelInstallationMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;panelInstallationMethod.Name" xml:space="preserve">
+    <value>panelInstallationMethod</value>
+  </data>
+  <data name="&gt;&gt;panelInstallationMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelInstallationMethod.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelInstallationMethod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelInstallationMethod.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CdRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="UrlRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="CdDropDownBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="UrlTextBox" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelAttachNewIsoStore" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,120,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 4</value>
+    <value>3, 3</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>544, 40</value>
+    <value>542, 40</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -139,10 +238,10 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>panelInstallationMethod</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>2</value>
@@ -150,8 +249,11 @@
   <data name="CdRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="CdRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="CdRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>6, 46</value>
   </data>
   <data name="CdRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 17</value>
@@ -166,10 +268,10 @@
     <value>CdRadioButton</value>
   </data>
   <data name="&gt;&gt;CdRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CdRadioButton.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
+    <value>panelInstallationMethod</value>
   </data>
   <data name="&gt;&gt;CdRadioButton.ZOrder" xml:space="preserve">
     <value>0</value>
@@ -181,7 +283,7 @@
     <value>NoControl</value>
   </data>
   <data name="UrlRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 65</value>
+    <value>6, 105</value>
   </data>
   <data name="UrlRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 12, 3, 3</value>
@@ -199,16 +301,16 @@
     <value>UrlRadioButton</value>
   </data>
   <data name="&gt;&gt;UrlRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UrlRadioButton.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
+    <value>panelInstallationMethod</value>
   </data>
   <data name="&gt;&gt;UrlRadioButton.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="PvBootBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
   <data name="PvBootBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -220,6 +322,87 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;PvBootTextBox.Name" xml:space="preserve">
+    <value>PvBootTextBox</value>
+  </data>
+  <data name="&gt;&gt;PvBootTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PvBootTextBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;PvBootTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>532, 70</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>PvBootBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="PvBootTextBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="PvBootBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1, 182</value>
+  </data>
+  <data name="PvBootBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 3</value>
+  </data>
+  <data name="PvBootBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>544, 92</value>
+  </data>
+  <data name="PvBootBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="PvBootBox.Text" xml:space="preserve">
+    <value>Advanced OS &amp;boot parameters</value>
+  </data>
+  <data name="&gt;&gt;PvBootBox.Name" xml:space="preserve">
+    <value>PvBootBox</value>
+  </data>
+  <data name="&gt;&gt;PvBootBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PvBootBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;PvBootBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="PvBootTextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -238,7 +421,7 @@
     <value>PvBootTextBox</value>
   </data>
   <data name="&gt;&gt;PvBootTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;PvBootTextBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -274,7 +457,7 @@
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -282,68 +465,11 @@
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>532, 70</value>
-  </data>
-  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
-    <value>PvBootBox</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="PvBootTextBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="PvBootBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 202</value>
-  </data>
-  <data name="PvBootBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 3</value>
-  </data>
-  <data name="PvBootBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>544, 92</value>
-  </data>
-  <data name="PvBootBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="PvBootBox.Text" xml:space="preserve">
-    <value>Advanced OS &amp;boot parameters</value>
-  </data>
-  <data name="&gt;&gt;PvBootBox.Name" xml:space="preserve">
-    <value>PvBootBox</value>
-  </data>
-  <data name="&gt;&gt;PvBootBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PvBootBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;PvBootBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="CdDropDownBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
   <data name="CdDropDownBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 29</value>
+    <value>23, 69</value>
   </data>
   <data name="CdDropDownBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 3, 3, 3</value>
@@ -361,16 +487,16 @@
     <value>XenAdmin.Controls.ISODropDownBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CdDropDownBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
+    <value>panelInstallationMethod</value>
   </data>
   <data name="&gt;&gt;CdDropDownBox.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="UrlTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
   <data name="UrlTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 88</value>
+    <value>23, 128</value>
   </data>
   <data name="UrlTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 3, 3, 3</value>
@@ -385,19 +511,13 @@
     <value>UrlTextBox</value>
   </data>
   <data name="&gt;&gt;UrlTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UrlTextBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
+    <value>panelInstallationMethod</value>
   </data>
   <data name="&gt;&gt;UrlTextBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="linkLabelAttachNewIsoStore.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -409,7 +529,7 @@
     <value>NoControl</value>
   </data>
   <data name="linkLabelAttachNewIsoStore.Location" type="System.Drawing.Point, System.Drawing">
-    <value>419, 26</value>
+    <value>419, 66</value>
   </data>
   <data name="linkLabelAttachNewIsoStore.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>12, 0, 3, 0</value>
@@ -430,48 +550,18 @@
     <value>linkLabelAttachNewIsoStore</value>
   </data>
   <data name="&gt;&gt;linkLabelAttachNewIsoStore.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;linkLabelAttachNewIsoStore.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
+    <value>panelInstallationMethod</value>
   </data>
   <data name="&gt;&gt;linkLabelAttachNewIsoStore.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 47</value>
-  </data>
-  <data name="tableLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>548, 132</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CdRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="UrlRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CdDropDownBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="UrlTextBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelAttachNewIsoStore" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <metadata name="comboBoxToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="comboBoxToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -484,7 +574,7 @@
     <value>comboBoxToolTip</value>
   </data>
   <data name="&gt;&gt;comboBoxToolTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>Page_InstallationMedia</value>


### PR DESCRIPTION
- Show the page and grey out the irrelevant options (i.e. the installation media if the template has no CD drive).
- Only disable the Installation media step if the template has no installation media and we don't show the boot options (because is HVM).

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
