### PR TITLE
CP-7644: Write XenCenter product version and build number

### DIFF
--- a/mk/archive-push.sh
+++ b/mk/archive-push.sh
@@ -54,7 +54,7 @@ then
 fi
 
 #update local xenadmin-ref.hg repository
-cp ${OUTPUT_DIR}/{manifest,latest-*-build} ${ROOT}/xenadmin-ref.hg
+cp ${OUTPUT_DIR}/{manifest,latest-*-build,xcversion} ${ROOT}/xenadmin-ref.hg
 cd ${ROOT}/xenadmin-ref.hg && hg commit -m "Latest successful build ${get_BUILD_ID}"
 
 if [ ${XS_BRANCH} = "trunk" ]

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -431,6 +431,10 @@ else
     echo ${get_BUILD_URL} >> ${OUTPUT_DIR}/latest-successful-build
 fi
 
+# Write out version information
+echo "xc_product_version=${XC_PRODUCT_VERSION}" >> ${OUTPUT_DIR}/xcversion
+echo "build_number=${BUILD_NUMBER}" >> ${OUTPUT_DIR}/xcversion
+
 echo "Build phase succeeded at "
 date
 


### PR DESCRIPTION
Write out the XenCenter version and build number into a version file so
that other tools can determine them from the build artifacts.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>