### PR TITLE
CP-13389: Change build scripts to use .NET 4.5

### DIFF
--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -186,7 +186,7 @@ version_brand_csharp "XenAdmin CommandLib XenCenterLib XenModel XenOvfApi XenOvf
 
 #build
 
-MSBUILD="MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.0"
+MSBUILD="MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.5 /p:VisualStudioVersion=13.0"
 
 cd ${REPO}
 $MSBUILD XenAdmin.sln

--- a/mk/xenadmintests.sh
+++ b/mk/xenadmintests.sh
@@ -55,7 +55,7 @@ ${MYSCP} ./output/xenadmin/XenAdminTests.tgz Administrator@$ADDR:/tmp/
 ${MYTESTSSH} 'cd /tmp && tar xzf /tmp/XenAdminTests.tgz && chmod -R 777 /tmp/Release'
 
 set +e
-$VIADAEMON $ADDR 'nunit-console.exe /process=separate /noshadow /err="C:\cygwin\tmp\error.nunit.log" /timeout=40000 /output="C:\cygwin\tmp\output.nunit.log" /xml="C:\cygwin\tmp\XenAdminTests.xml" "C:\cygwin\tmp\Release\XenAdminTests.dll" "/framework=net-4.0"' &
+$VIADAEMON $ADDR 'nunit-console.exe /process=separate /noshadow /err="C:\cygwin\tmp\error.nunit.log" /timeout=40000 /output="C:\cygwin\tmp\output.nunit.log" /xml="C:\cygwin\tmp\XenAdminTests.xml" "C:\cygwin\tmp\Release\XenAdminTests.dll" "/framework=net-4.5"' &
 pid=$!
 (sleep $TIMEOUT ; kill $pid 2>/dev/null ) &
 sleeperpid=$!


### PR DESCRIPTION
- Configured msbuild to build .Net4.5 with visual studio 2013 (13.0)
- Changed .Net platform version to 4.5 in tests script

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>