### PR TITLE
CA-146588: Crash in search tab with multiselect

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1746,7 +1746,21 @@ namespace XenAdmin
                             }
                             else
                             {
-                                gt = SelectionManager.Selection.GroupAncestor;
+                                var selectedGroups = SelectionManager.Selection.Where(s => s.GroupingTag != null);
+
+                                if (selectedGroups.Count() == 1)
+                                {
+                                    var groupingTag = selectedGroups.First().GroupingTag;
+
+                                    if (SelectionManager.Selection.Where(s => s.GroupingTag == null).All(s => s.GroupAncestor == groupingTag))
+                                        gt = groupingTag;
+                                    else
+                                        gt = null;
+                                }
+                                else
+                                {
+                                    gt = SelectionManager.Selection.GroupAncestor;
+                                }
                             }
 
                             if (gt != null)


### PR DESCRIPTION
-Fixed search on Objects view when multiple items were selected. If one item is selected the behaviuor is unchanged. If multiple items are selected the common ancestor's search is displayed if there is one, otherwise we display the search view that belongs to the root node (Objects by Type).
