### PR TITLE
CA-160996: XenCenter: Subscribe to fewer events in DockerContainers

### DIFF
--- a/XenModel/DockerContainers.cs
+++ b/XenModel/DockerContainers.cs
@@ -106,20 +106,20 @@ namespace XenAdmin.Model
         {
             InvokeHelper.AssertOnEventThread();
 
-            IXenObject ixmo = e.Element as IXenObject;
-            if (ixmo == null)
+            VM vm = e.Element as VM;
+            if (vm == null)
                 return;
 
             switch (e.Action)
             {
                 case CollectionChangeAction.Add:
-                    ixmo.PropertyChanged += ServerXenObject_PropertyChanged;
-                    UpdateDockerContainer(ixmo);
+                    vm.PropertyChanged += ServerXenObject_PropertyChanged;
+                    UpdateDockerContainer(vm);
                     break;
 
                 case CollectionChangeAction.Remove:
-                    ixmo.PropertyChanged -= ServerXenObject_PropertyChanged;
-                    RemoveObject(ixmo);
+                    vm.PropertyChanged -= ServerXenObject_PropertyChanged;
+                    RemoveObject(vm);
                     break;
 
                 default:
@@ -140,9 +140,15 @@ namespace XenAdmin.Model
         private static void ServerXenObject_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             IXenObject xenObject = (IXenObject) sender;
+
+            VM vm = xenObject as VM;
+
+            if (vm == null)
+                return;
+
             if (e.PropertyName == "other_config")
             {
-                UpdateDockerContainer(xenObject);
+                UpdateDockerContainer(vm);
             }
         }
 
@@ -157,27 +163,27 @@ namespace XenAdmin.Model
             connection.Cache.UpdateDockerContainersForVM(new List<DockerContainer>(), (VM)ixmo);
         }
 
-        private static void UpdateAll(IXenObject[] ixmos)
+        private static void UpdateAll(VM[] vms)
         {
-            foreach (IXenObject ixmo in ixmos)
+            foreach (VM vm in vms)
             {
-                ixmo.PropertyChanged -= ServerXenObject_PropertyChanged;
-                ixmo.PropertyChanged += ServerXenObject_PropertyChanged;
-                UpdateDockerContainer(ixmo);
+                vm.PropertyChanged -= ServerXenObject_PropertyChanged;
+                vm.PropertyChanged += ServerXenObject_PropertyChanged;
+                UpdateDockerContainer(vm);
             }
         }
 
-        private static void UpdateDockerContainer(IXenObject ixmo)
+        private static void UpdateDockerContainer(VM vm)
         {
             InvokeHelper.AssertOnEventThread();
             
-            if (ixmo as VM == null)
+            if (vm == null)
                 return;
             
-            IXenConnection connection = ixmo.Connection;
+            IXenConnection connection = vm.Connection;
 
-            var dockerVMs = GetDockerVMs(ixmo);
-            connection.Cache.UpdateDockerContainersForVM(dockerVMs, (VM)ixmo);
+            var dockerVMs = GetDockerVMs(vm);
+            connection.Cache.UpdateDockerContainersForVM(dockerVMs, vm);
         }
 
         public static List<DockerContainer> GetContainersFromOtherConfig(VM vm)

--- a/XenModel/DockerContainers.cs
+++ b/XenModel/DockerContainers.cs
@@ -106,9 +106,9 @@ namespace XenAdmin.Model
         {
             InvokeHelper.AssertOnEventThread();
 
-            VM vm = e.Element as VM;
-            if (vm == null)
-                return;
+            Trace.Assert(e.Element is VM);
+
+            var vm = e.Element as VM;
 
             switch (e.Action)
             {
@@ -139,12 +139,9 @@ namespace XenAdmin.Model
 
         private static void ServerXenObject_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            IXenObject xenObject = (IXenObject) sender;
+            Trace.Assert(sender is VM);
 
-            VM vm = xenObject as VM;
-
-            if (vm == null)
-                return;
+            VM vm = sender as VM;
 
             if (e.PropertyName == "other_config")
             {
@@ -152,15 +149,12 @@ namespace XenAdmin.Model
             }
         }
 
-        private static void RemoveObject(IXenObject ixmo)
+        private static void RemoveObject(VM vm)
         {
             InvokeHelper.AssertOnEventThread();
 
-            if (ixmo as VM == null)
-                return;
-
-            IXenConnection connection = ixmo.Connection;
-            connection.Cache.UpdateDockerContainersForVM(new List<DockerContainer>(), (VM)ixmo);
+            IXenConnection connection = vm.Connection;
+            connection.Cache.UpdateDockerContainersForVM(new List<DockerContainer>(), vm);
         }
 
         private static void UpdateAll(VM[] vms)

--- a/XenModel/Network/Cache.cs
+++ b/XenModel/Network/Cache.cs
@@ -38,6 +38,7 @@ using XenAPI;
 using XenAdmin.Core;
 using XenAdmin.Model;
 using System.Linq;
+using System.Diagnostics;
 
 namespace XenAdmin.Network
 {
@@ -566,6 +567,8 @@ namespace XenAdmin.Network
         private bool dockerContainersChanged = false;
         public void UpdateDockerContainersForVM(IList<DockerContainer> containers, VM vm)
         {
+            Trace.Assert(vm != null);
+
             //updating existing, adding new containers
             dockerContainersChanged = dockerContainersChanged || containers.Count > 0;
             foreach (var c in containers)

--- a/XenModel/Network/Cache.cs
+++ b/XenModel/Network/Cache.cs
@@ -564,22 +564,21 @@ namespace XenAdmin.Network
         }
 
         private bool dockerContainersChanged = false;
-        public void UpdateDockerContainersForVM(IEnumerable<DockerContainer> containers, VM vm)
+        public void UpdateDockerContainersForVM(IList<DockerContainer> containers, VM vm)
         {
-            dockerContainersChanged = true;
-         
             //updating existing, adding new containers
+            dockerContainersChanged = dockerContainersChanged || containers.Count > 0;
             foreach (var c in containers)
             {
                 _dockerContainers[new XenRef<DockerContainer>(c)] = c;
             }
 
-            IEnumerable<KeyValuePair<XenRef<DockerContainer>, DockerContainer>> containersGoneFromThisVM = null;
+            List<KeyValuePair<XenRef<DockerContainer>, DockerContainer>> containersGoneFromThisVM = null;
             //removing the ones that are not there anymore on this VM
             lock (_dockerContainers)
             {
                 containersGoneFromThisVM = _dockerContainers.Where(c => c.Value != null && c.Value.Parent.uuid == vm.uuid && !containers.Any(cont => cont.uuid == c.Value.uuid)).ToList();
-
+                dockerContainersChanged = dockerContainersChanged || containersGoneFromThisVM.Count > 0;
                 foreach (var c in containersGoneFromThisVM)
                 {
                     _dockerContainers.Remove(new XenRef<DockerContainer>(c.Value));

--- a/XenModel/Network/ICache.cs
+++ b/XenModel/Network/ICache.cs
@@ -82,7 +82,7 @@ namespace XenAdmin.Network
         VM[] VMs { get; }
         IEnumerable<IXenObject> XenSearchableObjects { get; }
         DockerContainer[] DockerContainers { get; }
-        void UpdateDockerContainersForVM(IEnumerable<DockerContainer> d, VM v);
+        void UpdateDockerContainersForVM(IList<DockerContainer> d, VM v);
         void CheckDockerContainersBatchChange();
     }
 }


### PR DESCRIPTION
-ServerXenObject-PropertyChanged eventhandler now returns immediately for a non-VM sender
-Changed IXenObject to VM wherever possible to explicitly state that those methods are expecting VMs
-The UpdateDockerContainersForVM method sets the dockerContainersChanged flag only if there are changes

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>