### PR TITLE
CP-10929: On the General tab, Update 'Properties' button visibility for ...

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -383,6 +383,7 @@ namespace XenAdmin.TabPages
         public void EnableDisableEdit()
         {
             buttonProperties.Enabled = xenObject != null && !xenObject.Locked && xenObject.Connection != null && xenObject.Connection.IsConnected;
+            buttonProperties.Visible = !(xenObject is DockerContainer);
         }
 
         public void BuildList()
@@ -428,10 +429,7 @@ namespace XenAdmin.TabPages
             else if (xenObject is StorageLinkRepository)
                 base.Text = Messages.SR_GENERAL_TAB_TITLE;
             else if (xenObject is DockerContainer)
-            {
-                buttonProperties.Visible = false;
                 base.Text = Messages.CONTAINER_GENERAL_TAB_TITLE;
-            }
 
             panel2.SuspendLayout();
             // Clear all the data from the sections (visible and non visible)


### PR DESCRIPTION
...all object types

This fixes the following issue: when displaying the General tab of a container, the Properties button is hidden, but not made visible again when switching to another object type (e.g. VM)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>