### PR TITLE
CA-147167: Null reference exception in GeneralTabPage

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -152,6 +152,9 @@ namespace XenAdmin.TabPages
         {
             set
             {
+                if (value == null)
+                    return;
+
                 SetupAnStartLicenseStatus(value);
                 if (xenObject != value)
                 {


### PR DESCRIPTION
Returning immediately (if null) as suggested by the reviewer.
