### PR TITLE
CA-161620: If the supplemental pack installation fails, then XenCenter will display a message suggesting the user refers to the users guide for installing via the CLI.

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.designer.cs
@@ -33,10 +33,11 @@ namespace XenAdmin.Wizards.PatchingWizard
             this.textBoxLog = new System.Windows.Forms.TextBox();
             this.progressBar = new System.Windows.Forms.ProgressBar();
             this.labelError = new System.Windows.Forms.Label();
-            this.panel1 = new System.Windows.Forms.Panel();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.panel1.SuspendLayout();
+            this.panel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.errorLinkLabel = new System.Windows.Forms.LinkLabel();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // labelTitle
@@ -60,20 +61,32 @@ namespace XenAdmin.Wizards.PatchingWizard
             // 
             this.labelError.AutoEllipsis = true;
             resources.ApplyResources(this.labelError, "labelError");
+            this.labelError.BackColor = System.Drawing.SystemColors.Control;
             this.labelError.Name = "labelError";
-            // 
-            // panel1
-            // 
-            resources.ApplyResources(this.panel1, "panel1");
-            this.panel1.Controls.Add(this.labelError);
-            this.panel1.Controls.Add(this.pictureBox1);
-            this.panel1.Name = "panel1";
             // 
             // pictureBox1
             // 
+            this.pictureBox1.BackColor = System.Drawing.SystemColors.Control;
             resources.ApplyResources(this.pictureBox1, "pictureBox1");
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.TabStop = false;
+            // 
+            // panel1
+            // 
+            this.panel1.BackColor = System.Drawing.SystemColors.Control;
+            resources.ApplyResources(this.panel1, "panel1");
+            this.panel1.Controls.Add(this.pictureBox1, 0, 0);
+            this.panel1.Controls.Add(this.errorLinkLabel, 2, 0);
+            this.panel1.Controls.Add(this.labelError, 1, 0);
+            this.panel1.Name = "panel1";
+            // 
+            // errorLinkLabel
+            // 
+            resources.ApplyResources(this.errorLinkLabel, "errorLinkLabel");
+            this.errorLinkLabel.BackColor = System.Drawing.SystemColors.Control;
+            this.errorLinkLabel.Name = "errorLinkLabel";
+            this.errorLinkLabel.TabStop = true;
+            this.errorLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.errorLinkLabel_LinkClicked);
             // 
             // PatchingWizard_PatchingPage
             // 
@@ -84,9 +97,9 @@ namespace XenAdmin.Wizards.PatchingWizard
             this.Controls.Add(this.textBoxLog);
             this.Controls.Add(this.labelTitle);
             this.Name = "PatchingWizard_PatchingPage";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -98,8 +111,9 @@ namespace XenAdmin.Wizards.PatchingWizard
         private System.Windows.Forms.TextBox textBoxLog;
         private System.Windows.Forms.ProgressBar progressBar;
         private System.Windows.Forms.Label labelError;
-        private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.TableLayoutPanel panel1;
+        private System.Windows.Forms.LinkLabel errorLinkLabel;
 
     }
 }

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.resx
@@ -112,16 +112,16 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelTitle.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="labelTitle.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 13</value>
   </data>
@@ -138,7 +138,7 @@
     <value>labelTitle</value>
   </data>
   <data name="&gt;&gt;labelTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelTitle.Parent" xml:space="preserve">
     <value>$this</value>
@@ -146,9 +146,9 @@
   <data name="&gt;&gt;labelTitle.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="textBoxLog.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="textBoxLog.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 71</value>
@@ -160,7 +160,7 @@
     <value>Both</value>
   </data>
   <data name="textBoxLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>502, 230</value>
+    <value>502, 228</value>
   </data>
   <data name="textBoxLog.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -169,7 +169,7 @@
     <value>textBoxLog</value>
   </data>
   <data name="&gt;&gt;textBoxLog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;textBoxLog.Parent" xml:space="preserve">
     <value>$this</value>
@@ -196,7 +196,7 @@
     <value>progressBar</value>
   </data>
   <data name="&gt;&gt;progressBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;progressBar.Parent" xml:space="preserve">
     <value>$this</value>
@@ -207,14 +207,20 @@
   <data name="labelError.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="labelError.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="labelError.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>35, 0</value>
+    <value>35, 8</value>
+  </data>
+  <data name="labelError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 8, 3, 3</value>
   </data>
   <data name="labelError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 13</value>
+    <value>407, 21</value>
   </data>
   <data name="labelError.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -226,16 +232,13 @@
     <value>labelError</value>
   </data>
   <data name="&gt;&gt;labelError.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelError.Parent" xml:space="preserve">
     <value>panel1</value>
   </data>
   <data name="&gt;&gt;labelError.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panel1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+    <value>2</value>
   </data>
   <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -256,28 +259,67 @@
     <value>pictureBox1</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
     <value>panel1</value>
   </data>
   <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="errorLinkLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="errorLinkLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="errorLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>448, 8</value>
+  </data>
+  <data name="errorLinkLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 8, 3, 3</value>
+  </data>
+  <data name="errorLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 13</value>
+  </data>
+  <data name="errorLinkLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="errorLinkLabel.Text" xml:space="preserve">
+    <value>&amp;More info...</value>
+  </data>
+  <data name="errorLinkLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;errorLinkLabel.Name" xml:space="preserve">
+    <value>errorLinkLabel</value>
+  </data>
+  <data name="&gt;&gt;errorLinkLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;errorLinkLabel.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;errorLinkLabel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Bottom</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 312</value>
+    <value>0, 303</value>
   </data>
-  <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+  <data name="panel1.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>511, 32</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="panel1.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -286,7 +328,7 @@
     <value>panel1</value>
   </data>
   <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -294,14 +336,17 @@
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="panel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="errorLinkLabel" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="labelError" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>511, 344</value>
+    <value>511, 335</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PatchingWizard_PatchingPage</value>

--- a/XenModel/Actions/SupplementalPack/InstallSupplementalPackAction.cs
+++ b/XenModel/Actions/SupplementalPack/InstallSupplementalPackAction.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using XenAPI;
 
 
@@ -43,7 +44,11 @@ namespace XenAdmin.Actions
         private Dictionary<Host, VDI> suppPackVdis;
 
         public InstallSupplementalPackAction(Dictionary<Host, VDI> suppPackVdis, bool suppressHistory)
-            : base(null, string.Format(Messages.APPLYING_UPDATE, suppPackVdis.Count), suppressHistory)
+            : base(null, 
+            suppPackVdis.Count > 1
+                ? string.Format(Messages.UPDATES_WIZARD_APPLYING_UPDATE_MULTIPLE_HOSTS, suppPackVdis.Count) 
+                : string.Format(Messages.UPDATES_WIZARD_APPLYING_UPDATE, suppPackVdis.First().Value, suppPackVdis.First().Key), 
+            suppressHistory)
         {
             this.suppPackVdis = suppPackVdis;
         }
@@ -73,15 +78,20 @@ namespace XenAdmin.Actions
             }
             catch (Failure failure)
             {
-                log.WarnFormat("Plugin call install-supp-pack.install({0}) on {1} failed with {2}", vdi.uuid, host.Name,
-                               failure.Message);
-                throw;
+                log.WarnFormat("Plugin call install-supp-pack.install({0}) on {1} failed with {2}", vdi.uuid, host.Name, failure.Message);
+                log.WarnFormat("Supplemental pack installation error description: {0}", string.Join(";", failure.ErrorDescription));
+                throw new SupplementalPackInstallFailedException(string.Format(Messages.SUPP_PACK_INSTALL_FAILED, vdi.Name, host.Name), failure);
             }
             finally
             {
                 Connection = null;
             }
         }
+    }
 
+    public class SupplementalPackInstallFailedException : ApplicationException
+    {
+        public SupplementalPackInstallFailedException(string message, Exception innerException) :
+            base(message, innerException) { }
     }
 }

--- a/XenModel/Actions/SupplementalPack/InstallSupplementalPackAction.cs
+++ b/XenModel/Actions/SupplementalPack/InstallSupplementalPackAction.cs
@@ -78,8 +78,8 @@ namespace XenAdmin.Actions
             }
             catch (Failure failure)
             {
-                log.WarnFormat("Plugin call install-supp-pack.install({0}) on {1} failed with {2}", vdi.uuid, host.Name, failure.Message);
-                log.WarnFormat("Supplemental pack installation error description: {0}", string.Join(";", failure.ErrorDescription));
+                log.ErrorFormat("Plugin call install-supp-pack.install({0}) on {1} failed with {2}", vdi.uuid, host.Name, failure.Message);
+                log.ErrorFormat("Supplemental pack installation error description: {0}", string.Join(";", failure.ErrorDescription));
                 throw new SupplementalPackInstallFailedException(string.Format(Messages.SUPP_PACK_INSTALL_FAILED, vdi.Name, host.Name), failure);
             }
             finally

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -31715,7 +31715,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Installing update {0} to {1} ... .
+        ///   Looks up a localized string similar to Installing update {0} to {1}... .
         /// </summary>
         public static string UPDATES_WIZARD_APPLYING_UPDATE {
             get {
@@ -31724,7 +31724,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Installing update to {0} servers.
+        ///   Looks up a localized string similar to Installing update to {0} servers....
         /// </summary>
         public static string UPDATES_WIZARD_APPLYING_UPDATE_MULTIPLE_HOSTS {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -4647,15 +4647,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Applying update to {0} server(s).
-        /// </summary>
-        public static string APPLYING_UPDATE {
-            get {
-                return ResourceManager.GetString("APPLYING_UPDATE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Applying {0} update(s) to {1} server(s).
         /// </summary>
         public static string APPLYING_UPDATES {
@@ -24816,8 +24807,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///{0} error..
+        ///   Looks up a localized string similar to {0} error..
         /// </summary>
         public static string PATCHING_WIZARD_ERROR {
             get {
@@ -30433,6 +30423,26 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to install supplemental pack &apos;{0}&apos; on &apos;{1}&apos;..
+        /// </summary>
+        public static string SUPP_PACK_INSTALL_FAILED {
+            get {
+                return ResourceManager.GetString("SUPP_PACK_INSTALL_FAILED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}
+        ///
+        ///Refer to the &quot;XenServer Administrator&apos;s Guide&quot; for instructions on how to manually install a supplemental pack on a XenServer host..
+        /// </summary>
+        public static string SUPP_PACK_INSTALL_FAILED_MORE_INFO {
+            get {
+                return ResourceManager.GetString("SUPP_PACK_INSTALL_FAILED_MORE_INFO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} (not installed on {1}).
         /// </summary>
         public static string SUPP_PACK_MISSING_ON {
@@ -31710,6 +31720,15 @@ namespace XenAdmin {
         public static string UPDATES_WIZARD_APPLYING_UPDATE {
             get {
                 return ResourceManager.GetString("UPDATES_WIZARD_APPLYING_UPDATE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installing update to {0} servers.
+        /// </summary>
+        public static string UPDATES_WIZARD_APPLYING_UPDATE_MULTIPLE_HOSTS {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_APPLYING_UPDATE_MULTIPLE_HOSTS", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1685,9 +1685,6 @@ Warning: you must ensure that the SR is not in use by any server not connected t
   <data name="APPLYING_PATCH" xml:space="preserve">
     <value>Applying Update '{0}' to Server '{1}'...</value>
   </data>
-  <data name="APPLYING_UPDATE" xml:space="preserve">
-    <value>Applying update to {0} server(s)</value>
-  </data>
   <data name="APPLYING_UPDATES" xml:space="preserve">
     <value>Applying {0} update(s) to {1} server(s)</value>
   </data>
@@ -8727,8 +8724,7 @@ It is strongly recommended that you Cancel and apply the latest version of the p
     <value>{0,4}{1}</value>
   </data>
   <data name="PATCHING_WIZARD_ERROR" xml:space="preserve">
-    <value>
-{0} error.</value>
+    <value>{0} error.</value>
   </data>
   <data name="PATCHING_WIZARD_HOST_CHECK_OK" xml:space="preserve">
     <value>{0}: {1} ok.</value>
@@ -10539,6 +10535,14 @@ Do you want to connect to the pool master '{1}'?</value>
   <data name="SUPP_PACK_DESCTIPTION" xml:space="preserve">
     <value>{0} (version {1})</value>
   </data>
+  <data name="SUPP_PACK_INSTALL_FAILED" xml:space="preserve">
+    <value>Failed to install supplemental pack '{0}' on '{1}'.</value>
+  </data>
+  <data name="SUPP_PACK_INSTALL_FAILED_MORE_INFO" xml:space="preserve">
+    <value>{0}
+
+Refer to the "XenServer Administrator's Guide" for instructions on how to manually install a supplemental pack on a XenServer host.</value>
+  </data>
   <data name="SUPP_PACK_MISSING_ON" xml:space="preserve">
     <value>{0} (not installed on {1})</value>
   </data>
@@ -10943,6 +10947,9 @@ Verify that the file is a valid xensearch export.</value>
   </data>
   <data name="UPDATES_WIZARD_APPLYING_UPDATE" xml:space="preserve">
     <value>Installing update {0} to {1} ... </value>
+  </data>
+  <data name="UPDATES_WIZARD_APPLYING_UPDATE_MULTIPLE_HOSTS" xml:space="preserve">
+    <value>Installing update to {0} servers</value>
   </data>
   <data name="UPDATES_WIZARD_APPLY_FAILED" xml:space="preserve">
     <value>The update failed to apply.  Would you like to view the output?</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10946,10 +10946,10 @@ Verify that the file is a valid xensearch export.</value>
     <value>Installed update</value>
   </data>
   <data name="UPDATES_WIZARD_APPLYING_UPDATE" xml:space="preserve">
-    <value>Installing update {0} to {1} ... </value>
+    <value>Installing update {0} to {1}... </value>
   </data>
   <data name="UPDATES_WIZARD_APPLYING_UPDATE_MULTIPLE_HOSTS" xml:space="preserve">
-    <value>Installing update to {0} servers</value>
+    <value>Installing update to {0} servers...</value>
   </data>
   <data name="UPDATES_WIZARD_APPLY_FAILED" xml:space="preserve">
     <value>The update failed to apply.  Would you like to view the output?</value>


### PR DESCRIPTION

- When the install fails, log the full error description
- Added a specific exception for the supp pack installation failure
- Better action title (depending on the number of servers it applies to)
- Added a "More Info" button on the "Update" page, which displays a message with more information on the supp pack installation failure

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>