### PR TITLE
CP-10797: Ensuring sufficient disk space for service pack installation: ...

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -98,6 +98,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 var existPatch = PatchingWizard_SelectPatchPage.SelectedExistingPatch;
 
                 DisablePage(PatchingWizard_PrecheckPage, updateType == UpdateType.NewOem);
+                DisablePage(PatchingWizard_UploadPage, updateType == UpdateType.NewOem);
 
                 PatchingWizard_SelectServers.SelectedUpdateType = updateType;
                 PatchingWizard_SelectServers.Patch = existPatch;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.Designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.Designer.cs
@@ -34,6 +34,7 @@
             this.labelProgress = new System.Windows.Forms.Label();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.flickerFreeListBox1 = new XenAdmin.Controls.FlickerFreeListBox();
+            this.diskSpaceErrorLinkLabel = new System.Windows.Forms.LinkLabel();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -44,10 +45,12 @@
             this.tableLayoutPanel1.Controls.Add(this.labelProgress, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.progressBar1, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.flickerFreeListBox1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.diskSpaceErrorLinkLabel, 1, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // label2
             // 
+            this.tableLayoutPanel1.SetColumnSpan(this.label2, 2);
             resources.ApplyResources(this.label2, "label2");
             this.label2.Name = "label2";
             // 
@@ -58,18 +61,25 @@
             // 
             // progressBar1
             // 
+            this.tableLayoutPanel1.SetColumnSpan(this.progressBar1, 2);
             resources.ApplyResources(this.progressBar1, "progressBar1");
             this.progressBar1.Name = "progressBar1";
             // 
             // flickerFreeListBox1
             // 
+            this.tableLayoutPanel1.SetColumnSpan(this.flickerFreeListBox1, 2);
             resources.ApplyResources(this.flickerFreeListBox1, "flickerFreeListBox1");
             this.flickerFreeListBox1.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.flickerFreeListBox1.FormattingEnabled = true;
-            this.flickerFreeListBox1.Items.AddRange(new object[] {
-            resources.GetString("flickerFreeListBox1.Items")});
             this.flickerFreeListBox1.Name = "flickerFreeListBox1";
             this.flickerFreeListBox1.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.flickerFreeListBox1_DrawItem);
+            // 
+            // diskSpaceErrorLinkLabel
+            // 
+            resources.ApplyResources(this.diskSpaceErrorLinkLabel, "diskSpaceErrorLinkLabel");
+            this.diskSpaceErrorLinkLabel.Name = "diskSpaceErrorLinkLabel";
+            this.diskSpaceErrorLinkLabel.TabStop = true;
+            this.diskSpaceErrorLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.diskspaceErrorLinkLabel_LinkClicked);
             // 
             // PatchingWizard_UploadPage
             // 
@@ -78,7 +88,6 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "PatchingWizard_UploadPage";
             this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -90,5 +99,6 @@
         private System.Windows.Forms.Label labelProgress;
         private System.Windows.Forms.ProgressBar progressBar1;
         private Controls.FlickerFreeListBox flickerFreeListBox1;
+        private System.Windows.Forms.LinkLabel diskSpaceErrorLinkLabel;
     }
 }

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -167,7 +167,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 {
                     action.Changed += delegate
                     {
-                        Program.Invoke(Program.MainWindow, () => UpdateActionProgress(action));
+                        Program.Invoke(Program.MainWindow, () => UpdateActionDescription(action));
                     };
                     diskSpaceActions.Add(action);
                 }
@@ -230,17 +230,21 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         private void UpdateActionProgress(AsyncAction action)
         {
-            if (action == null) // reset progress
+            UpdateActionDescription(action);
+            progressBar1.Value = action == null ? 0 : action.PercentComplete;
+        }
+
+        private void UpdateActionDescription(AsyncAction action)
+        {
+            if (action == null) // reset action description
             {
-                progressBar1.Value = 0;
                 labelProgress.Text = "";
-                labelProgress.ForeColor = Color.Black;
+                labelProgress.ForeColor = SystemColors.ControlText;
             }
-            else if (action.StartedRunning) // update progress and description for started actions
+            else if (action.StartedRunning) // update description for started actions
             {
-                progressBar1.Value = action.PercentComplete;
                 labelProgress.Text = GetActionDescription(action);
-                labelProgress.ForeColor = !action.IsCompleted || action.Succeeded ? Color.Black : Color.Red;
+                labelProgress.ForeColor = !action.IsCompleted || action.Succeeded ? SystemColors.ControlText : Color.Red;
             }
         }
 
@@ -325,13 +329,11 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         private void flickerFreeListBox1_DrawItem(object sender, DrawItemEventArgs e)
         {
-            if (e.Index < 0)
+            if (e.Index < 0 || !(flickerFreeListBox1.Items[e.Index] is KeyValuePair<Host, AsyncAction>))
                 return;
             var hostAndAction = (KeyValuePair<Host, AsyncAction>)flickerFreeListBox1.Items[e.Index];
-            Host host = hostAndAction.Key;
-            if (host == null)
-                return;
-            AsyncAction action = hostAndAction.Value;
+            var host = hostAndAction.Key;
+            var action = hostAndAction.Value;
             
             using (SolidBrush backBrush = new SolidBrush(flickerFreeListBox1.BackColor))
             {

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -157,9 +157,6 @@ Please wait for this operation to complete, then click Next to continue with the
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="labelProgress.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="labelProgress.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -167,7 +164,7 @@ Please wait for this operation to complete, then click Next to continue with the
     <value>NoControl</value>
   </data>
   <data name="labelProgress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 357</value>
+    <value>3, 354</value>
   </data>
   <data name="labelProgress.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -176,7 +173,7 @@ Please wait for this operation to complete, then click Next to continue with the
     <value>1, 1, 1, 1</value>
   </data>
   <data name="labelProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>694, 15</value>
+    <value>618, 18</value>
   </data>
   <data name="labelProgress.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -232,14 +229,11 @@ Please wait for this operation to complete, then click Next to continue with the
   <data name="flickerFreeListBox1.ItemHeight" type="System.Int32, mscorlib">
     <value>18</value>
   </data>
-  <data name="flickerFreeListBox1.Items" xml:space="preserve">
-    <value>Nothing to upload</value>
-  </data>
   <data name="flickerFreeListBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 40</value>
   </data>
   <data name="flickerFreeListBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>694, 311</value>
+    <value>694, 308</value>
   </data>
   <data name="flickerFreeListBox1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -255,6 +249,42 @@ Please wait for this operation to complete, then click Next to continue with the
   </data>
   <data name="&gt;&gt;flickerFreeListBox1.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>627, 354</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 18</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.Text" xml:space="preserve">
+    <value>&amp;More info...</value>
+  </data>
+  <data name="diskSpaceErrorLinkLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;diskSpaceErrorLinkLabel.Name" xml:space="preserve">
+    <value>diskSpaceErrorLinkLabel</value>
+  </data>
+  <data name="&gt;&gt;diskSpaceErrorLinkLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;diskSpaceErrorLinkLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;diskSpaceErrorLinkLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -287,7 +317,7 @@ Please wait for this operation to complete, then click Next to continue with the
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label2" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelProgress" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="flickerFreeListBox1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label2" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="labelProgress" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="flickerFreeListBox1" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="diskSpaceErrorLinkLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenModel/Actions/Pool_Patch/CheckDiskSpaceForPatchUploadAction.cs
+++ b/XenModel/Actions/Pool_Patch/CheckDiskSpaceForPatchUploadAction.cs
@@ -67,7 +67,7 @@ namespace XenAdmin.Actions
             : base(host.Connection, Messages.ACTION_CHECK_DISK_SPACE_TITLE, "", suppressHistory)
         {
             if (host == null)
-                throw new NullReferenceException();
+                throw new ArgumentNullException("host");
             Host = host;
             this.fileName = fileName;
             fileSize = size;

--- a/XenModel/Actions/Pool_Patch/CheckDiskSpaceForPatchUploadAction.cs
+++ b/XenModel/Actions/Pool_Patch/CheckDiskSpaceForPatchUploadAction.cs
@@ -1,0 +1,154 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using XenAPI;
+
+
+namespace XenAdmin.Actions
+{
+    public class CheckDiskSpaceForPatchUploadAction : PureAsyncAction
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private readonly string fileName;
+        private readonly long fileSize;
+
+       
+
+        /// <summary>
+        /// This constructor is used to check disk space for uploading a single patch
+        /// </summary>
+        public CheckDiskSpaceForPatchUploadAction(Host host, Pool_patch patch, bool suppressHistory)
+            : this(host, patch.Name, patch.size, suppressHistory)
+        { }
+
+        /// <summary>
+        /// This constructor is used to check disk space for uploading a single update file
+        /// </summary>
+        public CheckDiskSpaceForPatchUploadAction(Host host, string path, bool suppressHistory)
+            : this(host, FileName(path), FileSize(path), suppressHistory)
+        { }
+
+        /// <summary>
+        /// This constructor is used to check disk space for uploading a file of given size
+        /// </summary>
+        public CheckDiskSpaceForPatchUploadAction(Host host, string fileName, long size, bool suppressHistory)
+            : base(host.Connection, Messages.ACTION_CHECK_DISK_SPACE_TITLE, "", suppressHistory)
+        {
+            if (host == null)
+                throw new NullReferenceException();
+            Host = host;
+            this.fileName = fileName;
+            fileSize = size;
+        }
+
+        private static long FileSize(string path)
+        {
+            FileInfo fileInfo = new FileInfo(path);
+            return fileInfo.Length;
+        }
+
+        private static string FileName(string path)
+        {
+            FileInfo fileInfo = new FileInfo(path);
+            return fileInfo.Name;
+        }
+
+        protected override void Run()
+        {
+            SafeToExit = false;
+            Description = String.Format(Messages.ACTION_CHECK_DISK_SPACE_DESCRIPTION, Host.Name);
+            if (!IsEnoughDiskSpace())
+            {
+                DiskSpaceRequirements diskSpaceRequirements = null;
+                var getDiskSpaceRequirementsAction = new GetDiskSpaceRequirementsAction(Host, fileName, fileSize, true);
+                try
+                {
+                    getDiskSpaceRequirementsAction.RunExternal(Session);
+                    diskSpaceRequirements = getDiskSpaceRequirementsAction.DiskSpaceRequirements;
+                }
+                catch (Failure failure)
+                {
+                    log.WarnFormat("Getting disk space requirements on {0} failed with: {1}", Host.Name, failure.Message);
+                }
+                Exception = new NotEnoughSpaceException(Host.Name, fileName, diskSpaceRequirements);
+            }
+        }
+
+        private bool IsEnoughDiskSpace()
+        {
+            string result;
+            try
+            {
+                result = Host.call_plugin(Session, Host.opaque_ref, "disk-space", "check_patch_upload", 
+                    new Dictionary<string, string> { { "size", fileSize.ToString() } });
+            }
+            catch (Failure failure)
+            {
+                log.WarnFormat("Plugin call disk-space.check_patch_upload({0}) on {1} failed with {2}", fileSize, Host.Name,
+                               failure.Message);
+                return true;
+            }
+            return result.ToLower() == "true";
+        }
+    }
+
+    public class NotEnoughSpaceException : Exception
+    {
+        private readonly string host;
+        private readonly string fileName;
+
+        public DiskSpaceRequirements DiskSpaceRequirements { get; private set; }
+
+        public NotEnoughSpaceException(string host, string fileName)
+        {
+            this.host = host;
+            this.fileName = fileName;
+            DiskSpaceRequirements = null;
+        }
+
+        public NotEnoughSpaceException(string host, string fileName, DiskSpaceRequirements diskSpaceRequirements)
+        {
+            this.host = host;
+            this.fileName = fileName;
+            DiskSpaceRequirements = diskSpaceRequirements;
+        }
+
+        public override string Message
+        {
+            get { return String.Format(Messages.NOT_ENOUGH_SPACE_MESSAGE, host, fileName); }
+        }
+    }
+}
+

--- a/XenModel/Actions/Pool_Patch/CleanupDiskSpaceAction.cs
+++ b/XenModel/Actions/Pool_Patch/CleanupDiskSpaceAction.cs
@@ -1,0 +1,72 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using XenAPI;
+
+
+namespace XenAdmin.Actions
+{
+    public class CleanupDiskSpaceAction : PureAsyncAction
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private readonly Pool_patch excludedPatch;
+
+        public CleanupDiskSpaceAction(Host host, Pool_patch excludedPatch, bool suppressHistory)
+            : base(host.Connection, Messages.ACTION_CLEANUP_DISK_SPACE_TITLE, "", suppressHistory)
+        {
+            if (host == null)
+                throw new NullReferenceException();
+            Host = host;
+            this.excludedPatch = excludedPatch;
+        }
+
+        protected override void Run()
+        {
+            Description = String.Format(Messages.ACTION_CLEANUP_DISK_SPACE_DESCRIPTION, Host.Name);
+            try
+            {
+                var args = new Dictionary<string, string> {{"exclude", excludedPatch.uuid}};
+                Result = Host.call_plugin(Session, Host.opaque_ref, "disk-space", "cleanup_disk_space", args);
+                if (Result.ToLower() == "true")
+                    Description = String.Format(Messages.ACTION_CLEANUP_DISK_SPACE_SUCCESS, Host.Name);
+            }
+            catch (Failure failure)
+            {
+                log.WarnFormat("Plugin call disk-space.cleanup_disk_space() on {0} failed with {1}", Host.Name,
+                               failure.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/XenModel/Actions/Pool_Patch/CleanupDiskSpaceAction.cs
+++ b/XenModel/Actions/Pool_Patch/CleanupDiskSpaceAction.cs
@@ -46,7 +46,7 @@ namespace XenAdmin.Actions
             : base(host.Connection, Messages.ACTION_CLEANUP_DISK_SPACE_TITLE, "", suppressHistory)
         {
             if (host == null)
-                throw new NullReferenceException();
+                throw new ArgumentNullException("host");
             Host = host;
             this.excludedPatch = excludedPatch;
         }

--- a/XenModel/Actions/Pool_Patch/GetDiskSpaceRequirementsAction.cs
+++ b/XenModel/Actions/Pool_Patch/GetDiskSpaceRequirementsAction.cs
@@ -71,7 +71,7 @@ namespace XenAdmin.Actions
             : base(host.Connection, Messages.ACTION_GET_DISK_SPACE_REQUIREMENTS_TITLE, suppressHistory)
         {
             if (host == null)
-                throw new NullReferenceException();
+                throw new ArgumentNullException("host");
             Host = host;
             this.updateName = updateName;
             updateSize = size; 

--- a/XenModel/Actions/Pool_Patch/GetDiskSpaceRequirementsAction.cs
+++ b/XenModel/Actions/Pool_Patch/GetDiskSpaceRequirementsAction.cs
@@ -1,0 +1,174 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using XenAPI;
+
+
+namespace XenAdmin.Actions
+{
+    public class GetDiskSpaceRequirementsAction : PureAsyncAction
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private readonly string updateName;
+        private readonly long updateSize;
+        private readonly Pool_patch currentPatch;
+
+        public DiskSpaceRequirements DiskSpaceRequirements { get; private set; }
+
+        /// <summary>
+        /// This constructor is used to calculate the disk space requirements for installing or uploading a single patch
+        /// </summary>
+        public GetDiskSpaceRequirementsAction(Host host, Pool_patch patch, bool suppressHistory)
+            : this(host, patch.Name, patch.size, suppressHistory)
+        {
+            currentPatch = patch;
+        }
+
+        /// <summary>
+        /// This constructor is used to calculate the disk space requirements for uploading a single update file
+        /// </summary>
+        public GetDiskSpaceRequirementsAction(Host host, string path, bool suppressHistory)
+            : this(host, FileName(path), FileSize(path), suppressHistory)
+        { }
+
+        /// <summary>
+        /// This constructor is used to check disk space for installing or uploading an update of given size
+        /// </summary>
+        public GetDiskSpaceRequirementsAction(Host host, string updateName, long size, bool suppressHistory)
+            : base(host.Connection, Messages.ACTION_GET_DISK_SPACE_REQUIREMENTS_TITLE, suppressHistory)
+        {
+            if (host == null)
+                throw new NullReferenceException();
+            Host = host;
+            this.updateName = updateName;
+            updateSize = size; 
+        }
+
+        private static long FileSize(string path)
+        {
+            FileInfo fileInfo = new FileInfo(path);
+            return fileInfo.Length;
+        }
+
+        private static string FileName(string path)
+        {
+            FileInfo fileInfo = new FileInfo(path);
+            return fileInfo.Name;
+        }
+
+        protected override void Run()
+        {
+            Description = String.Format(Messages.ACTION_GET_DISK_SPACE_REQUIREMENTS_DESCRIPTION, Host.Name);
+
+            long requiredDiskSpace = updateSize;
+            string result;
+
+            // get available disk space
+            long availableDiskSpace = 0;
+            try
+            {
+                result = Host.call_plugin(Session, Host.opaque_ref, "disk-space", "get_avail_host_disk_space", new Dictionary<string, string>());
+                availableDiskSpace = Convert.ToInt64(result);
+            }
+            catch (Failure failure)
+            {
+                log.WarnFormat("Plugin call disk-space.get_avail_host_disk_space on {0} failed with {1}", Host.Name, failure.Message);
+            }
+
+            // get reclaimable disk space (excluding current patch)
+            long reclaimableDiskSpace = 0;
+            try
+            {
+                var args = new Dictionary<string, string>();
+                if (currentPatch != null)
+                    args.Add("exclude", currentPatch.uuid);
+                 result = Host.call_plugin(Session, Host.opaque_ref, "disk-space", "get_reclaimable_disk_space", args);
+                 reclaimableDiskSpace = Convert.ToInt64(result);
+            }
+            catch (Failure failure)
+            {
+                log.WarnFormat("Plugin call disk-space.get_reclaimable_disk_space on {0} failed with {1}", Host.Name, failure.Message);
+            }
+
+            DiskSpaceRequirements = new DiskSpaceRequirements(Host, updateName, requiredDiskSpace, availableDiskSpace, reclaimableDiskSpace);
+
+            log.WarnFormat("Cleanup message: \r\n{0}", DiskSpaceRequirements.GetSpaceRequirementsMessage());
+        }
+    }
+
+
+    public class DiskSpaceRequirements
+    {
+        public readonly Host Host;
+        public readonly string UpdateName;
+        public readonly long RequiredDiskSpace;
+        public readonly long AvailableDiskSpace;
+        public readonly long ReclaimableDiskSpace;
+
+        public DiskSpaceRequirements(Host host, string updateName, long requiredDiskSpace, long availableDiskSpace, long reclaimableDiskSpace)
+        {
+            Host = host;
+            UpdateName = updateName;
+            RequiredDiskSpace = requiredDiskSpace;
+            AvailableDiskSpace = availableDiskSpace;
+            ReclaimableDiskSpace = reclaimableDiskSpace;
+        }
+
+        public bool CanCleanup
+        {
+            get { return RequiredDiskSpace < ReclaimableDiskSpace; }
+        }
+
+        public string GetSpaceRequirementsMessage()
+        {
+            StringBuilder sbMessage = new StringBuilder();
+
+            sbMessage.AppendFormat(Messages.NOT_ENOUGH_SPACE_MESSAGE, Host.Name, UpdateName);
+            sbMessage.AppendLine();
+            sbMessage.AppendLine();
+            sbMessage.AppendFormat(Messages.NOT_ENOUGH_SPACE_MESSAGE_REQUIRED_SPACE, Util.DiskSizeString(RequiredDiskSpace));
+            sbMessage.AppendLine();
+            sbMessage.AppendFormat(Messages.NOT_ENOUGH_SPACE_MESSAGE_AVAILABLE_SPACE, Util.DiskSizeString(AvailableDiskSpace));
+            sbMessage.AppendLine();
+            sbMessage.AppendLine();
+            if (CanCleanup)
+                sbMessage.AppendFormat(Messages.NOT_ENOUGH_SPACE_MESSAGE_CLEANUP, Util.DiskSizeString(ReclaimableDiskSpace));
+            else
+                sbMessage.AppendLine(Messages.NOT_ENOUGH_SPACE_MESSAGE_NOCLEANUP);
+            return sbMessage.ToString();
+        }
+    }
+}

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -349,6 +349,51 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking disk space on {0}.
+        /// </summary>
+        public static string ACTION_CHECK_DISK_SPACE_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("ACTION_CHECK_DISK_SPACE_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check disk space.
+        /// </summary>
+        public static string ACTION_CHECK_DISK_SPACE_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_CHECK_DISK_SPACE_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cleaning up disk space on {0}.
+        /// </summary>
+        public static string ACTION_CLEANUP_DISK_SPACE_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("ACTION_CLEANUP_DISK_SPACE_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully cleaned up disk space on {0}.
+        /// </summary>
+        public static string ACTION_CLEANUP_DISK_SPACE_SUCCESS {
+            get {
+                return ResourceManager.GetString("ACTION_CLEANUP_DISK_SPACE_SUCCESS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clean up disk space.
+        /// </summary>
+        public static string ACTION_CLEANUP_DISK_SPACE_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_CLEANUP_DISK_SPACE_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Creating {0} ....
         /// </summary>
         public static string ACTION_CREATE_BOND_DESCRIPTION {
@@ -894,6 +939,24 @@ namespace XenAdmin {
         public static string ACTION_GET_DATASOURCES {
             get {
                 return ResourceManager.GetString("ACTION_GET_DATASOURCES", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Getting space requirements on {0}.
+        /// </summary>
+        public static string ACTION_GET_DISK_SPACE_REQUIREMENTS_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("ACTION_GET_DISK_SPACE_REQUIREMENTS_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Get space requirements.
+        /// </summary>
+        public static string ACTION_GET_DISK_SPACE_REQUIREMENTS_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_GET_DISK_SPACE_REQUIREMENTS_TITLE", resourceCulture);
             }
         }
         
@@ -23353,6 +23416,51 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is not enough space on &apos;{0}&apos; to upload update &apos;{1}&apos;..
+        /// </summary>
+        public static string NOT_ENOUGH_SPACE_MESSAGE {
+            get {
+                return ResourceManager.GetString("NOT_ENOUGH_SPACE_MESSAGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Space available: {0}.
+        /// </summary>
+        public static string NOT_ENOUGH_SPACE_MESSAGE_AVAILABLE_SPACE {
+            get {
+                return ResourceManager.GetString("NOT_ENOUGH_SPACE_MESSAGE_AVAILABLE_SPACE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XenCenter can free up {0} by removing residual update files. Do you wish to proceed with the cleanup?.
+        /// </summary>
+        public static string NOT_ENOUGH_SPACE_MESSAGE_CLEANUP {
+            get {
+                return ResourceManager.GetString("NOT_ENOUGH_SPACE_MESSAGE_CLEANUP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You need to manually free up more space and try again..
+        /// </summary>
+        public static string NOT_ENOUGH_SPACE_MESSAGE_NOCLEANUP {
+            get {
+                return ResourceManager.GetString("NOT_ENOUGH_SPACE_MESSAGE_NOCLEANUP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Space required: {0}.
+        /// </summary>
+        public static string NOT_ENOUGH_SPACE_MESSAGE_REQUIRED_SPACE {
+            get {
+                return ResourceManager.GetString("NOT_ENOUGH_SPACE_MESSAGE_REQUIRED_SPACE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not in any folder.
         /// </summary>
         public static string NOT_IN_A_FOLDER {
@@ -24107,6 +24215,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &amp;Clean up....
+        /// </summary>
+        public static string PATCHINGWIZARD_CLEANUP {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_CLEANUP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No action required.
         /// </summary>
         public static string PATCHINGWIZARD_MODEPAGE_NOACTION {
@@ -24166,6 +24283,15 @@ namespace XenAdmin {
         public static string PATCHINGWIZARD_MODEPAGE_UNKNOWNACTION {
             get {
                 return ResourceManager.GetString("PATCHINGWIZARD_MODEPAGE_UNKNOWNACTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &amp;More info....
+        /// </summary>
+        public static string PATCHINGWIZARD_MORE_INFO {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_MORE_INFO", resourceCulture);
             }
         }
         
@@ -31807,7 +31933,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Already uploaded to selected server(s).
+        ///   Looks up a localized string similar to Already uploaded.
         /// </summary>
         public static string UPLOAD_PATCH_ALREADY_UPLOADED {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -213,6 +213,21 @@
   <data name="ACTION_CHANGING_SHADOW_MULTIPLIER_FOR" xml:space="preserve">
     <value>Changing shadow multiplier for '{0}'...</value>
   </data>
+  <data name="ACTION_CHECK_DISK_SPACE_DESCRIPTION" xml:space="preserve">
+    <value>Checking disk space on {0}</value>
+  </data>
+  <data name="ACTION_CHECK_DISK_SPACE_TITLE" xml:space="preserve">
+    <value>Check disk space</value>
+  </data>
+  <data name="ACTION_CLEANUP_DISK_SPACE_DESCRIPTION" xml:space="preserve">
+    <value>Cleaning up disk space on {0}</value>
+  </data>
+  <data name="ACTION_CLEANUP_DISK_SPACE_SUCCESS" xml:space="preserve">
+    <value>Successfully cleaned up disk space on {0}</value>
+  </data>
+  <data name="ACTION_CLEANUP_DISK_SPACE_TITLE" xml:space="preserve">
+    <value>Clean up disk space</value>
+  </data>
   <data name="ACTION_CREATE_BOND_DESCRIPTION" xml:space="preserve">
     <value>Creating {0} ...</value>
   </data>
@@ -398,6 +413,12 @@
   </data>
   <data name="ACTION_GET_DATASOURCES" xml:space="preserve">
     <value>Fetch data sources</value>
+  </data>
+  <data name="ACTION_GET_DISK_SPACE_REQUIREMENTS_DESCRIPTION" xml:space="preserve">
+    <value>Getting space requirements on {0}</value>
+  </data>
+  <data name="ACTION_GET_DISK_SPACE_REQUIREMENTS_TITLE" xml:space="preserve">
+    <value>Get space requirements</value>
   </data>
   <data name="ACTION_GET_METADATA_VDIS_DONE" xml:space="preserve">
     <value>Action completed. {0} VDIs found.</value>
@@ -8128,6 +8149,21 @@ It is strongly recommended that you Cancel and apply the latest version of the p
   <data name="NOT_CONTAINS" xml:space="preserve">
     <value>does not contain</value>
   </data>
+  <data name="NOT_ENOUGH_SPACE_MESSAGE" xml:space="preserve">
+    <value>There is not enough space on '{0}' to upload update '{1}'.</value>
+  </data>
+  <data name="NOT_ENOUGH_SPACE_MESSAGE_AVAILABLE_SPACE" xml:space="preserve">
+    <value>Space available: {0}</value>
+  </data>
+  <data name="NOT_ENOUGH_SPACE_MESSAGE_CLEANUP" xml:space="preserve">
+    <value>XenCenter can free up {0} by removing residual update files. Do you wish to proceed with the cleanup?</value>
+  </data>
+  <data name="NOT_ENOUGH_SPACE_MESSAGE_NOCLEANUP" xml:space="preserve">
+    <value>You need to manually free up more space and try again.</value>
+  </data>
+  <data name="NOT_ENOUGH_SPACE_MESSAGE_REQUIRED_SPACE" xml:space="preserve">
+    <value>Space required: {0}</value>
+  </data>
   <data name="NOT_IN_A_FOLDER" xml:space="preserve">
     <value>Not in any folder</value>
   </data>
@@ -8348,6 +8384,9 @@ It is strongly recommended that you Cancel and apply the latest version of the p
   <data name="PASTE" xml:space="preserve">
     <value>Paste</value>
   </data>
+  <data name="PATCHINGWIZARD_CLEANUP" xml:space="preserve">
+    <value>&amp;Clean up...</value>
+  </data>
   <data name="PATCHINGWIZARD_MODEPAGE_NOACTION" xml:space="preserve">
     <value>No action required</value>
   </data>
@@ -8368,6 +8407,9 @@ It is strongly recommended that you Cancel and apply the latest version of the p
   </data>
   <data name="PATCHINGWIZARD_MODEPAGE_UNKNOWNACTION" xml:space="preserve">
     <value>Unknown</value>
+  </data>
+  <data name="PATCHINGWIZARD_MORE_INFO" xml:space="preserve">
+    <value>&amp;More info...</value>
   </data>
   <data name="PATCHINGWIZARD_PATCHINGPAGE_POOL_RESOLVE" xml:space="preserve">
     <value>Resolve pool problems</value>
@@ -11018,7 +11060,7 @@ Do you want to continue?</value>
     <value>Uploading to server '{0}'...</value>
   </data>
   <data name="UPLOAD_PATCH_ALREADY_UPLOADED" xml:space="preserve">
-    <value>Already uploaded to selected server(s)</value>
+    <value>Already uploaded</value>
   </data>
   <data name="UPLOAD_PATCH_DESCRIPTION" xml:space="preserve">
     <value>Uploading...</value>

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -83,6 +83,9 @@
     <Compile Include="Actions\Pool\CreatePoolAction.cs" />
     <Compile Include="Actions\Pool\PoolAction.cs" />
     <Compile Include="Actions\Pool\SetGpuPlacementPolicyAction.cs" />
+    <Compile Include="Actions\Pool_Patch\CheckDiskSpaceForPatchUploadAction.cs" />
+    <Compile Include="Actions\Pool_Patch\CleanupDiskSpaceAction.cs" />
+    <Compile Include="Actions\Pool_Patch\GetDiskSpaceRequirementsAction.cs" />
     <Compile Include="Actions\SupplementalPack\InstallSupplementalPackAction.cs" />
     <Compile Include="Actions\SupplementalPack\UploadSupplementalPackAction.cs" />
     <Compile Include="Actions\Pool_Patch\ApplyPatchAction.cs" />


### PR DESCRIPTION
...In the Install Update Wizard check if there is enough space to upload a hotfix

- Before starting the upload to the master hosts, check if there is enough disk space (check only performed for Cream or greater hosts)
- If enough space available the upload starts automatically; otherwise an error is displayed
- If we can free up enough disk space then we offer the option to Clean up. Otherwise we provide the user with the information on required and available space and the user will have to manually free up required space.

- Also Disable the Upload page for oem updates

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>