### PR TITLE
CP-10926: Handle exception when running the action that gets the config drive parameters

### DIFF
--- a/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.Designer.cs
@@ -30,11 +30,11 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_CloudConfigParameters));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.ConfigDriveTemplateTextBox = new System.Windows.Forms.TextBox();
-            this.topLabel = new System.Windows.Forms.Label();
             this.warningsTable = new System.Windows.Forms.TableLayoutPanel();
             this.imgStopVM = new System.Windows.Forms.PictureBox();
-            this.labelStopVM = new System.Windows.Forms.Label();
+            this.labelWarning = new System.Windows.Forms.Label();
+            this.topLabel = new System.Windows.Forms.Label();
+            this.ConfigDriveTemplateTextBox = new System.Windows.Forms.TextBox();
             this.ConfigDriveTemplateLabel = new System.Windows.Forms.Label();
             this.IncludeConfigDriveCheckBox = new System.Windows.Forms.CheckBox();
             this.reloadDefaults = new System.Windows.Forms.Button();
@@ -54,26 +54,12 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.tableLayoutPanel1.Controls.Add(this.reloadDefaults, 0, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
-            // ConfigDriveTemplateTextBox
-            // 
-            this.ConfigDriveTemplateTextBox.AcceptsReturn = true;
-            resources.ApplyResources(this.ConfigDriveTemplateTextBox, "ConfigDriveTemplateTextBox");
-            this.ConfigDriveTemplateTextBox.Name = "ConfigDriveTemplateTextBox";
-            this.tableLayoutPanel1.SetRowSpan(this.ConfigDriveTemplateTextBox, 2);
-            this.ConfigDriveTemplateTextBox.TextChanged += new System.EventHandler(this.ConfigDriveTemplateTextBox_TextChanged);
-            // 
-            // topLabel
-            // 
-            resources.ApplyResources(this.topLabel, "topLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.topLabel, 2);
-            this.topLabel.Name = "topLabel";
-            // 
             // warningsTable
             // 
             resources.ApplyResources(this.warningsTable, "warningsTable");
             this.tableLayoutPanel1.SetColumnSpan(this.warningsTable, 2);
             this.warningsTable.Controls.Add(this.imgStopVM, 0, 0);
-            this.warningsTable.Controls.Add(this.labelStopVM, 1, 0);
+            this.warningsTable.Controls.Add(this.labelWarning, 1, 0);
             this.warningsTable.Name = "warningsTable";
             // 
             // imgStopVM
@@ -83,10 +69,24 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.imgStopVM.Name = "imgStopVM";
             this.imgStopVM.TabStop = false;
             // 
-            // labelStopVM
+            // labelWarning
             // 
-            resources.ApplyResources(this.labelStopVM, "labelStopVM");
-            this.labelStopVM.Name = "labelStopVM";
+            resources.ApplyResources(this.labelWarning, "labelWarning");
+            this.labelWarning.Name = "labelWarning";
+            // 
+            // topLabel
+            // 
+            resources.ApplyResources(this.topLabel, "topLabel");
+            this.tableLayoutPanel1.SetColumnSpan(this.topLabel, 2);
+            this.topLabel.Name = "topLabel";
+            // 
+            // ConfigDriveTemplateTextBox
+            // 
+            this.ConfigDriveTemplateTextBox.AcceptsReturn = true;
+            resources.ApplyResources(this.ConfigDriveTemplateTextBox, "ConfigDriveTemplateTextBox");
+            this.ConfigDriveTemplateTextBox.Name = "ConfigDriveTemplateTextBox";
+            this.tableLayoutPanel1.SetRowSpan(this.ConfigDriveTemplateTextBox, 2);
+            this.ConfigDriveTemplateTextBox.TextChanged += new System.EventHandler(this.ConfigDriveTemplateTextBox_TextChanged);
             // 
             // ConfigDriveTemplateLabel
             // 
@@ -135,6 +135,6 @@ namespace XenAdmin.Wizards.NewVMWizard
         private System.Windows.Forms.Button reloadDefaults;
         private System.Windows.Forms.TableLayoutPanel warningsTable;
         private System.Windows.Forms.PictureBox imgStopVM;
-        private System.Windows.Forms.Label labelStopVM;
+        private System.Windows.Forms.Label labelWarning;
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Collections.Generic;
 using XenAdmin.Core;
+using XenAdmin.Dialogs;
 using XenAPI;
 using XenAdmin.Controls;
 using XenAdmin.Actions;
@@ -43,6 +44,8 @@ namespace XenAdmin.Wizards.NewVMWizard
 {
     public partial class Page_CloudConfigParameters : XenTabPage, IEditPage
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         private VM vmOrTemplate;
         private string existingConfig;
 
@@ -132,7 +135,9 @@ namespace XenAdmin.Wizards.NewVMWizard
             var configDrive = vmOrTemplate.CloudConfigDrive;
             GetCloudConfigParameters(configDrive);
         }
-        
+
+        private bool errorRetrievingConfigParameters;
+
         private void GetCloudConfigParameters(VDI configDrive)
         {
             var defaultConfig = configDrive == null;
@@ -148,11 +153,19 @@ namespace XenAdmin.Wizards.NewVMWizard
                         parameters,
                         true); //hidefromlogs
 
-            action.RunExternal(Connection.Session);
-            var result = action.Result.Replace("\n", Environment.NewLine);
-
-            ConfigDriveTemplateTextBox.Text = result;
-            existingConfig = result;
+            try
+            {
+                action.RunExternal(Connection.Session);
+                var result = action.Result.Replace("\n", Environment.NewLine);
+                ConfigDriveTemplateTextBox.Text = result;
+                existingConfig = result;
+                errorRetrievingConfigParameters = false;
+            }
+            catch (Exception)
+            {
+                log.Warn("Could not get the config drive parameters");
+                errorRetrievingConfigParameters = true;
+            }
         }
 
         private void GetDefaultParameters()
@@ -169,13 +182,18 @@ namespace XenAdmin.Wizards.NewVMWizard
             bool canEdit = inNewVmWizard || vmOrTemplate.is_a_template ||
                            vmOrTemplate.power_state == vm_power_state.Halted;
 
+            canEdit = canEdit && !errorRetrievingConfigParameters;
+
             ConfigDriveTemplateTextBox.ReadOnly = !canEdit;
             warningsTable.Visible = !canEdit;
+            labelWarning.Text = errorRetrievingConfigParameters ? Messages.VM_CLOUD_CONFIG_DRIVE_UNAVAILABLE : Messages.VM_CLOUD_CONFIG_DRIVE_READONLY;
         }
 
         private void reloadDefaults_Click(object sender, EventArgs e)
         {
             GetDefaultParameters();
+            if (errorRetrievingConfigParameters)
+                new ThreeButtonDialog(new ThreeButtonDialog.Details(SystemIcons.Error, Messages.VM_CLOUD_CONFIG_DRIVE_CANNOT_RETRIEVE_DEFAULT)).ShowDialog(this);
         }
 
         #region Implementation of IEditPage

--- a/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.cs
@@ -178,14 +178,12 @@ namespace XenAdmin.Wizards.NewVMWizard
             // IncludeConfigDriveCheckBox and reloadDefaults only visible in the New VM Wizard
             IncludeConfigDriveCheckBox.Visible = reloadDefaults.Visible = inNewVmWizard;
 
-            // the cloud config cannot be edited on non-halted VMs
-            bool canEdit = inNewVmWizard || vmOrTemplate.is_a_template ||
-                           vmOrTemplate.power_state == vm_power_state.Halted;
-
-            canEdit = canEdit && !errorRetrievingConfigParameters;
+            // for existing VMs, the cloud config cannot be edited on non-halted VMs or when we failed to retrive the existing cloud config parameters
+            bool canEdit = inNewVmWizard ||
+                           !errorRetrievingConfigParameters && (vmOrTemplate.is_a_template || vmOrTemplate.power_state == vm_power_state.Halted);
 
             ConfigDriveTemplateTextBox.ReadOnly = !canEdit;
-            warningsTable.Visible = !canEdit;
+            warningsTable.Visible = errorRetrievingConfigParameters || !canEdit;
             labelWarning.Text = errorRetrievingConfigParameters ? Messages.VM_CLOUD_CONFIG_DRIVE_UNAVAILABLE : Messages.VM_CLOUD_CONFIG_DRIVE_READONLY;
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CloudConfigParameters.resx
@@ -159,43 +159,43 @@
   <data name="&gt;&gt;imgStopVM.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="labelStopVM.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="labelWarning.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="labelStopVM.AutoSize" type="System.Boolean, mscorlib">
+  <data name="labelWarning.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelStopVM.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="labelWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="labelStopVM.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="labelWarning.Location" type="System.Drawing.Point, System.Drawing">
     <value>25, 3</value>
   </data>
-  <data name="labelStopVM.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="labelWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 10</value>
   </data>
-  <data name="labelStopVM.MaximumSize" type="System.Drawing.Size, System.Drawing">
+  <data name="labelWarning.MaximumSize" type="System.Drawing.Size, System.Drawing">
     <value>584, 999</value>
   </data>
-  <data name="labelStopVM.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="labelWarning.Size" type="System.Drawing.Size, System.Drawing">
     <value>521, 13</value>
   </data>
-  <data name="labelStopVM.TabIndex" type="System.Int32, mscorlib">
+  <data name="labelWarning.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="labelStopVM.Text" xml:space="preserve">
+  <data name="labelWarning.Text" xml:space="preserve">
     <value>The cloud-config parameters can only be changed when the VM is shut down.</value>
   </data>
-  <data name="&gt;&gt;labelStopVM.Name" xml:space="preserve">
-    <value>labelStopVM</value>
+  <data name="&gt;&gt;labelWarning.Name" xml:space="preserve">
+    <value>labelWarning</value>
   </data>
-  <data name="&gt;&gt;labelStopVM.Type" xml:space="preserve">
+  <data name="&gt;&gt;labelWarning.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;labelStopVM.Parent" xml:space="preserve">
+  <data name="&gt;&gt;labelWarning.Parent" xml:space="preserve">
     <value>warningsTable</value>
   </data>
-  <data name="&gt;&gt;labelStopVM.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;labelWarning.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="warningsTable.Location" type="System.Drawing.Point, System.Drawing">
@@ -223,7 +223,7 @@
     <value>0</value>
   </data>
   <data name="warningsTable.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="imgStopVM" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStopVM" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,100,Absolute,100,Absolute,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="imgStopVM" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelWarning" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,100,Absolute,100,Absolute,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="topLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -33586,6 +33586,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to retrieve the default cloud-config parameters..
+        /// </summary>
+        public static string VM_CLOUD_CONFIG_DRIVE_CANNOT_RETRIEVE_DEFAULT {
+            get {
+                return ResourceManager.GetString("VM_CLOUD_CONFIG_DRIVE_CANNOT_RETRIEVE_DEFAULT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Config drive included.
         /// </summary>
         public static string VM_CLOUD_CONFIG_DRIVE_INCLUDED {
@@ -33600,6 +33609,24 @@ namespace XenAdmin {
         public static string VM_CLOUD_CONFIG_DRIVE_NOT_INCLUDED {
             get {
                 return ResourceManager.GetString("VM_CLOUD_CONFIG_DRIVE_NOT_INCLUDED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cloud-config parameters can only be changed when the VM is shut down..
+        /// </summary>
+        public static string VM_CLOUD_CONFIG_DRIVE_READONLY {
+            get {
+                return ResourceManager.GetString("VM_CLOUD_CONFIG_DRIVE_READONLY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cloud-config parameters could not be retrieved..
+        /// </summary>
+        public static string VM_CLOUD_CONFIG_DRIVE_UNAVAILABLE {
+            get {
+                return ResourceManager.GetString("VM_CLOUD_CONFIG_DRIVE_UNAVAILABLE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -11628,11 +11628,20 @@ To learn more about the XenServer Dynamic Workload Balancing feature or to start
   <data name="VM_APPLIANCE_SUMMARY" xml:space="preserve">
     <value>vApp name:\r\n    {0}\r\n\r\nSelected VMs:\r\n    {1}</value>
   </data>
+  <data name="VM_CLOUD_CONFIG_DRIVE_CANNOT_RETRIEVE_DEFAULT" xml:space="preserve">
+    <value>Unable to retrieve the default cloud-config parameters.</value>
+  </data>
   <data name="VM_CLOUD_CONFIG_DRIVE_INCLUDED" xml:space="preserve">
     <value>Config drive included</value>
   </data>
   <data name="VM_CLOUD_CONFIG_DRIVE_NOT_INCLUDED" xml:space="preserve">
     <value>Config drive not included</value>
+  </data>
+  <data name="VM_CLOUD_CONFIG_DRIVE_READONLY" xml:space="preserve">
+    <value>The cloud-config parameters can only be changed when the VM is shut down.</value>
+  </data>
+  <data name="VM_CLOUD_CONFIG_DRIVE_UNAVAILABLE" xml:space="preserve">
+    <value>The cloud-config parameters could not be retrieved.</value>
   </data>
   <data name="VM_ENLIGHTENMENT" xml:space="preserve">
     <value>Container Management</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8760,6 +8760,13 @@ The update is installed on '{1}', but the update installation file may have sinc
 
 Upload the update from an .xsupdate file instead.</value>
   </data>
+  <data name="PATCH_DOWNLOAD_FAILED_MORE_INFO_NOT_APPLIED" xml:space="preserve">
+    <value>Failed to download the update {0} from '{1}'.
+
+The update has previously been uploaded to '{1}', but the update installation file may have since been deleted.
+
+Upload the update from an .xsupdate file instead.</value>
+  </data>
   <data name="PATCH_EXPANDED_DESCRIPTION" xml:space="preserve">
     <value>{0} 
 Date modified: {1}
@@ -12641,12 +12648,5 @@ You will need to navigate to the Console on each of the selected VMs to complete
   </data>
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
-  </data>
-  <data name="PATCH_DOWNLOAD_FAILED_MORE_INFO_NOT_APPLIED" xml:space="preserve">
-    <value>Failed to download the update {0} from '{1}'.
-
-The update has previously been uploaded to '{1}', but the update installation file may have since been deleted.
-
-Upload the update from an .xsupdate file instead.</value>
   </data>
 </root>


### PR DESCRIPTION

- If failed to retrieve the config parameters, then make the ConfigDriveTemplate textbox read-only and display the reason why it is not editable (similar with what we do for running VMs).
- In the New VM Wizard, if the action on "Reset to Default" button fails, then popup a message box with an error saying that we were unable to retrieve the default parameters. In this case, the ConfigDriveTemplate textbox remains unchanged.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>