### PR TITLE
CA-156200: HANDLE_INVALID shown on Rolling Pool Upgrade completed page

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/PlanActionWithSession.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/PlanActionWithSession.cs
@@ -69,7 +69,9 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 timeout = timeout - 1;
             }
 
-            throw new Failure(new List<String>(new [] { Failure.HANDLE_INVALID, t.opaque_ref }));
+            if (typeof(T) == typeof(Host))
+                throw new Failure(Failure.HOST_OFFLINE);
+            throw new Failure(Failure.HANDLE_INVALID, typeof(T).Name, t.opaque_ref);
         }
 
         protected abstract void RunWithSession(ref Session session);

--- a/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/AutomaticBackgroundThread.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/AutomaticBackgroundThread.cs
@@ -81,7 +81,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
                                 if (planAction is UpgradeHostPlanAction)
                                 {
                                     Host hostAfterReboot = host.Connection.Resolve(new XenRef<Host>(host.opaque_ref));
-                                    if (Helpers.SameServerVersion(hostAfterReboot, hostVersion))
+                                    if (hostAfterReboot != null && Helpers.SameServerVersion(hostAfterReboot, hostVersion))
                                     {
                                         log.ErrorFormat("Host '{0}' rebooted with the same version '{1}'", hostAfterReboot.Name, hostAfterReboot.LongProductVersion);
                                         OnReportException(new Exception(Messages.REBOOT_WITH_SAME_VERSION),
@@ -90,7 +90,11 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
                                         if (hostAfterReboot.IsMaster())
                                             _cancel = true;
                                     }
-                                    log.InfoFormat("Host '{0}' upgraded with version '{1}'", hostAfterReboot.Name, hostAfterReboot.LongProductVersion);
+                                    if (hostAfterReboot != null)
+                                        log.InfoFormat("Host '{0}' upgraded with version '{1}'", hostAfterReboot.Name, hostAfterReboot.LongProductVersion);
+                                    else
+                                        log.InfoFormat("Cannot check host's version after reboot because the host '{0}' cannot be resolved", host.Name);
+                                   
                                 }
                             }
                             catch (Exception e)

--- a/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/UpgradeManualHostPlanAction.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/UpgradeManualHostPlanAction.cs
@@ -81,17 +81,17 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
 
                 if (Host.enabled)
                 {
-                    log.DebugFormat("Disabling host {0}", Host.Name);
+                    log.DebugFormat("Disabling host {0}", _host.Name);
                     XenAPI.Host.disable(session, Host.opaque_ref);
                 }
 
                 timer.Start();
                 rebooting = true;
-                
-                log.DebugFormat("Upgrading host {0}", Host.Name);
+
+                log.DebugFormat("Upgrading host {0}", _host.Name);
                 Status = Messages.PLAN_ACTION_STATUS_INSTALLING_XENSERVER;
-                
-                log.DebugFormat("Waiting for host {0} to reboot", Host.Name);
+
+                log.DebugFormat("Waiting for host {0} to reboot", _host.Name);
                 WaitForReboot(ref session, _session => XenAPI.Host.async_reboot(_session, Host.opaque_ref));
 
                 Status = Messages.PLAN_ACTION_STATUS_RECONNECTING_STORAGE;
@@ -99,10 +99,10 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                     host.CheckAndPlugPBDs();  // Wait for PBDs to become plugged on all hosts
                 
                 rebooting = false;
-                log.DebugFormat("Host {0} rebooted", Host.Name);
+                log.DebugFormat("Host {0} rebooted", _host.Name);
                 
                 Status = Messages.PLAN_ACTION_STATUS_HOST_UPGRADED;
-                log.DebugFormat("Upgraded host {0}",Host.Name);
+                log.DebugFormat("Upgraded host {0}", _host.Name);
             }
             finally
             {

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
@@ -331,7 +331,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
         {
             Program.Invoke(this, () =>
                                      {
-                                         if (host != null && !host.enabled)
+                                         if (host != null && !host.enabled && host.Connection != null && host.Connection.Session != null)
                                              new EnableHostAction(host, false,
                                                                   AddHostToPoolCommand.EnableNtolDialog).RunExternal(host.Connection.Session);
                                      });

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1918,7 +1918,7 @@ namespace XenAdmin.Core
 
        public static bool SameServerVersion(Host host, string longProductVersion)
        {
-           return host.LongProductVersion == longProductVersion;
+           return host != null && host.LongProductVersion == longProductVersion;
        }
 
        public static bool EnabledTargetExists(Host host, IXenConnection connection)


### PR DESCRIPTION
- while upgrading a host, throw a HOST_OFFLINE ("Server could not be contacted") exception if the host can no longer be resolved (instead of HANDLE_INVALID)
- also corrected the parameters of the HANDLE_INVALID exception, as an extra parameter is needed for the friendly error name.
- in the UpdateManualHostPlanAction class I replaced Host with the private property _host in several places, so we are no longer trying to resolve the host each time we want to write something into logs
- added some null checks, to avoid reporting null reference exception

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>