### PR TITLE
CP-9365: XenCenter work for HVM linux support

### DIFF
--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -450,7 +450,7 @@ namespace XenAPI
 
                 try
                 {
-                    XmlNode xn = xd.SelectSingleNode(@"restrictions/restriction[@property='allow-gpu-passthrough']");
+                    XmlNode xn = xd.SelectSingleNode(@"restrictions/restriction[@field='allow-gpu-passthrough']");
                     if (xn == null)
                         return true;
 


### PR DESCRIPTION
- Modifying/fixing xpath that is used to find allow-gpu-passthrough restriction (in the getter of CanHaveVGpu property)
