### PR TITLE
CP-10926: Make the textbox on Cloud-Config Parameters page read-only (instead of disabled) if the config drive parameters cannot be changed

### DIFF
--- a/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.cs
@@ -169,7 +169,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             bool canEdit = inNewVmWizard || vmOrTemplate.is_a_template ||
                            vmOrTemplate.power_state == vm_power_state.Halted;
 
-            ConfigDriveTemplateLabel.Enabled = ConfigDriveTemplateTextBox.Enabled = canEdit;
+            ConfigDriveTemplateTextBox.ReadOnly = !canEdit;
             warningsTable.Visible = !canEdit;
         }
 


### PR DESCRIPTION


Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>