### PR TITLE
CA-173358: Change the unit of vbd-io-throughput data sources to MiB

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/DataSet.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataSet.cs
@@ -160,6 +160,11 @@ namespace XenAdmin.Controls.CustomDataGraph
             {
                 if (settype.Contains("iops"))
                     dataSet.CustomYRange = new DataRange(1, 0, 1, Unit.CountsPerSecond, RangeScaleMode.Auto);
+                else if (settype.Contains("io_throughput"))
+                {
+                    dataSet.CustomYRange = new DataRange(1, 0, 1, Unit.BytesPerSecond, RangeScaleMode.Auto);
+                    dataSet.MultiplyingFactor = (int)Util.BINARY_MEGA; //xapi units are in mebibytes/sec
+                }
                 else if (settype.EndsWith("iowait"))
                 {
                     dataSet.CustomYRange = new DataRange(100, 0, 10, Unit.Percentage, RangeScaleMode.Auto);


### PR DESCRIPTION
The unit of VBD IO throughput is changed to MiB after merged all
VBD related data sources from xcp-rrdd to rrdp-iostat,

Signed-off-by: Kaifeng Zhu <kaifeng.zhu@citrix.com>