### PR TITLE
CA-143826: When in Notifications view, the context should be empty

### DIFF
--- a/XenAdmin/Commands/SelectionBroadcaster.cs
+++ b/XenAdmin/Commands/SelectionBroadcaster.cs
@@ -109,6 +109,9 @@ namespace XenAdmin.Commands
         /// </summary>
         public event EventHandler SelectionChanged;
 
+        public abstract void SaveAndClearSelection();
+        public abstract void RestoreSavedSelection();
+
         #region IDisposable Members
 
         /// <summary>

--- a/XenAdmin/Commands/SelectionManager.cs
+++ b/XenAdmin/Commands/SelectionManager.cs
@@ -42,6 +42,7 @@ namespace XenAdmin.Commands
     internal class SelectionManager : SelectionBroadcaster
     {
         private SelectedItemCollection _selection = new SelectedItemCollection();
+        private SelectedItemCollection savedSelection = new SelectedItemCollection();
 
         /// <summary>
         /// Sets the main selection for XenCenter.
@@ -85,6 +86,21 @@ namespace XenAdmin.Commands
         public override void RefreshSelection()
         {
             SetSelection(Selection);
+        }
+
+        public override void SaveAndClearSelection()
+        {
+            savedSelection = new SelectedItemCollection(_selection);
+            SetSelection(new SelectedItemCollection());
+        }
+        
+        public override void RestoreSavedSelection() 
+        {
+            if (savedSelection != null)
+            {
+                SetSelection(new SelectedItemCollection(savedSelection));
+                savedSelection = null;
+            }
         }
     }
 }

--- a/XenAdmin/Controls/MainWindowControls/NavigationPane.cs
+++ b/XenAdmin/Controls/MainWindowControls/NavigationPane.cs
@@ -278,11 +278,15 @@ namespace XenAdmin.Controls.MainWindowControls
         {
             if (currentMode == NavigationMode.Notifications)
             {
+                SelectionManager.SaveAndClearSelection();
+
                 //restore the last selected view
                 SwitchToNotificationsView(lastNotificationsMode);
             }
             else
             {
+                SelectionManager.RestoreSavedSelection();
+
                 //show the navigationView first and then hide the notificationsView
                 //to avoid instantaneous appearance of empty panels
                 navigationView.Visible = true;


### PR DESCRIPTION
-I defined save and restore selection functionality in SelectionBroadcaster and implemented them in SelectionManager. The NavigationPanel now uses these to: 1) save the current Selection (context)  when the user switches to the Notification view, 2) to restore previous selection when switching away from the Notifications view.
