### PR TITLE
CA-164686: Host got removed from XC when it is removed from a pool

### DIFF
--- a/XenAdmin/Network/XenConnectionUI.cs
+++ b/XenAdmin/Network/XenConnectionUI.cs
@@ -120,9 +120,9 @@ namespace XenAdmin.Network
                 if (f.ErrorDescription[0] == Failure.HOST_IS_SLAVE)
                 {
                     string oldHost = connection.Name;
-                    ((XenConnection)connection).Hostname = f.ErrorDescription[1];
+                    string poolMasterName = f.ErrorDescription[1];
 
-                    string pool_name = XenConnection.ConnectedElsewhere(((XenConnection)connection).Hostname);
+                    string pool_name = XenConnection.ConnectedElsewhere(poolMasterName);
                     if (pool_name != null)
                     {
                         if (!Program.RunInAutomatedTestMode)
@@ -152,11 +152,12 @@ namespace XenAdmin.Network
                             new ThreeButtonDialog(
                                 new ThreeButtonDialog.Details(
                                     SystemIcons.Warning,
-                                    String.Format(Messages.SLAVE_CONNECTION_ERROR, oldHost, ((XenConnection)connection).Hostname),
+                                    String.Format(Messages.SLAVE_CONNECTION_ERROR, oldHost, poolMasterName),
                                     Messages.CONNECT_TO_SERVER),
                                 ThreeButtonDialog.ButtonYes,
                                 ThreeButtonDialog.ButtonNo).ShowDialog(owner))
                         {
+                            ((XenConnection) connection).Hostname = poolMasterName;
                             BeginConnect(connection, true, owner, false);
                         }
                     }


### PR DESCRIPTION
- On receiving a HOST_IS_SLAVE exception, only change connection.Hostname property if we need to connect to the pool master. Leave it unchanged if we are already connected to the pool, as no further action is required. This will ensure that we don't change the Hostname of a slave back to the master, if the user tries to connect to it immediately after it has been removed from the pool.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>