### PR TITLE
CA-150369: Update XenCenter with latest C# bindings

### DIFF
--- a/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
+++ b/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
@@ -1267,7 +1267,7 @@ namespace XenAPI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The edition you supplied is invalid. Valid editions are &apos;free&apos;, &apos;enterprise&apos; and &apos;platinum&apos;..
+        ///   Looks up a localized string similar to The edition you supplied is invalid..
         /// </summary>
         public static string INVALID_EDITION {
             get {

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -520,7 +520,7 @@
     <value>The device name {0} is invalid</value>
   </data>
   <data name="INVALID_EDITION" xml:space="preserve">
-    <value>The edition you supplied is invalid. Valid editions are 'free', 'enterprise' and 'platinum'.</value>
+    <value>The edition you supplied is invalid.</value>
   </data>
   <data name="INVALID_FEATURE_STRING" xml:space="preserve">
     <value>The given feature string is not valid.</value>


### PR DESCRIPTION
- Updated friendly error name for INVALID_EDITION

Signed-off-by: Mihaela Stoica mihaela.stoica@citrix.com
