### PR TITLE
CP-11364: XC to use xapi.secret when creating CIFS SRs

### DIFF
--- a/XenModel/Actions/StorageLink/SrCreateAction.cs
+++ b/XenModel/Actions/StorageLink/SrCreateAction.cs
@@ -113,7 +113,7 @@ namespace XenAdmin.Actions
             log.DebugFormat("is shared='{0}'", _srIsShared);
 
             string secretuuid = null;
-            if (Helpers.MidnightRideOrGreater(Connection) && _srType != XenAPI.SR.SRTypes.cifs) //TEMPORARY: cifs SRs will not use XAPI Secret until development work has been finished. For CP-11364 revert this line. 
+            if (Helpers.MidnightRideOrGreater(Connection))
             {
                 string value;
                 if (_dconf.TryGetValue("cifspassword", out value))


### PR DESCRIPTION
Dev tested on dt62