### PR TITLE
CP-12161: Add the Call Home service to the XenCenter installer

### DIFF
--- a/WixInstaller/XenCenter.l10n.diff
+++ b/WixInstaller/XenCenter.l10n.diff
@@ -158,7 +158,7 @@
                              </Component>
                          </Directory>
                          <Directory Id="EXTERNALTOOLS" ShortName="External" Name="External Tools">
-@@ -213,6 +237,8 @@
+@@ -247,6 +271,8 @@
          <Feature Id="MainProgram" Title="Citrix XenCenter" Description="The complete package" Display="expand" Level="1" ConfigurableDirectory="INSTALLDIR" AllowAdvertise="no" InstallDefault="local" Absent="disallow">
              <ComponentRef Id="MainExecutable" />
              <ComponentRef Id="HelpFiles" />
@@ -167,7 +167,7 @@
              <ComponentRef Id="ReportViewer" />
              <ComponentRef Id="TestResources" />
              <ComponentRef Id="SchemasFilesComponent" />
-@@ -227,7 +253,7 @@
+@@ -262,7 +288,7 @@
          <Property Id="ARPPRODUCTICON" Value="XenCenterICO" />
          <MajorUpgrade AllowDowngrades="no" AllowSameVersionUpgrades="yes" DowngradeErrorMessage="!(loc.ErrorNewerProduct)" Schedule="afterInstallInitialize"/>
          <PropertyRef Id="NETFRAMEWORK40FULL" />

--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -194,7 +194,40 @@
                             </Component>
                         </Directory>
                     </Directory>
-                </Directory>
+                	<Directory Id="HEALTHCHECKSERVICEDIR" Name="XenServerHealthCheckService">
+							<Component Id="XenServerHealthCheck" Guid="{9D686BFC-B4FD-435F-AC74-0ACE29425095}">
+								<File Id="HealthCheck_XenServerHealthCheck.exe" Name="XenServerHealthCheck.exe" KeyPath="yes" Source="..\XenServerHealthCheck\bin\Release\XenServerHealthCheck.exe" />
+								<File Id="HealthCheck_CommandLib.dll" Name="CommandLib.dll" Source="..\XenServerHealthCheck\bin\Release\CommandLib.dll" />
+								<File Id="HealthCheck_CookComputing.XmlRpcV2.dll" Name="CookComputing.XmlRpcV2.dll" Source="..\XenServerHealthCheck\bin\Release\CookComputing.XmlRpcV2.dll" />
+								<File Id="HealthCheck_ICSharpCode.SharpZipLib.dll" Name="ICSharpCode.SharpZipLib.dll" Source="..\XenServerHealthCheck\bin\Release\ICSharpCode.SharpZipLib.dll" />
+								<File Id="HealthCheck_Ionic.Zip.dll" Name="Ionic.Zip.dll" Source="..\XenServerHealthCheck\bin\Release\Ionic.Zip.dll" />
+								<File Id="HealthCheck_log4net.dll" Name="log4net.dll" Source="..\XenServerHealthCheck\bin\Release\log4net.dll" />
+								<File Id="HealthCheck_XenCenterLib.dll" Name="XenCenterLib.dll" Source="..\XenServerHealthCheck\bin\Release\XenCenterLib.dll" />
+								<File Id="HealthCheck_XenModel.dll" Name="XenModel.dll" Source="..\XenServerHealthCheck\bin\Release\XenModel.dll" />
+								<File Id="HealthCheck_XenServerHealthCheck.exe.config" Name="XenServerHealthCheck.exe.config" Source="..\XenServerHealthCheck\bin\Release\XenServerHealthCheck.exe.config" />
+								<ServiceInstall
+								  Id="ServiceInstaller"
+								  Type="ownProcess"
+								  Vital="no"
+								  Name="XenServerHealthCheck"
+								  DisplayName="Citrix XenServer Health Check Service"
+								  Description="Citrix XenServer Health Check Service"
+								  Start="auto"
+								  Account="LocalSystem"
+								  ErrorControl="normal"
+								  Interactive="no"
+								/>
+								<ServiceControl 
+									Id="StartService" 
+									Start="install" 
+									Stop="both" 
+									Remove="uninstall" 
+									Name="XenServerHealthCheck" 
+									Wait="yes" 
+								/>
+							</Component>
+						</Directory>
+				</Directory>
             </Directory>
             <Directory Id="ProgramMenuFolder">
                 <Directory Id="ApplicationProgramsFolder" Name="Citrix" />
@@ -220,6 +253,7 @@
             <ComponentRef Id="ReportViewer" />
             <ComponentRef Id="TestResources" />
             <ComponentRef Id="SchemasFilesComponent" />
+			<ComponentRef Id="XenServerHealthCheck" />
             <ComponentRef Id="ExternalToolsComponent" />
             <ComponentRef Id="RegistryEntries" />
             <ComponentRef Id="ApplicationShortcut" />


### PR DESCRIPTION
Adding XenServerHealthCheck service to the WiX installer

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>