### PR TITLE
CA-158601: Bump XenCenter version number for Cream

### DIFF
--- a/mk/declarations.sh
+++ b/mk/declarations.sh
@@ -34,7 +34,7 @@
 #Set and uncomment this to override the 3rd value of the product number 
 #normally fetched from branding
 #
-#PRODUCT_MICRO_VERSION_OVERRIDE=<My override value here>
+PRODUCT_MICRO_VERSION_OVERRIDE=2
 
 #this is the XenServer branch we're building; change this when making a new branch
 


### PR DESCRIPTION
-Set microversion to 2, because 1 has already been used (hotfix)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>