### PR TITLE
CA-145341: G11n: SC: Overlap and Truncated strings in "Workload Reports" dialog.

### DIFF
--- a/XenAdmin/Controls/Wlb/WlbReportView.resx
+++ b/XenAdmin/Controls/Wlb/WlbReportView.resx
@@ -304,7 +304,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelStartDate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 7</value>
+    <value>3, 7</value>
   </data>
   <data name="labelStartDate.Size" type="System.Drawing.Size, System.Drawing">
     <value>61, 13</value>


### PR DESCRIPTION
For issue 1, move the "labelStartDate" location to left with 4 points.
This would make the gap between "labelStartDate" and "StartDatePicker" larger than others under Windows EN.
For issue 2, would not extend the size of "StartDatePicker" and "EndDatePicker" since they would occupy other labels and comboBoxes' room.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
