### PR TITLE
CP-12160: XenServerHealthCheck: upload server status report to CIS.

### DIFF
--- a/XenModel/XenAPI-Extensions/Pool.cs
+++ b/XenModel/XenAPI-Extensions/Pool.cs
@@ -456,6 +456,7 @@ namespace XenAPI
         public const string LAST_SUCCESSFUL_UPLOAD = "LastSuccessfulUpload";
         public const string LAST_FAILED_UPLOAD = "LastFailedUpload";
         public const string NEW_UPLOAD_REQUEST = "NewUploadRequest";
+        public const string UPLOAD_UUID = "UploadUuid";
 
         public CallHomeSettings(CallHomeStatus status, int intervalInDays, DayOfWeek dayOfWeek, int timeOfDay, int retryInterval)
         {

--- a/XenServerHealthCheck/XenServerHealthCheck.csproj
+++ b/XenServerHealthCheck/XenServerHealthCheck.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -56,7 +57,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="XenServerHealthCheckUpload.cs" />
     <Compile Include="XenServerHealthCheckBugTool.cs" />
+    <Compile Include="XenServerHealthCheckBundleUpload.cs" />
     <Compile Include="ProjectInstaller.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
@@ -1,0 +1,210 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using XenAdmin.Core;
+using XenAdmin.Network;
+using XenAPI;
+
+
+namespace XenServerHealthCheck
+{
+    public class XenServerHealthCheckBundleUpload
+    {
+        public XenServerHealthCheckBundleUpload(IXenConnection _connection)
+        {
+            connection = _connection;
+        }
+
+        private IXenConnection connection;
+
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        public const int TIMEOUT = 24 * 60 * 60 * 1000;
+        public const int VERBOSITY_LEVEL = 2;
+
+        public void runUpload()
+        {
+            DateTime startTime = DateTime.UtcNow;
+            string uploadToken = "";
+            Session session = new Session(connection.Hostname, 80);
+            session.APIVersion = API_Version.LATEST;
+
+            try
+            {
+                session.login_with_password(connection.Username, connection.Password);
+                connection.LoadCache(session);
+                var pool = Helpers.GetPoolOfOne(connection);
+                if (pool != null)
+                {
+                    uploadToken = pool.CallHomeSettings.GetUploadToken(connection);
+                }
+
+                if (string.IsNullOrEmpty(uploadToken))
+                {
+                    if (session != null)
+                        session.logout();
+                    session = null;
+                    log.ErrorFormat("The upload token is not retrieved for {0}", connection.Hostname);
+                    updateCallHomeSettings(false, startTime);
+                    return;
+                }
+
+            }
+            catch (Exception e)
+            {
+                if (session != null)
+                    session.logout();
+                session = null;
+                log.Error(e, e);
+                updateCallHomeSettings(false, startTime);
+                return;
+            }
+
+            try
+            {
+                CancellationTokenSource cts = new CancellationTokenSource();
+                Func<string> upload = delegate()
+                {
+                    try
+                    {
+                        return bundleUpload(connection, session, uploadToken, cts.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return "";
+                    }
+                };
+                System.Threading.Tasks.Task<string> task = new System.Threading.Tasks.Task<string>(upload);
+                task.Start();
+                if (!task.Wait(TIMEOUT))
+                {
+                    cts.Cancel();
+                    updateCallHomeSettings(false, startTime);
+                    task.Wait();
+                    return;
+                }
+
+                if (task.Status == System.Threading.Tasks.TaskStatus.RanToCompletion)
+                {
+                    string upload_uuid = task.Result;
+                    if(!string.IsNullOrEmpty(upload_uuid))
+                        updateCallHomeSettings(true, startTime, upload_uuid);
+                    else
+                        updateCallHomeSettings(false, startTime);
+                }
+                else
+                    updateCallHomeSettings(false, startTime);
+            }
+            catch (Exception e)
+            {
+                if (session != null)
+                    session.logout();
+                session = null;
+                log.Error(e, e);
+                updateCallHomeSettings(false, startTime);
+            }
+
+        }
+
+        public void updateCallHomeSettings(bool success, DateTime time, string uploadUuid = "")
+        {
+            Session session = new Session(connection.Hostname, 80);
+            session.login_with_password(connection.Username, connection.Password);
+            connection.LoadCache(session);
+
+            // Round-trip format time
+            DateTime rtime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+            string stime = rtime.ToString("o");
+
+            // record upload_uuid,
+            // release the lock,
+            // set the time of LAST_SUCCESSFUL_UPLOAD or LAST_FAILED_UPLOAD
+            Dictionary<string, string> config = Pool.get_health_check_config(session, connection.Cache.Pools[0].opaque_ref);
+            config[CallHomeSettings.UPLOAD_LOCK] = "";
+            if (success)
+            {
+                config[CallHomeSettings.LAST_SUCCESSFUL_UPLOAD] = stime;
+                config[CallHomeSettings.UPLOAD_UUID] = uploadUuid;
+            }
+            else
+                config[CallHomeSettings.LAST_FAILED_UPLOAD] = stime;
+            Pool.set_health_check_config(session, connection.Cache.Pools[0].opaque_ref, config);
+
+            if (session != null)
+                session.logout();
+            session = null;
+        }
+
+        public string bundleUpload(IXenConnection connection, Session session, string uploadToken, System.Threading.CancellationToken cancel)
+        {
+            // Collect the server status report and generate zip file to upload.
+            XenServerHealthCheckBugTool bugTool = new XenServerHealthCheckBugTool();
+            try
+            {
+                bugTool.RunBugtool(connection, session);
+            }
+            catch (Exception e)
+            {
+                if (session != null)
+                    session.logout();
+                session = null;
+                log.Error(e, e);
+                return "";
+            }
+
+            string bundleToUpload = bugTool.outputFile;
+            if(string.IsNullOrEmpty(bundleToUpload) || !File.Exists(bundleToUpload))
+            {
+                log.ErrorFormat("Server Status Report is NOT collected");
+                return "";
+            }
+
+            // Upload the zip file to CIS uploading server.
+            XenServerHealthCheckUpload upload = new XenServerHealthCheckUpload(uploadToken, VERBOSITY_LEVEL);
+            string upload_uuid = upload.UploadZip(bundleToUpload, cancel);
+            if (File.Exists(bundleToUpload))
+                File.Delete(bundleToUpload);
+
+            // Return the uuid of upload.
+            if(string.IsNullOrEmpty(upload_uuid))
+            {
+                // Fail to upload the zip to CIS server.
+                log.ErrorFormat("Fail to upload the Server Status Report {0} to CIS server", bundleToUpload);
+                return "";
+            }
+
+            return upload_uuid;
+        }
+    }
+}

--- a/XenServerHealthCheck/XenServerHealthCheckService.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckService.cs
@@ -106,8 +106,16 @@ namespace XenServerHealthCheck
                     connection.LoadCache(session);
                     if (RequestUploadTask.Request(connection, session) || RequestUploadTask.OnDemandRequest(connection, session))
                     {
-                        //Create thread to do log uploading
-                        log.InfoFormat("Will upload report for XenServer {0}", connection.Hostname);
+                        // Create a task to collect server status report and upload to CIS server
+                        log.InfoFormat("Start to upload server status report for XenServer {0}", connection.Hostname);
+
+                        XenServerHealthCheckBundleUpload upload = new XenServerHealthCheckBundleUpload(connection);
+                        Action uploadAction = delegate()
+                        {
+                            upload.runUpload();
+                        };
+                        System.Threading.Tasks.Task task = new System.Threading.Tasks.Task(uploadAction);
+                        task.Start();
                     }
                     session.logout();
                     session = null;

--- a/XenServerHealthCheck/XenServerHealthCheckUpload.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckUpload.cs
@@ -1,0 +1,216 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Net;
+using System.Web.Script.Serialization;
+
+
+namespace XenServerHealthCheck
+{
+    public class XenServerHealthCheckUpload
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        public const string UPLOAD_URL = "https://rttf-staging.citrix.com/feeds/api/";
+        public const int CHUNK_SIZE = 1 * 1024 * 1024;
+        private JavaScriptSerializer serializer;
+        private int verbosityLevel;
+
+        private string uploadToken;
+
+        public XenServerHealthCheckUpload(string token, int verbosity)
+        {
+            uploadToken = token;
+            verbosityLevel = verbosity;
+            serializer = new JavaScriptSerializer();
+            serializer.MaxJsonLength = int.MaxValue;
+        }
+
+        // Request an upload and fetch the uploading id from CIS.
+        public string InitiateUpload(long size)
+        {
+            // Request a new bundle upload to CIS server.
+            Uri uri = new Uri(UPLOAD_URL + "bundle/?size=" + size.ToString());
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+            if (uploadToken != null)
+            {
+                request.Headers.Add("Authorization", "BT " + uploadToken);
+            }
+
+            request.Method = "POST";
+            request.ContentType = "application/json";
+            request.ServicePoint.Expect100Continue = false;
+
+            using (var streamWriter = new StreamWriter(request.GetRequestStream()))
+            {
+                // Add the log verbosity level in json cotent.
+                string verbosity = "{\"verbosity\":\"2\"}";
+                streamWriter.Write(verbosity);
+            }
+
+            Dictionary<string, object> res = new Dictionary<string, object>();
+            try
+            {
+                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                using (StreamReader reader = new StreamReader(response.GetResponseStream()))
+                {
+                    string respString = reader.ReadToEnd();
+                    res = (Dictionary<string, object>)serializer.DeserializeObject(respString);
+                }
+                response.Close();
+            }
+            catch (WebException e)
+            {
+                log.ErrorFormat("Exception while requesting a new CIS uploading: {0}", e);
+                return "";
+            }
+
+            if (res.ContainsKey("id"))
+            {
+                // Get the uuid of uploading
+                return (string)res["id"];
+            }
+            else
+            {
+                // Fail to initialize the upload request
+                return "";
+            }
+        }
+
+        // Upload a chunk.
+        public bool UploadChunk(string address, string filePath, long offset, long thisChunkSize, string uploadToken)
+        {
+            Uri uri = new Uri(address);
+            HttpWebRequest req = (HttpWebRequest)WebRequest.Create(uri);
+            req.Method = "POST";
+            req.ContentType = "application/octet-stream";
+            req.Headers.Add("Authorization", "BT " + uploadToken);
+
+            using (Stream destination = req.GetRequestStream())
+            {
+                using (FileStream source = File.Open(filePath, FileMode.Open))
+                {
+                    source.Position = offset;
+                    int bytes = Convert.ToInt32(thisChunkSize);
+                    byte[] buffer = new byte[CHUNK_SIZE];
+                    int read;
+                    while (bytes > 0 &&
+                           (read = source.Read(buffer, 0, Math.Min(buffer.Length, bytes))) > 0)
+                    {
+                        destination.Write(buffer, 0, read);
+                        bytes -= read;
+                    }
+                }
+                HttpWebResponse resp = req.GetResponse() as HttpWebResponse;
+                HttpStatusCode statusCode = resp.StatusCode;
+
+                // After sending every chunk upload request to server, response will contain a status indicating if it is complete.
+                using (StreamReader reader = new StreamReader(resp.GetResponseStream()))
+                {
+                    string respString = reader.ReadToEnd();
+                    Dictionary<string, object> res = (Dictionary<string, object>)serializer.DeserializeObject(respString);
+                    log.InfoFormat("The status of chunk upload: {0}", res["status"]);
+                }
+
+                resp.Close();
+
+                if (statusCode == HttpStatusCode.OK)
+                    return true;
+                else
+                    return false;
+            }
+        }
+
+        // Upload the zip file.
+        public string UploadZip(string fileName, System.Threading.CancellationToken cancel)
+        {
+            FileInfo fileInfo = new FileInfo(fileName);
+            long size = fileInfo.Length;
+
+            // Fetch the upload UUID from CIS server.
+            string uploadUuid = InitiateUpload(size);
+            if (string.IsNullOrEmpty(uploadUuid))
+            {
+                log.ErrorFormat("Cannot fetch the upload UUID from CIS server");
+                return "";
+            }
+
+            // Start to upload zip file.
+            log.InfoFormat("Upload ID: {0}", uploadUuid);
+            StringBuilder url = new StringBuilder(UPLOAD_URL + "upload_raw_chunk/?id=" + uploadUuid);
+
+            long offset = 0;
+            while (offset < size)
+            {
+                url.Append(String.Format("&offset={0}", offset));
+                long remainingSize = size - offset;
+                long thisChunkSize = (remainingSize > CHUNK_SIZE) ? CHUNK_SIZE : remainingSize;
+
+                try
+                {
+                    for (int i = 0; i < 3; i++)
+                    {
+                        if (cancel.IsCancellationRequested)
+                        {
+                            return "";
+                        }
+
+                        if (UploadChunk(url.ToString(), fileName, offset, thisChunkSize, uploadToken))
+                        {
+                            // This chunk is successfully uploaded
+                            offset += thisChunkSize;
+                            break;
+                        }
+
+                        // Fail to upload the chunk for 3 times so fail the bundle upload.
+                        log.ErrorFormat("Fail to upload the chunk");
+                        return "";
+                    }
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, e);
+                    return "";
+                }
+
+            }
+
+            log.InfoFormat("Succeed to upload bundle {0}", fileName);
+            return uploadUuid;
+
+        }
+
+    }
+}

--- a/XenServerHealthCheck/app.config
+++ b/XenServerHealthCheck/app.config
@@ -1,21 +1,22 @@
 <?xml version="1.0"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net" />
   </configSections>
   <appSettings>
     <add key="log4net.Config" value="Log4Net.config" />
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
   <log4net>
     <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender">
-      <file value="${PROGRAMDATA}/Citrix/XenServerHealthCheck/logs/XenServerHealthCheck.log"/>
-      <appendToFile value="true"/>
-      <maxSizeRollBackups value="5"/>
-      <maximumFileSize value="10MB"/>
-      <rollingStyle value="Size"/>
-      <staticLogFileName value="true"/>
+      <file value="${PROGRAMDATA}/Citrix/XenServerHealthCheck/logs/XenServerHealthCheck.log" />
+      <appendToFile value="true" />
+      <maxSizeRollBackups value="5" />
+      <maximumFileSize value="10MB" />
+      <rollingStyle value="Size" />
+      <staticLogFileName value="true" />
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date %-5level %logger [%thread] - %message%newline"/>
+        <conversionPattern value="%date %-5level %logger [%thread] - %message%newline" />
       </layout>
     </appender>
     <root>
@@ -23,4 +24,19 @@
       <appender-ref ref="RollingLogFileAppender" />
     </root>
   </log4net>
-  <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+  </startup>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
+</configuration>


### PR DESCRIPTION
When an upload request is triggered,
1. fetch the upload token from CallHomeSettings,
2. generate the server status report and upload it to CIS server,
3. update the corresponding fields of CallHomeSettings when the
   upload is finished successfully or failed.

Signed-off-by: Hui Zhang <hui.zhang@citrix.com>