### PR TITLE
CA-120187: Manifestation of "anonymous" action when repairing multiple storages

### DIFF
--- a/XenAdmin/Dialogs/RepairSRDialog.cs
+++ b/XenAdmin/Dialogs/RepairSRDialog.cs
@@ -277,7 +277,7 @@ namespace XenAdmin.Dialogs
                     subActions.Add(new SrRepairAction(sr.Connection, sr, false));
                 }
 
-                _repairAction = new MultipleAction(null, string.Empty, string.Empty, string.Empty, subActions);
+                _repairAction = new MultipleAction(null, string.Empty, string.Empty, string.Empty, subActions, true);
             }
             
             _repairAction.Changed += action_Changed;


### PR DESCRIPTION
Passing suppressHistory=false in the MultipleAction's constructor (so no action item will be displayed in the Event view for the MultipleAction itself)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>