### PR TITLE
CA-143823: Split line of pool audit trail granularity should not be displayed if connecting with WLB6.1

### DIFF
--- a/XenAdmin/SettingsPanels/Wlb/WlbAdvancedSettingsPage.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbAdvancedSettingsPage.cs
@@ -269,6 +269,7 @@ namespace XenAdmin.SettingsPanels
         private void HidePoolAuditTrailGranularitySection()
         {
             label2.Visible = false;
+            label3.Visible = false;
             sectionHeaderLabelAuditTrail.Visible = false;
             labelAuditTrail.Visible = false;
             auditTrailPanel.Visible = false;


### PR DESCRIPTION
Hide the split line when the pool connects with WLB6.1 server.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
