### PR TITLE
CA-161097: Renamed Container member to Docker container to fix build failures

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1852,11 +1852,11 @@ namespace XenAdmin
                 }
                 else if (t == TabPageDockerProcess)
                 {
-                    DockerProcessPage.Container = SelectionManager.Selection.First as DockerContainer;
+                    DockerProcessPage.DockerContainer = SelectionManager.Selection.First as DockerContainer;
                 }
                 else if (t == TabPageDockerDetails)
                 {
-                    DockerDetailsPage.Container = SelectionManager.Selection.First as DockerContainer;
+                    DockerDetailsPage.DockerContainer = SelectionManager.Selection.First as DockerContainer;
                 }
             }
 

--- a/XenAdmin/TabPages/DockerDetailsPage.cs
+++ b/XenAdmin/TabPages/DockerDetailsPage.cs
@@ -50,7 +50,7 @@ namespace XenAdmin.TabPages
         private Host host;
         private string cachedResult;
 
-        public DockerContainer Container
+        public DockerContainer DockerContainer
         {
             get
             {

--- a/XenAdmin/TabPages/DockerProcessPage.cs
+++ b/XenAdmin/TabPages/DockerProcessPage.cs
@@ -60,7 +60,7 @@ namespace XenAdmin.TabPages
             RefreshTimer.Interval = REFRESH_INTERVAL;
         }
 
-        public DockerContainer Container
+        public DockerContainer DockerContainer
         {
             get
             {


### PR DESCRIPTION

This fixes the build errors:
- error CS0108: Warning as Error: 'XenAdmin.TabPages.DockerDetailsPage.Container' hides inherited member 'System.ComponentModel.Component.Container'.
- error CS0108: Warning as Error: 'XenAdmin.TabPages.DockerProcessPage.Container' hides inherited member 'System.ComponentModel.Component.Container'.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>