### PR TITLE
CP-12158: Add debug log for XenServer Health Check Service

### DIFF
--- a/XenServerHealthCheck/ServerListHelper.cs
+++ b/XenServerHealthCheck/ServerListHelper.cs
@@ -62,7 +62,7 @@ namespace XenServerHealthCheck
                     }
                     catch (Exception exn)
                     {
-                        log.Error(exn, exn);
+                        log.Error("Decrypt server information failed", exn);
                     }
                 }
             }
@@ -159,7 +159,7 @@ namespace XenServerHealthCheck
             }
             catch (Exception exp)
             {
-                log.Error(exp, exp);
+                log.Error("Get server list from XenCenter failed", exp);
             }
 
             return encServerList;

--- a/XenServerHealthCheck/XenServerHealthCheck.cs
+++ b/XenServerHealthCheck/XenServerHealthCheck.cs
@@ -31,6 +31,8 @@
 
 using System;
 using System.ServiceProcess;
+using System.Reflection;
+using System.IO;
 
 namespace XenServerHealthCheck
 {
@@ -41,6 +43,7 @@ namespace XenServerHealthCheck
         /// </summary>
         static void Main()
         {
+            log4net.Config.XmlConfigurator.ConfigureAndWatch(new FileInfo(Assembly.GetCallingAssembly().Location + ".config"));
             ServiceBase[] ServicesToRun;
             ServicesToRun = new ServiceBase[] 
 			{ 

--- a/XenServerHealthCheck/XenServerHealthCheckService.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckService.cs
@@ -56,6 +56,7 @@ namespace XenServerHealthCheck
         protected override void OnStart(string[] args)
         {
             // Set up a timer to trigger the uploading service.
+            log.Info("XenServer Health Check Service starting...");
             System.Timers.Timer timer = new System.Timers.Timer();
             timer.Interval = 30 * 60000; // 30 minitues
             timer.Elapsed += new System.Timers.ElapsedEventHandler(this.OnTimer);
@@ -64,15 +65,18 @@ namespace XenServerHealthCheck
 
         protected override void OnStop()
         {
+            log.Info("XenServer Health Check Service stopping...");
         }
 
         
 
         public void OnTimer(object sender, System.Timers.ElapsedEventArgs args)
         {
+            log.Info("XenServer Health Check Service start to refresh uploading tasks");
             List<IXenConnection> Connections = ServerListHelper.GetServerList();
             foreach (IXenConnection connection in Connections)
             {
+                log.InfoFormat("Check server {0} with user {1}", connection.Hostname, connection.Username);
                 Session _session = new Session(connection.Hostname, 80);
                 _session.APIVersion = API_Version.LATEST;
                 try

--- a/XenServerHealthCheck/app.config
+++ b/XenServerHealthCheck/app.config
@@ -1,3 +1,26 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net"/>
+  </configSections>
+  <appSettings>
+    <add key="log4net.Config" value="Log4Net.config" />
+  </appSettings>
+  <log4net>
+    <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender">
+      <file value="${PROGRAMDATA}/Citrix/XenServerHealthCheck/logs/XenServerHealthCheck.log"/>
+      <appendToFile value="true"/>
+      <maxSizeRollBackups value="5"/>
+      <maximumFileSize value="10MB"/>
+      <rollingStyle value="Size"/>
+      <staticLogFileName value="true"/>
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date %-5level %logger [%thread] - %message%newline"/>
+      </layout>
+    </appender>
+    <root>
+      <level value="ALL" />
+      <appender-ref ref="RollingLogFileAppender" />
+    </root>
+  </log4net>
+  <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>


### PR DESCRIPTION
Log will be located at ${PROGRAMDATA}/Citrix/XenServerHealthCheck/logs/XenServerHealthCheck.log

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>