### PR TITLE
CP-13245: Check if the update is applicable to the servers on the Sel…

### DIFF
--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -390,45 +390,31 @@ namespace XenAdmin.TabPages
             if (string.IsNullOrEmpty(patchUri))
                 return;
 
-            Uri address = new Uri(patchUri);
-            string tempFile = Path.GetTempFileName();
-
-            var action = new DownloadAndUnzipXenServerPatchAction(patchAlert.Description, address, tempFile);
-            ActionProgressDialog dialog = new ActionProgressDialog(action, ProgressBarStyle.Continuous, false) { ShowCancel = true };
-
-            action.Completed += s =>
+            Program.Invoke(Program.MainWindow, () =>
             {
-                if (action.Succeeded)
-                {
-                    Program.Invoke(Program.MainWindow, () =>
-                    {
-                        var wizard = new PatchingWizard();
-                        wizard.Show();
-                        wizard.NextStep();
-                        wizard.AddFile(action.PatchPath);
-                        wizard.NextStep();
+                var wizard = new PatchingWizard();
+                wizard.Show();
+                wizard.NextStep();
+                wizard.AddAlert(patchAlert);
+                wizard.NextStep();
 
-                        var hosts = patchAlert.DistinctHosts;
-                        if (hosts.Count > 0)
-                        {
-                            wizard.SelectServers(hosts);
-                        }
-                        else
-                        {
-                            string disconnectedServerNames =
-                                clickedRow.Cells[ColumnLocation.Index].Value.ToString();
-
-                            new ThreeButtonDialog(
-                                new ThreeButtonDialog.Details(SystemIcons.Warning,
-                                                              string.Format(Messages.UPDATES_WIZARD_DISCONNECTED_SERVER, 
-                                                                            disconnectedServerNames),
-                                                              Messages.UPDATES_WIZARD)).ShowDialog(this);
-                        }
-                    });
+                var hosts = patchAlert.DistinctHosts;
+                if (hosts.Count > 0)
+                {                          
+                    wizard.SelectServers(hosts);
                 }
-            };
+                else
+                {
+                    string disconnectedServerNames =
+                           clickedRow.Cells[ColumnLocation.Index].Value.ToString();
 
-            dialog.Show(this);
+                    new ThreeButtonDialog(
+                        new ThreeButtonDialog.Details(SystemIcons.Warning,
+                                                      string.Format(Messages.UPDATES_WIZARD_DISCONNECTED_SERVER, 
+                                                                   disconnectedServerNames),
+                                                      Messages.UPDATES_WIZARD)).ShowDialog(this);
+                 }
+            });
         }
 
         private void ToolStripMenuItemCopy_Click(object sender, EventArgs e)

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -37,6 +37,7 @@ using XenAdmin.Dialogs;
 using XenAPI;
 using System.Linq;
 using System.IO;
+using XenAdmin.Alerts;
 
 namespace XenAdmin.Wizards.PatchingWizard
 {
@@ -77,6 +78,14 @@ namespace XenAdmin.Wizards.PatchingWizard
             AddPage(PatchingWizard_PatchingPage);
         }
 
+        public void AddAlert(XenServerPatchAlert alert)
+        {
+            PatchingWizard_SelectPatchPage.SelectDownloadAlert(alert);
+            PatchingWizard_SelectPatchPage.SelectedUpdateAlert = alert;
+            PatchingWizard_SelectServers.SelectedUpdateAlert = alert;
+            PatchingWizard_UploadPage.SelectedUpdateAlert = alert;
+        }
+
         public void AddFile(string path)
         {
             PatchingWizard_SelectPatchPage.AddFile(path);
@@ -104,6 +113,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 PatchingWizard_SelectServers.SelectedUpdateType = updateType;
                 PatchingWizard_SelectServers.Patch = existPatch;
+                PatchingWizard_SelectServers.SelectedUpdateAlert = alertPatch;
 
                 PatchingWizard_UploadPage.SelectedUpdateType = updateType;
                 PatchingWizard_UploadPage.SelectedExistingPatch = existPatch;
@@ -111,6 +121,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 PatchingWizard_UploadPage.SelectedUpdateAlert = alertPatch; 
 
                 PatchingWizard_ModePage.Patch = existPatch;
+                PatchingWizard_ModePage.SelectedUpdateAlert = alertPatch;
 
                 PatchingWizard_PrecheckPage.Patch = existPatch;
                 PatchingWizard_PatchingPage.Patch = existPatch;
@@ -269,7 +280,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         private void RemoveDownloadedPatches()
         {
-            foreach (string downloadedPatch in PatchingWizard_UploadPage.AllDownloadedPatches)
+            foreach(string downloadedPatch in PatchingWizard_UploadPage.AllDownloadedPatches.Values)
             {
                 File.Delete(downloadedPatch);
             }

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Wizards.PatchingWizard
     public partial class PatchingWizard_SelectPatchPage : XenTabPage
     {
         private bool CheckForUpdatesInProgress;
-        public Alert SelectedUpdateAlert;
+        public XenServerPatchAlert SelectedUpdateAlert;
         
         public PatchingWizard_SelectPatchPage()
         {
@@ -69,6 +69,18 @@ namespace XenAdmin.Wizards.PatchingWizard
                 CheckForUpdatesInProgress = false;
                 OnPageUpdated();
             });
+        }
+
+        public void SelectDownloadAlert(XenServerPatchAlert alert)
+        {
+            downloadUpdateRadioButton.Checked = true;
+            foreach (PatchGridViewRow row in dataGridViewPatches.Rows)
+            {
+                if(row.UpdateAlert.Equals(alert))
+                {
+                    row.Selected = true;
+                }
+            }
         }
 
         public override string Text
@@ -136,7 +148,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                     }
                 }
                 SelectedUpdateAlert = downloadUpdateRadioButton.Checked
-                                             ? ((PatchGridViewRow)dataGridViewPatches.SelectedRows[0]).UpdateAlert
+                                             ? (XenServerPatchAlert)((PatchGridViewRow)dataGridViewPatches.SelectedRows[0]).UpdateAlert
                                              : null;
 
                 if (SelectedExistingPatch != null && !SelectedExistingPatch.Connection.IsConnected)
@@ -180,12 +192,15 @@ namespace XenAdmin.Wizards.PatchingWizard
                     updates.Reverse();
             }
            foreach (Alert alert in updates)
-           {   
-               PatchGridViewRow row = new PatchGridViewRow(alert);
-               if (!dataGridViewPatches.Rows.Contains(row))
+           {
+               if (alert is XenServerPatchAlert)
                {
-                   dataGridViewPatches.Rows.Add(row);
-               }                
+                   PatchGridViewRow row = new PatchGridViewRow(alert);
+                   if (!dataGridViewPatches.Rows.Contains(row))
+                   {
+                       dataGridViewPatches.Rows.Add(row);
+                   }
+               }
             }
         }
         
@@ -201,12 +216,14 @@ namespace XenAdmin.Wizards.PatchingWizard
                 return false;
             }
             if (downloadUpdateRadioButton.Checked)
-            {
+            {                
                 if (dataGridViewPatches.SelectedRows.Count == 1)
                 {
                     DataGridViewExRow row = (DataGridViewExRow)dataGridViewPatches.SelectedRows[0];
                     if (row.Enabled)
+                    {
                         return true;
+                    }
                 }
             }
             else if (selectFromDiskRadioButton.Checked)

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -25769,6 +25769,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Update not applicable.
+        /// </summary>
+        public static string PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_NOT_APPLICABLE {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_NOT_APPLICABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select Servers.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_TEXT {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8895,6 +8895,9 @@ However, there is not enough space to perform the repartitioning, so the current
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_ALREADY_APPLIED" xml:space="preserve">
     <value>Update already applied</value>
   </data>
+  <data name="PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_NOT_APPLICABLE" xml:space="preserve">
+    <value>Update not applicable</value>
+  </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_TEXT" xml:space="preserve">
     <value>Select Servers</value>
   </data>


### PR DESCRIPTION
…ect Servers Page.

CA-157785: Hotfix wizard forgets which servers should be greyed out.
When clicking Download and Install update in the Updates Tab, instead of opening a new dialog, it opens the Updates Wizard on the Select Servers Page and download the file in the Upload Page.
Fixes issue regarding the upload of the update every time that the user gets to Upload Page. Now it only uploads it if it has not been uploaded before.
Fixes issue regarding the download of the update every time the user goes back to the Select Patch Page. If the user goes back, but does not change the choice of the update, the download will not be done again.