### PR TITLE
CA-157501: Fixing inconsistent GPU dialogs in XS "Standard" when compare...

### DIFF
--- a/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
@@ -126,7 +126,7 @@ namespace XenAdmin.Controls
             if (vgpuType != null)
             {
                 IsVgpuSubitem = gpuGroup.supported_VGPU_types.Count > 1;
-                IsFractionalVgpu = vgpuType.max_heads != 0;
+                IsFractionalVgpu = !vgpuType.IsPassthrough;
                 if (disabledVGpuTypes != null && disabledVGpuTypes.Select(t => t.opaque_ref).Contains(vgpuType.opaque_ref))
                     IsNotEnabledVgpu = true;
             }

--- a/XenAdmin/Controls/GPU/GpuConfiguration.cs
+++ b/XenAdmin/Controls/GPU/GpuConfiguration.cs
@@ -198,7 +198,7 @@ namespace XenAdmin.Controls.GPU
 
         private void SetCells()
         {
-            bool isPassThru = VGpuType.max_heads == 0;
+            bool isPassThru = VGpuType.IsPassthrough;
 
             nameColumn.Value = isPassThru ? Messages.VGPU_PASSTHRU_TOSTRING : VGpuType.model_name;
 

--- a/XenAdmin/Controls/GPU/GpuRow.cs
+++ b/XenAdmin/Controls/GPU/GpuRow.cs
@@ -53,7 +53,7 @@ namespace XenAdmin.Controls.GPU
             this.xenObject = xenObject;
             pGpuLabel.Text = pGpuList[0].Name;
             RepopulateAllowedTypes(pGpuList[0]);
-            vGpuCapability = !Helpers.FeatureForbidden(xenObject, Host.RestrictVgpu) && pGpuList.Any(pgpu => pgpu.HasVGpu);
+            vGpuCapability = !Helpers.FeatureForbidden(xenObject, Host.RestrictVgpu) && pGpuList[0].HasVGpu;
             Rebuild(pGpuList);
             SetupPage();
         }

--- a/XenAdmin/Controls/GPU/GpuRow.cs
+++ b/XenAdmin/Controls/GPU/GpuRow.cs
@@ -34,7 +34,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using XenAdmin.Controls.DataGridViewEx;
-using XenAdmin.Network;
+using XenAdmin.Core;
 using XenAdmin.Properties;
 using XenAPI;
 
@@ -53,6 +53,7 @@ namespace XenAdmin.Controls.GPU
             this.xenObject = xenObject;
             pGpuLabel.Text = pGpuList[0].Name;
             RepopulateAllowedTypes(pGpuList[0]);
+            vGpuCapability = !Helpers.FeatureForbidden(xenObject, Host.RestrictVgpu) && pGpuList.Any(pgpu => pgpu.HasVGpu);
             Rebuild(pGpuList);
             SetupPage();
         }
@@ -60,6 +61,8 @@ namespace XenAdmin.Controls.GPU
         private readonly IXenObject xenObject;
 
         private Dictionary<PGPU, CheckBox> pGpus = new Dictionary<PGPU, CheckBox>();
+
+        private readonly bool vGpuCapability;
 
         private void Rebuild(List<PGPU> pGpuList)
         {
@@ -91,7 +94,7 @@ namespace XenAdmin.Controls.GPU
 
                 // add pGPU shiny bar
                 var gpuShinyBar = new GpuShinyBar();
-                var checkBox = pGpuList.Count > 1 ? new CheckBox() : null; 
+                var checkBox = (pGpuList.Count > 1 && vGpuCapability) ? new CheckBox() : null; 
                 AddShinyBar(gpuShinyBar, checkBox, ref index);
                 gpuShinyBar.Initialize(pgpu);
 
@@ -141,8 +144,9 @@ namespace XenAdmin.Controls.GPU
 
         private void SetupPage()
         {
-            multipleSelectionPanel.Visible = (pGpus.Count > 1);
+            multipleSelectionPanel.Visible = (pGpus.Count > 1) && vGpuCapability;
             editButton.Text = (pGpus.Count > 1) ? Messages.GPU_EDIT_ALLOWED_TYPES_MULTIPLE : Messages.GPU_EDIT_ALLOWED_TYPES_SINGLE;
+            editButton.Visible = vGpuCapability;
         }
 
         private GpuShinyBar FindGpuShinyBar(PGPU pGpu)

--- a/XenAdmin/Controls/GPU/GpuRow.resx
+++ b/XenAdmin/Controls/GPU/GpuRow.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="allowedTypesImageList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="allowedTypesImageList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <data name="allowedTypesImageList.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj0yLjAuMC4w
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAABY
-        CQAAAk1TRnQBSQFMAgEBAgEAARgBAwEYAQMBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        CQAAAk1TRnQBSQFMAgEBAgEAASABAwEgAQMBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
         AwABQAMAARADAAEBAQABCAYAAQQYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
         AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
         AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
@@ -167,11 +167,11 @@
         BAABgAEBAR8BBwQAAYABAgH/AYMEAAHAAeIB/wHDBAAB4QH7Af8B4QQAAfMC/wHhBAAD/wHxBAAL
 </value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="panelWithBorder.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="panelWithBorder.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
@@ -187,7 +187,7 @@
   <data name="allowedTypesLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="allowedTypesLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt</value>
   </data>
@@ -200,6 +200,9 @@
   <data name="allowedTypesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 6, 0, 3</value>
   </data>
+  <data name="allowedTypesLabel.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 16</value>
+  </data>
   <data name="allowedTypesLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>217, 16</value>
   </data>
@@ -207,7 +210,7 @@
     <value>22</value>
   </data>
   <data name="allowedTypesLabel.Text" xml:space="preserve">
-    <value>Allowed vGPU types:</value>
+    <value>vGPU types:</value>
   </data>
   <data name="allowedTypesLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -238,6 +241,9 @@
   </data>
   <data name="pGpuLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 6, 3, 3</value>
+  </data>
+  <data name="pGpuLabel.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 16</value>
   </data>
   <data name="pGpuLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>436, 16</value>
@@ -279,7 +285,7 @@
     <value>pGpuPictureBox</value>
   </data>
   <data name="&gt;&gt;pGpuPictureBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pGpuPictureBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -287,7 +293,7 @@
   <data name="&gt;&gt;pGpuPictureBox.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <metadata name="ImageColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ImageColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ImageColumn.HeaderText" xml:space="preserve">
@@ -296,7 +302,7 @@
   <data name="ImageColumn.Width" type="System.Int32, mscorlib">
     <value>20</value>
   </data>
-  <metadata name="TextColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="TextColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="TextColumn.HeaderText" xml:space="preserve">
@@ -363,7 +369,7 @@
     <value>shinyBarsContainerPanel</value>
   </data>
   <data name="&gt;&gt;shinyBarsContainerPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;shinyBarsContainerPanel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -399,7 +405,7 @@
     <value>editButton</value>
   </data>
   <data name="&gt;&gt;editButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;editButton.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -426,7 +432,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>panelWithBorder</value>
@@ -456,7 +462,7 @@
     <value>clearAllButton</value>
   </data>
   <data name="&gt;&gt;clearAllButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;clearAllButton.Parent" xml:space="preserve">
     <value>multipleSelectionPanel</value>
@@ -483,7 +489,7 @@
     <value>selectAllButton</value>
   </data>
   <data name="&gt;&gt;selectAllButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;selectAllButton.Parent" xml:space="preserve">
     <value>multipleSelectionPanel</value>
@@ -507,7 +513,7 @@
     <value>multipleSelectionPanel</value>
   </data>
   <data name="&gt;&gt;multipleSelectionPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;multipleSelectionPanel.Parent" xml:space="preserve">
     <value>panelWithBorder</value>
@@ -545,11 +551,11 @@
   <data name="&gt;&gt;panelWithBorder.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>112</value>
-  </metadata>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>112</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
@@ -564,24 +570,24 @@
     <value>allowedTypesImageList</value>
   </data>
   <data name="&gt;&gt;allowedTypesImageList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ImageColumn.Name" xml:space="preserve">
     <value>ImageColumn</value>
   </data>
   <data name="&gt;&gt;ImageColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TextColumn.Name" xml:space="preserve">
     <value>TextColumn</value>
   </data>
   <data name="&gt;&gt;TextColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>GpuRow</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/XenAdmin/Controls/GPU/GpuShinyBar.cs
+++ b/XenAdmin/Controls/GPU/GpuShinyBar.cs
@@ -76,7 +76,8 @@ namespace XenAdmin.Controls.GPU
             Rectangle barArea = barRect;
 
             // Grid
-            DrawGrid(g, barArea, barArea.Width);
+            if (maxCapacity > 1)
+                DrawGrid(g, barArea, barArea.Width);
 
             double left = barArea.Left;
 

--- a/XenAdmin/Controls/GPU/GpuShinyBar.cs
+++ b/XenAdmin/Controls/GPU/GpuShinyBar.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using XenAdmin.Controls.Ballooning;
+using XenAdmin.Core;
 using XenAPI;
 
 namespace XenAdmin.Controls.GPU
@@ -49,6 +50,7 @@ namespace XenAdmin.Controls.GPU
         private List<VGPU> vGPUs;
         private Dictionary<VGPU, VM> vms;
         private long capacity;
+        private long maxCapacity;
 
         public void Initialize(PGPU pGPU)
         {
@@ -60,8 +62,9 @@ namespace XenAdmin.Controls.GPU
             foreach (VGPU vgpu in vGPUs)
                 vms[vgpu] = vgpu.Connection.Resolve(vgpu.VM);
 
-            capacity = vGPUs.Count > 0 && pGPU.supported_VGPU_max_capacities.ContainsKey(vGPUs[0].type) 
-                ? pGPU.supported_VGPU_max_capacities[vGPUs[0].type] : 8;
+            maxCapacity = !Helpers.FeatureForbidden(pGPU, Host.RestrictVgpu) && pGPU.HasVGpu ? 8 : 1;
+            capacity = vGPUs.Count > 0 && pGPU.supported_VGPU_max_capacities.ContainsKey(vGPUs[0].type)
+                ? pGPU.supported_VGPU_max_capacities[vGPUs[0].type] : maxCapacity;
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -81,7 +84,7 @@ namespace XenAdmin.Controls.GPU
             int i = 0;
             vGPUs.Sort();
 
-            long segmentLength = barArea.Width / (capacity > 0 ? capacity : 8);
+            long segmentLength = barArea.Width / (capacity > 0 ? capacity : maxCapacity);
             foreach (VGPU vgpu in vGPUs)
             {
                 VM vm = vms[vgpu];
@@ -107,7 +110,7 @@ namespace XenAdmin.Controls.GPU
             int line_bottom = barArea.Top + barArea.Height / 2;
             int line_top = barArea.Top - line_height;
 
-            long incr = max / (capacity > 0 ? capacity : 8);
+            long incr = max / (capacity > 0 ? capacity : maxCapacity);
 
             // Draw the grid
             using (Pen pen = new Pen(GpuShinyBarColors.Grid))

--- a/XenAdmin/Dialogs/PropertiesDialog.cs
+++ b/XenAdmin/Dialogs/PropertiesDialog.cs
@@ -207,10 +207,8 @@ namespace XenAdmin.Dialogs
 
                 if (is_pool_or_standalone)
                 {
-                    if (Helpers.ClearwaterOrGreater(xenObject.Connection)
-                        && !Helpers.FeatureForbidden(xenObjectCopy, Host.RestrictVgpu)
-                        && Helpers.VgpuCapability(xenObjectCopy.Connection)) 
-                    ShowTab(PoolGpuEditPage = new PoolGpuEditPage());
+                    if (Helpers.VGpuCapability(xenObjectCopy.Connection)) 
+                        ShowTab(PoolGpuEditPage = new PoolGpuEditPage());
                 }
 
                 if (is_network)
@@ -219,7 +217,7 @@ namespace XenAdmin.Dialogs
                 if (is_vm && !wlb_enabled)
                     ShowTab(HomeServerPage = new HomeServerEditPage());
 
-                if (is_hvm)
+                if (is_vm && ((VM)xenObjectCopy).CanHaveGpu)
                 {
                     if (Helpers.BostonOrGreater(xenObject.Connection))
                     {
@@ -234,7 +232,10 @@ namespace XenAdmin.Dialogs
                             ShowTab(GpuEditPage = new GpuEditPage());
                         }
                     }
+                }
 
+                if (is_hvm)
+                {
                     ShowTab(VMAdvancedEditPage = new VMAdvancedEditPage());
                 }
 

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1295,10 +1295,7 @@ namespace XenAdmin
 
             bool isPoolOrLiveStandaloneHost = isPoolSelected || (isHostSelected && isHostLive && selectionPool == null);
 
-            if (!multi && !SearchMode && ((isHostSelected && isHostLive) || isPoolOrLiveStandaloneHost))
-            {
-                ShowTab(TabPageGPU, Helpers.ClearwaterSp1OrGreater(selectionConnection) && Helpers.GpuCapability(selectionConnection));
-            }
+            ShowTab(TabPageGPU, !multi && !SearchMode && ((isHostSelected && isHostLive) || isPoolOrLiveStandaloneHost) && Helpers.ClearwaterSp1OrGreater(selectionConnection) && Helpers.GpuCapability(selectionConnection));
 
             pluginManager.SetSelectedXenObject(SelectionManager.Selection.FirstAsXenObject);
 

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1294,11 +1294,11 @@ namespace XenAdmin
             ShowTab(TabPageNICs, !multi && !SearchMode && ((isHostSelected && isHostLive)));
 
             bool isPoolOrLiveStandaloneHost = isPoolSelected || (isHostSelected && isHostLive && selectionPool == null);
-            bool showGpu = SelectionManager.Selection.All(s => Helpers.ClearwaterOrGreater(s.Connection)) &&
-                           !Helpers.FeatureForbidden(SelectionManager.Selection.FirstAsXenObject, Host.RestrictVgpu) &&
-                           Helpers.VgpuCapability(selectionConnection);
 
-            ShowTab(TabPageGPU, !multi && !SearchMode && ((isHostSelected && isHostLive) || isPoolOrLiveStandaloneHost) && showGpu);
+            if (!multi && !SearchMode && ((isHostSelected && isHostLive) || isPoolOrLiveStandaloneHost))
+            {
+                ShowTab(TabPageGPU, Helpers.ClearwaterSp1OrGreater(selectionConnection) && Helpers.GpuCapability(selectionConnection));
+            }
 
             pluginManager.SetSelectedXenObject(SelectionManager.Selection.FirstAsXenObject);
 

--- a/XenAdmin/SettingsPanels/GpuEditPage.cs
+++ b/XenAdmin/SettingsPanels/GpuEditPage.cs
@@ -200,7 +200,7 @@ namespace XenAdmin.SettingsPanels
                 {
                     var vgpuGroup = Connection.Resolve(vgpu.GPU_group);
 
-                    if (Helpers.FeatureForbidden(Connection, Host.RestrictVgpu))
+                    if (Helpers.FeatureForbidden(Connection, Host.RestrictVgpu) || !vm.CanHaveVGpu)
                         currentGpuTuple = new GpuTuple(vgpuGroup, null, null);
                     else
                     {
@@ -243,7 +243,7 @@ namespace XenAdmin.SettingsPanels
             Array.Sort(gpu_groups);
             foreach (GPU_group gpu_group in gpu_groups)
             {
-                if (Helpers.FeatureForbidden(Connection, Host.RestrictVgpu))
+                if (Helpers.FeatureForbidden(Connection, Host.RestrictVgpu) || !vm.CanHaveVGpu)
                 {
                     comboBoxGpus.Items.Add(new GpuTuple(gpu_group, null, null));  //GPU pass-through item
                 }

--- a/XenAdmin/TabPages/GpuPage.cs
+++ b/XenAdmin/TabPages/GpuPage.cs
@@ -36,6 +36,7 @@ using System.Linq;
 using System.Windows.Forms;
 using XenAdmin.Controls;
 using XenAdmin.Controls.GPU;
+using XenAdmin.Core;
 using XenAPI;
 
 namespace XenAdmin.TabPages
@@ -125,7 +126,8 @@ namespace XenAdmin.TabPages
             int initScroll = pageContainerPanel.VerticalScroll.Value;
             int top = pageContainerPanel.Padding.Top - initScroll;
 
-            AddRowToPanel(CreateGpuPlacementPolicyPanel(), ref top);
+            if (Helpers.VGpuCapability(xenObject.Connection))
+                AddRowToPanel(CreateGpuPlacementPolicyPanel(), ref top);
 
             foreach (GpuSettings settings in listSettings)
             {

--- a/XenAdmin/TabPages/GpuPage.cs
+++ b/XenAdmin/TabPages/GpuPage.cs
@@ -35,6 +35,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using XenAdmin.Controls;
+using XenAdmin.Controls.Common;
 using XenAdmin.Controls.GPU;
 using XenAdmin.Core;
 using XenAPI;
@@ -134,6 +135,9 @@ namespace XenAdmin.TabPages
                 AddRowToPanel(new GpuRow(xenObject, settingsToPGPUs[settings]), ref top);
             }
 
+            if (listSettings.Count == 0)
+                AddRowToPanel(CreateNoGpuPanel(), ref top);
+
             // Remove old controls
             foreach (Control c in oldControls)
             {
@@ -159,6 +163,15 @@ namespace XenAdmin.TabPages
                        };
         }
 
+        private AutoHeightLabel CreateNoGpuPanel()
+        {
+            return new AutoHeightLabel
+            {
+                Name = "noGpuPanel1",
+                Text = Messages.NO_GPU_ON_SERVER
+            };
+        }
+
         private void ReLayout()
         {
             Program.AssertOnEventThread();
@@ -174,7 +187,7 @@ namespace XenAdmin.TabPages
             }
         }
 
-        private void AddRowToPanel(UserControl row, ref int top)
+        private void AddRowToPanel(Control row, ref int top)
         {
             row.Top = top;
             row.Left = pageContainerPanel.Padding.Left - pageContainerPanel.HorizontalScroll.Value;

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -86,8 +86,6 @@ namespace XenAdmin.Wizards.NewVMWizard
             page_6b_LunPerVdi = new LunPerVdiNewVMMappingPage { Connection = xenConnection };
             pageVgpu = new GpuEditPage();
 
-            gpuCapability = Helpers.GpuCapability(connection);
-
             #region RBAC Warning Page Checks
             if (connection.Session.IsLocalSuperuser || Helpers.GetMaster(connection).external_auth_type == Auth.AUTH_TYPE_NONE)
             {
@@ -123,7 +121,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
                 page_RbacWarning.AddPermissionChecks(xenConnection, createCheck, affinityCheck, memCheck);
 
-                if (gpuCapability)
+                if (Helpers.GpuCapability(connection))
                 {
                     var vgpuCheck = new RBACWarningPage.WizardPermissionCheck(Messages.RBAC_WARNING_VM_WIZARD_GPU);
                     vgpuCheck.ApiCallsToCheck.Add("vgpu.create");
@@ -205,7 +203,6 @@ namespace XenAdmin.Wizards.NewVMWizard
                 page_7_Networking.SelectedTemplate = selectedTemplate;
 
                 RemovePage(pageVgpu);
-                // update gpuCapability to include "CanHaveGpu"
                 gpuCapability = Helpers.GpuCapability(xenConnection) && selectedTemplate.CanHaveGpu;
                 if (gpuCapability)
                     AddAfterPage(page_5_CpuMem, pageVgpu);

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -121,7 +121,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
                 page_RbacWarning.AddPermissionChecks(xenConnection, createCheck, affinityCheck, memCheck);
 
-                if (Helpers.GpuCapability(connection))
+                if (Helpers.ClearwaterSp1OrGreater(xenConnection) && Helpers.GpuCapability(xenConnection))
                 {
                     var vgpuCheck = new RBACWarningPage.WizardPermissionCheck(Messages.RBAC_WARNING_VM_WIZARD_GPU);
                     vgpuCheck.ApiCallsToCheck.Add("vgpu.create");
@@ -203,7 +203,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 page_7_Networking.SelectedTemplate = selectedTemplate;
 
                 RemovePage(pageVgpu);
-                gpuCapability = Helpers.GpuCapability(xenConnection) && selectedTemplate.CanHaveGpu;
+                gpuCapability = Helpers.ClearwaterSp1OrGreater(xenConnection) && Helpers.GpuCapability(xenConnection) && selectedTemplate.CanHaveGpu;
                 if (gpuCapability)
                     AddAfterPage(page_5_CpuMem, pageVgpu);
 

--- a/XenModel/Actions/VM/CreateVMAction.cs
+++ b/XenModel/Actions/VM/CreateVMAction.cs
@@ -147,8 +147,7 @@ namespace XenAdmin.Actions.VMActions
                 AppliesTo.Add(HomeServer != null ? HomeServer.opaque_ref : pool_of_one.opaque_ref);
 
             assignOrRemoveVgpu = (GpuGroup != null && VgpuType != null)
-                             || (!Helpers.FeatureForbidden(Connection, Host.RestrictVgpu)
-                                 && Helpers.VgpuCapability(Connection));
+                             || Helpers.GpuCapability(Connection);
 
             #region RBAC Dependencies
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -23119,6 +23119,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There are no GPUs on this server..
+        /// </summary>
+        public static string NO_GPU_ON_SERVER {
+            get {
+                return ResourceManager.GetString("NO_GPU_ON_SERVER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no halted or suspended VMs to export.
         /// </summary>
         public static string NO_HALTED_VMS {
@@ -31735,7 +31744,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Update succesfully uploaded to selected server(s).
+        ///   Looks up a localized string similar to Update successfully uploaded to selected server(s).
         /// </summary>
         public static string UPLOAD_PATCH_END_DESCRIPTION {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12319,5 +12319,7 @@ Desktop features enabled</value>
     <value>Eligible for support 
 Desktop+ features enabled</value>
   </data>
+  <data name="NO_GPU_ON_SERVER" xml:space="preserve">
+    <value>There are no GPUs on this server.</value>
+  </data>
 </root>
-

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -468,6 +468,16 @@ namespace XenAdmin.Core
                 HostBuildNumber(host) == CUSTOM_BUILD_NUMBER;
         }
 
+        /// <summary>
+        /// Clearwater SP1 has API version 2.1
+        /// </summary>
+        /// <param name="conn">May be null, in which case true is returned.</param>
+        /// <returns></returns>
+        public static bool ClearwaterSp1OrGreater(IXenConnection conn)
+        {
+            return conn == null || conn.Session == null || conn.Session.APIVersion >= API_Version.API_2_1;
+        }
+
         // CP-3435: Disable Check for Updates in Common Criteria Certification project
         public static bool CommonCriteriaCertificationRelease
         {
@@ -1889,9 +1899,26 @@ namespace XenAdmin.Core
            return connection.Cache.Hosts.Any(h => h.enabled);
        }
 
-       public static bool VgpuCapability(IXenConnection connection)
+       public static bool GpuCapability(IXenConnection connection)
        {
-           return connection != null && connection.Cache.GPU_groups.Any(g => g.PGPUs.Count > 0 && g.supported_VGPU_types.Count > 0);
+           if (!FeatureForbidden(connection, Host.RestrictGpu))
+           {
+               var pool = GetPoolOfOne(connection);
+               if (pool != null)
+                   return pool.HasGpu;
+           }
+           return false;
+       }
+
+       public static bool VGpuCapability(IXenConnection connection)
+       {
+           if (!FeatureForbidden(connection, Host.RestrictVgpu))
+           {
+               var pool = GetPoolOfOne(connection);
+               if (pool != null)
+                   return pool.HasVGpu;
+           }
+           return false;
        }
 
        /// <summary>

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1901,27 +1901,21 @@ namespace XenAdmin.Core
 
        public static bool GpuCapability(IXenConnection connection)
        {
-           if (!FeatureForbidden(connection, Host.RestrictGpu))
-           {
-               var pool = GetPoolOfOne(connection);
-               if (pool != null)
-                   return pool.HasGpu;
-           }
-           return false;
+           if (FeatureForbidden(connection, Host.RestrictGpu))
+               return false;
+           var pool = GetPoolOfOne(connection);
+           return pool != null && pool.HasGpu;
        }
 
-       public static bool VGpuCapability(IXenConnection connection)
-       {
-           if (!FeatureForbidden(connection, Host.RestrictVgpu))
-           {
-               var pool = GetPoolOfOne(connection);
-               if (pool != null)
-                   return pool.HasVGpu;
-           }
-           return false;
-       }
+        public static bool VGpuCapability(IXenConnection connection)
+        {
+            if (FeatureForbidden(connection, Host.RestrictVgpu))
+                return false;
+            var pool = GetPoolOfOne(connection);
+            return pool != null && pool.HasVGpu;
+        }
 
-       /// <summary>
+        /// <summary>
        /// Whether creation of VLAN 0 is allowed.
        /// </summary>
        public static bool VLAN0Allowed(IXenConnection connection)

--- a/XenModel/XenAPI-Extensions/PGPU.cs
+++ b/XenModel/XenAPI-Extensions/PGPU.cs
@@ -29,6 +29,8 @@
  * SUCH DAMAGE.
  */
 
+using System.Linq;
+
 namespace XenAPI
 {
     partial class PGPU
@@ -39,6 +41,17 @@ namespace XenAPI
             {
                 PCI pci = Connection.Resolve(PCI);
                 return pci != null ? pci.device_name : uuid;
+            }
+        }
+        /// <summary>
+        /// Has at least one supported_VGPU_type that is not passthrough
+        /// </summary>
+        public bool HasVGpu
+        {
+            get
+            {
+                var supportedTypes = Connection.ResolveAll(supported_VGPU_types);
+                return supportedTypes.Any(supportedType => supportedType.max_heads != 0);
             }
         }
     }

--- a/XenModel/XenAPI-Extensions/PGPU.cs
+++ b/XenModel/XenAPI-Extensions/PGPU.cs
@@ -51,7 +51,7 @@ namespace XenAPI
             get
             {
                 var supportedTypes = Connection.ResolveAll(supported_VGPU_types);
-                return supportedTypes.Any(supportedType => supportedType.max_heads != 0);
+                return supportedTypes.Any(supportedType => !supportedType.IsPassthrough);
             }
         }
     }

--- a/XenModel/XenAPI-Extensions/Pool.cs
+++ b/XenModel/XenAPI-Extensions/Pool.cs
@@ -389,6 +389,16 @@ namespace XenAPI
         {
             get { return Connection.Cache.Hosts.Sum(h => h.CpuSockets); }
         }
+        
+        public bool HasGpu
+        {
+            get { return Connection.Cache.PGPUs.Length > 0; }
+        }
+
+        public bool HasVGpu
+        {
+            get { return HasGpu && Connection.Cache.PGPUs.Any(pGpu => pGpu.HasVGpu); }
+        }
 
         #region IEquatable<Pool> Members
 

--- a/XenModel/XenAPI-Extensions/VGPU.cs
+++ b/XenModel/XenAPI-Extensions/VGPU.cs
@@ -38,7 +38,7 @@ namespace XenAPI
             get
             {
                 var vGPUType = Connection.Resolve(type);
-                return vGPUType == null || vGPUType.max_heads == 0;
+                return vGPUType == null || vGPUType.IsPassthrough;
             }
         }
     }

--- a/XenModel/XenAPI-Extensions/VGPU_type.cs
+++ b/XenModel/XenAPI-Extensions/VGPU_type.cs
@@ -40,7 +40,7 @@ namespace XenAPI
         {
             get
             {
-                if (max_heads == 0)
+                if (IsPassthrough)
                     return Messages.VGPU_PASSTHRU_TOSTRING;
 
                 return string.Format(Messages.VGPU_TOSTRING, model_name, Capacity);
@@ -52,7 +52,7 @@ namespace XenAPI
         {
             get
             {
-                if (max_heads == 0)
+                if (IsPassthrough)
                     return Messages.VGPU_PASSTHRU_TOSTRING;
 
                 var videoRam = framebuffer_size != 0 ? Util.SuperiorSizeString(framebuffer_size, 0): string.Empty;
@@ -104,6 +104,10 @@ namespace XenAPI
                 return capacity;
             }
         }
-        
+
+        public bool IsPassthrough
+        {
+            get { return max_heads == 0; }
+        }
     }
 }

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -464,6 +464,11 @@ namespace XenAPI
             }
         }
 
+        public bool CanHaveVGpu
+        {
+            get { return CanHaveGpu; }
+        }
+
         void set_other_config(string key, string value)
         {
             Dictionary<string, string> new_other_config =

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -436,7 +436,7 @@ namespace XenAPI
         ///   2a) the allow-gpu-passthrough restriction is absent or
         ///   2b) the allow-gpu-passthrough restriction is non-zero
         ///</summary>
-        public bool CanHaveVGpu
+        public bool CanHaveGpu
         {
             get
             {


### PR DESCRIPTION
...d with "Enterprise"

New properties:
- Pool.HasGpu = Pool has at least one PGPU
- Pool.HasVGpu = Pool has at least one PGPU that HasVGpu
- PGPU.HasVGpu = PGPU has at least one supported_VGPU_type that is not pass-through

New or modified helper functions:
- Helpers.GpuCapability = GPU feature not restricted (by licensing) and Pool.HasGpu
- Helpers.VGpuCapability = vGPU feature not restricted (by licensing) and Pool.HasVGpu
- Helpers.ClearwaterSp1OrGreater = API version is 2.1 or greater

The GPU dialogs are displayed as follows:
- GPU page on VM properties dialog: Visible only if VM.CanHaveGpu and the GPU feature not restricted (by licensing)
- GPU page on New VM Wizard: Visible only if VM.CanHaveGpu and the pool has GPU capability (Helpers.GpuCapability)
- GPU page on Pool properties dialog: Visible only if the pool has vGPU capability (Helpers.VGpuCapability)
- GPU tab: Visible only if the pool has GPU capability (Helpers.GpuCapability) and is Clearwater SP1 or greater
- On the GPU tab, the "Placement policy" panel: Visible only if the pool has vGPU capability (Helpers.VGpuCapability)
- On the GPU tab, the "Edit" button on the "vGPU types" panel: Visible only if the PGPU.HasVGpu and vGPU feature not restricted (by licensing)

Also:
- VM.CanHaveVGpu function renamed to CanHaveGpu
- On the GPU tab, renamed "Allowed vGPU types" to "vGPU types