### PR TITLE
CP-12153: Call Home Authentication

### DIFF
--- a/XenModel/Actions/CallHome/CallHomeAuthenticationAction.cs
+++ b/XenModel/Actions/CallHome/CallHomeAuthenticationAction.cs
@@ -140,12 +140,12 @@ namespace XenAdmin.Actions
                 result = streamReader.ReadToEnd();
             }
             TemplateResponse response = new JavaScriptSerializer().Deserialize<TemplateResponse>(result);
-            return response.token;
+            return response.Token;
         }
 
         class TemplateResponse
         {
-            public String token;
+            public string Token { get; set; }
         }
     }
 }


### PR DESCRIPTION
- added getter and setter to the token property to prevent "Field never assigned" warning

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>