### PR TITLE
CA-147941: Fixed the RPU wizard hang in "Reconnecting Storage" and connecting action stuck in progress state

### DIFF
--- a/XenAdmin/Controls/FilterLocationToolStripDropDownButton.cs
+++ b/XenAdmin/Controls/FilterLocationToolStripDropDownButton.cs
@@ -286,12 +286,12 @@ namespace XenAdmin.Controls
 
         private void connection_ConnectionStateChanged(object sender, EventArgs e)
         {
-            Program.Invoke(Parent, RefreshLists);
+            Program.Invoke(Program.MainWindow, RefreshLists);
         }
 
         private void connection_CachePopulated(object sender, EventArgs e)
         {
-            Program.Invoke(Parent, RefreshLists);
+            Program.Invoke(Program.MainWindow, RefreshLists);
         }
 
         private void XenConnections_CollectionChanged(object sender, CollectionChangeEventArgs e)

--- a/XenAdmin/Controls/MainWindowControls/NavigationView.cs
+++ b/XenAdmin/Controls/MainWindowControls/NavigationView.cs
@@ -313,7 +313,7 @@ namespace XenAdmin.Controls.MainWindowControls
 
         public void RequestRefreshTreeView()
         {
-            Program.BeginInvoke(this, treeViewUpdateManager.RequestUpdate);
+            Program.BeginInvoke(Program.MainWindow, treeViewUpdateManager.RequestUpdate);
         }
 
         private void SuspendRefreshTreeView()
@@ -345,7 +345,7 @@ namespace XenAdmin.Controls.MainWindowControls
             if (Disposing || IsDisposed || Program.Exiting)
                 return;
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
             {
                 if (ignoreRefreshTreeView > 0)
                 {

--- a/XenAdmin/TabPages/AlertSummaryPage.cs
+++ b/XenAdmin/TabPages/AlertSummaryPage.cs
@@ -139,7 +139,7 @@ namespace XenAdmin.TabPages
                 // 4) Take the top n as set by the filters
                 // 5) Add them to the control using the optimized AddRange()
 
-                Program.Invoke(this, SetFilterLabel);
+                Program.Invoke(Program.MainWindow, SetFilterLabel);
                 
                 List<Alert> alerts = Alert.NonDismissingAlerts;
                 alerts.RemoveAll(FilterAlert);
@@ -179,7 +179,7 @@ namespace XenAdmin.TabPages
                     alerts.RemoveRange(ALERT_CAP, alerts.Count - ALERT_CAP);
                 }
 
-                Program.Invoke(this, delegate
+                Program.Invoke(Program.MainWindow, delegate
                 {
                     List<DataGridViewRow> gridRows = new List<DataGridViewRow>();
                     log.Debug("Rebuilding alertList: Adding alert rows");
@@ -282,7 +282,7 @@ namespace XenAdmin.TabPages
         private bool FilterAlert(Alert alert)
         {
             bool hide = false;
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                                  hide = toolStripDropDownButtonDateFilter.HideByDate(alert.Timestamp.ToLocalTime())
                                         || toolStripDropDownButtonServerFilter.HideByLocation(alert.HostUuid)
                                         || toolStripDropDownSeveritiesFilter.HideBySeverity(alert.Priority));

--- a/XenAdmin/TabPages/HistoryPage.cs
+++ b/XenAdmin/TabPages/HistoryPage.cs
@@ -121,7 +121,7 @@ namespace XenAdmin.TabPages
             if (asyncAction != null)
                 asyncAction.RecomputeCanCancel();
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                 {
                     var row = FindRowFromAction(sender);
                     if (row != null)
@@ -203,7 +203,7 @@ namespace XenAdmin.TabPages
         private bool FilterAction(ActionBase action)
         {
             bool hide = false;
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                                  hide = toolStripDdbFilterDates.HideByDate(action.Started)
                                         || toolStripDdbFilterLocation.HideByLocation(action.GetApplicableHosts())
                                         || toolStripDdbFilterStatus.HideByStatus(action));

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -84,12 +84,12 @@ namespace XenAdmin.TabPages
 
         private void UpdatesCollectionChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, Rebuild);
+            Program.Invoke(Program.MainWindow, Rebuild);
         }
 
         private void CheckForUpdates_CheckForUpdatesStarted()
         {
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                 {
                     checksQueue++;
                     if (checksQueue > 1)
@@ -106,7 +106,7 @@ namespace XenAdmin.TabPages
 
         private void CheckForUpdates_CheckForUpdatesCompleted(bool succeeded, string errorMessage)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
                 {
                     checksQueue--;
                     toolStripButtonRefresh.Enabled = true;
@@ -258,7 +258,7 @@ namespace XenAdmin.TabPages
                 hosts = serverUpdate.DistinctHosts.Select(h => h.uuid).ToList();
 
             bool hide = false;
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                                  hide = toolStripDropDownButtonDateFilter.HideByDate(alert.Timestamp.ToLocalTime())
                                         || toolStripDropDownButtonServerFilter.HideByLocation(hosts));
             return hide;

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
@@ -421,7 +421,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             foreach (DataGridViewRowUpgrade row in rowsForHost)
             {
                 DataGridViewRowUpgrade closureRow = row;
-                Program.Invoke(this, () => closureRow.UpdateStatus(HostUpgradeState.Upgrading, plan.Status));
+                Program.Invoke(Program.MainWindow, () => closureRow.UpdateStatus(HostUpgradeState.Upgrading, plan.Status));
             }
         }
 


### PR DESCRIPTION
In some cases calling Control.Invoke() from a background thread causes that thread to go in a "sleep, wait, or join" mode, while waiting for Invoke to happen, although the UI thread is running normally.
If the Control is the MainWindow, it works as expected, but we've seen it happening while connecting or disconnecting from a large pool, on calling Invoke on controls like NavigationView, AlertSummaryPage, HistoryPage, etc.
To fix this, we call the Invoke on the MainWindow in all the places where we've seen the issue.

With this changes, the previous fix for CA-148245 (call RequestRefreshTreeView on CacheClearing event) is not needed anymore, so I removed that call.

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
