### PR TITLE
CA-161097: Pause the automatic refresh on Container processes page when the page is not visible

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1311,6 +1311,7 @@ namespace XenAdmin
             ShowTab(TabPageNetwork, !multi && !SearchMode && (isVMSelected || (isHostSelected && isHostLive) || isPoolSelected));
             ShowTab(TabPageNICs, !multi && !SearchMode && ((isHostSelected && isHostLive)));
             ShowTab(TabPageDockerProcess, !multi && !SearchMode && isDockerContainerSelected);
+            ShowTab(TabPageDockerDetails, !multi && !SearchMode && isDockerContainerSelected);
 
             bool isPoolOrLiveStandaloneHost = isPoolSelected || (isHostSelected && isHostLive && selectionPool == null);
 
@@ -1341,7 +1342,6 @@ namespace XenAdmin
 
             ShowTab(TabPageSearch, true);
 
-            ShowTab(TabPageDockerDetails, !multi && !SearchMode && isDockerContainerSelected);
             // N.B. Change NewTabs definition if you add more tabs here.
 
             // Save and restore focus on treeView, since selecting tabs in ChangeToNewTabs() has the
@@ -1852,7 +1852,7 @@ namespace XenAdmin
                 }
                 else if (t == TabPageDockerProcess)
                 {
-                    DockerProcessPage.DockerContainer = SelectionManager.Selection.First as DockerContainer;
+                    DockerProcessPage.XenObject = SelectionManager.Selection.FirstAsXenObject;
                 }
                 else if (t == TabPageDockerDetails)
                 {
@@ -1874,6 +1874,11 @@ namespace XenAdmin
                 DockerDetailsPage.ResumeRefresh();
             else
                 DockerDetailsPage.PauseRefresh();
+
+            if (t == TabPageDockerProcess)
+                DockerProcessPage.ResumeRefresh();
+            else
+                DockerProcessPage.PauseRefresh();
 
             if (t != null)
                 SetLastSelectedPage(SelectionManager.Selection.First, t);

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1852,11 +1852,11 @@ namespace XenAdmin
                 }
                 else if (t == TabPageDockerProcess)
                 {
-                    DockerProcessPage.XenObject = SelectionManager.Selection.FirstAsXenObject;
+                    DockerProcessPage.Container = SelectionManager.Selection.First as DockerContainer;
                 }
                 else if (t == TabPageDockerDetails)
                 {
-                    DockerDetailsPage.XenObject = SelectionManager.Selection.FirstAsXenObject;
+                    DockerDetailsPage.Container = SelectionManager.Selection.First as DockerContainer;
                 }
             }
 

--- a/XenAdmin/MainWindow.resx
+++ b/XenAdmin/MainWindow.resx
@@ -700,7 +700,7 @@
     <value>0</value>
   </data>
   <data name="TabPageDockerDetails.Text" xml:space="preserve">
-    <value>Detail</value>
+    <value>Details</value>
   </data>
   <data name="&gt;&gt;TabPageDockerDetails.Name" xml:space="preserve">
     <value>TabPageDockerDetails</value>

--- a/XenAdmin/TabPages/DockerDetailsPage.Designer.cs
+++ b/XenAdmin/TabPages/DockerDetailsPage.Designer.cs
@@ -79,7 +79,7 @@ namespace XenAdmin.TabPages
             // 
             // RefreshTimer
             // 
-            this.RefreshTimer.Tick += new System.EventHandler(this.RefreshButton_Click);
+            this.RefreshTimer.Tick += new System.EventHandler(this.RefreshTimer_Tick);
             // 
             // DockerDetailsPage
             // 

--- a/XenAdmin/TabPages/DockerDetailsPage.cs
+++ b/XenAdmin/TabPages/DockerDetailsPage.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using XenAdmin.Actions;
 using XenAPI;
 using XenAdmin.Model;
 using System.Xml;
@@ -41,11 +42,9 @@ namespace XenAdmin.TabPages
 {
     public partial class DockerDetailsPage : BaseTabPage
     {
-        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private const int REFRESH_INTERVAL = 20000;
 
         private IXenObject _xenObject;
-        private DockerContainer _container;
         private VM _vmResideOn;
         private Host _hostResideOn;
         private string _resultCache;
@@ -69,17 +68,43 @@ namespace XenAdmin.TabPages
                     _xenObject = value;
                     if (_xenObject is DockerContainer)
                     {
-                        _container = _xenObject as DockerContainer;
+                        var container = _xenObject as DockerContainer;
 
-                        _vmResideOn = _container.Parent;
+                        _vmResideOn = container.Parent;
                         if (_vmResideOn.resident_on == null || string.IsNullOrEmpty(_vmResideOn.resident_on.opaque_ref) || (_vmResideOn.resident_on.opaque_ref.ToLower().Contains("null")))
                             return;
 
-                        _hostResideOn = _container.Connection.Resolve(_vmResideOn.resident_on);
-                        Rebuild();
+                        _hostResideOn = container.Connection.Resolve(_vmResideOn.resident_on);
+                        RefreshTime.Text = Messages.LAST_REFRESH_IN_PROGRESS;
+                        StartUpdating();
                     }
                 }
             }
+        }
+
+        private void StartUpdating()
+        {
+            var args = new Dictionary<string, string>();
+            args["vmuuid"] = _vmResideOn.uuid;
+            args["object"] = ((DockerContainer)_xenObject).uuid;
+
+            var action = new ExecutePluginAction(_xenObject.Connection, _hostResideOn,
+                        "xscontainer", "get_inspect", args, true);
+
+            action.Completed += action_Completed;
+            action.RunAsync();
+        }
+
+        private void action_Completed(ActionBase sender)
+        {
+            var action = (AsyncAction)sender;
+            Program.Invoke(Program.MainWindow, () =>
+            {
+                if (action.Succeeded)
+                    Rebuild(action.Result);
+                else
+                    ShowInvalidInfo();
+            });
         }
 
         private void CreateTree(XmlNode node, TreeNode rootNode)
@@ -90,8 +115,10 @@ namespace XenAdmin.TabPages
                 rootNode.Text = node.Value;
             else
             {
-                if (node.Name == "SPECIAL_XS_ENCODED_ELEMENT")
+                if (node.Name == "SPECIAL_XS_ENCODED_ELEMENT" && node.Attributes != null)
+                {
                     rootNode.Text = node.Attributes["name"].Value;
+                }
                 else
                     rootNode.Text = node.Name;
             }
@@ -105,55 +132,35 @@ namespace XenAdmin.TabPages
             }
         }
 
-        public void Rebuild()
+        public void Rebuild(string currentResult)
         {
             Program.AssertOnEventThread();
-            if (_xenObject is DockerContainer)
+            RefreshTime.Text = String.Format(Messages.LAST_REFRESH_SUCCESS, DateTime.Now.ToString("HH:mm:ss"));
+            try
             {
-                RefreshTime.Text = String.Format(Messages.LAST_REFRESH_SUCCESS, DateTime.Now.ToString("HH:mm:ss"));
-                try
+                if (_resultCache == currentResult)
+                    return;
+                _resultCache = currentResult;
+                DetailtreeView.Nodes.Clear();
+
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml(currentResult);
+                IEnumerator ienum = doc.GetEnumerator();
+                XmlNode docker_inspect;
+                while (ienum.MoveNext())
                 {
-                    string expectResult = "True";
-                    var args = new Dictionary<string, string>{};
-                    args["vmuuid"] = _vmResideOn.uuid;
-                    args["object"] = _container.uuid;
-                    Session session = _container.Connection.DuplicateSession();
-                    string CurrentResult = XenAPI.Host.call_plugin(session, _hostResideOn.opaque_ref, "xscontainer", "get_inspect", args);
-                    if (_resultCache == CurrentResult)
-                        return;
-                    else
-                        _resultCache = CurrentResult;
-                    DetailtreeView.Nodes.Clear();
-                    if (CurrentResult.StartsWith(expectResult))
+                    docker_inspect = (XmlNode) ienum.Current;
+                    if (docker_inspect.NodeType != XmlNodeType.XmlDeclaration)
                     {
-                        CurrentResult = CurrentResult.Substring(expectResult.Length);
-                        XmlDocument doc = new XmlDocument();
-                        doc.LoadXml(CurrentResult);
-                        IEnumerator ienum = doc.GetEnumerator();
-                        XmlNode docker_inspect;
-                        while (ienum.MoveNext())
-                        {
-                            docker_inspect = (XmlNode)ienum.Current;
-                            if (docker_inspect.NodeType != XmlNodeType.XmlDeclaration)
-                            {
-                                TreeNode rootNode = new TreeNode();
-                                CreateTree(docker_inspect, rootNode);
-                                DetailtreeView.Nodes.Add(rootNode);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        RefreshTime.Text = Messages.LAST_REFRESH_FAIL;
+                        TreeNode rootNode = new TreeNode();
+                        CreateTree(docker_inspect, rootNode);
+                        DetailtreeView.Nodes.Add(rootNode);
                     }
                 }
-                catch (Failure failure)
-                {
-                    RefreshTime.Text = Messages.LAST_REFRESH_FAIL;
-                    log.WarnFormat("Plugin call xscontainer.get_inspect({0}) on {1} failed with {2}", _container.uuid, _hostResideOn.Name,
-                        failure.Message);
-                    throw;
-                }
+            }
+            catch (Failure)
+            {
+                ShowInvalidInfo();
             }
         }
 
@@ -164,9 +171,15 @@ namespace XenAdmin.TabPages
             RefreshTimer.Interval = REFRESH_INTERVAL;
         }
 
+        private void ShowInvalidInfo()
+        {
+            RefreshTime.Text = Messages.LAST_REFRESH_FAIL;
+            DetailtreeView.Nodes.Clear();
+        }
+
         private void RefreshButton_Click(object sender, EventArgs e)
         {
-            Rebuild();
+            StartUpdating();
         }
 
         public void PauseRefresh()
@@ -178,6 +191,5 @@ namespace XenAdmin.TabPages
         {
             RefreshTimer.Enabled = true;
         }
-        
     }
 }

--- a/XenAdmin/TabPages/DockerDetailsPage.resx
+++ b/XenAdmin/TabPages/DockerDetailsPage.resx
@@ -187,7 +187,7 @@
     <value>1</value>
   </data>
   <data name="RefreshButton.Text" xml:space="preserve">
-    <value>Refresh</value>
+    <value>&amp;Refresh</value>
   </data>
   <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
     <value>RefreshButton</value>

--- a/XenAdmin/TabPages/DockerProcessPage.Designer.cs
+++ b/XenAdmin/TabPages/DockerProcessPage.Designer.cs
@@ -14,7 +14,7 @@ namespace XenAdmin.TabPages
         protected override void Dispose(bool disposing)
         {
             // Deregister listeners.
-            DockerContainer = null;
+            xenObject = null;
 
             if (disposing && (components != null))
             {
@@ -48,7 +48,7 @@ namespace XenAdmin.TabPages
             this.ColumnPID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ColumnCommand = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ColumnCPUTime = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.RefreshTimer = new System.Windows.Forms.Timer(this.components);
             this.pageContainerPanel.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.panel1.SuspendLayout();
@@ -123,8 +123,8 @@ namespace XenAdmin.TabPages
             this.panel1.Name = "panel1";
             // 
             // listView1
-            //
-            this.listView1.AllowColumnReorder = true; 
+            // 
+            this.listView1.AllowColumnReorder = true;
             this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.ColumnPID,
             this.ColumnCommand,
@@ -147,10 +147,10 @@ namespace XenAdmin.TabPages
             // 
             resources.ApplyResources(this.ColumnCPUTime, "ColumnCPUTime");
             // 
-            // timer1
+            // RefreshTimer
             // 
-            this.timer1.Interval = 20000;
-            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            this.RefreshTimer.Interval = 20000;
+            this.RefreshTimer.Tick += new System.EventHandler(this.RefreshTimer_Tick);
             // 
             // DockerProcessPage
             // 
@@ -182,7 +182,7 @@ namespace XenAdmin.TabPages
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Label labelRefresh;
-        private System.Windows.Forms.Timer timer1;
+        private System.Windows.Forms.Timer RefreshTimer;
         private XenAdmin.Controls.ListViewEx listView1;
         private System.Windows.Forms.ColumnHeader ColumnPID;
         private System.Windows.Forms.ColumnHeader ColumnCommand;

--- a/XenAdmin/TabPages/DockerProcessPage.Designer.cs
+++ b/XenAdmin/TabPages/DockerProcessPage.Designer.cs
@@ -13,9 +13,6 @@ namespace XenAdmin.TabPages
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            // Deregister listeners.
-            xenObject = null;
-
             if (disposing && (components != null))
             {
                 components.Dispose();

--- a/XenAdmin/TabPages/DockerProcessPage.cs
+++ b/XenAdmin/TabPages/DockerProcessPage.cs
@@ -33,7 +33,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml;
 using System.Windows.Forms;
-
+using XenAdmin.Actions;
 using XenAdmin.Model;
 using XenAdmin.Controls;
 using XenAPI;
@@ -43,11 +43,12 @@ namespace XenAdmin.TabPages
 {
     internal partial class DockerProcessPage : BaseTabPage
     {
+        private const int REFRESH_INTERVAL = 20000;
 
-        private DockerContainer docker = null;
-        private Session session = null;
-        private Dictionary<string, string> args = new Dictionary<string, string>();
-        private string host = null;
+        private IXenObject xenObject;
+        private VM parentVM;
+        private Host host;
+        
         private readonly ListViewColumnSorter lvwColumnSorter = new ListViewColumnSorter();
 
         public DockerProcessPage()
@@ -55,125 +56,132 @@ namespace XenAdmin.TabPages
             InitializeComponent();
             listView1.ListViewItemSorter = lvwColumnSorter;
             base.Text = Messages.DOCKER_PROCESS_TAB_TITLE;
+            RefreshTimer.Interval = REFRESH_INTERVAL;
         }
 
-        public DockerContainer DockerContainer
+        public IXenObject XenObject
         {
             get
             {
-                return docker;
+                Program.AssertOnEventThread();
+                return xenObject;
             }
             set
             {
+                Program.AssertOnEventThread();
                 if (value == null) return;
 
-                if (docker == null || !docker.Equals(value))
+                if (xenObject == null || !xenObject.Equals(value))
                 {
-                    docker = value;
-                    if (docker.Connection == null || docker.Connection.Session == null)
+                    xenObject = value;
+                    if (xenObject.Connection == null || xenObject.Connection.Session == null || !(xenObject is DockerContainer))
                         return;
-                    session = docker.Connection.Session;
-                    host = XenAPI.Session.get_this_host(session, session.uuid);
-                    args["vmuuid"] = docker.Parent.uuid;
-                    args["object"] = docker.name_label;
+
+                    parentVM = ((DockerContainer) xenObject).Parent;
+
+                    if (parentVM == null)
+                        return;
+
+                    host = xenObject.Connection.Resolve(parentVM.resident_on);
+
                     listView1.Items.Clear();
                     labelRefresh.Text = Messages.LAST_REFRESH_IN_PROGRESS;
-                    // Set timer to 10ms to make the empty form shown promptly and
-                    // then fill the form with the contents retrieved from XenServer.
-                    timer1.Interval = 10;
-                    timer1.Enabled = true;
+                    StartUpdating();
                 }
             }
         }
 
-        private void updateList()
+        private void StartUpdating()
         {
-            bool getResult = false;
-            string value = "";
+            var args = new Dictionary<string, string>();
+            args["vmuuid"] = parentVM.uuid;
+            args["object"] = xenObject.Name;
+
+            var action = new ExecutePluginAction(xenObject.Connection, host,
+                        "xscontainer", "get_top", args, true); 
+
+            action.Completed += action_Completed;
+            action.RunAsync();
+        }
+
+        private void action_Completed(ActionBase sender)
+        {
+            var action = (AsyncAction)sender;
+            Program.Invoke(Program.MainWindow, () =>
+            {
+                if (action.Succeeded)
+                    UpdateList(action.Result);
+                else
+                    ShowInvalidInfo();
+            });
+        }
+
+        private void UpdateList(string xmlResult)
+        {
+            // Parse the XML result
+            XmlDocument xmlDoc = new XmlDocument();
             try
             {
-                // call plugin "xscontainer" with fn "get_top"
-                value = Host.call_plugin(session, host, "xscontainer", "get_top", args);
-                getResult = value.ToLower().StartsWith("true");
+                xmlDoc.LoadXml(xmlResult);
             }
-            catch (Failure)
+            catch (Exception)
             {
-                // Could not retrieve process info.
-                showInvalidInfo();
+                ShowInvalidInfo();
                 return;
             }
 
-            if (getResult)
+            string pid = "";
+            string command = "";
+            string cpuTime = "";
+            string[] row = { "", "", "" };
+            try
             {
-                // Parse the XML result
-                XmlDocument xmlDoc = new System.Xml.XmlDocument();
-                try
+                listView1.SuspendLayout();
+                listView1.Items.Clear();
+                XmlNodeList processList = xmlDoc.GetElementsByTagName("Process");
+                foreach (XmlNode process in processList)
                 {
-                    xmlDoc.LoadXml(value.Substring(4));
-                }
-                catch (Exception)
-                {
-                    showInvalidInfo();
-                    return;
-                }
-
-                string pid = "";
-                string command = "";
-                string cpuTime = "";
-                string[] row = { "", "", "" };
-                try
-                {
-                    listView1.SuspendLayout();
-                    listView1.Items.Clear();
-                    XmlNodeList processList = xmlDoc.GetElementsByTagName("Process");
-                    foreach (XmlNode process in processList)
+                    if (process.HasChildNodes)
                     {
-                        if (process.HasChildNodes)
+                        foreach (XmlNode child in process.ChildNodes)
                         {
-                            foreach (XmlNode child in process.ChildNodes)
-                            {
-                                XmlNode v = child.FirstChild;
-                                if (child.Name.Equals("PID"))
-                                    pid = v.Value;
-                                else if (child.Name.Equals("CMD"))
-                                    command = v.Value;
-                                else if (child.Name.Equals("TIME"))
-                                    cpuTime = v.Value;
-                            }
-
-                            row[0] = pid;
-                            row[1] = command;
-                            row[2] = cpuTime;
+                            XmlNode v = child.FirstChild;
+                            if (child.Name.Equals("PID"))
+                                pid = v.Value;
+                            else if (child.Name.Equals("CMD"))
+                                command = v.Value;
+                            else if (child.Name.Equals("TIME"))
+                                cpuTime = v.Value;
                         }
-                        listView1.Items.Add(new ListViewItem(row));
+
+                        row[0] = pid;
+                        row[1] = command;
+                        row[2] = cpuTime;
                     }
+                    listView1.Items.Add(new ListViewItem(row));
                 }
-                finally
-                {
-                    listView1.ResumeLayout();
-                    labelRefresh.Text = string.Format(Messages.LAST_REFRESH_SUCCESS, DateTime.Now.ToString("HH:mm:ss"));
-                }
-
             }
-
+            finally
+            {
+                listView1.ResumeLayout();
+                labelRefresh.Text = string.Format(Messages.LAST_REFRESH_SUCCESS, DateTime.Now.ToString("HH:mm:ss"));
+            }
         }
 
         private void RefreshButton_Click(object sender, EventArgs e)
         {
-            updateList();
+            StartUpdating();
         }
 
-        private void showInvalidInfo()
+        private void ShowInvalidInfo()
         {
             labelRefresh.Text = Messages.LAST_REFRESH_FAIL;
             listView1.Items.Clear();
         }
 
-        private void timer1_Tick(object sender, EventArgs e)
+        private void RefreshTimer_Tick(object sender, EventArgs e)
         {
-            // Set timer to 20s as the interval to refresh the processes' info.
-            timer1.Interval = 1000 * 20;
-            updateList();
+            StartUpdating();
         }
 
         // Sort by column. Refer to the implementation of PhysicalStoragePage.
@@ -200,6 +208,16 @@ namespace XenAdmin.TabPages
             }
 
             listView1.Sort();
+        }
+
+        public void PauseRefresh()
+        {
+            RefreshTimer.Enabled = false;
+        }
+
+        public void ResumeRefresh()
+        {
+            RefreshTimer.Enabled = true;
         }
     }
 }

--- a/XenAdmin/TabPages/DockerProcessPage.resx
+++ b/XenAdmin/TabPages/DockerProcessPage.resx
@@ -117,159 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="ColumnPID.Text" xml:space="preserve">
-    <value>Process ID</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ColumnPID.Width" type="System.Int32, mscorlib">
-    <value>74</value>
-  </data>
-  <data name="ColumnCommand.Text" xml:space="preserve">
-    <value>Command</value>
-  </data>
-  <data name="ColumnCommand.Width" type="System.Int32, mscorlib">
-    <value>479</value>
-  </data>
-  <data name="ColumnCPUTime.Text" xml:space="preserve">
-    <value>CPU Time Consumed</value>
-  </data>
-  <data name="ColumnCPUTime.Width" type="System.Int32, mscorlib">
-    <value>139</value>
-  </data>
-  <data name="listView1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="listView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="listView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 267</value>
-  </data>
-  <data name="listView1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;listView1.Name" xml:space="preserve">
-    <value>listView1</value>
-  </data>
-  <data name="&gt;&gt;listView1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ListViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;listView1.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;listView1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="RefreshButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="RefreshButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 5</value>
-  </data>
-  <data name="RefreshButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="RefreshButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="RefreshButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="RefreshButton.Text" xml:space="preserve">
-    <value>&amp;Refresh...</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
-    <value>RefreshButton</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="labelRefresh.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="labelRefresh.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelRefresh.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelRefresh.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 10</value>
-  </data>
-  <data name="labelRefresh.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="labelRefresh.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="labelRefresh.Text" xml:space="preserve">
-    <value>Last refresh: </value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Name" xml:space="preserve">
-    <value>labelRefresh</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 267</value>
-  </data>
-  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 34</value>
-  </data>
-  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 33</value>
-  </data>
-  <data name="panel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>900, 400</value>
-  </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 301</value>
-  </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
   <data name="&gt;&gt;panel1.Name" xml:space="preserve">
     <value>panel1</value>
   </data>
@@ -281,27 +128,6 @@
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 11.25pt</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 10</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 20</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Processes</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -315,6 +141,7 @@
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 78</value>
   </data>
@@ -333,9 +160,11 @@
   <data name="&gt;&gt;pageContainerPanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -426,6 +255,156 @@
   <data name="&gt;&gt;label7.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="RefreshButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="RefreshButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 5</value>
+  </data>
+  <data name="RefreshButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="RefreshButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 23</value>
+  </data>
+  <data name="RefreshButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="RefreshButton.Text" xml:space="preserve">
+    <value>&amp;Refresh...</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
+    <value>RefreshButton</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
+    <value>RefreshButton</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Name" xml:space="preserve">
+    <value>labelRefresh</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 267</value>
+  </data>
+  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 0</value>
+  </data>
+  <data name="flowLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 0</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>897, 34</value>
+  </data>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelRefresh.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="labelRefresh.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelRefresh.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelRefresh.Location" type="System.Drawing.Point, System.Drawing">
+    <value>111, 10</value>
+  </data>
+  <data name="labelRefresh.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 13</value>
+  </data>
+  <data name="labelRefresh.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelRefresh.Text" xml:space="preserve">
+    <value>Last refresh: </value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Name" xml:space="preserve">
+    <value>labelRefresh</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 11.25pt</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 10</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 20</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Processes</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>pageContainerPanel</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="TitleLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -459,7 +438,76 @@
   <data name="&gt;&gt;TitleLabel.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="listView1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="listView1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>897, 267</value>
+  </data>
+  <data name="listView1.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;listView1.Name" xml:space="preserve">
+    <value>listView1</value>
+  </data>
+  <data name="&gt;&gt;listView1.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ListViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;listView1.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;listView1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 33</value>
+  </data>
+  <data name="panel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 400</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>897, 301</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>pageContainerPanel</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ColumnPID.Text" xml:space="preserve">
+    <value>Process ID</value>
+  </data>
+  <data name="ColumnPID.Width" type="System.Int32, mscorlib">
+    <value>74</value>
+  </data>
+  <data name="ColumnCommand.Text" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="ColumnCommand.Width" type="System.Int32, mscorlib">
+    <value>479</value>
+  </data>
+  <data name="ColumnCPUTime.Text" xml:space="preserve">
+    <value>CPU Time Consumed</value>
+  </data>
+  <data name="ColumnCPUTime.Width" type="System.Int32, mscorlib">
+    <value>139</value>
+  </data>
+  <metadata name="RefreshTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -495,10 +543,10 @@
   <data name="&gt;&gt;ColumnCPUTime.Type" xml:space="preserve">
     <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;timer1.Name" xml:space="preserve">
-    <value>timer1</value>
+  <data name="&gt;&gt;RefreshTimer.Name" xml:space="preserve">
+    <value>RefreshTimer</value>
   </data>
-  <data name="&gt;&gt;timer1.Type" xml:space="preserve">
+  <data name="&gt;&gt;RefreshTimer.Type" xml:space="preserve">
     <value>System.Windows.Forms.Timer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/XenAdmin/TabPages/DockerProcessPage.resx
+++ b/XenAdmin/TabPages/DockerProcessPage.resx
@@ -117,6 +117,159 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="ColumnPID.Text" xml:space="preserve">
+    <value>Process ID</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ColumnPID.Width" type="System.Int32, mscorlib">
+    <value>74</value>
+  </data>
+  <data name="ColumnCommand.Text" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="ColumnCommand.Width" type="System.Int32, mscorlib">
+    <value>479</value>
+  </data>
+  <data name="ColumnCPUTime.Text" xml:space="preserve">
+    <value>CPU Time Consumed</value>
+  </data>
+  <data name="ColumnCPUTime.Width" type="System.Int32, mscorlib">
+    <value>139</value>
+  </data>
+  <data name="listView1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="listView1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>897, 267</value>
+  </data>
+  <data name="listView1.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;listView1.Name" xml:space="preserve">
+    <value>listView1</value>
+  </data>
+  <data name="&gt;&gt;listView1.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ListViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;listView1.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;listView1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="RefreshButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="RefreshButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 5</value>
+  </data>
+  <data name="RefreshButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="RefreshButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 23</value>
+  </data>
+  <data name="RefreshButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="RefreshButton.Text" xml:space="preserve">
+    <value>&amp;Refresh</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
+    <value>RefreshButton</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelRefresh.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="labelRefresh.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelRefresh.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelRefresh.Location" type="System.Drawing.Point, System.Drawing">
+    <value>83, 10</value>
+  </data>
+  <data name="labelRefresh.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 13</value>
+  </data>
+  <data name="labelRefresh.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelRefresh.Text" xml:space="preserve">
+    <value>Last refresh: </value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Name" xml:space="preserve">
+    <value>labelRefresh</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelRefresh.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 267</value>
+  </data>
+  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 0</value>
+  </data>
+  <data name="flowLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 0</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>897, 34</value>
+  </data>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 33</value>
+  </data>
+  <data name="panel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 400</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>897, 301</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <data name="&gt;&gt;panel1.Name" xml:space="preserve">
     <value>panel1</value>
   </data>
@@ -128,6 +281,27 @@
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 11.25pt</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 10</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 20</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Processes</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -141,7 +315,6 @@
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 78</value>
   </data>
@@ -160,11 +333,9 @@
   <data name="&gt;&gt;pageContainerPanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -255,156 +426,6 @@
   <data name="&gt;&gt;label7.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="RefreshButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="RefreshButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 5</value>
-  </data>
-  <data name="RefreshButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="RefreshButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="RefreshButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="RefreshButton.Text" xml:space="preserve">
-    <value>&amp;Refresh...</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
-    <value>RefreshButton</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
-    <value>RefreshButton</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Name" xml:space="preserve">
-    <value>labelRefresh</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 267</value>
-  </data>
-  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 34</value>
-  </data>
-  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="labelRefresh.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="labelRefresh.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelRefresh.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelRefresh.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 10</value>
-  </data>
-  <data name="labelRefresh.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="labelRefresh.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="labelRefresh.Text" xml:space="preserve">
-    <value>Last refresh: </value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Name" xml:space="preserve">
-    <value>labelRefresh</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelRefresh.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 11.25pt</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 10</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 20</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Processes</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>pageContainerPanel</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="TitleLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -437,75 +458,6 @@
   </data>
   <data name="&gt;&gt;TitleLabel.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="listView1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="listView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="listView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 267</value>
-  </data>
-  <data name="listView1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;listView1.Name" xml:space="preserve">
-    <value>listView1</value>
-  </data>
-  <data name="&gt;&gt;listView1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ListViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;listView1.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;listView1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 33</value>
-  </data>
-  <data name="panel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>900, 400</value>
-  </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 301</value>
-  </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
-    <value>pageContainerPanel</value>
-  </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ColumnPID.Text" xml:space="preserve">
-    <value>Process ID</value>
-  </data>
-  <data name="ColumnPID.Width" type="System.Int32, mscorlib">
-    <value>74</value>
-  </data>
-  <data name="ColumnCommand.Text" xml:space="preserve">
-    <value>Command</value>
-  </data>
-  <data name="ColumnCommand.Width" type="System.Int32, mscorlib">
-    <value>479</value>
-  </data>
-  <data name="ColumnCPUTime.Text" xml:space="preserve">
-    <value>CPU Time Consumed</value>
-  </data>
-  <data name="ColumnCPUTime.Width" type="System.Int32, mscorlib">
-    <value>139</value>
   </data>
   <metadata name="RefreshTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1519,7 +1519,7 @@ namespace XenAdmin.TabPages
 
         private void addStringEntry(PDSection s, string key, string value)
         {
-            s.AddEntry(key, value.Length != 0 ? value : Messages.NONE);
+            s.AddEntry(key, string.IsNullOrEmpty(value) ? Messages.NONE : value);
         }
 
         private void generateDockerInfoBox()

--- a/XenModel/Actions/DockerContainer/ExecuteContainerPluginAction.cs
+++ b/XenModel/Actions/DockerContainer/ExecuteContainerPluginAction.cs
@@ -1,0 +1,49 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using XenAdmin.Model;
+using XenAPI;
+
+
+namespace XenAdmin.Actions
+{
+    public class ExecuteContainerPluginAction : ExecutePluginAction
+    {
+        public DockerContainer Container;
+
+        public ExecuteContainerPluginAction(DockerContainer container, Host host, string plugin, string function, Dictionary<string, string> args, bool suppressHistory)
+            : base(container.Connection, host, plugin, function, args, suppressHistory)
+        {
+            Container = container;
+        }
+    }
+}

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Actions\Action.cs" />
     <Compile Include="Actions\CancellingAction.cs" />
     <Compile Include="Actions\DockerContainer\DockerContainerLifetimeAction.cs" />
+    <Compile Include="Actions\DockerContainer\ExecuteContainerPluginAction.cs" />
     <Compile Include="Actions\DockerContainer\VMEnlightenmentAction.cs" />
     <Compile Include="Actions\DR\GetMetadataVDIsAction.cs" />
     <Compile Include="Actions\DR\DrTaskCreateAction.cs" />


### PR DESCRIPTION

- Instead of calling the plugin on the UI thread, we call it through an action that we execute asynchronously  and on completion update the UI.
- Pause the refresh timer on leaving the page and resume it when entering the page again.
- We do this for both Processes and Details page.

Also fixing a Null reference exception on General tab.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>