### PR TITLE
CA-164816: After disabling HA on a pool, it should be possible to apply vGPU/GPU Passthrough to previously protected VMs

### DIFF
--- a/XenAdmin/SettingsPanels/GpuEditPage.cs
+++ b/XenAdmin/SettingsPanels/GpuEditPage.cs
@@ -307,7 +307,8 @@ namespace XenAdmin.SettingsPanels
                 return;
             }
 
-            if (VM.HaPriorityIsRestart(Connection, SelectedPriority))
+            Pool pool = Helpers.GetPool(Connection);
+            if (pool != null && pool.ha_enabled && VM.HaPriorityIsRestart(Connection, SelectedPriority))
             {
                 imgRDP.Visible = labelRDP.Visible =
                 imgNeedDriver.Visible = labelNeedDriver.Visible =


### PR DESCRIPTION

- When deciding whether to allow GPU configuration on a VM, check if the HA is enabled, not just the the VM's restart priority setting

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>