### PR TITLE
CP-12510: Update the error message displayed when a VM cannot migrate…

### DIFF
--- a/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
+++ b/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
@@ -4773,7 +4773,7 @@ namespace XenAPI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The VM is incompatible with the Virtual Hardware Platform version of this host..
+        ///   Looks up a localized string similar to The VM&apos;s Virtual Hardware Platform version is incompatible with this host..
         /// </summary>
         public static string VM_HOST_INCOMPATIBLE_VIRTUAL_HARDWARE_PLATFORM_VERSION {
             get {

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -1701,7 +1701,7 @@ Authorized Roles: {1}</value>
     <value>This VM operation cannot be performed on an older-versioned host during an upgrade.</value>
   </data>
   <data name="VM_HOST_INCOMPATIBLE_VIRTUAL_HARDWARE_PLATFORM_VERSION" xml:space="preserve">
-    <value>The VM is incompatible with the Virtual Hardware Platform version of this host.</value>
+    <value>The VM's Virtual Hardware Platform version is incompatible with this host.</value>
   </data>
   <data name="VM_HVM_REQUIRED" xml:space="preserve">
     <value>HVM is required for this operation</value>


### PR DESCRIPTION
… to a host with a different hardware platform version.

- Changed the friendly error name for VM_HOST_INCOMPATIBLE_VIRTUAL_HARDWARE_PLATFORM_VERSION to "The VM's Virtual Hardware Platform version is incompatible with this host."

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>