### PR TITLE
CA-169167: Screen resolution is less than the default value after switch to remote desktop

### DIFF
--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -199,10 +199,10 @@ namespace XenAdmin.ConsoleView
 
             toggleConsoleButton.EnabledChanged += toggleConsoleButton_EnabledChanged;
 
-            //If RDP enabled and AutoSwitchToRDP selected, switch RDP connection when open the tab.
+            //If RDP enabled and AutoSwitchToRDP selected, switch RDP connection will be done when VNC already get the correct screen resolution.
             //This change is only for Cream, because RDP port scan was removed in Cream.
             if ( Helpers.CreamOrGreater(source.Connection) && Properties.Settings.Default.AutoSwitchToRDP && RDPEnabled )
-                switchOnTabOpened = true;
+                vncScreen.AutoSwitchRDPLater = true;
         }
 
         //CA-75479 - add to aid debugging

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -69,6 +69,7 @@ namespace XenAdmin.ConsoleView
         private int ConnectionRetries = 0;
 
         private volatile bool useVNC = true;
+        private volatile bool autoSwitchRDPLater = false;
 
         private bool autoCaptureKeyboardAndMouse = true;
         internal bool showConnectionBar = true;
@@ -587,6 +588,27 @@ namespace XenAdmin.ConsoleView
         void ConnectionSuccess(object sender, EventArgs e)
         {
             ConnectionRetries = 0;
+            if (AutoSwitchRDPLater)
+            {
+                if (OnDetectRDP != null)
+                    Program.Invoke(this, OnDetectRDP);
+                AutoSwitchRDPLater = false;
+            }
+        }
+
+        internal bool AutoSwitchRDPLater
+        {
+            get
+            {
+                return autoSwitchRDPLater;
+            }
+            set
+            {
+                if (value != autoSwitchRDPLater)
+                {
+                    autoSwitchRDPLater = value;
+                }
+            }
         }
 
         internal bool UseVNC
@@ -702,7 +724,7 @@ namespace XenAdmin.ConsoleView
             //Disable the button first, but only if in text/default console (to allow user to return to the text console - ref. CA-70314)
             if (Helpers.CreamOrGreater(Source.Connection) && parentVNCTabView.IsRDPControlEnabled())
             {
-                parentVNCTabView.EnableToggleVNCButton();
+                parentVNCTabView.DisableToggleVNCButton();
             }
             else 
             {


### PR DESCRIPTION

Auto switch to RDP should be taken after VNC connection got the correct screen resolution.
Also not enable “enable RDP button” before VNC connection get the correct screen resolution.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>