### PR TITLE
CA-144708: Optimal server option doesn't seem to pass the Ronseal test

### DIFF
--- a/XenAdmin/Commands/VMOperationWlbHostCommand.cs
+++ b/XenAdmin/Commands/VMOperationWlbHostCommand.cs
@@ -57,7 +57,9 @@ namespace XenAdmin.Commands
 
             _host = host;
             _menuText = _host.Name.EscapeAmpersands();
-            _secondImage = Resources._000_host_0_star;
+            
+            //Default or failure case, there is no score/star rating actually, just don't display star
+            _secondImage = null;
             _menuImage = Resources._000_ServerDisconnected_h32bit_16;
             _recommendation = recommendation;
 


### PR DESCRIPTION
Based on the discussion of CA-144708, when error happens or the Current Server is listed and disabled
in the recommendation host list, there is no rating score and star actually, so it is good to hide the
zero star to avoid confusing.

This fix hides the zero star indication on XenCenter GUI.

Signed-off-by: Zheng Chai zheng.chai@citrix.com
