### PR TITLE
CA-176636: Transfer VM with manually assigned IP doesn't work.

### DIFF
--- a/XenAdmin/Wizards/ExportWizard/ExportApplianceWizard.cs
+++ b/XenAdmin/Wizards/ExportWizard/ExportApplianceWizard.cs
@@ -116,7 +116,7 @@ namespace XenAdmin.Wizards.ExportWizard
 										   m_pageTvmIp.NetworkUuid.Key,
 										   m_pageTvmIp.IsTvmIpStatic,
 										   m_pageTvmIp.TvmIpAddress,
-										   m_pageTvmIp.TvmIpAddress,
+										   m_pageTvmIp.TvmSubnetMask,
 										   m_pageTvmIp.TvmGateway,
                                            m_pageFinish.VerifyExport)).RunAsync();
 			}


### PR DESCRIPTION
The subnet mask is incorrectly set as the static IP.
Update it to correct address.

Signed-off-by: Hui Zhang <hui.zhang@citrix.com>