### PR TITLE
CP-7644: Put XenCenter product version and build number in manifest

### DIFF
--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -419,6 +419,8 @@ done
 
 #create manifest
 echo "@branch=${XS_BRANCH}" >> ${OUTPUT_DIR}/manifest
+echo "@xc_product_version=${XC_PRODUCT_VERSION}" >> ${OUTPUT_DIR}/manifest
+echo "@build_number=${BUILD_NUMBER}" >> ${OUTPUT_DIR}/manifest
 echo "xenadmin xenadmin.git ${get_REVISION:0:12}" >> ${OUTPUT_DIR}/manifest
 cat ${SCRATCH_DIR}/xe-phase-1-manifest | grep xencenter-ovf >> ${OUTPUT_DIR}/manifest
 cat ${SCRATCH_DIR}/xe-phase-1-manifest | grep chroot-lenny >> ${OUTPUT_DIR}/manifest


### PR DESCRIPTION
I can't test this, so I'm not sure if it works... can you test it and merge it if it works (and put a link to the build on the ticket so I can see what the manifest file looks like)?

Thanks