### PR TITLE
Upgrade build scripts to vs2013

### DIFF
--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -6819,7 +6819,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\$(Configuration)\$(TargetFileName)";#1</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">mt.exe -nologo -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\$(Configuration)\$(TargetFileName)";#1</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>copy "$(ProjectDir)\ReportViewer\resource_report.rdlc" "$(TargetDir)"

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>XenAdmin</RootNamespace>
     <AssemblyName>XenCenterMain</AssemblyName>
     <ApplicationIcon>AppIcon.ico</ApplicationIcon>
-    <SignManifests>false</SignManifests>
+    <SignManifests>true</SignManifests>
     <ManifestCertificateThumbprint>4C1DD393E361B8BBCFA1E1D09539C446F88C0A11</ManifestCertificateThumbprint>
     <ManifestTimestampUrl>http://timestamp.verisign.com/scripts/timestamp.dll</ManifestTimestampUrl>
     <FileUpgradeFlags>
@@ -6819,7 +6819,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"C:\Program Files\Microsoft SDKs\Windows\v6.0A\bin\mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\$(Configuration)\$(TargetFileName)";#1</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\$(Configuration)\$(TargetFileName)";#1</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>copy "$(ProjectDir)\ReportViewer\resource_report.rdlc" "$(TargetDir)"

--- a/devtools/check-roaming.sh
+++ b/devtools/check-roaming.sh
@@ -32,6 +32,7 @@
 
 set -eu
 
+echo "INFO:	check roaming"
 dir=$(readlink -f $(dirname "$0"))
 src=$(readlink -f "$dir/../XenAdmin")
 

--- a/devtools/deadcheck/deadcheck.sh
+++ b/devtools/deadcheck/deadcheck.sh
@@ -32,6 +32,8 @@
 
 set -eu
 
+echo "INFO:	deadcheck"
+
 dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 src="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../../XenAdmin" && pwd )"
 if [ ! -d "${src}" ]; then

--- a/devtools/spellcheck/spellcheck.sh
+++ b/devtools/spellcheck/spellcheck.sh
@@ -32,6 +32,8 @@
 
 set -eu
 
+echo "INFO:	spellcheck"
+
 dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 src="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 

--- a/mk/build.sh
+++ b/mk/build.sh
@@ -52,7 +52,7 @@ if [ -n "${FATAL}" ]; then
 fi
 
 
-if [ -n "${DEBUG+xxx}" ];
+if [ -v DEBUG ];
 then
   echo "INFO:	DEBUG mode activated (verbose)"
   set -x
@@ -84,11 +84,11 @@ fi
 
 production_jenkins_build()
 {
-    #source ${XENADMIN_DIR}/mk/bumpBuildNumber.sh
-    #source ${XENADMIN_DIR}/devtools/check-roaming.sh
-    #source ${XENADMIN_DIR}/devtools/i18ncheck/i18ncheck.sh
-    #source ${XENADMIN_DIR}/devtools/deadcheck/deadcheck.sh
-    #source ${XENADMIN_DIR}/devtools/spellcheck/spellcheck.sh
+    source ${XENADMIN_DIR}/mk/bumpBuildNumber.sh
+    source ${XENADMIN_DIR}/devtools/check-roaming.sh
+    source ${XENADMIN_DIR}/devtools/i18ncheck/i18ncheck.sh
+    source ${XENADMIN_DIR}/devtools/deadcheck/deadcheck.sh
+    source ${XENADMIN_DIR}/devtools/spellcheck/spellcheck.sh
     source ${XENADMIN_DIR}/mk/xenadmin-build.sh
     source ${XENADMIN_DIR}/mk/tests-checks.sh
     source ${XENADMIN_DIR}/mk/archive-push.sh

--- a/mk/build.sh
+++ b/mk/build.sh
@@ -39,7 +39,7 @@
 
 
 FATAL=""
-for DEP in nunit-console.exe zip unzip mkisofs wget curl hg git patch
+for DEP in nunit-console.exe zip unzip mkisofs wget curl hg git patch mt.exe signtool.exe
 do
   which $DEP >/dev/null 2>&1
   if [ $? -ne 0 ]; then

--- a/mk/build.sh
+++ b/mk/build.sh
@@ -39,7 +39,7 @@
 
 
 FATAL=""
-for DEP in nunit-console.exe zip unzip mkisofs wget curl hg git patch mt.exe signtool.exe
+for DEP in nunit-console.exe zip unzip mkisofs wget curl hg git patch mt.exe signtool.exe candle.exe light.exe
 do
   which $DEP >/dev/null 2>&1
   if [ $? -ne 0 ]; then

--- a/mk/build.sh
+++ b/mk/build.sh
@@ -85,10 +85,10 @@ fi
 production_jenkins_build()
 {
     #source ${XENADMIN_DIR}/mk/bumpBuildNumber.sh
-    source ${XENADMIN_DIR}/devtools/check-roaming.sh
-    source ${XENADMIN_DIR}/devtools/i18ncheck/i18ncheck.sh
-    source ${XENADMIN_DIR}/devtools/deadcheck/deadcheck.sh
-    source ${XENADMIN_DIR}/devtools/spellcheck/spellcheck.sh
+    #source ${XENADMIN_DIR}/devtools/check-roaming.sh
+    #source ${XENADMIN_DIR}/devtools/i18ncheck/i18ncheck.sh
+    #source ${XENADMIN_DIR}/devtools/deadcheck/deadcheck.sh
+    #source ${XENADMIN_DIR}/devtools/spellcheck/spellcheck.sh
     source ${XENADMIN_DIR}/mk/xenadmin-build.sh
     source ${XENADMIN_DIR}/mk/tests-checks.sh
     source ${XENADMIN_DIR}/mk/archive-push.sh

--- a/mk/bumpBuildNumber.sh
+++ b/mk/bumpBuildNumber.sh
@@ -29,7 +29,7 @@
 # SUCH DAMAGE.
 
 set -eu
-
+echo "INFO: bump build number"
 if [ $get_JOB_NAME = "devbuild" ] ; then
     echo Warning: devbuild detected so we will skip the build number increment. All dev builds will have build number 0.
     exit 0
@@ -45,17 +45,17 @@ else
 fi
 
 url="${JENKINS_SERVER}/job/${get_JOB_NAME}/"
-if curl -n -s --head --fail "${url}"; then
-  echo "URL exists: ${url}"
+if curl -n -s --fail "${url}" -o out.tmp ; then
+  echo "INFO:	URL exists: ${url}"
 else
-  echo "URL does not exist: ${url}"
+  echo "ERROR:	URL does not exist: ${url}"
   exit 1
 fi
 
-NEXT_BN=$(curl -n "http://hg.uk.xensource.com/cgi/next-xenadmin?job=$get_JOB_NAME&number=$get_BUILD_NUMBER&rev=$get_REVISION")
+NEXT_BN=$(curl -s -n "http://hg.uk.xensource.com/cgi/next-xenadmin?job=$get_JOB_NAME&number=$get_BUILD_NUMBER&rev=$get_REVISION")
 
-echo NEXT_BN=${NEXT_BN}
+echo "INFO:	NEXT_BN=${NEXT_BN}"
 
-curl -n --data "nextBuildNumber=${NEXT_BN}" --header "Content-Type: application/x-www-form-urlencoded" ${JENKINS_SERVER}/job/${get_JOB_NAME}/nextbuildnumber/submit
+curl -s -n --data "nextBuildNumber=${NEXT_BN}" --header "Content-Type: application/x-www-form-urlencoded" ${JENKINS_SERVER}/job/${get_JOB_NAME}/nextbuildnumber/submit
 
 set +u

--- a/mk/colour.sh
+++ b/mk/colour.sh
@@ -39,7 +39,7 @@ ROOTURL=https://xenbuilder.uk.xensource.com
 DEFAULT_OUTPUT=Red
 
 #Get the cookie
-curl -n -q -s -k $ROOTURL/plainlogin -o /dev/null -c /tmp/cookie$$
+curl -n -s -k $ROOTURL/plainlogin -o /dev/null -c /tmp/cookie$$
 
 #If this fails then declare the trunk red as there is a problem with the server
 #otherwise try to work out the actual color of the trunk
@@ -47,7 +47,7 @@ if [ $? -ne 0 ]; then
 	echo $DEFAULT_OUTPUT
 	exit 1
 else
-	curl -n -q -s -k $ROOTURL/ -o - -b /tmp/cookie$$ | sed -ne 's/.*Trunk is.*\(Green\|Red\|Orange\).*/\1/Ip'
+	curl -n -s -k $ROOTURL/ -o - -b /tmp/cookie$$ | sed -ne 's/.*Trunk is.*\(Green\|Red\|Orange\).*/\1/Ip'
 	rm /tmp/cookie$$
 fi
 

--- a/mk/declarations.sh
+++ b/mk/declarations.sh
@@ -90,6 +90,11 @@ then
     fi
 
 	XS_BRANCH=`cd $DIR;git config --get remote.origin.url|sed -e 's@.*carbon/\(.*\)/xenadmin.git.*@\1@'`
+	if [[ $XS_BRANCH == *"/"* ]]
+        then
+            XS_BRANCH="trunk"
+            echo "Failed to detect XS_BRANCH we will fallback to `trunk`."
+        fi
 else
 	if [ -z "${MERCURIAL_REVISION+xxx}" ]
 	then 

--- a/mk/tests-checks.sh
+++ b/mk/tests-checks.sh
@@ -48,7 +48,8 @@ cd ${TEST_DIR} && tar xzf XenAdminTests.tgz && chmod -R 777 Release
 
 
 set +e
-nunit-console /nologo /nodots /process=separate /noshadow /labels /err="$(cygpath -d ${TEST_DIR})\error.nunit.log" /timeout=40000 /output="$(cygpath -d ${TEST_DIR})\output.nunit.log" /xml="$(cygpath -d ${TEST_DIR})\XenAdminTests.xml" "$(cygpath -d ${TEST_DIR})\Release\XenAdminTests.dll" "/framework=net-4.0" &
+# /output="$(cygpath -d ${TEST_DIR})\output.nunit.log"
+nunit-console /nologo /nodots /process=separate /noshadow /labels /err="$(cygpath -d ${TEST_DIR})\error.nunit.log" /timeout=40000 /xml="$(cygpath -d ${TEST_DIR})\XenAdminTests.xml" "$(cygpath -d ${TEST_DIR})\Release\XenAdminTests.dll" "/framework=net-4.5" &
 
 pid=$!
 (sleep 3000 ; kill $pid 2>/dev/null ) &

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -225,9 +225,10 @@ cd ${REPO}/XenServerHealthCheck/bin/Release && ${REPO}/sign.bat XenServerHealthC
 WIX=${REPO}/WixInstaller
 WIX_BIN=${WIX}/bin
 WIX_SRC=${SCRATCH_DIR}/wixsrc
-CANDLE=${WIX_BIN}/candle.exe
-LIT=${WIX_BIN}/lit.exe
-LIGHT=${WIX_BIN}/light.exe
+# ${WIX_BIN}/
+CANDLE="candle.exe -nologo"
+LIT="lit.exe -nologo"
+LIGHT="light.exe -nologo"
 
 mkdir_clean ${WIX_SRC}
 ${UNZIP} ${SCRATCH_DIR}/wix3.5.2519.0-sources.zip -d ${SCRATCH_DIR}/wixsrc
@@ -273,9 +274,9 @@ compile_installer()
   
   if [ "${name}" = "VNCControl" ]
   then
-   ${LIGHT} obj${name}/$1.wixobj lib/WixUI_InstallDir.wixlib -loc wixlib/wixui_$2.wxl -ext WiXNetFxExtension -out out${name}/${name}.msi
+   ${LIGHT} -nologo obj${name}/$1.wixobj lib/WixUI_InstallDir.wixlib -loc wixlib/wixui_$2.wxl -ext WiXNetFxExtension -out out${name}/${name}.msi
   else
-   ${LIGHT} obj${name}/$1.wixobj lib/WixUI_InstallDir.wixlib -loc wixlib/wixui_$2.wxl -loc $2.wxl -ext WiXNetFxExtension -out out${name}/${name}.msi
+   ${LIGHT} -nologo obj${name}/$1.wixobj lib/WixUI_InstallDir.wixlib -loc wixlib/wixui_$2.wxl -loc $2.wxl -ext WiXNetFxExtension -out out${name}/${name}.msi
   fi
 }
 
@@ -326,13 +327,13 @@ cd ${WIX} && chmod a+rw XenCenter.l10n.msi && ${REPO}/sign.bat XenCenter.l10n.ms
 
 #create bundle exe installers - msi installers embedded
 DOTNETINST=${REPO}/dotNetInstaller
-DOTNETINST_BIN='/cygdrive/c/Program Files/dotNetInstaller/Bin'
 cp ${MICROSOFT_DOTNET_FRAMEWORK_INSTALLER_DIR}/dotNetFx40_Full_setup.exe ${DOTNETINST}
 cp ${WIX}/outXenCenter/XenCenter.msi ${DOTNETINST}
 cp ${WIX}/XenCenter.l10n.msi ${DOTNETINST}
-cp "${DOTNETINST_BIN}"/* ${DOTNETINST}
-cd ${DOTNETINST} && "${DOTNETINST}/InstallerLinker.exe" "/Output:XenCenterSetup.exe" "/Template:dotNetInstaller.exe" "/Configuration:XenCenterSetupBootstrapper.xml" "/e+" "/v+"
-cd ${DOTNETINST} && "${DOTNETINST}/InstallerLinker.exe" "/Output:XenCenterSetup.l10n.exe" "/Template:dotNetInstaller.exe" "/Configuration:XenCenterSetupBootstrapper_l10n.xml" "/e+" "/v+"
+
+cp "$(which dotNetInstaller.exe)" ${DOTNETINST}
+cd ${DOTNETINST} && InstallerLinker.exe "/Output:XenCenterSetup.exe" "/Template:dotNetInstaller.exe" "/Configuration:XenCenterSetupBootstrapper.xml" "/e+" "/v+"
+cd ${DOTNETINST} && InstallerLinker.exe "/Output:XenCenterSetup.l10n.exe" "/Template:dotNetInstaller.exe" "/Configuration:XenCenterSetupBootstrapper_l10n.xml" "/e+" "/v+"
 
 sign_files()
 {

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -34,7 +34,9 @@ set -eu
 
 source "$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/declarations.sh"
 
-WGET_OPT="-q -N --timestamp"
+#if [ -z "$DEBUG" ]
+#WGET_OPT="-q -N --timestamp"
+WGET_OPT="-N --timestamp"
 UNZIP="unzip -q -o"
 
 mkdir_clean()
@@ -59,7 +61,7 @@ fi
 CSET_NUMBER=$(cd ${REPO} && git rev-list HEAD -1 && echo "")
 
 #bring in version and branding info from latest xe-phase-1
-wget ${WGET_OPT} ${WEB_XE_PHASE_1}/globals -P ${SCRATCH_DIR}
+wget ${WGET_OPT} -P "${SCRATCH_DIR}" "${WEB_XE_PHASE_1}/globals"
 BRAND_CONSOLE=$(cat ${SCRATCH_DIR}/globals | grep -w BRAND_CONSOLE | sed -e 's/BRAND_CONSOLE=//g' -e 's/"//g')
 COMPANY_NAME_LEGAL=$(cat ${SCRATCH_DIR}/globals | grep -w COMPANY_NAME_LEGAL | sed -e 's/COMPANY_NAME_LEGAL=//g' -e 's/"//g')
 COMPANY_NAME_SHORT=$(cat ${SCRATCH_DIR}/globals | grep -w COMPANY_NAME_SHORT | sed -e 's/COMPANY_NAME_SHORT=//g' -e 's/"//g')
@@ -94,34 +96,36 @@ DISCUTILS_DIR=${REPO}/DiscUtils/src/bin/Release
 MICROSOFT_DOTNET_FRAMEWORK_INSTALLER_DIR=${REPO}/dotNetFx40_Full_setup
 PUTTY_DIR=${REPO}/putty
 
-wget ${WGET_OPT} ${WEB_DOTNET}/manifest -O ${SCRATCH_DIR}/dotnet-packages-manifest
-mkdir_clean ${XMLRPC_DIR} && wget ${WGET_OPT} ${WEB_DOTNET}/CookComputing.XmlRpcV2.dll -P ${XMLRPC_DIR}
-mkdir_clean ${LOG4NET_DIR} && wget ${WGET_OPT} ${WEB_DOTNET}/log4net.dll -P ${LOG4NET_DIR}
-mkdir_clean ${SHARPZIPLIB_DIR} && wget ${WGET_OPT} ${WEB_DOTNET}/ICSharpCode.SharpZipLib.dll -P ${SHARPZIPLIB_DIR}
-mkdir_clean ${DOTNETZIP_DIR} && wget ${WGET_OPT} ${WEB_DOTNET}/Ionic.Zip.dll -P ${DOTNETZIP_DIR}
-mkdir_clean ${DISCUTILS_DIR} && wget ${WGET_OPT} ${WEB_DOTNET}/DiscUtils.dll -P ${DISCUTILS_DIR}
-mkdir_clean ${MICROSOFT_DOTNET_FRAMEWORK_INSTALLER_DIR} && wget ${WGET_OPT} ${WEB_DOTNET}/dotNetFx40_Full_setup.exe -P ${MICROSOFT_DOTNET_FRAMEWORK_INSTALLER_DIR}
-mkdir_clean ${PUTTY_DIR} &&  wget ${WGET_OPT} ${WEB_DOTNET}/putty.exe -P ${PUTTY_DIR}
+set -ex
+wget ${WGET_OPT} -O "${SCRATCH_DIR}/dotnet-packages-manifest" "${WEB_DOTNET}/manifest"
+mkdir_clean ${XMLRPC_DIR} && wget ${WGET_OPT} -P ${XMLRPC_DIR}  ${WEB_DOTNET}/CookComputing.XmlRpcV2.dll
+mkdir_clean ${LOG4NET_DIR} && wget ${WGET_OPT} -P ${LOG4NET_DIR} ${WEB_DOTNET}/log4net.dll
+mkdir_clean ${SHARPZIPLIB_DIR} && wget ${WGET_OPT} -P ${SHARPZIPLIB_DIR} ${WEB_DOTNET}/ICSharpCode.SharpZipLib.dll
+mkdir_clean ${DOTNETZIP_DIR} && wget ${WGET_OPT} -P ${DOTNETZIP_DIR} ${WEB_DOTNET}/Ionic.Zip.dll
+mkdir_clean ${DISCUTILS_DIR} && wget ${WGET_OPT} -P ${DISCUTILS_DIR} ${WEB_DOTNET}/DiscUtils.dll
+mkdir_clean ${MICROSOFT_DOTNET_FRAMEWORK_INSTALLER_DIR} && wget ${WGET_OPT} -P "${MICROSOFT_DOTNET_FRAMEWORK_INSTALLER_DIR}" "${WEB_DOTNET}/dotNetFx40_Full_setup.exe"
+mkdir_clean ${PUTTY_DIR} &&  wget ${WGET_OPT} -P "${PUTTY_DIR}" "${WEB_DOTNET}/putty.exe"
 
+echo bbb
 #temporarily disabling signing
-#wget ${WGET_OPT} ${WEB_DOTNET}/sign.bat -P ${REPO} && chmod a+x ${REPO}/sign.bat
+#wget ${WGET_OPT} -P "${REPO}" "${WEB_DOTNET}/sign.bat" && chmod a+x ${REPO}/sign.bat
 echo @echo signing disabled > ${REPO}/sign.bat && chmod a+x ${REPO}/sign.bat
 
 #bring in stuff from xencenter-ovf latest xe-phase-1
-wget ${WGET_OPT} ${WEB_XE_PHASE_1}/XenCenterOVF.zip -P ${SCRATCH_DIR}
+wget ${WGET_OPT} -P "${SCRATCH_DIR}" "${WEB_XE_PHASE_1}/XenCenterOVF.zip"
 ${UNZIP} -d ${REPO}/XenOvfApi ${SCRATCH_DIR}/XenCenterOVF.zip
 
 #bring manifest from latest xe-phase-1
-wget ${WGET_OPT} ${WEB_XE_PHASE_1}/manifest -O ${SCRATCH_DIR}/xe-phase-1-manifest
+wget ${WGET_OPT} -O ${SCRATCH_DIR}/xe-phase-1-manifest "${WEB_XE_PHASE_1}/manifest"
 
 #bring XenServer.NET from latest xe-phase-2
-wget ${WGET_OPT} ${WEB_XE_PHASE_2}/XenServer-SDK.zip -P ${REPO} && ${UNZIP} -j ${REPO}/XenServer-SDK.zip XenServer-SDK/XenServer.NET/bin/XenServer.dll XenServer-SDK/XenServer.NET/bin/CookComputing.XmlRpcV2.dll -d ${REPO}/XenServer.NET
+wget ${WGET_OPT} -P "${REPO}" "${WEB_XE_PHASE_2}/XenServer-SDK.zip" && ${UNZIP} -j ${REPO}/XenServer-SDK.zip XenServer-SDK/XenServer.NET/bin/XenServer.dll XenServer-SDK/XenServer.NET/bin/CookComputing.XmlRpcV2.dll -d ${REPO}/XenServer.NET
 
 #bring in some more libraries
 mkdir_clean ${REPO}/NUnit
-wget ${WGET_OPT} ${WEB_LIB}/nunit.framework.dll -P ${REPO}/NUnit
-wget ${WGET_OPT} ${WEB_LIB}/Moq_dotnet4.dll --output-document ${REPO}/NUnit/Moq.dll
-wget ${WGET_OPT} ${WEB_LIB}/{wix3.5.2519.0-sources.zip,wix3.5.2519.0-binaries.zip} -P ${SCRATCH_DIR}
+wget ${WGET_OPT} -P ${REPO}/NUnit ${WEB_LIB}/nunit.framework.dll 
+wget ${WGET_OPT} -O ${REPO}/NUnit/Moq.dll ${WEB_LIB}/Moq_dotnet4.dll 
+wget ${WGET_OPT} -P ${SCRATCH_DIR} ${WEB_LIB}/{wix3.5.2519.0-sources.zip,wix3.5.2519.0-binaries.zip}
 
 #set version numbers and brand info
 
@@ -186,13 +190,17 @@ version_brand_csharp "XenAdmin CommandLib XenCenterLib XenModel XenOvfApi XenOvf
 
 #build
 
-run_msbuild()
-{
-  MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.0 /p:VisualStudioVersion=12.0
-}
+MSBUILD="MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.0 /p:VisualStudioVersion=12.0"
 
-cd ${REPO} && run_msbuild XenAdmin.sln
-cp ${REPO}/splash/XenAdmin/bin/Release/XenCenter.* ${REPO}/XenAdmin/bin/Release/
+
+cd ${REPO}
+$MSBUILD XenAdmin.sln
+$MSBUILD xe/Xe.csproj
+$MSBUILD VNCControl/VNCControl.sln
+SOLUTIONDIR=$(cygpath.exe -w "${REPO}/XenAdmin")
+$MSBUILD /p:SolutionDir="$SOLUTIONDIR" splash/splash.vcxproj
+exit
+#cp ${REPO}/splash/XenAdmin/bin/Release/XenCenter.* ${REPO}/XenAdmin/bin/Release/
 
 #sign (splash has already been signed through a post-build event)
 for file in XenCenter.exe XenCenterMain.exe CommandLib.dll MSTSCLib.dll XenCenterLib.dll XenCenterVNC.dll XenModel.dll XenOvf.dll XenOvfTransport.dll
@@ -346,14 +354,14 @@ mv -f ${WIX}/vnccontrol.wxs.tmp ${WIX}/vnccontrol.wxs
 compile_installer "VNCControl" "en-us" && sign_msi "VNCControl"
 
 #build the tests
-cd ${REPO}/XenAdminTests && run_msbuild
+cd ${REPO}/XenAdminTests && $MSBUILD
 #this script is used by XenRT
 cp ${REPO}/mk/xenadmintests.sh ${REPO}/XenAdminTests/bin/Release/
 cp ${REPO}/XenAdmin/ReportViewer/* ${REPO}/XenAdminTests/bin/Release/
 cd ${REPO}/XenAdminTests/bin/ && tar -czf XenAdminTests.tgz ./Release
 
 #build the CFUValidator
-cd ${REPO}/CFUValidator && run_msbuild
+cd ${REPO}/CFUValidator && $MSBUILD
 cd ${REPO}/CFUValidator/bin/ && tar -czf CFUValidator.tgz ./Release
 
 #include resources script and collect the resources for translations
@@ -409,7 +417,7 @@ rm -rf ${OUTPUT_DIR}/PACKAGES.main/opt
 #bring in the pdbs from dotnet-packages latest build
 for pdb in CookComputing.XmlRpcV2.pdb DiscUtils.pdb ICSharpCode.SharpZipLib.pdb Ionic.Zip.pdb log4net.pdb
 do
-  wget ${WGET_OPT} ${WEB_DOTNET}/${pdb} -P ${OUTPUT_DIR}
+  wget ${WGET_OPT} -P "${OUTPUT_DIR}" "${WEB_DOTNET}/${pdb}"
 done
 
 #create manifest

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -190,7 +190,7 @@ version_brand_csharp "XenAdmin CommandLib XenCenterLib XenModel XenOvfApi XenOvf
 
 #build
 
-MSBUILD="MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.0 /p:VisualStudioVersion=12.0"
+MSBUILD="MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.0 /p:VisualStudioVersion=13.0"
 
 
 cd ${REPO}

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -379,7 +379,6 @@ cd ${REPO}/XenAdmin/TestResources && tar -cf ${OUTPUT_DIR}/XenCenterTestResource
 cp ${REPO}/XenAdminTests/bin/XenAdminTests.tgz ${OUTPUT_DIR}/XenAdminTests.tgz
 cp ${REPO}/CFUValidator/bin/CFUValidator.tgz ${OUTPUT_DIR}/CFUValidator.tgz
 # next line fixes the weird build with msbuild
-cp -f "${REPO}/XenAdmin/bin/Release/splash.pdb" "${REPO}/XenAdmin/bin/Release/XenCenter.pdb"
 cp ${REPO}/XenAdmin/bin/Release/{XS56EFP1002,XS56E008,XS60E001,XS62E006}.xsupdate \
    ${REPO}/XenAdmin/bin/Release/{XS60E001-src-pkgs,XS62E006-src-pkgs}.tar.gz \
    ${REPO}/XenAdmin/bin/Release/{CommandLib.pdb,XenCenter.pdb,XenCenterLib.pdb,XenCenterMain.pdb,XenCenterVNC.pdb,XenModel.pdb,XenOvf.pdb,XenOvfTransport.pdb} \

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -199,7 +199,6 @@ $MSBUILD xe/Xe.csproj
 $MSBUILD VNCControl/VNCControl.sln
 SOLUTIONDIR=$(cygpath.exe -w "${REPO}/XenAdmin")
 $MSBUILD /p:SolutionDir="$SOLUTIONDIR" splash/splash.vcxproj
-exit
 #cp ${REPO}/splash/XenAdmin/bin/Release/XenCenter.* ${REPO}/XenAdmin/bin/Release/
 
 #sign (splash has already been signed through a post-build event)
@@ -380,6 +379,8 @@ cp ${WIX}/outVNCControl/VNCControl.msi ${OUTPUT_DIR}/VNCControl.msi
 cd ${REPO}/XenAdmin/TestResources && tar -cf ${OUTPUT_DIR}/XenCenterTestResources.tar * 
 cp ${REPO}/XenAdminTests/bin/XenAdminTests.tgz ${OUTPUT_DIR}/XenAdminTests.tgz
 cp ${REPO}/CFUValidator/bin/CFUValidator.tgz ${OUTPUT_DIR}/CFUValidator.tgz
+# next line fixes the weird build with msbuild
+cp -f "${REPO}/XenAdmin/bin/Release/splash.pdb" "${REPO}/XenAdmin/bin/Release/XenCenter.pdb"
 cp ${REPO}/XenAdmin/bin/Release/{XS56EFP1002,XS56E008,XS60E001,XS62E006}.xsupdate \
    ${REPO}/XenAdmin/bin/Release/{XS60E001-src-pkgs,XS62E006-src-pkgs}.tar.gz \
    ${REPO}/XenAdmin/bin/Release/{CommandLib.pdb,XenCenter.pdb,XenCenterLib.pdb,XenCenterMain.pdb,XenCenterVNC.pdb,XenModel.pdb,XenOvf.pdb,XenOvfTransport.pdb} \

--- a/mk/xenadmintests.sh
+++ b/mk/xenadmintests.sh
@@ -55,7 +55,7 @@ ${MYSCP} ./output/xenadmin/XenAdminTests.tgz Administrator@$ADDR:/tmp/
 ${MYTESTSSH} 'cd /tmp && tar xzf /tmp/XenAdminTests.tgz && chmod -R 777 /tmp/Release'
 
 set +e
-$VIADAEMON $ADDR 'C:/NUnit/bin/net-2.0/nunit-console.exe /process=separate /noshadow /err="C:\cygwin\tmp\error.nunit.log" /timeout=40000 /output="C:\cygwin\tmp\output.nunit.log" /xml="C:\cygwin\tmp\XenAdminTests.xml" "C:\cygwin\tmp\Release\XenAdminTests.dll" "/framework=net-4.0"' &
+$VIADAEMON $ADDR 'nunit-console.exe /process=separate /noshadow /err="C:\cygwin\tmp\error.nunit.log" /timeout=40000 /output="C:\cygwin\tmp\output.nunit.log" /xml="C:\cygwin\tmp\XenAdminTests.xml" "C:\cygwin\tmp\Release\XenAdminTests.dll" "/framework=net-4.0"' &
 pid=$!
 (sleep $TIMEOUT ; kill $pid 2>/dev/null ) &
 sleeperpid=$!

--- a/splash/splash.vcxproj
+++ b/splash/splash.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -20,10 +20,12 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -44,6 +46,12 @@
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>XenCenter</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>XenCenter</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -58,7 +66,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)XenCenter.exe</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -82,7 +90,7 @@
       <DisableSpecificWarnings>4995;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)XenCenter.exe</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName).exe</OutputFile>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>

--- a/xe/Xe.csproj
+++ b/xe/Xe.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>ThinCLI</RootNamespace>
     <AssemblyName>xe</AssemblyName>
     <ApplicationIcon>AppIcon.ico</ApplicationIcon>
-    <SignManifests>false</SignManifests>
+    <SignManifests>true</SignManifests>
     <ManifestCertificateThumbprint>4C1DD393E361B8BBCFA1E1D09539C446F88C0A11</ManifestCertificateThumbprint>
     <ManifestTimestampUrl>http://timestamp.verisign.com/scripts/timestamp.dll</ManifestTimestampUrl>
     <FileUpgradeFlags>
@@ -74,6 +74,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"C:\Program Files\Microsoft SDKs\Windows\v6.0A\bin\mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/xe/Xe.csproj
+++ b/xe/Xe.csproj
@@ -74,6 +74,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"mt.exe" -nologo -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/xva_verify/xva_verify.csproj
+++ b/xva_verify/xva_verify.csproj
@@ -72,6 +72,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">mt.exe -nologo -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/xva_verify/xva_verify.csproj
+++ b/xva_verify/xva_verify.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>xva_verify</AssemblyName>
     <ApplicationIcon>AppIcon.ico</ApplicationIcon>
     <StartupObject>MainClass</StartupObject>
-    <SignManifests>false</SignManifests>
+    <SignManifests>true</SignManifests>
     <ManifestCertificateThumbprint>4C1DD393E361B8BBCFA1E1D09539C446F88C0A11</ManifestCertificateThumbprint>
     <ManifestTimestampUrl>http://timestamp.verisign.com/scripts/timestamp.dll</ManifestTimestampUrl>
     <FileUpgradeFlags>
@@ -72,6 +72,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"C:\Program Files\Microsoft SDKs\Windows\v6.0A\bin\mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">"mt.exe" -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\Release\$(TargetFileName)";#1</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Upgraded build scripts to run on vs2013 and performed some cleanup of the output logging.
Important change: the build scripts expects to have all build tools in the PATH. It does check for them and fail fast, reporting you the missing ones. To solve it, just add them to the PATH. An easy tool to edit the PATH is RapidEE.