### PR TITLE
CA-169167: Screen resolution is less than the default value after switch to remote desktop

### DIFF
--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -204,10 +204,10 @@ namespace XenAdmin.ConsoleView
 
             toggleConsoleButton.EnabledChanged += toggleConsoleButton_EnabledChanged;
 
-            //If RDP enabled and AutoSwitchToRDP selected, switch RDP connection when open the tab.
+            //If RDP enabled and AutoSwitchToRDP selected, switch RDP connection will be done when VNC already get the correct screen resolution.
             //This change is only for Cream, because RDP port scan was removed in Cream.
             if ( Helpers.CreamOrGreater(source.Connection) && Properties.Settings.Default.AutoSwitchToRDP && RDPEnabled )
-                switchOnTabOpened = true;
+                vncScreen.AutoSwitchRDPLater = true;
         }
 
         //CA-75479 - add to aid debugging

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -601,17 +601,8 @@ namespace XenAdmin.ConsoleView
 
         internal bool AutoSwitchRDPLater
         {
-            get
-            {
-                return autoSwitchRDPLater;
-            }
-            set
-            {
-                if (value != autoSwitchRDPLater)
-                {
-                    autoSwitchRDPLater = value;
-                }
-            }
+            get;
+            set; 
         }
 
         internal bool UseVNC


### PR DESCRIPTION
Auto switch to RDP should be taken after VNC connection got the correct screen resolution.
Also not enable “enable RDP button” before VNC connection get the correct screen resolution.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>