### PR TITLE
CP-12282: Semantics of Move / Migrate / Copy for suspended VMs

### DIFF
--- a/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
@@ -60,7 +60,7 @@ namespace XenAdmin.Commands
             else
             {
                 MainWindowCommandInterface.ShowPerConnectionWizard(con,
-                    new CrossPoolMigrateWizard(con, selection, preSelectedHost, WizardMode.Move));
+                    new CrossPoolMigrateWizard(con, selection, preSelectedHost, GetWizardMode(selection)));
             }
 
         }
@@ -76,6 +76,14 @@ namespace XenAdmin.Commands
                 return false;
 
             return CrossPoolMigrateCommand.CanExecute(vm, preSelectedHost);
+        }
+
+        public static WizardMode GetWizardMode(SelectedItemCollection selection)
+        {
+            return selection != null && selection.Count > 0 && selection[0].XenObject is VM
+                       && (selection[0].XenObject as VM).power_state == vm_power_state.Suspended
+                           ? WizardMode.Migrate
+                           : WizardMode.Move;
         }
     }
 }

--- a/XenAdmin/Commands/MoveVMCommand.cs
+++ b/XenAdmin/Commands/MoveVMCommand.cs
@@ -32,6 +32,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
+using XenAdmin.Wizards.CrossPoolMigrateWizard;
 using XenAPI;
 using XenAdmin.Dialogs;
 using System.Collections.ObjectModel;
@@ -41,7 +42,7 @@ using XenAdmin.Dialogs.VMDialogs;
 namespace XenAdmin.Commands
 {
     /// <summary>
-    /// Launches the Copy-VM dialog for the selected VM.
+    /// Launches the Move-VM dialog for the selected VM.
     /// </summary>
     internal class MoveVMCommand : Command
     {
@@ -87,7 +88,9 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Messages.MAINWINDOW_MOVEVM;
+                return CrossPoolMoveVMCommand.GetWizardMode(GetSelection()) == WizardMode.Migrate
+                           ? Messages.MAINWINDOW_MIGRATEVM
+                           : Messages.MAINWINDOW_MOVEVM;
             }
         }
     }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19890,6 +19890,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &amp;Migrate VM....
+        /// </summary>
+        public static string MAINWINDOW_MIGRATEVM {
+            get {
+                return ResourceManager.GetString("MAINWINDOW_MIGRATEVM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &amp;Move VM....
         /// </summary>
         public static string MAINWINDOW_MOVEVM {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -6915,6 +6915,9 @@ This will permanently delete and reinitialize all local storage on the servers. 
   <data name="MAINWINDOW_LOG_REMOVECONNECTION" xml:space="preserve">
     <value>Removed connection to {0}</value>
   </data>
+  <data name="MAINWINDOW_MIGRATEVM" xml:space="preserve">
+    <value>&amp;Migrate VM...</value>
+  </data>
   <data name="MAINWINDOW_MIGRATE_TO_SERVER" xml:space="preserve">
     <value>M&amp;igrate to Server</value>
   </data>


### PR DESCRIPTION
Changed the name of the operation in XenCenter to "Migrate VM" for suspended VMs, instead of "Move VM".
This clarifies the distinction between copy/move and migration:
- running and suspended VMs can only be migrated
- stopped VMs can be moved and copied

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>