### PR TITLE
CA-164678: Got incorrect guest screen resolution with user's first switch to Remote Desktop from XenCenter Console

### DIFF
--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -489,6 +489,10 @@ namespace XenAdmin.ConsoleView
         {
             Program.AssertOnEventThread();
 
+            //When switch to RDP from VNC, if RDP IP is empty, do not try to switch.
+            if (String.IsNullOrEmpty(rdpIP) && !UseVNC && RemoteConsole != null)
+                return;
+
             bool wasFocused = false;
             this.Controls.Clear();
 


### PR DESCRIPTION
If user want to switch to RDP, but the RDP IP is empty, original logic will try to connect VNC again, within the VNC re-connection, the Desktop Size lost.

In this situation, we should not switch RDP.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>