### PR TITLE
CP-10825: Supp Pack installation through XenCenter: Display installed supplemental packs on host's General tab

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -649,6 +649,13 @@ namespace XenAdmin.TabPages
                 var menuItems = new[] { applypatch };
                 s.AddEntry(FriendlyName("Pool_patch.not_applied"), hostUnappliedPatches(host), menuItems, Color.Red);
             }
+
+            // add supplemental packs
+            var suppPacks = hostInstalledSuppPacks(host);
+            if (!string.IsNullOrEmpty(suppPacks))
+            {
+                s.AddEntry(FriendlyName("Supplemental_packs.installed"), suppPacks);
+            }
         }
 
         private void generateHABox()
@@ -1514,6 +1521,13 @@ namespace XenAdmin.TabPages
                     result.Add(patch.Name);
             }
 
+            result.Sort(StringUtility.NaturalCompare);
+            return string.Join("\n", result.ToArray());
+        }
+
+        private string hostInstalledSuppPacks(Host host)
+        {
+            var result = host.SuppPacks.Select(suppPack => suppPack.LongDescription).ToList();
             result.Sort(StringUtility.NaturalCompare);
             return string.Join("\n", result.ToArray());
         }

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -2653,6 +2653,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Installed supplemental packs.
+        /// </summary>
+        public static string Label_Supplemental_packs_installed {
+            get {
+                return ResourceManager.GetString("Label-Supplemental_packs.installed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Home Server.
         /// </summary>
         public static string Label_VM_affinity {

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1742,4 +1742,7 @@
   <data name="Label-host.edition-desktop-plus" xml:space="preserve">
     <value>XenApp/XenDesktop Platinum</value>
   </data>
+  <data name="Label-Supplemental_packs.installed" xml:space="preserve">
+    <value>Installed supplemental packs</value>
+  </data>
 </root>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -29650,6 +29650,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} (version {1}).
+        /// </summary>
+        public static string SUPP_PACK_DESCTIPTION {
+            get {
+                return ResourceManager.GetString("SUPP_PACK_DESCTIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} (not installed on {1}).
         /// </summary>
         public static string SUPP_PACK_MISSING_ON {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10279,6 +10279,9 @@ Do you want to connect to the pool master '{1}'?</value>
   <data name="SUNDAY_SHORT" xml:space="preserve">
     <value>Sun</value>
   </data>
+  <data name="SUPP_PACK_DESCTIPTION" xml:space="preserve">
+    <value>{0} (version {1})</value>
+  </data>
   <data name="SUPP_PACK_MISSING_ON" xml:space="preserve">
     <value>{0} (not installed on {1})</value>
   </data>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -1448,6 +1448,8 @@ namespace XenAPI
             private bool parsed = false;
             public bool IsValid { get { return parsed; } }
 
+            public string LongDescription { get { return string.Format(Messages.SUPP_PACK_DESCTIPTION, description, version); } }
+
             /// <summary>
             /// Try to parse the supp pack information from one key of software_version
             /// </summary>
@@ -1505,6 +1507,8 @@ namespace XenAPI
             get
             {
                 List<SuppPack> packs = new List<SuppPack>();
+                if (software_version == null)
+                    return packs;
                 foreach (string key in software_version.Keys)
                 {
                     SuppPack pack = new SuppPack(key, software_version[key]);


### PR DESCRIPTION

The 'Updates' section on host's General tab displays which packs have been installed onto a host, including the version number

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>