### PR TITLE
CA-173695: Reclaim freed space is failing with "Index and length must refer to a location with in the string" for AD users

### DIFF
--- a/XenModel/XenServerProxy/RbacCollectorProxy.cs
+++ b/XenModel/XenServerProxy/RbacCollectorProxy.cs
@@ -59,15 +59,21 @@ namespace XenAdmin.Core
                     return null;
             ProxyMethodInfo pmi = SimpleProxyMethodParser.ParseTypeAndNameOnly(proxyMethodName);
             string method = pmi.TypeName + "." + pmi.MethodName;
+            
             if (proxyMethodName == "task_get_record")
             {
                 Proxy_Task task = new Proxy_Task() { progress = 100, status=XenAPI.task_status_type.success.ToString(),result = ""};
                 return new Response<Proxy_Task>(task);
             }
+            
+            if (proxyMethodName == "host_call_plugin" && args != null && args.Length > 2 && args[2] == "trim")
+                return new Response<string>("True");;
+
             if (pmi.MethodName == "add_to_other_config" || pmi.MethodName == "remove_from_other_config")  // these calls are special because they can have per-key permissions
                 rbacMethods.Add(method, (string)args[2]);
             else
                 rbacMethods.Add(method);
+            
             return ResponseByType(returnType);
         }
 


### PR DESCRIPTION
This changeset fixes the mock to return "True" for host_call_plugin-->trim calls