### PR TITLE
CA-169170: “Switch to Remote desktop” button should not be disabled in Cream when Windows VM installed with latest PV tools.

### DIFF
--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -1347,7 +1347,9 @@ namespace XenAdmin.ConsoleView
             if (!vncScreen.UseVNC)
                 toggleConsoleButton_Click(null, null);
 
-            toggleConsoleButton.Enabled = false;
+            if (!Helpers.CreamOrGreater(source.Connection) || !RDPControlEnabled)
+                toggleConsoleButton.Enabled = false;
+            
             vncScreen.imediatelyPollForConsole();
         }
 


### PR DESCRIPTION

Check current XenServer Version, if current version is greater than Cream and PV tool installed, do not disable control button.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>