### PR TITLE
CA-143869: ZH-CN: Buttons are truncated on Workload Balancing Configuration

### DIFF
--- a/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.zh-CN.resx
@@ -331,10 +331,10 @@
     <value>0</value>
   </data>
   <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>738, 725</value>
+    <value>738, 682</value>
   </data>
   <data name="&gt;&gt;cancelButton.Name" xml:space="preserve">
     <value>cancelButton</value>
@@ -349,10 +349,10 @@
     <value>3</value>
   </data>
   <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>647, 725</value>
+    <value>647, 682</value>
   </data>
   <data name="&gt;&gt;okButton.Name" xml:space="preserve">
     <value>okButton</value>
@@ -535,7 +535,7 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>834, 755</value>
+    <value>834, 712</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>


### PR DESCRIPTION
Fix the display issues of Chinese version XenCenter/WLB (Apologize for missing this fix within CA-142045):
When WLB Configuration Dialog size is changing,
1. OK and Cancel buttons are truncated,
2. OK and Cancel buttons do not keep at the bottom/right corner of the dialog.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
