### PR TITLE
CA-178243: When only Automatic check for XenServer updates was checke…

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -52,6 +52,7 @@ namespace XenAdmin.Core
         private static List<XenServerVersion> XenServerVersions = new List<XenServerVersion>();
         private static List<XenServerPatch> XenServerPatches = new List<XenServerPatch>();
         private static List<XenCenterVersion> XenCenterVersions = new List<XenCenterVersion>();
+        private static List<XenServerVersion> XenServerVersionsCopy = new List<XenServerVersion>();
 
         private static readonly object updateAlertsLock = new object();
         private static readonly ChangeableList<Alert> updateAlerts = new ChangeableList<Alert>();
@@ -217,6 +218,9 @@ namespace XenAdmin.Core
                     var vers = action.XenServerVersions.Where(v => !XenServerVersions.Contains(v));
                     XenServerVersions.AddRange(vers);
 
+                    var versCopy = action.XenServerVersionCopy.Where(v => !XenServerVersions.Contains(v));
+                    XenServerVersionsCopy.AddRange(versCopy);
+
                     var patches = action.XenServerPatches.Where(p => !XenServerPatches.Contains(p));
                     XenServerPatches.AddRange(patches);
                 }
@@ -229,7 +233,7 @@ namespace XenAdmin.Core
                 if (xenServerUpdateAlert != null && !xenServerUpdateAlert.CanIgnore)
                     updateAlerts.Add(xenServerUpdateAlert);
 
-                var xenServerPatchAlerts = NewXenServerPatchAlerts(XenServerVersions, XenServerPatches);
+                var xenServerPatchAlerts = NewXenServerPatchAlerts(XenServerVersionsCopy, XenServerPatches);
                 if (xenServerPatchAlerts != null)
                     updateAlerts.AddRange(xenServerPatchAlerts.Where(alert => !alert.CanIgnore));
             }
@@ -432,7 +436,7 @@ namespace XenAdmin.Core
 
         public static void CheckServerPatches()
         {
-            var alerts = NewXenServerPatchAlerts(XenServerVersions, XenServerPatches);
+            var alerts = NewXenServerPatchAlerts(XenServerVersionsCopy, XenServerPatches);
             if (alerts == null)
                 return;
 

--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -49,10 +49,10 @@ namespace XenAdmin.Core
         public static event Action CheckForUpdatesStarted;
 
         private static readonly object downloadedUpdatesLock = new object();
-        private static List<XenServerVersion> XenServerVersions = new List<XenServerVersion>();
+        private static List<XenServerVersion> XenServerVersionsForAutoCheck = new List<XenServerVersion>();
         private static List<XenServerPatch> XenServerPatches = new List<XenServerPatch>();
         private static List<XenCenterVersion> XenCenterVersions = new List<XenCenterVersion>();
-        private static List<XenServerVersion> XenServerVersionsCopy = new List<XenServerVersion>();
+        private static List<XenServerVersion> XenServerVersions = new List<XenServerVersion>();
 
         private static readonly object updateAlertsLock = new object();
         private static readonly ChangeableList<Alert> updateAlerts = new ChangeableList<Alert>();
@@ -215,11 +215,11 @@ namespace XenAdmin.Core
                     var xcvs = action.XenCenterVersions.Where(v => !XenCenterVersions.Contains(v));
                     XenCenterVersions.AddRange(xcvs);
 
+                    var versForAutoCheck = action.XenServerVersionsForAutoCheck.Where(v => !XenServerVersionsForAutoCheck.Contains(v));
+                    XenServerVersionsForAutoCheck.AddRange(versForAutoCheck);
+
                     var vers = action.XenServerVersions.Where(v => !XenServerVersions.Contains(v));
                     XenServerVersions.AddRange(vers);
-
-                    var versCopy = action.XenServerVersionCopy.Where(v => !XenServerVersions.Contains(v));
-                    XenServerVersionsCopy.AddRange(versCopy);
 
                     var patches = action.XenServerPatches.Where(p => !XenServerPatches.Contains(p));
                     XenServerPatches.AddRange(patches);
@@ -229,11 +229,11 @@ namespace XenAdmin.Core
                 if (xenCenterAlert != null && !xenCenterAlert.IsDismissed())
                     updateAlerts.Add(xenCenterAlert);
 
-                var xenServerUpdateAlert = NewXenServerVersionAlert(XenServerVersions);
+                var xenServerUpdateAlert = NewXenServerVersionAlert(XenServerVersionsForAutoCheck);
                 if (xenServerUpdateAlert != null && !xenServerUpdateAlert.CanIgnore)
                     updateAlerts.Add(xenServerUpdateAlert);
 
-                var xenServerPatchAlerts = NewXenServerPatchAlerts(XenServerVersionsCopy, XenServerPatches);
+                var xenServerPatchAlerts = NewXenServerPatchAlerts(XenServerVersions, XenServerPatches);
                 if (xenServerPatchAlerts != null)
                     updateAlerts.AddRange(xenServerPatchAlerts.Where(alert => !alert.CanIgnore));
             }
@@ -427,7 +427,7 @@ namespace XenAdmin.Core
 
         public static void CheckServerVersion()
         {
-            var alert = NewXenServerVersionAlert(XenServerVersions);
+            var alert = NewXenServerVersionAlert(XenServerVersionsForAutoCheck);
             if (alert == null)
                 return;
 
@@ -436,7 +436,7 @@ namespace XenAdmin.Core
 
         public static void CheckServerPatches()
         {
-            var alerts = NewXenServerPatchAlerts(XenServerVersionsCopy, XenServerPatches);
+            var alerts = NewXenServerPatchAlerts(XenServerVersions, XenServerPatches);
             if (alerts == null)
                 return;
 

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -56,7 +56,19 @@ namespace XenAdmin.Actions
         public List<XenCenterVersion> XenCenterVersions { get; private set; }
         public List<XenServerVersion> XenServerVersions { get; private set; }
         public List<XenServerPatch> XenServerPatches { get; private set; }
-        public List<XenServerVersion> XenServerVersionCopy { get; private set; }
+
+        public List<XenServerVersion> XenServerVersionsForAutoCheck
+        {
+            get
+            {
+                if(_checkForServerVersion)
+                {
+                    return XenServerVersions;
+                }
+                return new List<XenServerVersion>();
+            }
+        }
+
         private readonly bool _checkForXenCenter;
         private readonly bool _checkForServerVersion;
         private readonly bool _checkForPatches;
@@ -67,7 +79,6 @@ namespace XenAdmin.Actions
             XenServerPatches = new List<XenServerPatch>();
             XenServerVersions = new List<XenServerVersion>();
             XenCenterVersions = new List<XenCenterVersion>();
-            XenServerVersionCopy = new List<XenServerVersion>();
 
             _checkForXenCenter = checkForXenCenter;
             _checkForServerVersion = checkForServerVersion;
@@ -241,14 +252,8 @@ namespace XenAdmin.Actions
                         patches.Add(patch);
                     }
 
-                    XenServerVersionCopy.Add(new XenServerVersion(version_oem, name, is_latest, url, patches, timestamp,
+                    XenServerVersions.Add(new XenServerVersion(version_oem, name, is_latest, url, patches, timestamp,
                                                                buildNumber));
-
-                    if (_checkForServerVersion)
-                    {
-                        XenServerVersions.Add(new XenServerVersion(version_oem, name, is_latest, url, patches, timestamp,
-                                                                   buildNumber));
-                    }
                 }
             }
         }

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -56,6 +56,7 @@ namespace XenAdmin.Actions
         public List<XenCenterVersion> XenCenterVersions { get; private set; }
         public List<XenServerVersion> XenServerVersions { get; private set; }
         public List<XenServerPatch> XenServerPatches { get; private set; }
+        public List<XenServerVersion> XenServerVersionCopy { get; private set; }
         private readonly bool _checkForXenCenter;
         private readonly bool _checkForServerVersion;
         private readonly bool _checkForPatches;
@@ -66,6 +67,7 @@ namespace XenAdmin.Actions
             XenServerPatches = new List<XenServerPatch>();
             XenServerVersions = new List<XenServerVersion>();
             XenCenterVersions = new List<XenCenterVersion>();
+            XenServerVersionCopy = new List<XenServerVersion>();
 
             _checkForXenCenter = checkForXenCenter;
             _checkForServerVersion = checkForServerVersion;
@@ -197,7 +199,7 @@ namespace XenAdmin.Actions
 
         private void GetXenServerVersions(XmlDocument xdoc)
         {
-            if (!_checkForServerVersion)
+            if (!_checkForServerVersion && !_checkForPatches)
                 return;
 
             foreach (XmlNode versions in xdoc.GetElementsByTagName(XenServerVersionsNode))
@@ -239,8 +241,14 @@ namespace XenAdmin.Actions
                         patches.Add(patch);
                     }
 
-                    XenServerVersions.Add(new XenServerVersion(version_oem, name, is_latest, url, patches, timestamp,
+                    XenServerVersionCopy.Add(new XenServerVersion(version_oem, name, is_latest, url, patches, timestamp,
                                                                buildNumber));
+
+                    if (_checkForServerVersion)
+                    {
+                        XenServerVersions.Add(new XenServerVersion(version_oem, name, is_latest, url, patches, timestamp,
+                                                                   buildNumber));
+                    }
                 }
             }
         }


### PR DESCRIPTION
…d in Updates Options, when opening XC, the grid appeared empty in the Updates Tab. This was because to get the list of XS updates, we need the list of XS versions. Created a list of XenServer versions that is used only to get the XenServer updates.