### PR TITLE
CP-11292: Remove storage motion constraints: Wording changes in the cros...

### DIFF
--- a/XenAdmin/Help/HelpManager.resx
+++ b/XenAdmin/Help/HelpManager.resx
@@ -1074,4 +1074,10 @@
   <data name="NewVMWizard_CloudConfigParametersPane" xml:space="preserve">
     <value>2055</value>
   </data>
+  <data name="CrossPoolMigrateWizard_CopyModePane" xml:space="preserve">
+    <value>9000</value>
+  </data>
+  <data name="CrossPoolMigrateWizard_IntraPoolCopyPane" xml:space="preserve">
+    <value>9000</value>
+  </data>
 </root>

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateCopyModePage.Designer.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateCopyModePage.Designer.cs
@@ -33,6 +33,8 @@
             this.labelRubric = new System.Windows.Forms.Label();
             this.intraPoolRadioButton = new System.Windows.Forms.RadioButton();
             this.crossPoolRadioButton = new System.Windows.Forms.RadioButton();
+            this.intraPoolDescriptionLabel = new System.Windows.Forms.Label();
+            this.crossPoolDescriptionLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -41,7 +43,9 @@
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.labelRubric, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.intraPoolRadioButton, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.crossPoolRadioButton, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.crossPoolRadioButton, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.intraPoolDescriptionLabel, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.crossPoolDescriptionLabel, 0, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // labelRubric
@@ -63,6 +67,18 @@
             this.crossPoolRadioButton.TabStop = true;
             this.crossPoolRadioButton.UseVisualStyleBackColor = true;
             // 
+            // intraPoolDescriptionLabel
+            // 
+            this.intraPoolDescriptionLabel.AutoEllipsis = true;
+            resources.ApplyResources(this.intraPoolDescriptionLabel, "intraPoolDescriptionLabel");
+            this.intraPoolDescriptionLabel.Name = "intraPoolDescriptionLabel";
+            // 
+            // crossPoolDescriptionLabel
+            // 
+            this.crossPoolDescriptionLabel.AutoEllipsis = true;
+            resources.ApplyResources(this.crossPoolDescriptionLabel, "crossPoolDescriptionLabel");
+            this.crossPoolDescriptionLabel.Name = "crossPoolDescriptionLabel";
+            // 
             // CrossPoolMigrateCopyModePage
             // 
             resources.ApplyResources(this, "$this");
@@ -81,6 +97,8 @@
         private System.Windows.Forms.Label labelRubric;
         private System.Windows.Forms.RadioButton intraPoolRadioButton;
         private System.Windows.Forms.RadioButton crossPoolRadioButton;
+        private System.Windows.Forms.Label intraPoolDescriptionLabel;
+        private System.Windows.Forms.Label crossPoolDescriptionLabel;
 
 
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateCopyModePage.resx
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateCopyModePage.resx
@@ -145,7 +145,7 @@
     <value>0</value>
   </data>
   <data name="labelRubric.Text" xml:space="preserve">
-    <value>Select where would you like to copy your VM. Depending on your selection, more settings will be required in the next steps.</value>
+    <value>Select where would you like to copy your VM.</value>
   </data>
   <data name="&gt;&gt;labelRubric.Name" xml:space="preserve">
     <value>labelRubric</value>
@@ -162,18 +162,20 @@
   <data name="intraPoolRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="intraPoolRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="intraPoolRadioButton.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 36</value>
   </data>
   <data name="intraPoolRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>292, 17</value>
+    <value>78, 17</value>
   </data>
   <data name="intraPoolRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="intraPoolRadioButton.Text" xml:space="preserve">
-    <value>Inside pool: Make a copy of the VM within the same pool
-</value>
+    <value>&amp;Within pool</value>
   </data>
   <data name="&gt;&gt;intraPoolRadioButton.Name" xml:space="preserve">
     <value>intraPoolRadioButton</value>
@@ -190,17 +192,23 @@
   <data name="crossPoolRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="crossPoolRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="crossPoolRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 59</value>
+    <value>3, 79</value>
+  </data>
+  <data name="crossPoolRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 6, 0, 0</value>
   </data>
   <data name="crossPoolRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>286, 17</value>
+    <value>74, 23</value>
   </data>
   <data name="crossPoolRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="crossPoolRadioButton.Text" xml:space="preserve">
-    <value>Across pools: Make a copy of the VM in a different pool</value>
+    <value>&amp;Cross-pool</value>
   </data>
   <data name="&gt;&gt;crossPoolRadioButton.Name" xml:space="preserve">
     <value>crossPoolRadioButton</value>
@@ -214,6 +222,78 @@
   <data name="&gt;&gt;crossPoolRadioButton.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="intraPoolDescriptionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="intraPoolDescriptionLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="intraPoolDescriptionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="intraPoolDescriptionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 56</value>
+  </data>
+  <data name="intraPoolDescriptionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>16, 0, 3, 0</value>
+  </data>
+  <data name="intraPoolDescriptionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>608, 20</value>
+  </data>
+  <data name="intraPoolDescriptionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="intraPoolDescriptionLabel.Text" xml:space="preserve">
+    <value>Make a copy of the VM within the same pool</value>
+  </data>
+  <data name="&gt;&gt;intraPoolDescriptionLabel.Name" xml:space="preserve">
+    <value>intraPoolDescriptionLabel</value>
+  </data>
+  <data name="&gt;&gt;intraPoolDescriptionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;intraPoolDescriptionLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;intraPoolDescriptionLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 105</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>16, 0, 3, 0</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>608, 20</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="crossPoolDescriptionLabel.Text" xml:space="preserve">
+    <value>Make a copy of the VM in a different pool</value>
+  </data>
+  <data name="&gt;&gt;crossPoolDescriptionLabel.Name" xml:space="preserve">
+    <value>crossPoolDescriptionLabel</value>
+  </data>
+  <data name="&gt;&gt;crossPoolDescriptionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;crossPoolDescriptionLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;crossPoolDescriptionLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -221,7 +301,7 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>614, 332</value>
@@ -242,7 +322,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelRubric" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="intraPoolRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="crossPoolRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,33.33333,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelRubric" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="intraPoolRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="crossPoolRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="intraPoolDescriptionLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="crossPoolDescriptionLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
@@ -30,8 +30,6 @@
  */
 
 using System.Collections.Generic;
-using System.Drawing;
-using XenAdmin.Dialogs;
 using XenAdmin.Wizards.CrossPoolMigrateWizard.Filters;
 using XenAdmin.Wizards.GenericPages;
 using XenAPI;
@@ -42,15 +40,19 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
     {
         private Host preSelectedHost;
         private List<VM> selectedVMs;
-        public CrossPoolMigrateDestinationPage(): this(null, null)
+        private WizardMode wizardMode;
+        
+        public CrossPoolMigrateDestinationPage(): this(null, null, WizardMode.Migrate)
         {
         }
 
-        public CrossPoolMigrateDestinationPage(Host preSelectedHost, List<VM> selectedVMs)
+        public CrossPoolMigrateDestinationPage(Host preSelectedHost, List<VM> selectedVMs, WizardMode wizardMode)
         {
             this.preSelectedHost = preSelectedHost;
             SetDefaultTarget(preSelectedHost);
             this.selectedVMs = selectedVMs;
+            this.wizardMode = wizardMode;
+            InitializeText();
         }
 
         public override bool EnableNext()
@@ -78,7 +80,15 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
         /// </summary>
         public override string Text { get { return Messages.CPM_WIZARD_DESTINATION_TAB_TITLE; } }
 
-        protected override string InstructionText { get { return Messages.CPM_WIZARD_DESTINATION_INSTRUCTIONS; } }
+        protected override string InstructionText 
+        {
+            get
+            {
+                if (selectedVMs != null && selectedVMs.Count > 1)
+                    return wizardMode == WizardMode.Copy ? Messages.CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY : Messages.CPM_WIZARD_DESTINATION_INSTRUCTIONS;
+                return wizardMode == WizardMode.Copy ? Messages.CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY_SINGLE : Messages.CPM_WIZARD_DESTINATION_INSTRUCTIONS_SINGLE;
+            }
+        }
 
         protected override string HomeServerText { get { return Messages.CPM_WIZARD_DESTINATION_DESTINATION; } }
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateFinishPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateFinishPage.cs
@@ -40,10 +40,15 @@ using XenAdmin.Wizards.GenericPages;
 namespace XenAdmin.Wizards.CrossPoolMigrateWizard
 {
     public partial class CrossPoolMigrateFinishPage : XenTabPage
-	{
-        public CrossPoolMigrateFinishPage()
+    {
+        private int selectionCount;
+        private WizardMode wizardMode;
+
+        public CrossPoolMigrateFinishPage(int selectionCount, WizardMode wizardMode)
 		{
-			InitializeComponent();
+            InitializeComponent();
+            this.selectionCount = selectionCount;
+            this.wizardMode = wizardMode;
 		}
 
 		/// <summary>
@@ -56,14 +61,19 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
 
         public override string HelpID { get { return "MigrationSummary"; } }
 
-		/// <summary>
-		/// Gets the page's title (headline)
-		/// </summary>
+        /// <summary>
+        /// Gets the page's title (headline)
+        /// </summary>
         public override string PageTitle { get { return Messages.CPM_WIZARD_FINISH_PAGE_TITLE; } }
 
 		public override void PopulatePage()
 		{
-			if (SummaryRetreiver == null)
+            if (selectionCount > 1)
+                m_labelIntro.Text = wizardMode == WizardMode.Copy ? Messages.CPM_WIZARD_FINISH_PAGE_INTRO_COPY : Messages.CPM_WIZARD_FINISH_PAGE_INTRO;
+            else
+                m_labelIntro.Text = wizardMode == WizardMode.Copy ? Messages.CPM_WIZARD_FINISH_PAGE_INTRO_COPY_SINGLE : Messages.CPM_WIZARD_FINISH_PAGE_INTRO_SINGLE;
+
+            if (SummaryRetreiver == null)
 				return;
 
 			var entries = SummaryRetreiver.Invoke();

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateNetworkingPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateNetworkingPage.cs
@@ -50,7 +50,10 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
         /// </summary>
         public override string Text { get { return Messages.CPM_WIZARD_SELECT_NETWORK_PAGE_TEXT; } }
 
-        public override string IntroductionText { get { return Messages.CPM_WIZARD_NETWORKING_INTRO; } }
+        public override string IntroductionText
+        {
+            get { return VmMappings != null && VmMappings.Count > 1 ? Messages.CPM_WIZARD_NETWORKING_INTRO : Messages.CPM_WIZARD_NETWORKING_INTRO_SINGLE; }
+        }
 
         public override string TableIntroductionText { get { return Messages.CPM_WIZARD_VM_SELECTION_INTRODUCTION; } }
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateTransferNetworkPage.resx
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateTransferNetworkPage.resx
@@ -121,55 +121,21 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 8</value>
-  </data>
-  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 10, 0</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 17</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Storage n&amp;etwork:</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
   <data name="networkComboBox.IntegralHeight" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="networkComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 3</value>
+    <value>101, 3</value>
   </data>
   <data name="networkComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>432, 24</value>
+    <value>432, 21</value>
   </data>
   <data name="networkComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -184,16 +150,59 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;networkComboBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 10, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 27</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Storage n&amp;etwork:</value>
+  </data>
+  <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 108</value>
+    <value>3, 75</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>608, 33</value>
+    <value>608, 27</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -211,7 +220,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="networkComboBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="networkComboBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -229,15 +238,15 @@
     <value>0, 0, 0, 20</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>762, 105</value>
+    <value>608, 72</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>Select a storage network on the destination pool or standalone server that will be used for the live migration of the VM’s virtual disks. 
+    <value>Select a storage network on the destination pool or standalone server that will be used for the live migration of the virtual disks. 
 
-For optimal performance and reliability during VM migration, ensure that the network used for the live storage migration is not being used for management or virtual machine traffic. </value>
+For optimal performance and reliability during VM migration, ensure that the network used for the storage migration is not being used for management or virtual machine traffic. </value>
   </data>
   <data name="&gt;&gt;label3.Name" xml:space="preserve">
     <value>label3</value>
@@ -261,7 +270,7 @@ For optimal performance and reliability during VM migration, ensure that the net
     <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>768, 415</value>
+    <value>614, 332</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -285,13 +294,10 @@ For optimal performance and reliability during VM migration, ensure that the net
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>120, 120</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+    <value>96, 96</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>768, 415</value>
+    <value>614, 332</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>CrossPoolMigrateTransferNetworkPage</value>

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
@@ -154,7 +154,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
         {
             CreateMappingsFromSelection(selection);
             UpdateWindowTitle();
-            m_pageDestination = new CrossPoolMigrateDestinationPage(hostPreSelection, VmsFromSelection(selection) )
+            m_pageDestination = new CrossPoolMigrateDestinationPage(hostPreSelection, VmsFromSelection(selection), wizardMode)
                                     {
                                         VmMappings = m_vmMappings,
                                     };
@@ -162,14 +162,14 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             m_pageStorage = new CrossPoolMigrateStoragePage();
             m_pageNetwork = new CrossPoolMigrateNetworkingPage();
             m_pageTransferNetwork = new CrossPoolMigrateTransferNetworkPage(VmsFromSelection(selection));
-            m_pageFinish = new CrossPoolMigrateFinishPage {SummaryRetreiver = GetVMMappingSummary};
+            m_pageFinish = new CrossPoolMigrateFinishPage(selection.Count(), wizardMode) { SummaryRetreiver = GetVMMappingSummary };
             m_pageTargetRbac = new RBACWarningPage();
 
             m_pageCopyMode = new CrossPoolMigrateCopyModePage(VmsFromSelection(selection));
             m_pageIntraPoolCopy = new IntraPoolCopyPage(VmsFromSelection(selection));
 
             if (wizardMode == WizardMode.Copy)
-                AddPages(m_pageCopyMode, m_pageDestination,  m_pageStorage, m_pageFinish);
+                AddPages(m_pageCopyMode, m_pageIntraPoolCopy);
             else
                 AddPages(m_pageDestination, m_pageStorage, m_pageFinish);
         }
@@ -326,7 +326,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                 if (m_pageCopyMode.IntraPoolCopySelected)
                 {
                     RemovePagesFrom(1);
-                    AddAfterPage(m_pageCopyMode, m_pageIntraPoolCopy, m_pageFinish);
+                    AddAfterPage(m_pageCopyMode, m_pageIntraPoolCopy);
                 }
                 else
                 {

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.resx
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.resx
@@ -127,13 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="DescriptionTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 75</value>
+    <value>131, 62</value>
   </data>
   <data name="DescriptionTextBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>342, 20</value>
   </data>
   <data name="DescriptionTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;DescriptionTextBox.Name" xml:space="preserve">
     <value>DescriptionTextBox</value>
@@ -151,13 +151,13 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="NameTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 49</value>
+    <value>131, 36</value>
   </data>
   <data name="NameTextBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>342, 20</value>
   </data>
   <data name="NameTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;NameTextBox.Name" xml:space="preserve">
     <value>NameTextBox</value>
@@ -199,7 +199,7 @@
     <value>4</value>
   </data>
   <data name="CloneRadioButton.Text" xml:space="preserve">
-    <value>&amp;Fast clone</value>
+    <value>F&amp;ast clone</value>
   </data>
   <data name="&gt;&gt;CloneRadioButton.Name" xml:space="preserve">
     <value>CloneRadioButton</value>
@@ -280,7 +280,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="toolTipContainer1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 19</value>
+    <value>9, 24</value>
   </data>
   <data name="toolTipContainer1.Size" type="System.Drawing.Size, System.Drawing">
     <value>455, 52</value>
@@ -346,7 +346,7 @@
     <value>3, 0, 3, 3</value>
   </data>
   <data name="srPicker1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>439, 151</value>
+    <value>439, 154</value>
   </data>
   <data name="srPicker1.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -367,16 +367,16 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 108</value>
+    <value>3, 95</value>
   </data>
   <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 10, 3, 10</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>470, 254</value>
+    <value>470, 267</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+    <value>5</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Copy mode</value>
@@ -409,13 +409,13 @@
     <value>0, 0, 0, 20</value>
   </data>
   <data name="labelRubric.Size" type="System.Drawing.Size, System.Drawing">
-    <value>470, 46</value>
+    <value>470, 33</value>
   </data>
   <data name="labelRubric.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
   <data name="labelRubric.Text" xml:space="preserve">
-    <value>Provide a name and a description (optional) for the new VM and then select a copy mode. Depending on your choice, you might need to select a storage repository for the new VM.</value>
+    <value>Provide a name and a description (optional) for the new VM and then select a copy mode. </value>
   </data>
   <data name="&gt;&gt;labelRubric.Name" xml:space="preserve">
     <value>labelRubric</value>
@@ -442,13 +442,13 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 46</value>
+    <value>3, 33</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>122, 26</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>1</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>Na&amp;me:</value>
@@ -481,13 +481,13 @@
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 72</value>
+    <value>3, 59</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
     <value>122, 26</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+    <value>3</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>&amp;Description:</value>

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -96,7 +96,7 @@ namespace XenAdmin.Wizards.GenericPages
             base.PageLeave(direction, ref cancel);
         }
 
-	    private void InitializeText()
+	    protected void InitializeText()
 	    {
 	        m_labelIntro.Text = InstructionText;
 	        label1.Text = HomeServerText;

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
@@ -208,7 +208,11 @@ namespace XenAdmin.Wizards.GenericPages
 
 				return m_vmMappings;
 			}
-			set { m_vmMappings = value; }
+			set
+			{
+			    m_vmMappings = value;
+                InitializeText();
+			}
 		}
 
         protected void SetButtonNextEnabled(bool enabled)

--- a/XenAdminTests/WizardTests/CrossPoolMigrateWizardTest.cs
+++ b/XenAdminTests/WizardTests/CrossPoolMigrateWizardTest.cs
@@ -44,7 +44,7 @@ namespace XenAdminTests.WizardTests.tampa_cpm_one_and_two_host_pools
     internal class CrossPoolMigrateWizardTest : CrossPoolMigrateWizardTestBase
     {
         public CrossPoolMigrateWizardTest()
-            : base(new[] { "Destination", "Storage", "Networking", "Live Migration Network", "Finish" }, true, true)
+            : base(new[] { "Destination Pool", "Storage", "Networking", "Migration Network", "Finish" }, true, true)
         {
             TargetPool = "PoolOfOne";
             SourcePool = "16And23";
@@ -56,7 +56,7 @@ namespace XenAdminTests.WizardTests.tampa_cpm_one_and_two_host_pools
     internal class CrossPoolMigrateWizardIntraPoolTest : CrossPoolMigrateWizardTestBase
     {
         public CrossPoolMigrateWizardIntraPoolTest()
-            : base(new[] { "Destination", "Storage", "Live Migration Network", "Finish" }, true, true)
+            : base(new[] { "Destination Pool", "Storage", "Migration Network", "Finish" }, true, true)
         {
             TargetPool = SourcePool = "16And23";
             Vm = "16local";
@@ -84,7 +84,7 @@ namespace XenAdminTests.WizardTests.tampa_cpm_one_and_two_host_pools
 
         protected override void TestPage(string pageName)
         {
-            if (pageName == "Destination")
+            if (pageName == "Destination Pool")
                 MW(()=>
                        {
                            Thread.Sleep(1000); //Allow the destination combo box to populate

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8277,7 +8277,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Live Migration Network:.
+        ///   Looks up a localized string similar to Migration Network:.
         /// </summary>
         public static string CPM_SUMMARY_KEY_TRANSFER_NETWORK {
             get {
@@ -8414,7 +8414,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The wizard is ready to begin migrating the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VMs and close the wizard..
+        ///   Looks up a localized string similar to The wizard is ready to begin migrating the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VMs..
         /// </summary>
         public static string CPM_WIZARD_FINISH_PAGE_INTRO {
             get {
@@ -8423,7 +8423,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The wizard is ready to begin copying the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VMs and close the wizard..
+        ///   Looks up a localized string similar to The wizard is ready to begin copying the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VMs..
         /// </summary>
         public static string CPM_WIZARD_FINISH_PAGE_INTRO_COPY {
             get {
@@ -8432,7 +8432,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The wizard is ready to begin copying the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VM and close the wizard..
+        ///   Looks up a localized string similar to The wizard is ready to begin copying the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VM..
         /// </summary>
         public static string CPM_WIZARD_FINISH_PAGE_INTRO_COPY_SINGLE {
             get {
@@ -8441,7 +8441,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The wizard is ready to begin migrating the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VM and close the wizard..
+        ///   Looks up a localized string similar to The wizard is ready to begin migrating the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VM..
         /// </summary>
         public static string CPM_WIZARD_FINISH_PAGE_INTRO_SINGLE {
             get {
@@ -8486,7 +8486,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Map the VM&apos;s virtual network interfaces to networks in the destination pool or standalone server..
+        ///   Looks up a localized string similar to Map the virtual network interfaces in the selected VM to networks in the destination pool or standalone server..
         /// </summary>
         public static string CPM_WIZARD_NETWORKING_INTRO_SINGLE {
             get {
@@ -8531,7 +8531,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Live Migration Network.
+        ///   Looks up a localized string similar to Migration Network.
         /// </summary>
         public static string CPM_WIZARD_SELECT_TRANSFER_NETWORK_PAGE_TEXT {
             get {
@@ -8540,7 +8540,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configure storage live migration settings.
+        ///   Looks up a localized string similar to Configure storage migration settings.
         /// </summary>
         public static string CPM_WIZARD_SELECT_TRANSFER_NETWORK_TITLE {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8023,7 +8023,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a name and a description (optional) for the new template and then select a copy mode. Depending on your choice, you might need to select a storage repository for the template..
+        ///   Looks up a localized string similar to Provide a name and a description (optional) for the new template and then select a copy mode..
         /// </summary>
         public static string COPY_TEMPLATE_INTRA_POOL_RUBRIC {
             get {
@@ -8104,7 +8104,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a name and a description (optional) for the new VM and then select a copy mode. Depending on your choice, you might need to select a storage repository for the VM..
+        ///   Looks up a localized string similar to Provide a name and a description (optional) for the new VM and then select a copy mode..
         /// </summary>
         public static string COPY_VM_INTRA_POOL_RUBRIC {
             get {
@@ -8250,7 +8250,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Migrate VM:.
+        ///   Looks up a localized string similar to VM:.
         /// </summary>
         public static string CPM_SUMMARY_KEY_MIGRATE_VM {
             get {
@@ -8304,7 +8304,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pl&amp;ace all migrated virtual disks on the same SR:.
+        ///   Looks up a localized string similar to Pl&amp;ace all virtual disks on the same SR:.
         /// </summary>
         public static string CPM_WIZARD_ALL_ON_SAME_SR_RADIO {
             get {
@@ -8313,7 +8313,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy mode.
+        ///   Looks up a localized string similar to Destination.
         /// </summary>
         public static string CPM_WIZARD_COPY_MODE_TAB_TITLE {
             get {
@@ -8322,7 +8322,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy mode.
+        ///   Looks up a localized string similar to Destination.
         /// </summary>
         public static string CPM_WIZARD_COPY_MODE_TITLE {
             get {
@@ -8340,7 +8340,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select the pool or standalone server where you want to migrate the selected VM(s)..
+        ///   Looks up a localized string similar to Select the pool or standalone server where you want to migrate the selected VMs to..
         /// </summary>
         public static string CPM_WIZARD_DESTINATION_INSTRUCTIONS {
             get {
@@ -8349,7 +8349,34 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Destination.
+        ///   Looks up a localized string similar to Select the pool or standalone server where you want to copy the selected VMs to..
+        /// </summary>
+        public static string CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the pool or standalone server where you want to copy the selected VM to..
+        /// </summary>
+        public static string CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY_SINGLE {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY_SINGLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the pool or standalone server where you want to migrate the selected VM to..
+        /// </summary>
+        public static string CPM_WIZARD_DESTINATION_INSTRUCTIONS_SINGLE {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_DESTINATION_INSTRUCTIONS_SINGLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Destination Pool.
         /// </summary>
         public static string CPM_WIZARD_DESTINATION_TAB_TITLE {
             get {
@@ -8387,7 +8414,43 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Review settings and begin live migration.
+        ///   Looks up a localized string similar to The wizard is ready to begin migrating the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VMs and close the wizard..
+        /// </summary>
+        public static string CPM_WIZARD_FINISH_PAGE_INTRO {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_FINISH_PAGE_INTRO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The wizard is ready to begin copying the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VMs and close the wizard..
+        /// </summary>
+        public static string CPM_WIZARD_FINISH_PAGE_INTRO_COPY {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_FINISH_PAGE_INTRO_COPY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The wizard is ready to begin copying the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VM and close the wizard..
+        /// </summary>
+        public static string CPM_WIZARD_FINISH_PAGE_INTRO_COPY_SINGLE {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_FINISH_PAGE_INTRO_COPY_SINGLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The wizard is ready to begin migrating the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VM and close the wizard..
+        /// </summary>
+        public static string CPM_WIZARD_FINISH_PAGE_INTRO_SINGLE {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_FINISH_PAGE_INTRO_SINGLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Review settings.
         /// </summary>
         public static string CPM_WIZARD_FINISH_PAGE_TITLE {
             get {
@@ -8396,7 +8459,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name and storage.
+        ///   Looks up a localized string similar to Name and Storage.
         /// </summary>
         public static string CPM_WIZARD_INTRA_POOL_COPY_TAB_TITLE {
             get {
@@ -8405,7 +8468,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name and storage.
+        ///   Looks up a localized string similar to Name and Storage.
         /// </summary>
         public static string CPM_WIZARD_INTRA_POOL_COPY_TITLE {
             get {
@@ -8414,11 +8477,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Map the virtual network interfaces in the VM(s) you are migrating to networks in the destination pool or standalone server..
+        ///   Looks up a localized string similar to Map the virtual network interfaces in the selected VMs to networks in the destination pool or standalone server..
         /// </summary>
         public static string CPM_WIZARD_NETWORKING_INTRO {
             get {
                 return ResourceManager.GetString("CPM_WIZARD_NETWORKING_INTRO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Map the VM&apos;s virtual network interfaces to networks in the destination pool or standalone server..
+        /// </summary>
+        public static string CPM_WIZARD_NETWORKING_INTRO_SINGLE {
+            get {
+                return ResourceManager.GetString("CPM_WIZARD_NETWORKING_INTRO_SINGLE", resourceCulture);
             }
         }
         
@@ -8432,7 +8504,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configure networking for the migrated VM(s).
+        ///   Looks up a localized string similar to Configure networking.
         /// </summary>
         public static string CPM_WIZARD_SELECT_NETWORK_PAGE_TITLE {
             get {
@@ -8450,7 +8522,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configure storage for the migrated VM(s).
+        ///   Looks up a localized string similar to Configure storage.
         /// </summary>
         public static string CPM_WIZARD_SELECT_STORAGE_PAGE_TITLE {
             get {
@@ -8477,7 +8549,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pla&amp;ce migrated virtual disks onto specified SRs:.
+        ///   Looks up a localized string similar to Pla&amp;ce virtual disks onto specified SRs:.
         /// </summary>
         public static string CPM_WIZARD_SPECIFIC_SR_RADIO {
             get {
@@ -8522,7 +8594,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &amp;Virtual network interfaces in migrated VMs:.
+        ///   Looks up a localized string similar to &amp;Virtual network interfaces:.
         /// </summary>
         public static string CPM_WIZARD_VM_SELECTION_INTRODUCTION {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2901,7 +2901,7 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
     <value>Clone the existing template, using a storage-level fast disk clone operation</value>
   </data>
   <data name="COPY_TEMPLATE_INTRA_POOL_RUBRIC" xml:space="preserve">
-    <value>Provide a name and a description (optional) for the new template and then select a copy mode. Depending on your choice, you might need to select a storage repository for the template.</value>
+    <value>Provide a name and a description (optional) for the new template and then select a copy mode.</value>
   </data>
   <data name="COPY_TEMPLATE_REMOVE" xml:space="preserve">
     <value>Delete original template after copy</value>
@@ -2928,7 +2928,7 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
     <value>Clone the existing VM, using a storage-level fast disk clone operation</value>
   </data>
   <data name="COPY_VM_INTRA_POOL_RUBRIC" xml:space="preserve">
-    <value>Provide a name and a description (optional) for the new VM and then select a copy mode. Depending on your choice, you might need to select a storage repository for the VM.</value>
+    <value>Provide a name and a description (optional) for the new VM and then select a copy mode.</value>
   </data>
   <data name="COPY_VM_REMOVE" xml:space="preserve">
     <value>Delete original VM after copy</value>
@@ -2975,7 +2975,7 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
     <value>Home Server:</value>
   </data>
   <data name="CPM_SUMMARY_KEY_MIGRATE_VM" xml:space="preserve">
-    <value>Migrate VM:</value>
+    <value>VM:</value>
   </data>
   <data name="CPM_SUMMARY_KEY_NETWORK" xml:space="preserve">
     <value>Networking:</value>
@@ -2993,25 +2993,34 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
     <value>Unset</value>
   </data>
   <data name="CPM_WIZARD_ALL_ON_SAME_SR_RADIO" xml:space="preserve">
-    <value>Pl&amp;ace all migrated virtual disks on the same SR:</value>
+    <value>Pl&amp;ace all virtual disks on the same SR:</value>
   </data>
   <data name="CPM_WIZARD_COPY_MODE_TAB_TITLE" xml:space="preserve">
-    <value>Copy mode</value>
+    <value>Destination</value>
   </data>
   <data name="CPM_WIZARD_COPY_MODE_TITLE" xml:space="preserve">
-    <value>Copy mode</value>
+    <value>Destination</value>
   </data>
   <data name="CPM_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Destination:</value>
   </data>
   <data name="CPM_WIZARD_DESTINATION_INSTRUCTIONS" xml:space="preserve">
-    <value>Select the pool or standalone server where you want to migrate the selected VM(s).</value>
+    <value>Select the pool or standalone server where you want to migrate the selected VMs to.</value>
+  </data>
+  <data name="CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY" xml:space="preserve">
+    <value>Select the pool or standalone server where you want to copy the selected VMs to.</value>
+  </data>
+  <data name="CPM_WIZARD_DESTINATION_INSTRUCTIONS_COPY_SINGLE" xml:space="preserve">
+    <value>Select the pool or standalone server where you want to copy the selected VM to.</value>
+  </data>
+  <data name="CPM_WIZARD_DESTINATION_INSTRUCTIONS_SINGLE" xml:space="preserve">
+    <value>Select the pool or standalone server where you want to migrate the selected VM to.</value>
   </data>
   <data name="CPM_WIZARD_DESTINATION_TABLE_INTRO" xml:space="preserve">
     <value>Specify a &amp;home server in the destination pool (optional):</value>
   </data>
   <data name="CPM_WIZARD_DESTINATION_TAB_TITLE" xml:space="preserve">
-    <value>Destination</value>
+    <value>Destination Pool</value>
   </data>
   <data name="CPM_WIZARD_DESTINATION_TITLE" xml:space="preserve">
     <value>Select the destination pool or standalone server</value>
@@ -3021,29 +3030,44 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
 
 Please reconnect the host and try again.</value>
   </data>
+  <data name="CPM_WIZARD_FINISH_PAGE_INTRO" xml:space="preserve">
+    <value>The wizard is ready to begin migrating the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VMs and close the wizard.</value>
+  </data>
+  <data name="CPM_WIZARD_FINISH_PAGE_INTRO_COPY" xml:space="preserve">
+    <value>The wizard is ready to begin copying the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VMs and close the wizard.</value>
+  </data>
+  <data name="CPM_WIZARD_FINISH_PAGE_INTRO_COPY_SINGLE" xml:space="preserve">
+    <value>The wizard is ready to begin copying the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VM and close the wizard.</value>
+  </data>
+  <data name="CPM_WIZARD_FINISH_PAGE_INTRO_SINGLE" xml:space="preserve">
+    <value>The wizard is ready to begin migrating the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VM and close the wizard.</value>
+  </data>
   <data name="CPM_WIZARD_FINISH_PAGE_TITLE" xml:space="preserve">
-    <value>Review settings and begin live migration</value>
+    <value>Review settings</value>
   </data>
   <data name="CPM_WIZARD_INTRA_POOL_COPY_TAB_TITLE" xml:space="preserve">
-    <value>Name and storage</value>
+    <value>Name and Storage</value>
   </data>
   <data name="CPM_WIZARD_INTRA_POOL_COPY_TITLE" xml:space="preserve">
-    <value>Name and storage</value>
+    <value>Name and Storage</value>
   </data>
   <data name="CPM_WIZARD_NETWORKING_INTRO" xml:space="preserve">
-    <value>Map the virtual network interfaces in the VM(s) you are migrating to networks in the destination pool or standalone server.</value>
+    <value>Map the virtual network interfaces in the selected VMs to networks in the destination pool or standalone server.</value>
+  </data>
+  <data name="CPM_WIZARD_NETWORKING_INTRO_SINGLE" xml:space="preserve">
+    <value>Map the VM's virtual network interfaces to networks in the destination pool or standalone server.</value>
   </data>
   <data name="CPM_WIZARD_SELECT_NETWORK_PAGE_TEXT" xml:space="preserve">
     <value>Networking</value>
   </data>
   <data name="CPM_WIZARD_SELECT_NETWORK_PAGE_TITLE" xml:space="preserve">
-    <value>Configure networking for the migrated VM(s)</value>
+    <value>Configure networking</value>
   </data>
   <data name="CPM_WIZARD_SELECT_STORAGE_PAGE_TEXT" xml:space="preserve">
     <value>Storage</value>
   </data>
   <data name="CPM_WIZARD_SELECT_STORAGE_PAGE_TITLE" xml:space="preserve">
-    <value>Configure storage for the migrated VM(s)</value>
+    <value>Configure storage</value>
   </data>
   <data name="CPM_WIZARD_SELECT_TRANSFER_NETWORK_PAGE_TEXT" xml:space="preserve">
     <value>Live Migration Network</value>
@@ -3052,7 +3076,7 @@ Please reconnect the host and try again.</value>
     <value>Configure storage live migration settings</value>
   </data>
   <data name="CPM_WIZARD_SPECIFIC_SR_RADIO" xml:space="preserve">
-    <value>Pla&amp;ce migrated virtual disks onto specified SRs:</value>
+    <value>Pla&amp;ce virtual disks onto specified SRs:</value>
   </data>
   <data name="CPM_WIZARD_STORAGE_INSTRUCTIONS" xml:space="preserve">
     <value>Select one or more storage repositories (SR) in the destination pool or standalone server.</value>
@@ -3067,7 +3091,7 @@ Please reconnect the host and try again.</value>
     <value>The selected VMs are no longer available for migration. Please verify your selection is valid and relaunch the wizard.</value>
   </data>
   <data name="CPM_WIZARD_VM_SELECTION_INTRODUCTION" xml:space="preserve">
-    <value>&amp;Virtual network interfaces in migrated VMs:</value>
+    <value>&amp;Virtual network interfaces:</value>
   </data>
   <data name="CPM_WLB_ENABLED_ON_HOST_FAILURE_REASON" xml:space="preserve">
     <value>WLB is enabled on the host</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2984,7 +2984,7 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
     <value>Storage:</value>
   </data>
   <data name="CPM_SUMMARY_KEY_TRANSFER_NETWORK" xml:space="preserve">
-    <value>Live Migration Network:</value>
+    <value>Migration Network:</value>
   </data>
   <data name="CPM_SUMMARY_NETWORK_NOT_FOUND" xml:space="preserve">
     <value>Network not found</value>
@@ -3031,16 +3031,16 @@ You can only connect to a single Citrix XenServer Express Edition server at a ti
 Please reconnect the host and try again.</value>
   </data>
   <data name="CPM_WIZARD_FINISH_PAGE_INTRO" xml:space="preserve">
-    <value>The wizard is ready to begin migrating the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VMs and close the wizard.</value>
+    <value>The wizard is ready to begin migrating the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VMs.</value>
   </data>
   <data name="CPM_WIZARD_FINISH_PAGE_INTRO_COPY" xml:space="preserve">
-    <value>The wizard is ready to begin copying the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VMs and close the wizard.</value>
+    <value>The wizard is ready to begin copying the selected VMs using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VMs.</value>
   </data>
   <data name="CPM_WIZARD_FINISH_PAGE_INTRO_COPY_SINGLE" xml:space="preserve">
-    <value>The wizard is ready to begin copying the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VM and close the wizard.</value>
+    <value>The wizard is ready to begin copying the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to copy the VM.</value>
   </data>
   <data name="CPM_WIZARD_FINISH_PAGE_INTRO_SINGLE" xml:space="preserve">
-    <value>The wizard is ready to begin migrating the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VM and close the wizard.</value>
+    <value>The wizard is ready to begin migrating the selected VM using the settings shown below. Please review these settings and click Previous if you need to go back and make any changes, otherwise click Finish to migrate the VM.</value>
   </data>
   <data name="CPM_WIZARD_FINISH_PAGE_TITLE" xml:space="preserve">
     <value>Review settings</value>
@@ -3055,7 +3055,7 @@ Please reconnect the host and try again.</value>
     <value>Map the virtual network interfaces in the selected VMs to networks in the destination pool or standalone server.</value>
   </data>
   <data name="CPM_WIZARD_NETWORKING_INTRO_SINGLE" xml:space="preserve">
-    <value>Map the VM's virtual network interfaces to networks in the destination pool or standalone server.</value>
+    <value>Map the virtual network interfaces in the selected VM to networks in the destination pool or standalone server.</value>
   </data>
   <data name="CPM_WIZARD_SELECT_NETWORK_PAGE_TEXT" xml:space="preserve">
     <value>Networking</value>
@@ -3070,10 +3070,10 @@ Please reconnect the host and try again.</value>
     <value>Configure storage</value>
   </data>
   <data name="CPM_WIZARD_SELECT_TRANSFER_NETWORK_PAGE_TEXT" xml:space="preserve">
-    <value>Live Migration Network</value>
+    <value>Migration Network</value>
   </data>
   <data name="CPM_WIZARD_SELECT_TRANSFER_NETWORK_TITLE" xml:space="preserve">
-    <value>Configure storage live migration settings</value>
+    <value>Configure storage migration settings</value>
   </data>
   <data name="CPM_WIZARD_SPECIFIC_SR_RADIO" xml:space="preserve">
     <value>Pla&amp;ce virtual disks onto specified SRs:</value>


### PR DESCRIPTION
...s pool migrate wizard

- changes to the text to be suitable for migrate and copy operations, where possible
- added different text for copy on some pages
- also different text for single and multiple selection
- changes to text alignment, tab order, hotkeys on the copy pages
- removed Finish page from the intra-pool copy wizard

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>