### PR TITLE
CA-165464: Switch to RDP on VM with RDP enable if auto-switch selected

### DIFF
--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -198,6 +198,11 @@ namespace XenAdmin.ConsoleView
             UpdateButtons();
 
             toggleConsoleButton.EnabledChanged += toggleConsoleButton_EnabledChanged;
+
+            //If RDP enabled and AutoSwitchToRDP selected, switch RDP connection when open the tab.
+            //This change is only for Cream, because RDP port scan was removed in Cream.
+            if ( Helpers.CreamOrGreater(source.Connection) && Properties.Settings.Default.AutoSwitchToRDP && RDPEnabled )
+                switchOnTabOpened = true;
         }
 
         //CA-75479 - add to aid debugging


### PR DESCRIPTION

This code change is to set “switchOnTabOpened” in below condition:
1.	XenCenter have “Automatically switch to the Remote Desktop console when it becomes available" selected
2.	VM have RDP enabled.
3.	XenServer Version is Cream or greater.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>