### PR TITLE
CA-142429: The end time does not refresh when running pool audit trail report.

### DIFF
--- a/XenAdmin/Controls/Wlb/WlbReportView.cs
+++ b/XenAdmin/Controls/Wlb/WlbReportView.cs
@@ -1285,6 +1285,7 @@ namespace XenAdmin.Controls.Wlb
                     _currentReportSection = 1;
                     _startLine = 1;
                     _endLine = _lineLimit;
+                    _endTime = String.Empty;
                 }
                 else
                 {


### PR DESCRIPTION
For pool audit trail report, when click "Run Report",
reset "_endTime" so that the end time will be re-retrieved.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
