### PR TITLE
CA-167309: When clipboard sharing is turned off in the options, should not be possible to copy-and-paste from the guest to the XenCenter machine

### DIFF
--- a/XenAdmin/ConsoleView/VNCGraphicsClient.cs
+++ b/XenAdmin/ConsoleView/VNCGraphicsClient.cs
@@ -581,6 +581,8 @@ namespace XenAdmin.ConsoleView
             }
             else
             {
+                if (!RedirectingClipboard())
+                    return;
                 Program.Invoke(this, delegate()
                 {
                     if (Clipboard.ContainsText() && Clipboard.GetText() == text)


### PR DESCRIPTION

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>