### PR TITLE
CA-142045: Buttons are truncated on Workload Balancing Configuration for New Pool wizard.

### DIFF
--- a/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.Designer.cs
+++ b/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.Designer.cs
@@ -60,42 +60,6 @@ namespace XenAdmin.Dialogs.Wlb
             this.wlbThresholdsPage,
             this.wlbMetricWeightingPage,
             this.wlbHostExclusionPage,
-            this.wlbAdvancedSettingsPage,
-            this.wlbOptimizationModePage,
-            this.wlbAutomationPage,
-            this.wlbThresholdsPage,
-            this.wlbMetricWeightingPage,
-            this.wlbHostExclusionPage,
-            this.wlbAdvancedSettingsPage,
-            this.wlbOptimizationModePage,
-            this.wlbAutomationPage,
-            this.wlbThresholdsPage,
-            this.wlbMetricWeightingPage,
-            this.wlbHostExclusionPage,
-            this.wlbAdvancedSettingsPage,
-            this.wlbOptimizationModePage,
-            this.wlbAutomationPage,
-            this.wlbThresholdsPage,
-            this.wlbMetricWeightingPage,
-            this.wlbHostExclusionPage,
-            this.wlbAdvancedSettingsPage,
-            this.wlbOptimizationModePage,
-            this.wlbAutomationPage,
-            this.wlbThresholdsPage,
-            this.wlbMetricWeightingPage,
-            this.wlbHostExclusionPage,
-            this.wlbAdvancedSettingsPage,
-            this.wlbOptimizationModePage,
-            this.wlbAutomationPage,
-            this.wlbThresholdsPage,
-            this.wlbMetricWeightingPage,
-            this.wlbHostExclusionPage,
-            this.wlbAdvancedSettingsPage,
-            this.wlbOptimizationModePage,
-            this.wlbAutomationPage,
-            this.wlbThresholdsPage,
-            this.wlbMetricWeightingPage,
-            this.wlbHostExclusionPage,
             this.wlbAdvancedSettingsPage});
             resources.ApplyResources(this.verticalTabs, "verticalTabs");
             // 
@@ -167,6 +131,7 @@ namespace XenAdmin.Dialogs.Wlb
             // 
             resources.ApplyResources(this, "$this");
             this.Name = "WlbConfigurationDialog";
+            this.SizeChanged += new System.EventHandler(this.WlbConfigurationDialog_SizeChanged);
             this.Controls.SetChildIndex(this.cancelButton, 0);
             this.Controls.SetChildIndex(this.okButton, 0);
             this.Controls.SetChildIndex(this.splitContainer, 0);

--- a/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.cs
+++ b/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.cs
@@ -215,5 +215,15 @@ namespace XenAdmin.Dialogs.Wlb
             }
         }
 
+        private void WlbConfigurationDialog_SizeChanged(object sender, EventArgs e)
+        {
+            // When the size of configuration dialog is changed,
+            // the SplitContainer panels should expand and contract correspondingly.
+            // Originally the dialog height is 750, SplitContainer height is 674,
+            // the difference is 76.
+            // The SplitContainer height must track the change of the dialog height.
+            splitContainer.Height = this.Height - 76;
+        }
+
     }
 }

--- a/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.resx
+++ b/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.resx
@@ -331,10 +331,10 @@
     <value>0</value>
   </data>
   <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>738, 725</value>
+    <value>738, 682</value>
   </data>
   <data name="&gt;&gt;cancelButton.Name" xml:space="preserve">
     <value>cancelButton</value>
@@ -349,10 +349,10 @@
     <value>3</value>
   </data>
   <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>647, 725</value>
+    <value>647, 682</value>
   </data>
   <data name="&gt;&gt;okButton.Name" xml:space="preserve">
     <value>okButton</value>
@@ -535,7 +535,7 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>834, 755</value>
+    <value>834, 712</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>


### PR DESCRIPTION
Fix the display issues when WLB Configuration Dialog size is changing:
1. OK and Cancel buttons are truncated.
2. OK and Cancel buttons do not keep at the bottom/right corner of the dialog.
3. The height of the SplitContainer does not track the change of the height of the dialog.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
