### PR TITLE
CP-11039: Change VM.CanHaveVGpu to use the new allow-vgpu flag

### DIFF
--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -489,9 +489,37 @@ namespace XenAPI
             }
         }
 
+        /// <summary>Returns true if
+        /// 1) the guest is HVM and
+        ///   2a) the allow-vgpu restriction is absent or
+        ///   2b) the allow-vgpu restriction is non-zero
+        ///</summary>
         public bool CanHaveVGpu
         {
-            get { return CanHaveGpu; }
+            get
+            {
+                if (!IsHVM || !CanHaveGpu)
+                    return false;
+
+                XmlDocument xd = GetRecommendations();
+
+                if (xd == null)
+                    return true;
+
+                try
+                {
+                    XmlNode xn = xd.SelectSingleNode(@"restrictions/restriction[@field='allow-vgpu']");
+                    if (xn == null || xn.Attributes == null)
+                        return true;
+
+                    return
+                        Convert.ToInt32(xn.Attributes["value"].Value) != 0;
+                }
+                catch
+                {
+                    return true;
+                }
+            }
         }
 
         void set_other_config(string key, string value)


### PR DESCRIPTION
-  A VM can have vGPU if it is HVM and the the allow-vgpu restriction is absent or is non-zero
- allow-vgpu is 0 for HVM Linux VMs

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>