### PR TITLE
CA-148245: Fix the error where XenCenter did not refresh immediately after disconnecting a server

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -765,6 +765,8 @@ namespace XenAdmin
             Alert.RemoveAlert(alert => alert.Connection != null && alert.Connection.Equals(connection));
             Updates.CheckServerPatches();
             Updates.CheckServerVersion();
+
+            RequestRefreshTreeView();
         }
 
         void connection_CachePopulated(object sender, EventArgs e)


### PR DESCRIPTION
Added a RequestRefreshTreeView on ClearingCache event.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
