### PR TITLE
CA-149867: Invoke on MainWindow instead of various controls

### DIFF
--- a/XenAdmin/ConsoleView/VNCGraphicsClient.cs
+++ b/XenAdmin/ConsoleView/VNCGraphicsClient.cs
@@ -239,10 +239,10 @@ namespace XenAdmin.ConsoleView
             Program.AssertOffEventThread();
 
             // Set the remote clipboard based on the current contents.
-            Program.Invoke(this, (EventHandler)ClipboardChanged, null, null);
+            Program.Invoke(Program.MainWindow, (EventHandler)ClipboardChanged, null, null);
 
             if (ConnectionSuccess != null)
-                Program.Invoke(this, ConnectionSuccess, sender, e);
+                Program.Invoke(Program.MainWindow, ConnectionSuccess, sender, e);
         }
 
         private void OnError(object sender, Exception e)
@@ -481,7 +481,7 @@ namespace XenAdmin.ConsoleView
                 RemoteCursor.Dispose();
             RemoteCursor = new CustomCursor(image, x, y);
 
-            Program.Invoke(this, delegate()
+            Program.Invoke(Program.MainWindow, delegate()
             {
                 if (cursorOver)
                     this.Cursor = RemoteCursor.Cursor;
@@ -581,7 +581,7 @@ namespace XenAdmin.ConsoleView
             }
             else
             {
-                Program.Invoke(this, delegate()
+                Program.Invoke(Program.MainWindow, delegate()
                 {
                     if (Clipboard.ContainsText() && Clipboard.GetText() == text)
                         return;
@@ -604,7 +604,7 @@ namespace XenAdmin.ConsoleView
             // Cannot do an invoke with a locked back buffer, as it may event thread
             // (onPaint) tried to lock back buffer as well - therefore deadlock.
 
-            Program.Invoke(this, delegate()
+            Program.Invoke(Program.MainWindow, delegate()
             {
                 Bitmap old_back_buffer;
                 lock (backBuffer)

--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -310,7 +310,7 @@ namespace XenAdmin.ConsoleView
         /// </summary>
         private void Default_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 deregisterShortCutKeys();
                 registerShortCutKeys();
@@ -490,7 +490,7 @@ namespace XenAdmin.ConsoleView
             else if (e.PropertyName == "VBDs")
             {
                 //The CD device may have changed
-                Program.Invoke(this, setupCD);
+                Program.Invoke(Program.MainWindow, setupCD);
             }
             else if (e.PropertyName == "guest_metrics")
             {
@@ -609,11 +609,11 @@ namespace XenAdmin.ConsoleView
 
                 if (hostMetrics.live)
                 {
-                    Program.Invoke(this, showTopBarContents);
+                    Program.Invoke(Program.MainWindow, showTopBarContents);
                 }
                 else
                 {
-                    Program.Invoke(this, hideTopBarContents);
+                    Program.Invoke(Program.MainWindow, hideTopBarContents);
                 }
             }
             else
@@ -623,11 +623,11 @@ namespace XenAdmin.ConsoleView
                     case vm_power_state.Halted:
                     case vm_power_state.Paused:
                     case vm_power_state.Suspended:
-                        Program.Invoke(this, hideTopBarContents);
+                        Program.Invoke(Program.MainWindow, hideTopBarContents);
                         break;
                     case vm_power_state.Running:
-                        Program.Invoke(this, showTopBarContents);
-                        Program.Invoke(this, maybeEnableButton);
+                        Program.Invoke(Program.MainWindow, showTopBarContents);
+                        Program.Invoke(Program.MainWindow, maybeEnableButton);
                         break;
                 }
             }
@@ -966,7 +966,7 @@ namespace XenAdmin.ConsoleView
         {
             Program.AssertOffEventThread();
 
-            Program.Invoke(this, delegate()
+            Program.Invoke(Program.MainWindow, delegate()
             {
                 lock (this.insKeyTimer)
                 {
@@ -1092,7 +1092,7 @@ namespace XenAdmin.ConsoleView
   }
         void Connection_BeforeConnectionEnd(object sender, EventArgs e)
         {
-            Program.Invoke(this, toggleFullscreen);
+            Program.Invoke(Program.MainWindow, toggleFullscreen);
         }
 
         private const bool RDP = true;
@@ -1113,7 +1113,7 @@ namespace XenAdmin.ConsoleView
 
         private void OnDetectRDP()
         {
-            Program.Invoke(this, OnDetectRDP_);
+            Program.Invoke(Program.MainWindow, OnDetectRDP_);
         }
 
         private void OnDetectRDP_()
@@ -1145,7 +1145,7 @@ namespace XenAdmin.ConsoleView
 
         private void OnDetectVNC()
         {
-            Program.Invoke(this, OnDetectVNC_);
+            Program.Invoke(Program.MainWindow, OnDetectVNC_);
         }
 
         private void OnDetectVNC_()
@@ -1263,7 +1263,7 @@ namespace XenAdmin.ConsoleView
         {
             bool hasToReconnect = vncScreen.rdpIP == null;
             vncScreen.rdpIP = vncScreen.PollPort(XSVNCScreen.RDP_PORT, true);
-            Program.Invoke(this, (MethodInvoker)(() =>
+            Program.Invoke(Program.MainWindow, (MethodInvoker)(() =>
             {
                 if (hasToReconnect)
                 {

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -173,7 +173,7 @@ namespace XenAdmin.ConsoleView
         void Default_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "EnableRDPPolling")
-                Program.Invoke(this, startPolling);
+                Program.Invoke(Program.MainWindow, startPolling);
         }
 
         private void UnregisterEventListeners()
@@ -205,7 +205,7 @@ namespace XenAdmin.ConsoleView
 
                     cachedNetworks = newNetworks;
 
-                    Program.Invoke(this, startPolling);
+                    Program.Invoke(Program.MainWindow, startPolling);
                 }
             }
         }
@@ -293,7 +293,7 @@ namespace XenAdmin.ConsoleView
                 if (connectionPoller != null)
                     connectionPoller.Change(Timeout.Infinite, Timeout.Infinite);
                 if (OnDetectRDP != null)
-                    Program.Invoke(this, OnDetectRDP);
+                    Program.Invoke(Program.MainWindow, OnDetectRDP);
             }
             else
             {
@@ -306,7 +306,7 @@ namespace XenAdmin.ConsoleView
                     if (connectionPoller != null)
                         connectionPoller.Change(Timeout.Infinite, Timeout.Infinite);
                     if (OnDetectRDP != null)
-                        Program.Invoke(this, OnDetectRDP);
+                        Program.Invoke(Program.MainWindow, OnDetectRDP);
                 }
             }
         }
@@ -322,7 +322,7 @@ namespace XenAdmin.ConsoleView
                 if (connectionPoller != null)
                     connectionPoller.Change(Timeout.Infinite, Timeout.Infinite);
                 if (OnDetectVNC != null)
-                    Program.Invoke(this, OnDetectVNC);
+                    Program.Invoke(Program.MainWindow, OnDetectVNC);
             }
         }
 
@@ -766,7 +766,7 @@ namespace XenAdmin.ConsoleView
             else if (e.PropertyName == "domid")
             {
                 // Reboot / start / shutdown
-                Program.Invoke(this, startPolling);
+                Program.Invoke(Program.MainWindow, startPolling);
             }
 
             if (e.PropertyName == "power_state" || e.PropertyName == "VGPUs")
@@ -907,7 +907,7 @@ namespace XenAdmin.ConsoleView
                         bool lifecycleOperationInProgress = sourceVM.current_operations.Values.Any(VM.is_lifecycle_operation);
                         if (haveTriedLoginWithoutPassword && !lifecycleOperationInProgress)
                         {
-                            Program.Invoke(this, delegate
+                            Program.Invoke(Program.MainWindow, delegate
                             {
                                 promptForPassword(ignoreNextError ? null : error);
                             });
@@ -978,7 +978,7 @@ namespace XenAdmin.ConsoleView
 
         private void OnUserCancelledAuth()
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 Log.Debug("User cancelled during VNC authentication");
                 if (UserCancelledAuth != null)
@@ -1021,7 +1021,7 @@ namespace XenAdmin.ConsoleView
 
         private void InvokeConnection(VNCGraphicsClient v, Stream stream, Console console)
         {
-            Program.Invoke(this, delegate()
+            Program.Invoke(Program.MainWindow, delegate()
             {
                 // This is the last chance that we have to make sure that we've not already
                 // connected this VNCGraphicsClient.  Now that we are back on the event thread,
@@ -1069,7 +1069,7 @@ namespace XenAdmin.ConsoleView
             if (this.Disposing || this.IsDisposed)
                 return;
 
-            Program.Invoke(this, delegate()
+            Program.Invoke(Program.MainWindow, delegate()
             {
                 VNCGraphicsClient v = (VNCGraphicsClient)sender;
 

--- a/XenAdmin/Controls/Ballooning/VMMemoryControlsNoEdit.cs
+++ b/XenAdmin/Controls/Ballooning/VMMemoryControlsNoEdit.cs
@@ -105,7 +105,7 @@ namespace XenAdmin.Controls.Ballooning
         void vm_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "power_state" || e.PropertyName == "virtualisation_status" || e.PropertyName == "name_label")
-                Program.Invoke(this,Refresh);
+                Program.Invoke(Program.MainWindow,Refresh);
         }
 
         void vm_metrics_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/XenAdmin/Controls/CheckableDataGridView/CheckableDataGridView.cs
+++ b/XenAdmin/Controls/CheckableDataGridView/CheckableDataGridView.cs
@@ -327,13 +327,13 @@ namespace XenAdmin.Controls.CheckableDataGridView
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SuspendDrawing()
         {
-            Program.Invoke(this, () => HelpersGUI.SuspendDrawing(this) );
+            Program.Invoke(Program.MainWindow, () => HelpersGUI.SuspendDrawing(this) );
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ResumeDrawing()
         {
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                                      {
                                          HelpersGUI.ResumeDrawing(this);
                                          Refresh();
@@ -351,7 +351,7 @@ namespace XenAdmin.Controls.CheckableDataGridView
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void DrawUpdatedRow(Queue<object> textToUse, bool cellDataLoaded, bool rowDisabled, int rowIndex)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
                                      {
                                          try{
                                             

--- a/XenAdmin/Controls/ComboBoxes/CDChanger.cs
+++ b/XenAdmin/Controls/ComboBoxes/CDChanger.cs
@@ -155,7 +155,7 @@ namespace XenAdmin.Controls
 
             action.Completed += delegate
                 {
-                    Program.Invoke(this, delegate()
+                    Program.Invoke(Program.MainWindow, delegate()
                         {
                             changing = false;
                             SelectCD();

--- a/XenAdmin/Controls/ComboBoxes/ISODropDownBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/ISODropDownBox.cs
@@ -362,7 +362,7 @@ namespace XenAdmin.Controls
                 sr.PropertyChanged += sr_PropertyChanged;
             }
 
-            Program.Invoke(this, refreshAll);
+            Program.Invoke(Program.MainWindow, refreshAll);
         }
 
         public virtual void refreshAll()

--- a/XenAdmin/Controls/ConsolePanel.cs
+++ b/XenAdmin/Controls/ConsolePanel.cs
@@ -261,7 +261,7 @@ namespace XenAdmin.Controls
 
             if (!vncViews.ContainsKey(vm))
             {
-                Program.Invoke(this, delegate
+                Program.Invoke(Program.MainWindow, delegate
                 {
                     // use elevated credentials, if provided, to create a vncView (CA-91132)
                     useElevatedCredentials = !String.IsNullOrEmpty(elevatedUsername) && !String.IsNullOrEmpty(elevatedPassword);
@@ -291,7 +291,7 @@ namespace XenAdmin.Controls
             if (useElevatedCredentials)
             {
                 //used the elevated credentials for snapshot, need to close vnc when finished
-                Program.Invoke(this, () => view.Dispose());
+                Program.Invoke(Program.MainWindow, () => view.Dispose());
             }
 
             return snapshot;

--- a/XenAdmin/Controls/FilterLocationToolStripDropDownButton.cs
+++ b/XenAdmin/Controls/FilterLocationToolStripDropDownButton.cs
@@ -310,25 +310,25 @@ namespace XenAdmin.Controls
             if (e.Action == CollectionChangeAction.Add)
                 HostCheckStates[((Host)e.Element).uuid] = true;
 
-            Program.Invoke(Parent, RefreshLists);
+            Program.Invoke(Program.MainWindow, RefreshLists);
         }
 
         private void pool_PropertyChanged(object obj, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "other_config" || e.PropertyName == "name_label")
-                Program.Invoke(Parent, RefreshLists);
+                Program.Invoke(Program.MainWindow, RefreshLists);
         }
 
         private void hostMetrics_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "live")
-                Program.Invoke(Parent, RefreshLists);
+                Program.Invoke(Program.MainWindow, RefreshLists);
         }
 
         private void host_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "name_label" || e.PropertyName == "metrics")
-                Program.Invoke(Parent, RefreshLists);
+                Program.Invoke(Program.MainWindow, RefreshLists);
         }
 
         protected override void OnDropDownItemClicked(ToolStripItemClickedEventArgs e)

--- a/XenAdmin/Controls/HaNtolControl.cs
+++ b/XenAdmin/Controls/HaNtolControl.cs
@@ -178,7 +178,7 @@ namespace XenAdmin.Controls
 
             while (!exitNtolUpdateThread)
             {
-                Program.Invoke(this, () =>
+                Program.Invoke(Program.MainWindow, () =>
                     {
                         // Don't do GUI stuff if we've been told to exit
                         if (!exitNtolUpdateThread)
@@ -213,7 +213,7 @@ namespace XenAdmin.Controls
                                         ? (Pool.get_ha_host_failures_to_tolerate(dupSess, p.opaque_ref))
                                         : ntolMax;
 
-                    Program.Invoke(this, () =>
+                    Program.Invoke(Program.MainWindow, () =>
                         {
                             // Don't do GUI stuff if we've been told to exit
                             if (!exitNtolUpdateThread)
@@ -228,7 +228,7 @@ namespace XenAdmin.Controls
                 {
                     log.Warn(e, e);
                     ntol = -1;
-                    Program.Invoke(this, () =>
+                    Program.Invoke(Program.MainWindow, () =>
                         {
                             // Don't do GUI stuff if we've been told to exit
                             if (!exitNtolUpdateThread)
@@ -302,7 +302,7 @@ namespace XenAdmin.Controls
                 || e.PropertyName.StartsWith("memory"))
             {
                 // Trigger ntol update
-                Program.Invoke(this, () => waitingNtolUpdate.Set());
+                Program.Invoke(Program.MainWindow, () => waitingNtolUpdate.Set());
             }
         }
 

--- a/XenAdmin/Controls/MainWindowControls/NavigationView.cs
+++ b/XenAdmin/Controls/MainWindowControls/NavigationView.cs
@@ -152,7 +152,7 @@ namespace XenAdmin.Controls.MainWindowControls
         {
             try
             {
-                Program.Invoke(this, () =>
+                Program.Invoke(Program.MainWindow, () =>
                 {
                     if (!e.Background)
                     {
@@ -174,7 +174,7 @@ namespace XenAdmin.Controls.MainWindowControls
         {
             try
             {
-                Program.Invoke(this, () =>
+                Program.Invoke(Program.MainWindow, () =>
                 {
                     ResumeRefreshTreeView();
 
@@ -577,7 +577,7 @@ namespace XenAdmin.Controls.MainWindowControls
 
             EventHandler<RenameCompletedEventArgs> completed = delegate(object s, RenameCompletedEventArgs ee)
             {
-                Program.Invoke(this, delegate
+                Program.Invoke(Program.MainWindow, delegate
                 {
                     ResumeRefreshTreeView();
 

--- a/XenAdmin/Controls/NetworkingTab/NetworkList.cs
+++ b/XenAdmin/Controls/NetworkingTab/NetworkList.cs
@@ -249,7 +249,7 @@ namespace XenAdmin.Controls.NetworkingTab
 
         void VM_guest_metrics_BatchCollectionChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, BuildList);
+            Program.Invoke(Program.MainWindow, BuildList);
         }
 
         void Default_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -639,22 +639,22 @@ namespace XenAdmin.Controls.NetworkingTab
 
         void NetworkCollectionChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, BuildList);
+            Program.Invoke(Program.MainWindow, BuildList);
         }
 
         void PIFCollectionChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, BuildList);
+            Program.Invoke(Program.MainWindow, BuildList);
         }
 
         void CollectionChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, BuildList);
+            Program.Invoke(Program.MainWindow, BuildList);
         }
 
         void action_Completed(ActionBase sender)
         {
-            Program.Invoke(this, BuildList);
+            Program.Invoke(Program.MainWindow, BuildList);
         }
 
         void Server_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -665,7 +665,7 @@ namespace XenAdmin.Controls.NetworkingTab
             // does not digress with this fix.
             if (shouldRefreshBuildList(e))
             {
-                Program.Invoke(this, RefreshAllItems);
+                Program.Invoke(Program.MainWindow, RefreshAllItems);
             }
         }
 
@@ -732,7 +732,7 @@ namespace XenAdmin.Controls.NetworkingTab
             Proxy_VIF proxyVIF = d.GetNewSettings();
             UpdateVIFCommand command = new UpdateVIFCommand(Program.MainWindow, vm, vif, proxyVIF);
             InBuildList = true;
-            command.Completed += new EventHandler((s, f) => Program.Invoke(this, () =>
+            command.Completed += new EventHandler((s, f) => Program.Invoke(Program.MainWindow, () =>
                                                                                      {
                                                                                          InBuildList = false;
                                                                                          BuildList();

--- a/XenAdmin/Controls/PoolHostPicker.cs
+++ b/XenAdmin/Controls/PoolHostPicker.cs
@@ -74,7 +74,7 @@ namespace XenAdmin.Controls
         void PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if(e.PropertyName == "name_label" || e.PropertyName == "metrics" || e.PropertyName == "enabled" || e.PropertyName == "live" || e.PropertyName == "patches")
-                Program.Invoke(this, buildList);
+                Program.Invoke(Program.MainWindow, buildList);
         }
 
         public void buildList()
@@ -188,12 +188,12 @@ namespace XenAdmin.Controls
 
         void xc_CachePopulated(object sender, EventArgs e)
         {
-            Program.Invoke(this, buildList);
+            Program.Invoke(Program.MainWindow, buildList);
         }
 
         void xc_ConnectionStateChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, buildList);
+            Program.Invoke(Program.MainWindow, buildList);
         }
 
         private CustomTreeNode lastSelected;

--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -264,12 +264,12 @@ namespace XenAdmin.Controls
         private void Server_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "name_label" || e.PropertyName == "PBDs" || e.PropertyName == "physical_utilisation" || e.PropertyName == "currently_attached" || e.PropertyName == "default_SR")
-                Program.Invoke(this, refresh);
+                Program.Invoke(Program.MainWindow, refresh);
         }
 
         void SR_CollectionChanged(object sender, CollectionChangeEventArgs e)
         {
-            Program.Invoke(this, refresh);
+            Program.Invoke(Program.MainWindow, refresh);
         }
 
         /// <summary>

--- a/XenAdmin/Controls/Wlb/WlbOptimizePool.cs
+++ b/XenAdmin/Controls/Wlb/WlbOptimizePool.cs
@@ -253,7 +253,7 @@ namespace XenAdmin.Controls.Wlb
         /// <param name="e">PropertyChangedEventArgs</param>
         private void Pool_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 if (_xenObject != null && Program.MainWindow.TheTabControl.SelectedTab == Program.MainWindow.TabPageWLB)
                 {
@@ -321,7 +321,7 @@ namespace XenAdmin.Controls.Wlb
                 if ((e.PropertyName == "resident_VMs" && IsHostOnListView(((Host)sender), true)) 
                     || (e.PropertyName == "enabled" && !((Host)sender).enabled))
                 {
-                    Program.Invoke(this, delegate()
+                    Program.Invoke(Program.MainWindow, delegate()
                      {
                          BuildRecList();
                      });
@@ -643,7 +643,7 @@ namespace XenAdmin.Controls.Wlb
                     _recommendations = thisAction.WLBOptPoolRecommendations;
                     if (_recommendations != null && IsGoodRecommendation(_recommendations) && _xenObject.Connection == action.Connection)
                     {
-                        Program.Invoke(this, delegate()
+                        Program.Invoke(Program.MainWindow, delegate()
                         {
                             PopulateData(_recommendations);
 
@@ -659,7 +659,7 @@ namespace XenAdmin.Controls.Wlb
                     }
                     else
                     {
-                        Program.Invoke(this, delegate()
+                        Program.Invoke(Program.MainWindow, delegate()
                         {
                             statusLabel.Text = Messages.WLB_OPT_POOL_NO_RECOMMENDATION;
                             EnableControls(true, false);

--- a/XenAdmin/Controls/XenSearch/QueryElement.cs
+++ b/XenAdmin/Controls/XenSearch/QueryElement.cs
@@ -319,7 +319,7 @@ namespace XenAdmin.Controls.XenSearch
 
         void queryType_SomeThingChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, Setup);
+            Program.Invoke(Program.MainWindow, Setup);
         }
 
         private void RefreshSubQueryElements()

--- a/XenAdmin/Dialogs/ActionProgressDialog.cs
+++ b/XenAdmin/Dialogs/ActionProgressDialog.cs
@@ -109,7 +109,7 @@ namespace XenAdmin.Dialogs
                 return;
 
             action.RecomputeCanCancel();
-            Program.Invoke(this, action_Changed_);
+            Program.Invoke(Program.MainWindow, action_Changed_);
         }
 
         private void action_Changed_()
@@ -146,7 +146,7 @@ namespace XenAdmin.Dialogs
             if (Disposing || IsDisposed || Program.Exiting)
                 return;
 
-            Program.Invoke(this, action_Completed_);
+            Program.Invoke(Program.MainWindow, action_Completed_);
         }
 
         private void action_Completed_()

--- a/XenAdmin/Dialogs/AssignLicenseDialog.cs
+++ b/XenAdmin/Dialogs/AssignLicenseDialog.cs
@@ -227,7 +227,7 @@ namespace XenAdmin.Dialogs
 
             command.Succedded += delegate
                                      {
-                                         Program.Invoke(this, () =>
+                                         Program.Invoke(Program.MainWindow, () =>
                                             {
                                                 DialogResult = DialogResult.OK;
                                                 Close();

--- a/XenAdmin/Dialogs/AttachDiskDialog.cs
+++ b/XenAdmin/Dialogs/AttachDiskDialog.cs
@@ -73,7 +73,7 @@ namespace XenAdmin.Dialogs
 
         void SR_CollectionChanged(object sender, CollectionChangeEventArgs e)
         {
-            Program.Invoke(this, BuildList);
+            Program.Invoke(Program.MainWindow, BuildList);
         }
 
         private bool skipSelectedIndexChanged;
@@ -192,7 +192,7 @@ namespace XenAdmin.Dialogs
         {
             if (e.PropertyName == "name_label" || e.PropertyName == "VDIs" || e.PropertyName == "VBDs" || e.PropertyName == "default_SR")
             {
-                Program.Invoke(this, BuildList);
+                Program.Invoke(Program.MainWindow, BuildList);
             }
         }
 

--- a/XenAdmin/Dialogs/ChangeServerPasswordDialog.cs
+++ b/XenAdmin/Dialogs/ChangeServerPasswordDialog.cs
@@ -72,7 +72,7 @@ namespace XenAdmin.Dialogs
         {
             if (e.PropertyName == "name_label")
             {
-                Program.Invoke(this, UpdateText);
+                Program.Invoke(Program.MainWindow, UpdateText);
             }
         }
 

--- a/XenAdmin/Dialogs/DecompressApplianceDialog.cs
+++ b/XenAdmin/Dialogs/DecompressApplianceDialog.cs
@@ -128,14 +128,14 @@ namespace XenAdmin.Dialogs
 
 		private void m_worker_ProgressChanged(object sender, ProgressChangedEventArgs e)
 		{
-		    Program.Invoke(this, () => m_progressBar.Value = e.ProgressPercentage);
+		    Program.Invoke(Program.MainWindow, () => m_progressBar.Value = e.ProgressPercentage);
 		}
 
 		private void m_worker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
 		{
 			if (e.Error != null)//failure
 			{
-				Program.Invoke(this, () =>
+				Program.Invoke(Program.MainWindow, () =>
 				                     	{
 											m_tlpProgress.Visible = false;
 				                     		ShowError(e.Error.Message);
@@ -147,7 +147,7 @@ namespace XenAdmin.Dialogs
 			}
 			else if (e.Cancelled)//user cancelled
 			{
-				Program.Invoke(this, () =>
+				Program.Invoke(Program.MainWindow, () =>
 				                     	{
 											File.Delete(m_decompressedFile);
 				                     		DialogResult = DialogResult.Cancel;
@@ -155,7 +155,7 @@ namespace XenAdmin.Dialogs
 			}
 			else//success
 			{
-				Program.Invoke(this, () =>
+				Program.Invoke(Program.MainWindow, () =>
 				                     	{
 											m_progressBar.Value = 100;
 											File.Delete(m_compressedFile);

--- a/XenAdmin/Dialogs/DialogWithProgress.cs
+++ b/XenAdmin/Dialogs/DialogWithProgress.cs
@@ -155,7 +155,7 @@ namespace XenAdmin.Dialogs
 
                     while (ClientSize.Height < expectedHeight)
                     {
-                        Program.Invoke(this, delegate()
+                        Program.Invoke(Program.MainWindow, delegate()
                         {
                             ClientSize = new Size(ClientSize.Width, (int) (((2.0 * ClientSize.Height) / 3.0) + (expectedHeight / 3.0) + 1.0));
                         });
@@ -165,7 +165,7 @@ namespace XenAdmin.Dialogs
 
                 worker.RunWorkerCompleted += new RunWorkerCompletedEventHandler(delegate(object o, RunWorkerCompletedEventArgs e)
                 {
-                    Program.Invoke(this, delegate()
+                    Program.Invoke(Program.MainWindow, delegate()
                     {
                         MinimumSize = new Size(MinimumSize.Width, MinimumSize.Height + dx);
 

--- a/XenAdmin/Dialogs/DownloadApplianceDialog.cs
+++ b/XenAdmin/Dialogs/DownloadApplianceDialog.cs
@@ -114,14 +114,14 @@ namespace XenAdmin.Dialogs
 
 		private void webclient_DownloadProgressChanged(object sender, DownloadProgressChangedEventArgs e)
 		{
-			Program.Invoke(this, () => m_progressBar.Value = e.ProgressPercentage);
+			Program.Invoke(Program.MainWindow, () => m_progressBar.Value = e.ProgressPercentage);
 		}
 
 		private void webclient_DownloadFileCompleted(object sender, AsyncCompletedEventArgs e)
 		{
 			if (e.Error != null) //failure
 			{
-				Program.Invoke(this, () =>
+				Program.Invoke(Program.MainWindow, () =>
 				                     	{
 				                     		DownloadedPath = null;
 				                     		m_tlpProgress.Visible = false;
@@ -131,7 +131,7 @@ namespace XenAdmin.Dialogs
 			}
 			else if (e.Cancelled) //user cancelled
 			{
-				Program.Invoke(this, () =>
+				Program.Invoke(Program.MainWindow, () =>
 				                     	{
 				                     		DownloadedPath = null;
 				                     		DialogResult = DialogResult.Cancel;
@@ -139,7 +139,7 @@ namespace XenAdmin.Dialogs
 			}
 			else //success
 			{
-				Program.Invoke(this, () =>
+				Program.Invoke(Program.MainWindow, () =>
 				                     	{
 				                     		var appfile = (ApplianceFile)e.UserState;
 											

--- a/XenAdmin/Dialogs/EditVmHaPrioritiesDialog.cs
+++ b/XenAdmin/Dialogs/EditVmHaPrioritiesDialog.cs
@@ -155,7 +155,7 @@ namespace XenAdmin.Dialogs
             {
                 if (!pool.ha_enabled)
                 {
-                    Program.Invoke(this, delegate()
+                    Program.Invoke(Program.MainWindow, delegate()
                     {
                         new ThreeButtonDialog(
                            new ThreeButtonDialog.Details(

--- a/XenAdmin/Dialogs/EvacuateHostDialog.cs
+++ b/XenAdmin/Dialogs/EvacuateHostDialog.cs
@@ -222,14 +222,14 @@ namespace XenAdmin.Dialogs
         void solveActionCompleted(ActionBase sender)
         {
             // this should rescan the vm errors and update the dialog.
-            Program.Invoke(this, update);
+            Program.Invoke(Program.MainWindow, update);
         }
 
         private void hostUpdate(object o, PropertyChangedEventArgs args)
         {
             if (args == null || args.PropertyName == "name_label" || args.PropertyName == "resident_VMs")
             {
-                Program.Invoke(this, update);
+                Program.Invoke(Program.MainWindow, update);
             }
         }
 
@@ -276,7 +276,7 @@ namespace XenAdmin.Dialogs
                         reasons = Host.get_vms_which_prevent_evacuation(session, host.opaque_ref);
 
                     // take care of errors
-                    Program.Invoke(this, delegate()
+                    Program.Invoke(Program.MainWindow, delegate()
                     {
                         foreach (KeyValuePair<XenRef<VM>, String[]> kvp in reasons)
                         {
@@ -328,11 +328,11 @@ namespace XenAdmin.Dialogs
         {
             if (args.PropertyName == "resident_on" || args.PropertyName == "allowed_operations")
             {
-                Program.Invoke(this, dataGridViewVms.Refresh);
+                Program.Invoke(Program.MainWindow, dataGridViewVms.Refresh);
             }
             else if (args.PropertyName == "virtualisation_status")
             {
-                Program.Invoke(this, update);
+                Program.Invoke(Program.MainWindow, update);
             }
             else if (args.PropertyName == "guest_metrics")
             {
@@ -349,13 +349,13 @@ namespace XenAdmin.Dialogs
         void gm_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "PV_drivers_version")
-                Program.Invoke(this, update);
+                Program.Invoke(Program.MainWindow, update);
         }
 
         private void host_PropertyChanged(object sender, PropertyChangedEventArgs args)
         {
             populateHosts();
-            Program.Invoke(this, NewMasterComboBox.Refresh);
+            Program.Invoke(Program.MainWindow, NewMasterComboBox.Refresh);
         }
 
         private void populateVMs()
@@ -638,12 +638,12 @@ namespace XenAdmin.Dialogs
 
         private void action_Changed(ActionBase action)
         {
-            Program.Invoke(this, () => UpdateProgressControls(action));
+            Program.Invoke(Program.MainWindow, () => UpdateProgressControls(action));
         }
 
         private void action_Completed(ActionBase sender)
         {
-            Program.Invoke(this, delegate()
+            Program.Invoke(Program.MainWindow, delegate()
             {
                 if (sender == null)
                     return;
@@ -679,7 +679,7 @@ namespace XenAdmin.Dialogs
                 ProcessError(null, failure.ErrorDescription.ToArray());
             });
 
-            Program.Invoke(this, () => FinalizeProgressControls(sender));
+            Program.Invoke(Program.MainWindow, () => FinalizeProgressControls(sender));
         }
 
         private void ProcessError(String vmRef, String[] ErrorDescription)
@@ -778,7 +778,7 @@ namespace XenAdmin.Dialogs
 
             row.UpdateError(message, solution);
 
-            Program.Invoke(this, dataGridViewVms.Refresh);
+            Program.Invoke(Program.MainWindow, dataGridViewVms.Refresh);
         }
 
         private void CloseButton_Click(object sender, EventArgs e)

--- a/XenAdmin/Dialogs/GraphDetailsDialog.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.cs
@@ -85,7 +85,7 @@ namespace XenAdmin.Dialogs
 
         void getDataSorucesAction_Completed(ActionBase sender)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 GetDataSourcesAction action = sender as GetDataSourcesAction;
                 if (action != null)

--- a/XenAdmin/Dialogs/IscsiDeviceConfigDialog.cs
+++ b/XenAdmin/Dialogs/IscsiDeviceConfigDialog.cs
@@ -405,7 +405,7 @@ namespace XenAdmin.Dialogs
 
         private void IscsiPopulateIqnsAction_Completed(ActionBase sender)
         {
-            Program.Invoke(this, (System.Threading.WaitCallback)IscsiPopulateIqnsAction_Completed_, sender);
+            Program.Invoke(Program.MainWindow, (System.Threading.WaitCallback)IscsiPopulateIqnsAction_Completed_, sender);
         }
 
         private void IscsiPopulateIqnsAction_Completed_(object o)
@@ -480,7 +480,7 @@ namespace XenAdmin.Dialogs
 
         private void IscsiPopulateLunsAction_Completed(ActionBase sender)
         {
-            Program.Invoke(this, (WaitCallback)IscsiPopulateLunsAction_Completed_, sender);
+            Program.Invoke(Program.MainWindow, (WaitCallback)IscsiPopulateLunsAction_Completed_, sender);
         }
 
         private void IscsiPopulateLunsAction_Completed_(object o)

--- a/XenAdmin/Dialogs/LicenseManager/LicenseManager.cs
+++ b/XenAdmin/Dialogs/LicenseManager/LicenseManager.cs
@@ -164,7 +164,7 @@ namespace XenAdmin.Dialogs
 
         void checkableDataGridView_RefreshAll(object sender, EventArgs eventArgs)
         {
-            Program.Invoke(this, Controller.Repopulate);
+            Program.Invoke(Program.MainWindow, Controller.Repopulate);
         }
 
         #region ISummaryPanelView Members
@@ -198,7 +198,7 @@ namespace XenAdmin.Dialogs
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void DrawSummaryForHighlightedRow(CheckableDataGridViewRow row, SummaryTextComponent summaryComponent, Action runOnUrlClick)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
                                      {
                                          LicenseDataGridViewRow lRow = row as LicenseDataGridViewRow;
                                          if(lRow == null || lRow.XenObject == null)

--- a/XenAdmin/Dialogs/MessageBoxTest.cs
+++ b/XenAdmin/Dialogs/MessageBoxTest.cs
@@ -74,7 +74,7 @@ namespace XenAdmin.Dialogs
         private void refreshTick(object state)
         {
             timer.Change(System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite);
-            Program.Invoke(this, refreshTick_);
+            Program.Invoke(Program.MainWindow, refreshTick_);
         }
 
         private void refreshTick_()

--- a/XenAdmin/Dialogs/RepairSRDialog.cs
+++ b/XenAdmin/Dialogs/RepairSRDialog.cs
@@ -115,17 +115,17 @@ namespace XenAdmin.Dialogs
 
         private void PBD_CollectionChanged(object sender, CollectionChangeEventArgs e)
         {
-            Program.Invoke(this, Build);
+            Program.Invoke(Program.MainWindow, Build);
         }
 
         private void Host_CollectionChanged(object sender, CollectionChangeEventArgs e)
         {
-            Program.Invoke(this, Build);
+            Program.Invoke(Program.MainWindow, Build);
         }
 
         private void Server_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            Program.Invoke(this, Build);
+            Program.Invoke(Program.MainWindow, Build);
         }
 
         private void hostsTreeView_BeforeSelect(object sender, TreeViewCancelEventArgs e)
@@ -287,7 +287,7 @@ namespace XenAdmin.Dialogs
 
         private void action_Changed(ActionBase action)
         {
-            Program.Invoke(this, () => UpdateProgressControls(action));
+            Program.Invoke(Program.MainWindow, () => UpdateProgressControls(action));
         }
 
         private void action_Completed(ActionBase sender)
@@ -298,7 +298,7 @@ namespace XenAdmin.Dialogs
                 SucceededWithWarningDescription = Messages.REPAIR_SR_WARNING_MULTIPATHS_DOWN;
             }
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                 {
                     if (sender is MultipleAction)
                         Build();

--- a/XenAdmin/Dialogs/ResolvingSubjectsDialog.cs
+++ b/XenAdmin/Dialogs/ResolvingSubjectsDialog.cs
@@ -115,7 +115,7 @@ namespace XenAdmin.Dialogs
 
         void resolveAction_NameResolveComplete(object sender, string enteredName, string resolvedName, string sid, Exception exception)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 foreach (ListViewItemSubjectWrapper i in entryListView.Items)
                 {
@@ -134,7 +134,7 @@ namespace XenAdmin.Dialogs
 
         void resolveAction_AllResolveComplete()
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
            {
                LabelStatus.Text = Messages.ADDING_RESOLVED_TO_ACCESS_LIST;
            });
@@ -142,7 +142,7 @@ namespace XenAdmin.Dialogs
 
         void resolveAction_SubjectAddComplete(object sender, Subject subject, Exception exception)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 foreach (ListViewItemSubjectWrapper i in entryListView.Items)
                 {
@@ -160,7 +160,7 @@ namespace XenAdmin.Dialogs
 
         private void addAction_Completed(ActionBase sender)
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 if (resolveAction.Cancelled)
                 {

--- a/XenAdmin/Dialogs/VMAppliances/VMAppliancesDialog.cs
+++ b/XenAdmin/Dialogs/VMAppliances/VMAppliancesDialog.cs
@@ -206,7 +206,7 @@ namespace XenAdmin.Dialogs.VMAppliances
 
         private void vm_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
             {
                 // Find row for VM
                 ListViewItem item = FindItemFromVM((VM)sender);
@@ -241,7 +241,7 @@ namespace XenAdmin.Dialogs.VMAppliances
                     break;
             }
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
             {
                 // Find row for VM
                 ListViewItem item = FindItemFromVM(vm);

--- a/XenAdmin/Dialogs/WarningDialogs/CloseXenCenterWarningDialog.cs
+++ b/XenAdmin/Dialogs/WarningDialogs/CloseXenCenterWarningDialog.cs
@@ -225,12 +225,12 @@ namespace XenAdmin.Dialogs.WarningDialogs
             if (!action.IsCompleted)
                 return;
 
-            Program.Invoke(this, () => RemoveActionRow(action));
+            Program.Invoke(Program.MainWindow, () => RemoveActionRow(action));
         }
 
         private void action_Completed(ActionBase action)
         {
-            Program.Invoke(this, () => RemoveActionRow(action));
+            Program.Invoke(Program.MainWindow, () => RemoveActionRow(action));
         }
 
         private void dataGridView_CellClick(object sender, DataGridViewCellEventArgs e)

--- a/XenAdmin/SettingsPanels/VMHAEditPage.cs
+++ b/XenAdmin/SettingsPanels/VMHAEditPage.cs
@@ -252,7 +252,7 @@ namespace XenAdmin.SettingsPanels
             }
             finally
             {
-                Program.Invoke(this, delegate()
+                Program.Invoke(Program.MainWindow, delegate()
                 {
                     if (verticalTabs != null)
                         verticalTabs.Refresh();

--- a/XenAdmin/TabPages/AdPage.cs
+++ b/XenAdmin/TabPages/AdPage.cs
@@ -209,7 +209,7 @@ namespace XenAdmin.TabPages
             action.Completed -= action_Completed;
 
             if (_xenObject != null && _xenObject.Connection == action.Connection)
-                Program.Invoke(this, checkAdType);
+                Program.Invoke(Program.MainWindow, checkAdType);
         }
 
         void Session_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -227,7 +227,7 @@ namespace XenAdmin.TabPages
         {
             if (e.PropertyName == "external_auth_type" || e.PropertyName == "name_label")
             {
-                Program.Invoke(this, checkAdType);
+                Program.Invoke(Program.MainWindow, checkAdType);
             }
         }
 
@@ -241,14 +241,14 @@ namespace XenAdmin.TabPages
         {
             if (e.PropertyName == "name_label")
             {
-                Program.Invoke(this, checkAdType);
+                Program.Invoke(Program.MainWindow, checkAdType);
             }
             else if (e.PropertyName == "master")
             {
                 if (master != null)
                     master.PropertyChanged -= new PropertyChangedEventHandler(master_PropertyChanged);
 
-                Program.Invoke(this, RefreshMaster);
+                Program.Invoke(Program.MainWindow, RefreshMaster);
             }
         }
 
@@ -522,7 +522,7 @@ namespace XenAdmin.TabPages
                 {
 
                     bool showing = false;
-                    Program.Invoke(this, delegate
+                    Program.Invoke(Program.MainWindow, delegate
                     {
                         showing = Program.MainWindow.TheTabControl.SelectedTab == Program.MainWindow.TabPageAD;
 
@@ -536,7 +536,7 @@ namespace XenAdmin.TabPages
                         Dictionary<string, bool> loggedSids = new Dictionary<string, bool>();
                         foreach (string s in loggedInSids)
                             loggedSids.Add(s, true);
-                        Program.Invoke(this, delegate
+                        Program.Invoke(Program.MainWindow, delegate
                         {
                             foreach (AdSubjectRow r in GridViewSubjectList.Rows)
                             {
@@ -566,7 +566,7 @@ namespace XenAdmin.TabPages
 
         private void showLoggedInStatusError()
         {
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 foreach (AdSubjectRow r in GridViewSubjectList.Rows)
                 {

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -351,7 +351,7 @@ namespace XenAdmin.TabPages
                 return;
             }
 
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 if (e.PropertyName == "PBDs")
                 {

--- a/XenAdmin/TabPages/NICPage.cs
+++ b/XenAdmin/TabPages/NICPage.cs
@@ -116,7 +116,7 @@ namespace XenAdmin.TabPages
                 PIF pif = e.Element as PIF;
                 UnregisterPIFEventHandlers(pif);
             }
-            Program.Invoke(this, updateList);
+            Program.Invoke(Program.MainWindow, updateList);
         }
 
         private void RegisterPIFEventHandlers(PIF pif)

--- a/XenAdmin/TabPages/NetworkPage.cs
+++ b/XenAdmin/TabPages/NetworkPage.cs
@@ -273,7 +273,7 @@ namespace XenAdmin.TabPages
 
         void CollectionChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, RepopulateManagementInterfaces);
+            Program.Invoke(Program.MainWindow, RepopulateManagementInterfaces);
         }
         #endregion
     }

--- a/XenAdmin/TabPages/PerformancePage.cs
+++ b/XenAdmin/TabPages/PerformancePage.cs
@@ -261,7 +261,7 @@ namespace XenAdmin.TabPages
         private void pool_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "gui_config")
-                Program.Invoke(this, () => GraphList.LoadGraphs(XenObject));
+                Program.Invoke(Program.MainWindow, () => GraphList.LoadGraphs(XenObject));
         }
 
         private void DeregEvents()
@@ -293,7 +293,7 @@ namespace XenAdmin.TabPages
 
         private void ArchiveMaintainer_ArchivesUpdated(object sender, EventArgs args)
         {
-            Program.Invoke(this, RefreshAll);
+            Program.Invoke(Program.MainWindow, RefreshAll);
         }
 
         private void RefreshAll()

--- a/XenAdmin/TabPages/PhysicalStoragePage.cs
+++ b/XenAdmin/TabPages/PhysicalStoragePage.cs
@@ -182,7 +182,7 @@ namespace XenAdmin.TabPages
             }
             else
             {
-                Program.Invoke(this, () => RefreshRowForSr((SR)sender));
+                Program.Invoke(Program.MainWindow, () => RefreshRowForSr((SR)sender));
             }
         }
 

--- a/XenAdmin/TabPages/SrStoragePage.cs
+++ b/XenAdmin/TabPages/SrStoragePage.cs
@@ -277,7 +277,7 @@ namespace XenAdmin.TabPages
         {
             if (e.PropertyName != "ShowHiddenVMs")
                 return;
-            Program.Invoke(this, () => BuildList(false));
+            Program.Invoke(Program.MainWindow, () => BuildList(false));
         }
         #endregion
 
@@ -689,18 +689,18 @@ namespace XenAdmin.TabPages
                     return;
 
                 if (refreshRequest.Reset)
-                    Program.Invoke(owner, page.dataGridViewVDIs.Rows.Clear);
+                    Program.Invoke(Program.MainWindow, page.dataGridViewVDIs.Rows.Clear);
 
-                Program.Invoke(owner, page.RefreshButtons);
+                Program.Invoke(Program.MainWindow, page.RefreshButtons);
 
                 IEnumerable<VDIRow> currentVDIRows = Enumerable.Empty<VDIRow>();
-                Program.Invoke(owner, () => currentVDIRows = page.GetCurrentVDIRows());
+                Program.Invoke(Program.MainWindow, () => currentVDIRows = page.GetCurrentVDIRows());
                 VDIsData data = GetCurrentData(refreshRequest.SR, currentVDIRows);
 
                 if (worker.CancellationPending)
                     return;
 
-                Program.Invoke(owner, () => ((SrStoragePage)owner).RefreshDataGridView(data));
+                Program.Invoke(Program.MainWindow, () => ((SrStoragePage)owner).RefreshDataGridView(data));
             }
 
             public void AddRequest(RefreshGridRequest refreshGridRequest)

--- a/XenAdmin/TabPages/VMStoragePage.cs
+++ b/XenAdmin/TabPages/VMStoragePage.cs
@@ -201,7 +201,7 @@ namespace XenAdmin.TabPages
             if (e.PropertyName == "VBDs")
                 BuildList();
             else if (e.PropertyName == "power_state" || e.PropertyName == "Locked")
-                Program.Invoke(this, UpdateButtons);
+                Program.Invoke(Program.MainWindow, UpdateButtons);
         }
 
         private void BuildList()

--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageRetrieveData.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageRetrieveData.cs
@@ -198,12 +198,12 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
 
         private void _action_Completed(ActionBase sender)
         {
-            Program.Invoke(this, finish);
+            Program.Invoke(Program.MainWindow, finish);
         }
 
         private void _action_Changed(object sender)
         {
-            Program.Invoke(this, actionchanged);
+            Program.Invoke(Program.MainWindow, actionchanged);
         }
 
         private void flickerFreeListBox1_DrawItem(object sender, DrawItemEventArgs e)

--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageSelectCapabilities.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageSelectCapabilities.cs
@@ -161,7 +161,7 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
 
         private void Common_action_Completed(ActionBase sender)
         {
-            Program.Invoke(this, delegate()
+            Program.Invoke(Program.MainWindow, delegate()
             {
                 if (cancelled)
                     return;

--- a/XenAdmin/Wizards/BugToolWizardFiles/GenericSelectHostsPage.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/GenericSelectHostsPage.cs
@@ -313,7 +313,7 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
 
         private void connection_CachePopulated(object sender, EventArgs e)
         {
-            Program.Invoke(this, buildList);
+            Program.Invoke(Program.MainWindow, buildList);
         }
 
         private void Host_CollectionChanged(object sender, CollectionChangeEventArgs e)
@@ -325,7 +325,7 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
         {
             if (e.PropertyName == "name_label" || e.PropertyName == "master")
             {
-                Program.Invoke(this, buildList);
+                Program.Invoke(Program.MainWindow, buildList);
             }
         }
 
@@ -333,7 +333,7 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
         {
             if (e.PropertyName == "live")
             {
-                Program.Invoke(this, buildList);
+                Program.Invoke(Program.MainWindow, buildList);
             }
         }
 
@@ -341,13 +341,13 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
         {
             if (e.PropertyName == "name_label" || e.PropertyName == "enabled" || e.PropertyName == "patches" || e.PropertyName == "metrics")
             {
-                Program.Invoke(this, buildList);
+                Program.Invoke(Program.MainWindow, buildList);
             }
         }
 
         private void connection_ConnectionStateChanged(object sender, EventArgs e)
         {
-            Program.Invoke(this, (CollectionChangeEventHandler)XenConnections_CollectionChanged, this, null);
+            Program.Invoke(Program.MainWindow, (CollectionChangeEventHandler)XenConnections_CollectionChanged, this, null);
         }
 
         private void XenConnections_CollectionChanged(object sender, CollectionChangeEventArgs e)

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.cs
@@ -241,7 +241,7 @@ namespace XenAdmin.Wizards.DRWizards
         {
             lock (_lock)
             {
-                Program.Invoke(this, () =>
+                Program.Invoke(Program.MainWindow, () =>
                                          {
                                              dataGridView1.Rows.Clear();
                                              progressBar1.Value = 0;

--- a/XenAdmin/Wizards/GenericPages/RBACWarningPage.cs
+++ b/XenAdmin/Wizards/GenericPages/RBACWarningPage.cs
@@ -97,7 +97,7 @@ namespace XenAdmin.Wizards.GenericPages
         void Connection_ConnectionResult(object sender, ConnectionResultEventArgs e)
         {
             if (e.Connected)
-                Program.Invoke(this, RefreshPage);
+                Program.Invoke(Program.MainWindow, RefreshPage);
         }
 
         public override void PageLeave(PageLoadedDirection direction, ref bool cancel)
@@ -238,7 +238,7 @@ namespace XenAdmin.Wizards.GenericPages
                 AddDetailsRow(description, PermissionCheckResult.Failed);
             }
 
-            Program.Invoke(this, () => blockProgress = true);
+            Program.Invoke(Program.MainWindow, () => blockProgress = true);
         }
 
         private void FinishedUpdating()
@@ -251,7 +251,7 @@ namespace XenAdmin.Wizards.GenericPages
                 return;
             }
             finished = true;
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 labelClickNext.Visible = !blockProgress;
                 OnPageUpdated();
@@ -283,7 +283,7 @@ namespace XenAdmin.Wizards.GenericPages
         {
             Program.AssertOffEventThread();
 
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
             {
                 blockProgress = false;
                 finished = false;
@@ -300,7 +300,7 @@ namespace XenAdmin.Wizards.GenericPages
             string text = string.Format(Messages.RBAC_WARNING_PAGE_HEADER_ROW_DESC, connection.Session.UserFriendlyName,
                                         connection.Session.FriendlyRoleDescription, connection.FriendlyName);
             PermissionCheckHeaderRow headerRow = new PermissionCheckHeaderRow(text);
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
                                      {
                                          headerRow.SetPermissionCheckInProgress(true);
                                          dataGridViewEx1.Rows.Add(headerRow);
@@ -311,7 +311,7 @@ namespace XenAdmin.Wizards.GenericPages
         private void UpdateHeaderRow(PermissionCheckHeaderRow headerRow, PermissionCheckResult checkResult)
         {
             Program.AssertOffEventThread();
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
                                      {
                                          headerRow.SetPermissionCheckInProgress(false);
                                          headerRow.UpdateDescription(checkResult);
@@ -321,7 +321,7 @@ namespace XenAdmin.Wizards.GenericPages
         private void AddDetailsRow(string desc, PermissionCheckResult checkResult)
         {
             Program.AssertOffEventThread();
-            Program.Invoke(this, delegate
+            Program.Invoke(Program.MainWindow, delegate
                                      {
                                          PermissionCheckDetailsRow detailsRow =
                                              new PermissionCheckDetailsRow(desc, checkResult);

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -494,7 +494,7 @@ namespace XenAdmin.Wizards.GenericPages
 		private void PropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == "name_label" || e.PropertyName == "metrics" || e.PropertyName == "enabled" || e.PropertyName == "live" || e.PropertyName == "patches")
-				Program.Invoke(this, PopulateComboBox);
+				Program.Invoke(Program.MainWindow, PopulateComboBox);
             
 		}
 
@@ -505,12 +505,12 @@ namespace XenAdmin.Wizards.GenericPages
 
 		private void xenConnection_CachePopulated(object sender, EventArgs e)
         {
-			Program.Invoke(this, PopulateComboBox);
+			Program.Invoke(Program.MainWindow, PopulateComboBox);
         }
 
 		private void xenConnection_ConnectionStateChanged(object sender, EventArgs e)
 		{
-			Program.Invoke(this, PopulateComboBox);
+			Program.Invoke(Program.MainWindow, PopulateComboBox);
 		}
 
 		#endregion

--- a/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
+++ b/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
@@ -387,7 +387,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
 
         private void vm_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                 {
                     VM vm = (VM)sender;
                     if (vm == null)

--- a/XenAdmin/Wizards/ImportWizard/ImportOptionsPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportOptionsPage.cs
@@ -242,7 +242,7 @@ namespace XenAdmin.Wizards.ImportWizard
             if (existingItems.Count() == 1)
 			{
                 if (selectable)
-                    Program.Invoke(this, () =>
+                    Program.Invoke(Program.MainWindow, () =>
                                              {
                                                  var wrapper = existingItems.First();
                                                  m_comboBoxISOLibraries.SuspendLayout();
@@ -260,11 +260,11 @@ namespace XenAdmin.Wizards.ImportWizard
                                                  }
                                              });
                 else
-                    Program.Invoke(this, PopulateComboBox);
+                    Program.Invoke(Program.MainWindow, PopulateComboBox);
 			}
 			else if (selectable)
 			{
-				Program.Invoke(this, PopulateComboBox);
+				Program.Invoke(Program.MainWindow, PopulateComboBox);
 			}
 		}
 

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -701,7 +701,7 @@ namespace XenAdmin.Wizards.ImportWizard
 
 		private void m_pageXvaStorage_ImportVmCompleted()
 		{
-			Program.Invoke(this, () =>
+			Program.Invoke(Program.MainWindow, () =>
 			                     	{
 			                     		if (CurrentStepTabPage.GetType() == typeof(StoragePickerPage))
 			                     		{

--- a/XenAdmin/Wizards/ImportWizard/StoragePickerPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/StoragePickerPage.cs
@@ -215,7 +215,7 @@ namespace XenAdmin.Wizards.ImportWizard
             // Once the object creation is complete, we look for the vm; When we found the vm we unregister this event handler;
             m_targetConnection.XenObjectsUpdated += targetConnection_XenObjectsUpdated;
 
-			Program.Invoke(this, CheckTask);
+			Program.Invoke(Program.MainWindow, CheckTask);
 		}
 
 		private void CheckTask()
@@ -284,7 +284,7 @@ namespace XenAdmin.Wizards.ImportWizard
 
         private void m_importXvaAction_Completed(ActionBase sender)
 		{
-			Program.Invoke(this, () =>
+			Program.Invoke(Program.MainWindow, () =>
 			{
 				Program.AssertOnEventThread();
 

--- a/XenAdmin/Wizards/NewPolicyWizard/NewPolicyArchivePage.cs
+++ b/XenAdmin/Wizards/NewPolicyWizard/NewPolicyArchivePage.cs
@@ -358,7 +358,7 @@ namespace XenAdmin.Wizards.NewPolicyWizard
         {
             AsyncAction action = (AsyncAction)sender;
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                                      {
                                          if (action.Result != "True" || action.Result == null)
                                          {

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CSLG.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CSLG.cs
@@ -235,7 +235,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
                         {
                             if (!action.Succeeded)
                             {
-                                Program.Invoke(dialog, dialog.Close);
+                                Program.Invoke(Program.MainWindow, dialog.Close);
                             }
                         };
 
@@ -258,7 +258,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
                                                     {
                                                         if (!scanAction.Succeeded)
                                                         {
-                                                            Program.Invoke(dialog, dialog.Close);
+                                                            Program.Invoke(Program.MainWindow, dialog.Close);
                                                         }
                                                     };
 

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/LVMoISCSI.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/LVMoISCSI.cs
@@ -497,7 +497,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
 
         private void IscsiPopulateIqnsAction_Completed(ActionBase sender)
         {
-            Program.Invoke(this, (System.Threading.WaitCallback)IscsiPopulateIqnsAction_Completed_, sender);
+            Program.Invoke(Program.MainWindow, (System.Threading.WaitCallback)IscsiPopulateIqnsAction_Completed_, sender);
         }
 
         private void IscsiPopulateIqnsAction_Completed_(object o)
@@ -611,7 +611,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
 
         private void IscsiPopulateLunsAction_Completed(ActionBase sender)
         {
-            Program.Invoke(this, (WaitCallback)IscsiPopulateLunsAction_Completed_, sender);
+            Program.Invoke(Program.MainWindow, (WaitCallback)IscsiPopulateLunsAction_Completed_, sender);
         }
 
         private void IscsiPopulateLunsAction_Completed_(object o)

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -117,7 +117,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 {
                     page_4_HomeServer.DisableStep = true;
                     BlockAffinitySelection = true;
-                    Program.Invoke(this, RefreshProgress);
+                    Program.Invoke(Program.MainWindow, RefreshProgress);
                 });
 
                 page_RbacWarning.AddPermissionChecks(xenConnection, createCheck, affinityCheck, memCheck);
@@ -129,7 +129,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                     vgpuCheck.WarningAction = new RBACWarningPage.PermissionCheckActionDelegate(() =>
                     {
                         pageVgpu.DisableStep = true;
-                        Program.Invoke(this, RefreshProgress);
+                        Program.Invoke(Program.MainWindow, RefreshProgress);
                     });
 
                     page_RbacWarning.AddPermissionChecks(xenConnection, vgpuCheck);

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -246,7 +246,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             lock (_lock)
             {
-                Program.Invoke(this, () =>
+                Program.Invoke(Program.MainWindow, () =>
                                          {
                                              dataGridView1.Rows.Clear();
                                              progressBar1.Value = 0;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -283,7 +283,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             if (action == null)
                 return;
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
             {
                 UpdateActionProgress(action);
                 flickerFreeListBox1.Refresh();
@@ -300,7 +300,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             action.Changed -= singleAction_Changed;
             action.Completed -= singleAction_Completed;
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
             {
                 if (action.Succeeded)
                 {
@@ -334,7 +334,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             canDownload = !(action.Exception is PatchDownloadFailedException);
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
             {
                 labelProgress.Text = GetActionDescription(action);
                 UpdateButtons();

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
@@ -264,7 +264,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
             UpgradeManualHostPlanAction action = upgradeHostPlanAction;
 
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
             {
                 using (Dialog = new NotModalThreeButtonDialog(SystemIcons.Information, msg, Messages.REBOOT, Messages.SKIP_SERVER))
                 {
@@ -300,7 +300,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                             string.Format(Messages.ROLLING_UPGRADE_REBOOT_AGAIN_MESSAGE, hostName)
                             , Messages.REBOOT_AGAIN_BUTTON_LABEL, Messages.SKIP_SERVER))
                         {
-                            Program.Invoke(this, () => dialog.ShowDialog(this));
+                            Program.Invoke(Program.MainWindow, () => dialog.ShowDialog(this));
                             if (dialog.DialogResult != DialogResult.OK) // Cancel or Unknown
                                 throw new Exception(Messages.HOST_REBOOTED_SAME_VERSION);
                             else
@@ -319,7 +319,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
         private void upgradeHostPlanAction_Timeout(object sender, EventArgs e)
         {
             var dialog = new NotModalThreeButtonDialog(SystemIcons.Exclamation, Messages.ROLLING_UPGRADE_TIMEOUT.Replace("\\n", "\n"), Messages.KEEP_WAITING_BUTTON_LABEL.Replace("\\n", "\n"), Messages.CANCEL);
-            Program.Invoke(this, () => dialog.ShowDialog(this));
+            Program.Invoke(Program.MainWindow, () => dialog.ShowDialog(this));
             if (dialog.DialogResult != DialogResult.OK) // Cancel or Unknown
             {
                 UpgradeHostPlanAction action = (UpgradeHostPlanAction)sender;
@@ -329,7 +329,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
         private void ReportException(Exception exception, PlanAction planAction, Host host)
         {
-            Program.Invoke(this, () =>
+            Program.Invoke(Program.MainWindow, () =>
                                      {
                                          if (host != null && !host.enabled)
                                              new EnableHostAction(host, false,


### PR DESCRIPTION
We observed that some threads can reach deadlock-ish state after they have Invoked into a control's UI thread. When it happens they are all in a waiting for join or in sleep state for very long time, although there should not be any deadlock situations.
It seems this has something to do with multiple parent controls and with which control we invoked on. This should not make a difference, because we have got one UI thread (for MainWindow) they should wait for, but we have seen it does.

The solution that fixed this issue was to invoke on the MainWindow instead of various controls (see a4fe507adf68302124bfc732ac11abde946e52cd ).

This changeset is changing all our Invokes to invoke into MainWindow
instead of a control itself. (MainWindow's UI thread is the only UI thread
all Control is using in XenCenter)
This changeset should be in place until we have found the root cause or the exact reason for the above.