### PR TITLE
CA-142255:XenCenter popup exception dialog which is unexpected

### DIFF
--- a/XenModel/XenAPI-Extensions/Role.cs
+++ b/XenModel/XenAPI-Extensions/Role.cs
@@ -223,13 +223,16 @@ namespace XenAPI
         /// <param name="validRoleList">The list of roles which can perform all the methods</param>
         public static bool CanPerform(RbacMethodList apiMethodsToRoleCheck, IXenConnection connection, out List<Role> validRoleList, bool debug)
         {
-            validRoleList = ValidRoleList(apiMethodsToRoleCheck, connection, debug);
+            if (!connection.IsConnected)
+            {
+                validRoleList = new List<Role>();
+                return false;
+            }
+            else
+                validRoleList = ValidRoleList(apiMethodsToRoleCheck, connection, debug);
             
             if (Helpers.MidnightRideOrGreater(connection))
             {
-                if (!connection.IsConnected)
-                    return false;
-
                 if (connection.Session.IsLocalSuperuser)
                     return true;
 


### PR DESCRIPTION
This problem happens because XenCenter maybe lost connection some times and the operation check here will use ValidRoleList check before connection check, which will cause the roles in connection be empty and generate that exception when connection is not connected.
Check connection status before get ValidRoleList will solve this problem.

Signed-off-by: Cheng Zhang cheng.zhang@citrix.com
