### PR TITLE
CP-11032: Remove storage motion constraints: Allow cross-pool move of stopped and suspended VMs

### DIFF
--- a/XenAdmin/Commands/CrossPoolMigrateCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMigrateCommand.cs
@@ -52,7 +52,7 @@ namespace XenAdmin.Commands
             : base(mainWindow, selection)
         { }
 
-        private Host preSelectedHost = null;
+        protected Host preSelectedHost = null;
         public CrossPoolMigrateCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selection, Host preSelectedHost)
             : base(mainWindow, selection)
         {
@@ -80,7 +80,8 @@ namespace XenAdmin.Commands
             }
             else
             {
-                MainWindowCommandInterface.ShowPerConnectionWizard(con, new CrossPoolMigrateWizard(con, selection, preSelectedHost));
+                MainWindowCommandInterface.ShowPerConnectionWizard(con, 
+                    new CrossPoolMigrateWizard(con, selection, preSelectedHost, WizardMode.Migrate));
             }
 
         }
@@ -110,7 +111,7 @@ namespace XenAdmin.Commands
                    vm.allowed_operations.Contains(vm_operations.migrate_send) &&
                    !Helpers.WlbEnabledAndConfigured(vm.Connection) &&
                    vm.SRs.ToList().All(sr=> sr != null && !sr.HBALunPerVDI) &&
-                   vm.Connection.Resolve(vm.resident_on) != preSelectedHost; //Not the same as the pre-selected host
+                   (vm.Connection.Resolve(vm.resident_on) == null || vm.Connection.Resolve(vm.resident_on) != preSelectedHost); //Not the same as the pre-selected host
         }
     }
 }

--- a/XenAdmin/Commands/CrossPoolMigrateCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMigrateCommand.cs
@@ -99,11 +99,16 @@ namespace XenAdmin.Commands
 
         protected override bool CanExecute(VM vm)
         {
+            return CanExecute(vm, preSelectedHost);
+        }
+
+        public static bool CanExecute(VM vm, Host preselectedHost)
+        {
             bool failureFound = false;
 
-            if(preSelectedHost != null)
+            if (preselectedHost != null)
             {
-                failureFound = new CrossPoolMigrateCanMigrateFilter(preSelectedHost, new List<VM> { vm }).FailureFound;
+                failureFound = new CrossPoolMigrateCanMigrateFilter(preselectedHost, new List<VM> { vm }).FailureFound;
             }
 
             return !failureFound &&
@@ -111,7 +116,7 @@ namespace XenAdmin.Commands
                    vm.allowed_operations.Contains(vm_operations.migrate_send) &&
                    !Helpers.WlbEnabledAndConfigured(vm.Connection) &&
                    vm.SRs.ToList().All(sr=> sr != null && !sr.HBALunPerVDI) &&
-                   (vm.Connection.Resolve(vm.resident_on) == null || vm.Connection.Resolve(vm.resident_on) != preSelectedHost); //Not the same as the pre-selected host
+                   (preselectedHost == null || vm.Connection.Resolve(vm.resident_on) != preselectedHost); //Not the same as the pre-selected host
         }
     }
 }

--- a/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
@@ -67,9 +67,15 @@ namespace XenAdmin.Commands
 
         protected override bool CanExecute(VM vm)
         {
-            if (vm == null || vm.is_a_template || vm.Locked)
+            return CanExecute(vm, preSelectedHost);
+        }
+
+        public new static bool CanExecute(VM vm, Host preSelectedHost)
+        {
+            if (vm == null || vm.is_a_template || vm.Locked || vm.power_state == vm_power_state.Running)
                 return false;
-            return base.CanExecute(vm);
+
+            return CrossPoolMigrateCommand.CanExecute(vm, preSelectedHost);
         }
     }
 }

--- a/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
@@ -1,0 +1,75 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using XenAPI;
+using XenAdmin.Core;
+using XenAdmin.Wizards.CrossPoolMigrateWizard;
+
+
+namespace XenAdmin.Commands
+{
+    internal class CrossPoolMoveVMCommand : CrossPoolMigrateCommand
+    {
+        public CrossPoolMoveVMCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selection)
+            : this(mainWindow, selection, null)
+        { }
+
+        public CrossPoolMoveVMCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selection, Host preSelectedHost)
+            : base(mainWindow, selection, preSelectedHost)
+        {
+            MenuText = Messages.MAINWINDOW_MOVEVM;
+        }
+
+        protected override void ExecuteCore(SelectedItemCollection selection)
+        {
+            var con = selection.GetConnectionOfFirstItem();
+
+            if (Helpers.FeatureForbidden(con, Host.RestrictCrossPoolMigrate))
+            {
+                ShowUpsellDialog(Parent);
+            }
+            else
+            {
+                MainWindowCommandInterface.ShowPerConnectionWizard(con,
+                    new CrossPoolMigrateWizard(con, selection, preSelectedHost, WizardMode.Move));
+            }
+
+        }
+
+        protected override bool CanExecute(VM vm)
+        {
+            if (vm == null || vm.is_a_template || vm.Locked)
+                return false;
+            return base.CanExecute(vm);
+        }
+    }
+}

--- a/XenAdmin/Commands/MoveVMCommand.cs
+++ b/XenAdmin/Commands/MoveVMCommand.cs
@@ -67,23 +67,20 @@ namespace XenAdmin.Commands
         {
             VM vm = (VM)selection[0].XenObject;
 
-            var cmd = new CrossPoolMoveVMCommand(MainWindowCommandInterface, selection);
-            if (cmd.CanExecute())
-                cmd.Execute();
+            if (CrossPoolMoveVMCommand.CanExecute(vm, null))
+                new CrossPoolMoveVMCommand(MainWindowCommandInterface, selection).Execute();
             else
                 MainWindowCommandInterface.ShowPerXenModelObjectWizard(vm, new MoveVMDialog(vm));
         }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {
-            if (new CrossPoolMoveVMCommand(MainWindowCommandInterface, selection).CanExecute())
-                return true;
             return selection.ContainsOneItemOfType<VM>() && selection.AtLeastOneXenObjectCan<VM>(CanExecute);
         }
 
         private static bool CanExecute(VM vm)
         {
-            return vm != null && vm.CanBeMoved;
+            return vm != null && (CrossPoolMoveVMCommand.CanExecute(vm, null) || vm.CanBeMoved);
         }
 
         public override string MenuText

--- a/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
+++ b/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
@@ -75,7 +75,7 @@ namespace XenAdmin.Dialogs.VMDialogs
 
         private void buttonMove_Click(object sender, EventArgs e)
         {
-            var action = new VMMoveAction(vm, srPicker1.SR, vm.GetStorageHost(false), vm.Name, vm.Description);
+            var action = new VMMoveAction(vm, srPicker1.SR, vm.GetStorageHost(false), vm.Name);
             action.RunAsync();
             Close();
         }

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
@@ -45,6 +45,8 @@ using XenAPI;
 
 namespace XenAdmin.Wizards.CrossPoolMigrateWizard
 {
+    public enum WizardMode { Migrate, Move, Copy }
+
     internal partial class CrossPoolMigrateWizard : XenWizardBase
 	{
         private CrossPoolMigrateDestinationPage m_pageDestination;
@@ -60,19 +62,23 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
 
         private Host hostPreSelection = null;
 
-        public CrossPoolMigrateWizard(IXenConnection con, IEnumerable<SelectedItem> selection, Host targetHostPreSelection)
+        private WizardMode wizardMode;
+
+        public CrossPoolMigrateWizard(IXenConnection con, IEnumerable<SelectedItem> selection, Host targetHostPreSelection, WizardMode mode)
             : base(con)
         {
             InitializeComponent();
             hostPreSelection = targetHostPreSelection;
+            wizardMode = mode;
             InitialiseWizard(selection);
         }
 
 
-        public CrossPoolMigrateWizard(IXenConnection con, IEnumerable<SelectedItem> selection)
+        public CrossPoolMigrateWizard(IXenConnection con, IEnumerable<SelectedItem> selection, WizardMode mode)
 			: base(con)
         {
             InitializeComponent();
+            wizardMode = mode;
             InitialiseWizard(selection);
         }
 
@@ -117,9 +123,11 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             return false;
         }
 
-        private void InitialiseWizard(IEnumerable<SelectedItem> selection)
+        protected void InitialiseWizard(IEnumerable<SelectedItem> selection)
         {
-            Text = Messages.CPM_WIZARD_TITLE;
+            Text = wizardMode == WizardMode.Migrate
+                    ? Messages.CPM_WIZARD_TITLE
+                    : wizardMode == WizardMode.Move ? Messages.MOVE_VM_WIZARD_TITLE : Messages.COPY_VM_WIZARD_TITLE;
             CreateMappingsFromSelection(selection);
             m_pageDestination = new CrossPoolMigrateDestinationPage(hostPreSelection, VmsFromSelection(selection) )
                                     {
@@ -132,7 +140,10 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             m_pageFinish = new CrossPoolMigrateFinishPage {SummaryRetreiver = GetVMMappingSummary};
             m_pageTargetRbac = new RBACWarningPage();
 
-            AddPages(m_pageDestination, m_pageStorage, m_pageTransferNetwork, m_pageFinish);
+            if (wizardMode == WizardMode.Migrate)
+                AddPages(m_pageDestination, m_pageStorage, m_pageTransferNetwork, m_pageFinish);
+            else
+                AddPages(m_pageDestination, m_pageStorage, m_pageFinish);
         }
 
         public override sealed string Text
@@ -173,7 +184,19 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                 if(target == null)
                     throw new ApplicationException("Cannot resolve the target host");
 
-                new VMCrossPoolMigrateAction(vm, target, SelectedTransferNetwork, pair.Value).RunAsync();
+                if (SelectedTransferNetwork == null)
+                {
+                    // select management interface
+                    var managementPif = NetworkingHelper.GetManagementPIF(target);
+                    SelectedTransferNetwork = TargetConnection.Resolve(managementPif.network);
+                }
+
+                if (wizardMode == WizardMode.Move && IsIntraPoolMigration(pair) && vm.CanBeMoved)
+                {
+                    new VMMoveAction(vm, pair.Value.Storage, target).RunAsync();
+                }
+                else
+                    new VMCrossPoolMigrateAction(vm, target, SelectedTransferNetwork, pair.Value).RunAsync();
             }
             
             base.FinishWizard();
@@ -204,10 +227,18 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
 
         private void AddHostNameToWindowTitle()
         {
-            if(m_vmMappings != null &&  m_vmMappings.Count > 0 ) 
-                Text = String.Format(Messages.CPM_WIZARD_TITLE_AND_LOCATION, m_vmMappings.First().Value.TargetName);
+            if(m_vmMappings != null &&  m_vmMappings.Count > 0 )
+            {
+                var messageText = wizardMode == WizardMode.Migrate
+                    ? Messages.CPM_WIZARD_TITLE_AND_LOCATION
+                    : wizardMode == WizardMode.Move ? Messages.MOVE_VM_WIZARD_TITLE_AND_LOCATION : Messages.COPY_VM_WIZARD_TITLE_AND_LOCATION;
+                Text = String.Format(messageText, m_vmMappings.First().Value.TargetName);
+            }
+                
             else
-                Text = Messages.CPM_WIZARD_TITLE;
+                Text = wizardMode == WizardMode.Migrate
+                    ? Messages.CPM_WIZARD_TITLE 
+                    : wizardMode == WizardMode.Move ? Messages.MOVE_VM_WIZARD_TITLE : Messages.COPY_VM_WIZARD_TITLE;
         }
 
         protected override void UpdateWizardContent(XenTabPage page)

--- a/XenAdmin/Wizards/GenericPages/VMMappingSummary.cs
+++ b/XenAdmin/Wizards/GenericPages/VMMappingSummary.cs
@@ -295,7 +295,8 @@ namespace XenAdmin.Wizards.GenericPages
             get
             {
                 List<SummaryDetails> decoratedSummary = summary.Details;
-                decoratedSummary.Add(new SummaryDetails(Messages.CPM_SUMMARY_KEY_TRANSFER_NETWORK, networkName));
+                if (!string.IsNullOrEmpty(networkName))
+                    decoratedSummary.Add(new SummaryDetails(Messages.CPM_SUMMARY_KEY_TRANSFER_NETWORK, networkName));
                 return decoratedSummary;
             }
         }

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Alerts\Types\MessageAlert.cs" />
     <Compile Include="Alerts\Types\XenServerPatchAlert.cs" />
     <Compile Include="Alerts\Types\XenServerVersionAlert.cs" />
+    <Compile Include="Commands\CrossPoolMoveVMCommand.cs" />
     <Compile Include="Commands\RestartDockerContainerCommand.cs" />
     <Compile Include="Commands\ResumeDockerContainerCommand.cs" />
     <Compile Include="Commands\PauseDockerContainerCommand.cs" />

--- a/XenAdminTests/WizardTests/CrossPoolMigrateWizardTest.cs
+++ b/XenAdminTests/WizardTests/CrossPoolMigrateWizardTest.cs
@@ -79,7 +79,7 @@ namespace XenAdminTests.WizardTests.tampa_cpm_one_and_two_host_pools
         {
             IXenConnection connection = GetAnyConnection(c => c.Name == SourcePool);
             return new CrossPoolMigrateWizard(connection,
-                new List<SelectedItem> { new SelectedItem(GetAnyVM(v => v.Name == Vm)) });
+                new List<SelectedItem> { new SelectedItem(GetAnyVM(v => v.Name == Vm)) }, WizardMode.Migrate);
         }
 
         protected override void TestPage(string pageName)

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8086,6 +8086,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy VM.
+        /// </summary>
+        public static string COPY_VM_WIZARD_TITLE {
+            get {
+                return ResourceManager.GetString("COPY_VM_WIZARD_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy VM to {0}.
+        /// </summary>
+        public static string COPY_VM_WIZARD_TITLE_AND_LOCATION {
+            get {
+                return ResourceManager.GetString("COPY_VM_WIZARD_TITLE_AND_LOCATION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Copyright © {0} All rights reserved..
         /// </summary>
         public static string COPYRIGHT {
@@ -21090,6 +21108,24 @@ namespace XenAdmin {
         public static string MOVE_VDI_CONTEXT_MENU {
             get {
                 return ResourceManager.GetString("MOVE_VDI_CONTEXT_MENU", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move VM.
+        /// </summary>
+        public static string MOVE_VM_WIZARD_TITLE {
+            get {
+                return ResourceManager.GetString("MOVE_VM_WIZARD_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move VM to {0}.
+        /// </summary>
+        public static string MOVE_VM_WIZARD_TITLE_AND_LOCATION {
+            get {
+                return ResourceManager.GetString("MOVE_VM_WIZARD_TITLE_AND_LOCATION", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2921,6 +2921,12 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
   <data name="COPY_VM_SLOW_CLONE_DESCRIPTION" xml:space="preserve">
     <value>Clone the existing template</value>
   </data>
+  <data name="COPY_VM_WIZARD_TITLE" xml:space="preserve">
+    <value>Copy VM</value>
+  </data>
+  <data name="COPY_VM_WIZARD_TITLE_AND_LOCATION" xml:space="preserve">
+    <value>Copy VM to {0}</value>
+  </data>
   <data name="COULD_NOT_OPEN_URL" xml:space="preserve">
     <value>Could not open URL '{0}'</value>
   </data>
@@ -7344,6 +7350,12 @@ To learn more about the XenServer Live VDI Migration feature or to start a XenSe
   </data>
   <data name="MOVE_VDI_CONTEXT_MENU" xml:space="preserve">
     <value>&amp;Move Virtual Disk...</value>
+  </data>
+  <data name="MOVE_VM_WIZARD_TITLE" xml:space="preserve">
+    <value>Move VM</value>
+  </data>
+  <data name="MOVE_VM_WIZARD_TITLE_AND_LOCATION" xml:space="preserve">
+    <value>Move VM to {0}</value>
   </data>
   <data name="MOVING" xml:space="preserve">
     <value>Moving...</value>

--- a/XenModel/Network/NetworkingHelper.cs
+++ b/XenModel/Network/NetworkingHelper.cs
@@ -58,7 +58,7 @@ namespace XenAdmin.Network
             return host == null ? null : GetManagementPIF(host);
         }
 
-        private static PIF GetManagementPIF(Host host)
+        public static PIF GetManagementPIF(Host host)
         {
             foreach (PIF pif in host.Connection.ResolveAll(host.PIFs))
             {

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -1801,6 +1801,22 @@ namespace XenAPI
                 }
             }
         }
+
+        public bool CanBeMoved
+        {
+            get
+            {
+                if (SRs.Any(sr => sr != null && sr.HBALunPerVDI))
+                    return false;
+
+                if (!is_a_template && !Locked && allowed_operations != null && allowed_operations.Contains(vm_operations.export) && power_state != vm_power_state.Suspended)
+                {
+                    return Connection.ResolveAll(VBDs).Find(v => v.IsOwner) != null;
+                }
+
+                return false;
+            }
+        }
     }
 
     public struct VMStartupOptions


### PR DESCRIPTION

- With these changes, a stopped or suspended VM can be moved across pools; this is performed as a vm migrate operation.
- The intra pool move will continue to be a vdi.copy + destroy operation for stopped VMs, but for suspended VMs we need to do it a as vm migrate operation.
- We use the Cross Pool migrate wizard for both intra and cross pool move operations, but introduced a wizard mode parameter in order to adapt the wizard to the specific operation we want to perform (migrate, move or copy)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>