### PR TITLE
CP-10772: Display the read caching status

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.Designer.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.Designer.cs
@@ -36,8 +36,12 @@ namespace XenAdmin.TabPages
             this.linkLabelExpand = new System.Windows.Forms.LinkLabel();
             this.linkLabelCollapse = new System.Windows.Forms.LinkLabel();
             this.panel2 = new XenAdmin.Controls.PanelNoFocusScroll();
+            this.panelReadCaching = new System.Windows.Forms.Panel();
+            this.pdSectionReadCaching = new XenAdmin.Controls.PDSection();
             this.panelDockerInfo = new System.Windows.Forms.Panel();
             this.pdSectionDockerInfo = new XenAdmin.Controls.PDSection();
+            this.panelDockerVersion = new System.Windows.Forms.Panel();
+            this.pdSectionDockerVersion = new XenAdmin.Controls.PDSection();
             this.panelStorageLinkSystemCapabilities = new System.Windows.Forms.Panel();
             this.pdSectionStorageLinkSystemCapabilities = new XenAdmin.Controls.PDSection();
             this.panelMultipathBoot = new System.Windows.Forms.Panel();
@@ -70,13 +74,13 @@ namespace XenAdmin.TabPages
             this.pdSectionCustomFields = new XenAdmin.Controls.PDSection();
             this.panelGeneral = new System.Windows.Forms.Panel();
             this.pdSectionGeneral = new XenAdmin.Controls.PDSection();
-            this.panelDockerVersion = new System.Windows.Forms.Panel();
-            this.pdSectionDockerVersion = new XenAdmin.Controls.PDSection();
             this.pageContainerPanel.SuspendLayout();
             this.panel1.SuspendLayout();
             this.panel3.SuspendLayout();
             this.panel2.SuspendLayout();
+            this.panelReadCaching.SuspendLayout();
             this.panelDockerInfo.SuspendLayout();
+            this.panelDockerVersion.SuspendLayout();
             this.panelStorageLinkSystemCapabilities.SuspendLayout();
             this.panelMultipathBoot.SuspendLayout();
             this.panelStorageLink.SuspendLayout();
@@ -93,7 +97,6 @@ namespace XenAdmin.TabPages
             this.panelManagementInterfaces.SuspendLayout();
             this.panelCustomFields.SuspendLayout();
             this.panelGeneral.SuspendLayout();
-            this.panelDockerVersion.SuspendLayout();
             this.SuspendLayout();
             // 
             // pageContainerPanel
@@ -140,6 +143,7 @@ namespace XenAdmin.TabPages
             // panel2
             // 
             resources.ApplyResources(this.panel2, "panel2");
+            this.panel2.Controls.Add(this.panelReadCaching);
             this.panel2.Controls.Add(this.panelDockerInfo);
             this.panel2.Controls.Add(this.panelDockerVersion);
             this.panel2.Controls.Add(this.panelStorageLinkSystemCapabilities);
@@ -160,6 +164,20 @@ namespace XenAdmin.TabPages
             this.panel2.Controls.Add(this.panelGeneral);
             this.panel2.Name = "panel2";
             // 
+            // panelReadCaching
+            // 
+            resources.ApplyResources(this.panelReadCaching, "panelReadCaching");
+            this.panelReadCaching.Controls.Add(this.pdSectionReadCaching);
+            this.panelReadCaching.Name = "panelReadCaching";
+            // 
+            // pdSectionReadCaching
+            // 
+            this.pdSectionReadCaching.BackColor = System.Drawing.Color.Gainsboro;
+            resources.ApplyResources(this.pdSectionReadCaching, "pdSectionReadCaching");
+            this.pdSectionReadCaching.Name = "pdSectionReadCaching";
+            this.pdSectionReadCaching.ShowCellToolTips = false;
+            this.pdSectionReadCaching.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.s_ExpandedEventHandler);
+            // 
             // panelDockerInfo
             // 
             resources.ApplyResources(this.panelDockerInfo, "panelDockerInfo");
@@ -172,6 +190,19 @@ namespace XenAdmin.TabPages
             resources.ApplyResources(this.pdSectionDockerInfo, "pdSectionDockerInfo");
             this.pdSectionDockerInfo.Name = "pdSectionDockerInfo";
             this.pdSectionDockerInfo.ShowCellToolTips = false;
+            // 
+            // panelDockerVersion
+            // 
+            resources.ApplyResources(this.panelDockerVersion, "panelDockerVersion");
+            this.panelDockerVersion.Controls.Add(this.pdSectionDockerVersion);
+            this.panelDockerVersion.Name = "panelDockerVersion";
+            // 
+            // pdSectionDockerVersion
+            // 
+            this.pdSectionDockerVersion.BackColor = System.Drawing.Color.Gainsboro;
+            resources.ApplyResources(this.pdSectionDockerVersion, "pdSectionDockerVersion");
+            this.pdSectionDockerVersion.Name = "pdSectionDockerVersion";
+            this.pdSectionDockerVersion.ShowCellToolTips = false;
             // 
             // panelStorageLinkSystemCapabilities
             // 
@@ -395,19 +426,6 @@ namespace XenAdmin.TabPages
             this.pdSectionGeneral.ShowCellToolTips = false;
             this.pdSectionGeneral.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.s_ExpandedEventHandler);
             // 
-            // panelDockerVersion
-            // 
-            resources.ApplyResources(this.panelDockerVersion, "panelDockerVersion");
-            this.panelDockerVersion.Controls.Add(this.pdSectionDockerVersion);
-            this.panelDockerVersion.Name = "panelDockerVersion";
-            // 
-            // pdSectionDockerVersion
-            // 
-            this.pdSectionDockerVersion.BackColor = System.Drawing.Color.Gainsboro;
-            resources.ApplyResources(this.pdSectionDockerVersion, "pdSectionDockerVersion");
-            this.pdSectionDockerVersion.Name = "pdSectionDockerVersion";
-            this.pdSectionDockerVersion.ShowCellToolTips = false;
-            // 
             // GeneralTabPage
             // 
             resources.ApplyResources(this, "$this");
@@ -420,7 +438,9 @@ namespace XenAdmin.TabPages
             this.panel3.PerformLayout();
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
+            this.panelReadCaching.ResumeLayout(false);
             this.panelDockerInfo.ResumeLayout(false);
+            this.panelDockerVersion.ResumeLayout(false);
             this.panelStorageLinkSystemCapabilities.ResumeLayout(false);
             this.panelMultipathBoot.ResumeLayout(false);
             this.panelStorageLink.ResumeLayout(false);
@@ -437,7 +457,6 @@ namespace XenAdmin.TabPages
             this.panelManagementInterfaces.ResumeLayout(false);
             this.panelCustomFields.ResumeLayout(false);
             this.panelGeneral.ResumeLayout(false);
-            this.panelDockerVersion.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -487,5 +506,7 @@ namespace XenAdmin.TabPages
         private System.Windows.Forms.Panel panelDockerVersion;
         private Controls.PDSection pdSectionDockerVersion;
         private Controls.PDSection pdSectionDockerInfo;
+        private System.Windows.Forms.Panel panelReadCaching;
+        private Controls.PDSection pdSectionReadCaching;
     }
 }

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -469,6 +469,7 @@ namespace XenAdmin.TabPages
                 generateVCPUsBox();
                 generateDockerInfoBox();
                 generateDockerVersionBox();
+                generateReadCachingBox();
             }
 
             // hide all the sections which haven't been populated, those that have make sure are visible
@@ -1373,6 +1374,27 @@ namespace XenAdmin.TabPages
                 s.AddEntry(Messages.CONTAINER_COMMAND, dockerContainer.command.Length != 0 ? dockerContainer.command : Messages.NONE);
                 s.AddEntry(Messages.CONTAINER_PORTS, dockerContainer.ports.Length != 0 ? dockerContainer.ports : Messages.NONE);
                 s.AddEntry(Messages.UUID, dockerContainer.uuid.Length != 0 ? dockerContainer.uuid : Messages.NONE);
+            }
+        }
+
+        private void generateReadCachingBox()
+        {
+            VM vm = xenObject as VM;
+            if (vm == null || !vm.IsRunning || !Helpers.CreamOrGreater(vm.Connection))
+                return;
+
+            PDSection s = pdSectionReadCaching;
+
+            if (vm.ReadCachingEnabled)
+            {
+                s.AddEntry(FriendlyName("VM.read_caching_status"), Messages.VM_READ_CACHING_ENABLED);
+                var vdiList = vm.ReadCachingVDIs.Select(vdi => vdi.NameWithLocation).ToArray();
+                s.AddEntry(FriendlyName("VM.read_caching_disks"), string.Join("\n", vdiList));
+            }
+            else
+            {
+                s.AddEntry(FriendlyName("VM.read_caching_status"), Messages.VM_READ_CACHING_DISABLED);
+                s.AddEntry(FriendlyName("VM.read_caching_reason"), vm.ReadCachingDisabledReason);
             }
         }
 

--- a/XenAdmin/TabPages/GeneralTabPage.resx
+++ b/XenAdmin/TabPages/GeneralTabPage.resx
@@ -125,6 +125,205 @@
   <data name="panel2.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="panelReadCaching.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelReadCaching.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionReadCaching.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pdSectionReadCaching.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionReadCaching.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionReadCaching.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionReadCaching.SectionTitle" xml:space="preserve">
+    <value>Read Caching</value>
+  </data>
+  <data name="pdSectionReadCaching.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 34</value>
+  </data>
+  <data name="pdSectionReadCaching.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionReadCaching.Name" xml:space="preserve">
+    <value>pdSectionReadCaching</value>
+  </data>
+  <data name="&gt;&gt;pdSectionReadCaching.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionReadCaching.Parent" xml:space="preserve">
+    <value>panelReadCaching</value>
+  </data>
+  <data name="&gt;&gt;pdSectionReadCaching.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelReadCaching.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelReadCaching.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 792</value>
+  </data>
+  <data name="panelReadCaching.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelReadCaching.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 44</value>
+  </data>
+  <data name="panelReadCaching.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;panelReadCaching.Name" xml:space="preserve">
+    <value>panelReadCaching</value>
+  </data>
+  <data name="&gt;&gt;panelReadCaching.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelReadCaching.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelReadCaching.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelDockerInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelDockerInfo.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionDockerInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pdSectionDockerInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionDockerInfo.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionDockerInfo.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionDockerInfo.SectionTitle" xml:space="preserve">
+    <value>Docker Information</value>
+  </data>
+  <data name="pdSectionDockerInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 34</value>
+  </data>
+  <data name="pdSectionDockerInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerInfo.Name" xml:space="preserve">
+    <value>pdSectionDockerInfo</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerInfo.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerInfo.Parent" xml:space="preserve">
+    <value>panelDockerInfo</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerInfo.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelDockerInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelDockerInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 748</value>
+  </data>
+  <data name="panelDockerInfo.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelDockerInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 44</value>
+  </data>
+  <data name="panelDockerInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;panelDockerInfo.Name" xml:space="preserve">
+    <value>panelDockerInfo</value>
+  </data>
+  <data name="&gt;&gt;panelDockerInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelDockerInfo.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelDockerInfo.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelDockerVersion.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelDockerVersion.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionDockerVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pdSectionDockerVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionDockerVersion.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionDockerVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionDockerVersion.SectionTitle" xml:space="preserve">
+    <value>Docker Version</value>
+  </data>
+  <data name="pdSectionDockerVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 34</value>
+  </data>
+  <data name="pdSectionDockerVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerVersion.Name" xml:space="preserve">
+    <value>pdSectionDockerVersion</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerVersion.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerVersion.Parent" xml:space="preserve">
+    <value>panelDockerVersion</value>
+  </data>
+  <data name="&gt;&gt;pdSectionDockerVersion.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelDockerVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelDockerVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 704</value>
+  </data>
+  <data name="panelDockerVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelDockerVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 44</value>
+  </data>
+  <data name="panelDockerVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;panelDockerVersion.Name" xml:space="preserve">
+    <value>panelDockerVersion</value>
+  </data>
+  <data name="&gt;&gt;panelDockerVersion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelDockerVersion.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelDockerVersion.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="panelStorageLinkSystemCapabilities.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -134,7 +333,6 @@
   <data name="pdSectionStorageLinkSystemCapabilities.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pdSectionStorageLinkSystemCapabilities.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
@@ -148,7 +346,7 @@
     <value>Capabilities</value>
   </data>
   <data name="pdSectionStorageLinkSystemCapabilities.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionStorageLinkSystemCapabilities.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -175,7 +373,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelStorageLinkSystemCapabilities.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelStorageLinkSystemCapabilities.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -190,7 +388,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelStorageLinkSystemCapabilities.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="panelMultipathBoot.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -214,7 +412,7 @@
     <value>Root Disk Multipathing</value>
   </data>
   <data name="pdSectionMultipathBoot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionMultipathBoot.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -241,7 +439,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMultipathBoot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelMultipathBoot.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -256,7 +454,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelMultipathBoot.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="panelStorageLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -280,7 +478,7 @@
     <value>StorageLink</value>
   </data>
   <data name="pdStorageLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdStorageLink.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -307,7 +505,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelStorageLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelStorageLink.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -322,7 +520,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelStorageLink.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="panelUpdates.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -346,7 +544,7 @@
     <value>Updates</value>
   </data>
   <data name="pdSectionUpdates.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionUpdates.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -373,7 +571,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelUpdates.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelUpdates.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -388,7 +586,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelUpdates.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="panelMemoryAndVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -412,7 +610,7 @@
     <value>CPUs</value>
   </data>
   <data name="pdSectionVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionVCPUs.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -439,7 +637,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMemoryAndVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelMemoryAndVCPUs.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -454,7 +652,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelMemoryAndVCPUs.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
   </data>
   <data name="panelMultipathing.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -478,7 +676,7 @@
     <value>Multipathing</value>
   </data>
   <data name="pdSectionMultipathing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionMultipathing.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -505,7 +703,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMultipathing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelMultipathing.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -520,7 +718,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelMultipathing.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="panelStatus.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -544,7 +742,7 @@
     <value>Status</value>
   </data>
   <data name="pdSectionStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionStatus.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -571,7 +769,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelStatus.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -586,7 +784,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelStatus.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="panelHighAvailability.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -610,7 +808,7 @@
     <value>High Availability</value>
   </data>
   <data name="pdSectionHighAvailability.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionHighAvailability.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -637,7 +835,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelHighAvailability.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelHighAvailability.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -652,7 +850,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelHighAvailability.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="panelBootOptions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -676,7 +874,7 @@
     <value>Boot Options</value>
   </data>
   <data name="pdSectionBootOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionBootOptions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -703,7 +901,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelBootOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelBootOptions.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -718,7 +916,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelBootOptions.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="panelCPU.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -742,7 +940,7 @@
     <value>CPUs</value>
   </data>
   <data name="pdSectionCPU.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionCPU.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -769,7 +967,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelCPU.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelCPU.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -784,7 +982,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelCPU.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>12</value>
   </data>
   <data name="panelLicense.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -808,7 +1006,7 @@
     <value>License Details</value>
   </data>
   <data name="pdSectionLicense.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionLicense.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -835,7 +1033,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelLicense.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelLicense.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -850,7 +1048,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelLicense.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>13</value>
   </data>
   <data name="panelVersion.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -874,7 +1072,7 @@
     <value>Version Details</value>
   </data>
   <data name="pdSectionVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionVersion.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -901,7 +1099,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelVersion.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -916,7 +1114,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelVersion.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>14</value>
   </data>
   <data name="panelMemory.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -940,7 +1138,7 @@
     <value>Memory</value>
   </data>
   <data name="pdSectionMemory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionMemory.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -967,7 +1165,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMemory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelMemory.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -982,7 +1180,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelMemory.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="panelManagementInterfaces.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1006,7 +1204,7 @@
     <value>Management Interfaces</value>
   </data>
   <data name="pdSectionManagementInterfaces.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionManagementInterfaces.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1033,7 +1231,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelManagementInterfaces.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelManagementInterfaces.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1048,7 +1246,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelManagementInterfaces.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>16</value>
   </data>
   <data name="panelCustomFields.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1072,7 +1270,7 @@
     <value>Custom Fields</value>
   </data>
   <data name="pdSectionCustomFields.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionCustomFields.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1099,7 +1297,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelCustomFields.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelCustomFields.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1114,7 +1312,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelCustomFields.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>17</value>
   </data>
   <data name="panelGeneral.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1138,7 +1336,7 @@
     <value>General</value>
   </data>
   <data name="pdSectionGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
+    <value>712, 34</value>
   </data>
   <data name="pdSectionGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1165,7 +1363,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
+    <value>712, 44</value>
   </data>
   <data name="panelGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1180,7 +1378,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelGeneral.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>18</value>
   </data>
   <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 39</value>
@@ -1376,139 +1574,6 @@
   </data>
   <data name="&gt;&gt;pageContainerPanel.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="panelDockerVersion.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panelDockerVersion.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="pdSectionDockerVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="pdSectionDockerVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 5</value>
-  </data>
-  <data name="pdSectionDockerVersion.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 34</value>
-  </data>
-  <data name="pdSectionDockerVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>1, 1, 1, 1</value>
-  </data>
-  <data name="pdSectionDockerVersion.SectionTitle" xml:space="preserve">
-    <value>Docker Version</value>
-  </data>
-  <data name="pdSectionDockerVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
-  </data>
-  <data name="pdSectionDockerVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerVersion.Name" xml:space="preserve">
-    <value>pdSectionDockerVersion</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerVersion.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerVersion.Parent" xml:space="preserve">
-    <value>panelDockerVersion</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerVersion.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panelDockerVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panelDockerVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 39</value>
-  </data>
-  <data name="panelDockerVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 5</value>
-  </data>
-  <data name="panelDockerVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
-  </data>
-  <data name="panelDockerVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;panelDockerVersion.Name" xml:space="preserve">
-    <value>panelDockerVersion</value>
-  </data>
-  <data name="&gt;&gt;panelDockerVersion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelDockerVersion.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panelDockerVersion.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="panelDockerInfo.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panelDockerInfo.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="pdSectionDockerInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="pdSectionDockerInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 5</value>
-  </data>
-  <data name="pdSectionDockerInfo.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 34</value>
-  </data>
-  <data name="pdSectionDockerInfo.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>1, 1, 1, 1</value>
-  </data>
-  <data name="pdSectionDockerInfo.SectionTitle" xml:space="preserve">
-    <value>Docker Information</value>
-  </data>
-  <data name="pdSectionDockerInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 34</value>
-  </data>
-  <data name="pdSectionDockerInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerInfo.Name" xml:space="preserve">
-    <value>pdSectionDockerInfo</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerInfo.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerInfo.Parent" xml:space="preserve">
-    <value>panelDockerInfo</value>
-  </data>
-  <data name="&gt;&gt;pdSectionDockerInfo.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panelDockerInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panelDockerInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 704</value>
-  </data>
-  <data name="panelDockerInfo.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 5</value>
-  </data>
-  <data name="panelDockerInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 44</value>
-  </data>
-  <data name="panelDockerInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;panelDockerInfo.Name" xml:space="preserve">
-    <value>panelDockerInfo</value>
-  </data>
-  <data name="&gt;&gt;panelDockerInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelDockerInfo.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panelDockerInfo.ZOrder" xml:space="preserve">
-    <value>17</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -2923,6 +2923,33 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Disks.
+        /// </summary>
+        public static string Label_VM_read_caching_disks {
+            get {
+                return ResourceManager.GetString("Label-VM.read_caching_disks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reason.
+        /// </summary>
+        public static string Label_VM_read_caching_reason {
+            get {
+                return ResourceManager.GetString("Label-VM.read_caching_reason", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Status.
+        /// </summary>
+        public static string Label_VM_read_caching_status {
+            get {
+                return ResourceManager.GetString("Label-VM.read_caching_status", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Topology.
         /// </summary>
         public static string Label_VM_Topology {

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1745,4 +1745,13 @@
   <data name="Label-Supplemental_packs.installed" xml:space="preserve">
     <value>Installed supplemental packs</value>
   </data>
+  <data name="Label-VM.read_caching_status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Label-VM.read_caching_disks" xml:space="preserve">
+    <value>Disks</value>
+  </data>
+  <data name="Label-VM.read_caching_reason" xml:space="preserve">
+    <value>Reason</value>
+  </data>
 </root>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -33659,6 +33659,51 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This VM is not using Read Caching.
+        /// </summary>
+        public static string VM_READ_CACHING_DISABLED {
+            get {
+                return ResourceManager.GetString("VM_READ_CACHING_DISABLED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not licensed for Read Caching.
+        /// </summary>
+        public static string VM_READ_CACHING_DISABLED_REASON_LICENSE {
+            get {
+                return ResourceManager.GetString("VM_READ_CACHING_DISABLED_REASON_LICENSE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Read Caching is not supported on any of the Storage Repositories used by this VM.
+        /// </summary>
+        public static string VM_READ_CACHING_DISABLED_REASON_SR_TYPE {
+            get {
+                return ResourceManager.GetString("VM_READ_CACHING_DISABLED_REASON_SR_TYPE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Read Caching is disabled on all supported Storage Repositories used by this VM.
+        /// </summary>
+        public static string VM_READ_CACHING_DISABLED_REASON_TURNED_OFF {
+            get {
+                return ResourceManager.GetString("VM_READ_CACHING_DISABLED_REASON_TURNED_OFF", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This VM has Read Caching enabled.
+        /// </summary>
+        public static string VM_READ_CACHING_ENABLED {
+            get {
+                return ResourceManager.GetString("VM_READ_CACHING_ENABLED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to VM reverted to &apos;{0}&apos;.
         /// </summary>
         public static string VM_REVERTED {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -576,6 +576,15 @@
   <data name="ACTION_REMOVE_ALERTS_PROGRESS_DESCRIPTION" xml:space="preserve">
     <value>Removing alert {0} of {1}...</value>
   </data>
+  <data name="ACTION_RESTART_CONTAINER_DESCRIPTION" xml:space="preserve">
+    <value>Restarting</value>
+  </data>
+  <data name="ACTION_RESTART_CONTAINER_END_DESCRIPTION" xml:space="preserve">
+    <value>Restarted</value>
+  </data>
+  <data name="ACTION_RESTART_CONTAINER_TITLE" xml:space="preserve">
+    <value>Restarting Docker Container '{0}'</value>
+  </data>
   <data name="ACTION_RESUMEANDSTARTVMS_PREPARING" xml:space="preserve">
     <value>Preparing to resume and start VMs...</value>
   </data>
@@ -6834,6 +6843,9 @@ This will permanently delete and reinitialize all local storage on the servers. 
   <data name="MAINWINDOW_REPAIR_SR_CONTEXT_MENU" xml:space="preserve">
     <value>Re&amp;pair...</value>
   </data>
+  <data name="MAINWINDOW_RESTART" xml:space="preserve">
+    <value>Re&amp;start</value>
+  </data>
   <data name="MAINWINDOW_RESTART_TOOLSTACK" xml:space="preserve">
     <value>Restart Toolstac&amp;k</value>
   </data>
@@ -11642,6 +11654,21 @@ To learn more about the XenServer Dynamic Workload Balancing feature or to start
   <data name="VM_PROTECTION_POLICY_SUCCEEDED" xml:space="preserve">
     <value>Succeeded</value>
   </data>
+  <data name="VM_READ_CACHING_ENABLED" xml:space="preserve">
+    <value>This VM has Read Caching enabled</value>
+  </data>
+  <data name="VM_READ_CACHING_DISABLED" xml:space="preserve">
+    <value>This VM is not using Read Caching</value>
+  </data>
+  <data name="VM_READ_CACHING_DISABLED_REASON_LICENSE" xml:space="preserve">
+    <value>Not licensed for Read Caching</value>
+  </data>
+  <data name="VM_READ_CACHING_DISABLED_REASON_SR_TYPE" xml:space="preserve">
+    <value>Read Caching is not supported on any of the Storage Repositories used by this VM</value>
+  </data>
+  <data name="VM_READ_CACHING_DISABLED_REASON_TURNED_OFF" xml:space="preserve">
+    <value>Read Caching is disabled on all supported Storage Repositories used by this VM</value>
+  </data>
   <data name="VM_REVERTED" xml:space="preserve">
     <value>VM reverted to '{0}'</value>
   </data>
@@ -12568,17 +12595,5 @@ You will need to navigate to the Console on each of the selected VMs to complete
   </data>
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
-  </data>
-  <data name="ACTION_RESTART_CONTAINER_DESCRIPTION" xml:space="preserve">
-    <value>Restarting</value>
-  </data>
-  <data name="ACTION_RESTART_CONTAINER_END_DESCRIPTION" xml:space="preserve">
-    <value>Restarted</value>
-  </data>
-  <data name="ACTION_RESTART_CONTAINER_TITLE" xml:space="preserve">
-    <value>Restarting Docker Container '{0}'</value>
-  </data>
-  <data name="MAINWINDOW_RESTART" xml:space="preserve">
-    <value>Re&amp;start</value>
   </data>
 </root>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -443,6 +443,16 @@ namespace XenAPI
             return h._RestrictExportResourceData;
         }
 
+        private bool _RestrictReadCaching
+        {
+            get { return BoolKeyPreferTrue(license_params, "restrict_read_caching"); }
+        }
+
+        public static bool RestrictReadCaching(Host h)
+        {
+            return h._RestrictReadCaching;
+        }
+
         public bool HasPBDTo(SR sr)
         {
             foreach (XenRef<PBD> pbd in PBDs)

--- a/XenModel/XenAPI-Extensions/VDI.cs
+++ b/XenModel/XenAPI-Extensions/VDI.cs
@@ -319,5 +319,26 @@ namespace XenAPI
                 return name_label.Contains(wssName);
             }
         }
+
+        /// <summary>
+        /// Whether the read caching is enabled on this disk
+        /// </summary>
+        public bool ReadCachingEnabled
+        {
+            get { return BoolKey(sm_config, "read-caching-enabled"); }
+        }
+
+        /// <summary>
+        /// Whether the read caching is supported on this disk
+        /// </summary>
+        public bool ReadCachingSupported
+        {
+            get
+            {
+                var sr = Connection.Resolve(SR);
+                var srType = sr != null ? sr.GetSRType(false) : XenAPI.SR.SRTypes.unknown;
+                return srType == XenAPI.SR.SRTypes.ext || srType == XenAPI.SR.SRTypes.nfs;
+            }
+        }
     }
 }

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -1712,6 +1712,61 @@ namespace XenAPI
                 return info;
             }
         }
+
+        public bool ReadCachingEnabled
+        {
+            get
+            {
+                return ReadCachingVDIs.Count > 0;
+            }
+        }
+
+        /// <summary>
+        /// Return the list of VDIs that have Read Caching enabled
+        /// </summary>
+        public List<VDI> ReadCachingVDIs
+        {
+            get
+            {
+                var readCachingVdis = new List<VDI>();
+                foreach (var vbd in Connection.ResolveAll(VBDs).Where(vbd => vbd != null && vbd.currently_attached))
+                {
+                    var vdi = Connection.Resolve(vbd.VDI);
+                    if (vdi != null && vdi.ReadCachingEnabled)
+                        readCachingVdis.Add(vdi);
+                }
+                return readCachingVdis;
+            }
+        }
+
+        /// <summary>
+        /// Whether the Read Caching is supported on any of the VDIs
+        /// </summary>
+        public bool ReadCachingSupported
+        {
+            get
+            {
+                foreach (var vbd in Connection.ResolveAll(VBDs).Where(vbd => vbd != null && vbd.currently_attached))
+                {
+                    var vdi = Connection.Resolve(vbd.VDI);
+                    if (vdi != null && vdi.ReadCachingSupported)
+                        return true;
+                }
+                return false;
+            }
+        }
+        
+        public string ReadCachingDisabledReason
+        {
+            get 
+            { 
+                if (Helpers.FeatureForbidden(Connection, Host.RestrictReadCaching))
+                    return Messages.VM_READ_CACHING_DISABLED_REASON_LICENSE;
+                if (!ReadCachingSupported)
+                    return Messages.VM_READ_CACHING_DISABLED_REASON_SR_TYPE;
+                return Messages.VM_READ_CACHING_DISABLED_REASON_TURNED_OFF;
+            }
+        }
     }
 
     public struct VMStartupOptions


### PR DESCRIPTION
- Show a “Read Caching” section on the General Tab of a VM when the VM is running on a Cream or greater host
- When the Read Caching is enabled, the “Read Caching” section will contain two entries: Status and Disks (list of disks with RC enabled)
- When the Read Caching is disabled, the “Read Caching” section will contain two entries: Status and Reason

(Also fixed the sorting of Messages.resx)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>