### PR TITLE
CP-12769: Send server connection details to the Health Check Service

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -875,7 +875,7 @@ namespace XenAdmin
             var newCallHomeSettings = pool.CallHomeSettings;
             new TransferCallHomeSettingsAction(pool, newCallHomeSettings,
                 newCallHomeSettings.GetSecretyInfo(pool.Connection, CallHomeSettings.UPLOAD_CREDENTIAL_USER_SECRET),
-                newCallHomeSettings.GetSecretyInfo(pool.Connection, CallHomeSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET), false).RunAsync();
+                newCallHomeSettings.GetSecretyInfo(pool.Connection, CallHomeSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET), true).RunAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
- Call TransferCallHomeSettingsAction with suppressHistory=true so the action doesn't show on the Events page
- This change also fixes LogsTabTests test failure.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>