### PR TITLE
CA-145608: Starts up at blank search page

### DIFF
--- a/XenAdmin/Commands/SelectionManager.cs
+++ b/XenAdmin/Commands/SelectionManager.cs
@@ -42,7 +42,7 @@ namespace XenAdmin.Commands
     internal class SelectionManager : SelectionBroadcaster
     {
         private SelectedItemCollection _selection = new SelectedItemCollection();
-        private SelectedItemCollection savedSelection = new SelectedItemCollection();
+        private SelectedItemCollection savedSelection = null;
 
         /// <summary>
         /// Sets the main selection for XenCenter.


### PR DESCRIPTION
-Fixed field initialisation that caused XenCenter to immediately switch away from the Home Page when started
