### PR TITLE
Fix an error in the tests where the tests can select a default templa…

### DIFF
--- a/XenAdminTests/TestObjectProvider.cs
+++ b/XenAdminTests/TestObjectProvider.cs
@@ -37,6 +37,7 @@ using XenAdmin.Core;
 using XenAdmin.Model;
 using XenAdmin.Network;
 using XenAdmin.Network.StorageLink;
+using XenAdminTests.XenModelTests;
 using XenAPI;
 
 namespace XenAdminTests
@@ -158,7 +159,8 @@ namespace XenAdminTests
 
                 foreach (VM vm in connection.Cache.VMs)
                 {
-                    if (vm.is_a_template && !vm.is_a_snapshot &&
+                    if (vm.is_a_template && !vm.is_a_snapshot && 
+                        vm.Show(XenAdminConfigManager.Provider.ShowHiddenVMs) &&
                         vm.DefaultTemplate && (cond == null || cond(vm)))
                         return vm;
                 }


### PR DESCRIPTION
…te which is not shown in the tree

(e.g. XenSource P2V Server, which is an internal template, not displayed in the tree)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>