### PR TITLE
CA-178338: XenServerHealthCheckService: bundle uploading update.

### DIFF
--- a/XenModel/Actions/CallHome/XenServerHealthCheckUpload.cs
+++ b/XenModel/Actions/CallHome/XenServerHealthCheckUpload.cs
@@ -66,7 +66,9 @@ namespace XenServerHealthCheck
         public string InitiateUpload(long size)
         {
             // Request a new bundle upload to CIS server.
-            Uri uri = new Uri(UPLOAD_URL + "bundle/?size=" + size.ToString());
+            string FULL_URL = UPLOAD_URL + "bundle/?size=" + size.ToString();
+            log.InfoFormat("InitiateUpload, UPLOAD_URL: {0}", FULL_URL);
+            Uri uri = new Uri(FULL_URL);
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
             if (uploadToken != null)
             {
@@ -116,6 +118,7 @@ namespace XenServerHealthCheck
         // Upload a chunk.
         public bool UploadChunk(string address, string filePath, long offset, long thisChunkSize, string uploadToken)
         {
+            log.InfoFormat("UploadChunk, UPLOAD_URL: {0}", address);
             Uri uri = new Uri(address);
             HttpWebRequest req = (HttpWebRequest)WebRequest.Create(uri);
             req.Method = "POST";
@@ -160,6 +163,7 @@ namespace XenServerHealthCheck
         // Upload the zip file.
         public string UploadZip(string fileName, System.Threading.CancellationToken cancel)
         {
+            log.InfoFormat("Start to upload bundle {0}", fileName);
             FileInfo fileInfo = new FileInfo(fileName);
             long size = fileInfo.Length;
 
@@ -172,7 +176,7 @@ namespace XenServerHealthCheck
             }
 
             // Start to upload zip file.
-            log.InfoFormat("Upload ID: {0}", uploadUuid);
+            log.InfoFormat("Upload server returns Upload ID: {0}", uploadUuid);
 
             long offset = 0;
             while (offset < size)

--- a/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
@@ -246,7 +246,21 @@ namespace XenServerHealthCheck
             // Upload the zip file to CIS uploading server.
             XenServerHealthCheckUpload upload = new XenServerHealthCheckUpload(uploadToken, VERBOSITY_LEVEL,
                                                                                Properties.Settings.Default.UPLOAD_URL);
-            string upload_uuid = upload.UploadZip(bundleToUpload, cancel);
+
+            string upload_uuid = "";
+            try
+            {
+                upload_uuid = upload.UploadZip(bundleToUpload, cancel);
+            }
+            catch (Exception e)
+            {
+                if (session != null)
+                    session.logout();
+                session = null;
+                log.Error(e, e);
+                return "";
+            }
+
             if (File.Exists(bundleToUpload))
                 File.Delete(bundleToUpload);
 


### PR DESCRIPTION
1. Add logs to track the uploading process.
2. Catch the potential exception.

Signed-off-by: Hui Zhang <hui.zhang@citrix.com>