### PR TITLE
CA-142313: XenCenter WLB Report "Run Reports" button should be disabled when popup.

### DIFF
--- a/XenAdmin/Controls/Wlb/WlbReportView.cs
+++ b/XenAdmin/Controls/Wlb/WlbReportView.cs
@@ -1535,7 +1535,6 @@ namespace XenAdmin.Controls.Wlb
             _startLine = 1;
             _endLine = _lineLimit;
             _currentReportSection = 0;
-            btnRunReport.Enabled = true;
             btnRunReport.Text = Messages.RUN_REPORT;
             btnLaterReport.Visible = false;
         }


### PR DESCRIPTION
Gray the "Run Report" button when none of the reports is selected.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
