### PR TITLE
CA-164176: Make sure that the Install Update does not get stuck on precheck stage after cleanup on slave

### DIFF
--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostOutOfSpaceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostOutOfSpaceProblem.cs
@@ -115,5 +115,13 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
                 return false;
             }
         }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as HostOutOfSpaceProblem;
+            if (other == null || diskSpaceReq == null || other.diskSpaceReq == null)
+                return false;
+            return diskSpaceReq.Equals(other.diskSpaceReq);
+        }
     }
 }


### PR DESCRIPTION

- override the Equals function on HostOutOfSpaceProblem to check the disk space requirements, not the Description.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>