### PR TITLE
CA-173695: Reclaim freed space is failing with "Index and length must…

### DIFF
--- a/XenModel/XenServerProxy/RbacCollectorProxy.cs
+++ b/XenModel/XenServerProxy/RbacCollectorProxy.cs
@@ -66,7 +66,7 @@ namespace XenAdmin.Core
                 return new Response<Proxy_Task>(task);
             }
             
-            if (proxyMethodName == "host_call_plugin" && args != null && args.Length > 2 && args[2] == "trim")
+            if (proxyMethodName == "host_call_plugin" && args != null && args.Length > 2 && "trim".Equals(args[2]))
                 return new Response<string>("True");;
 
             if (pmi.MethodName == "add_to_other_config" || pmi.MethodName == "remove_from_other_config")  // these calls are special because they can have per-key permissions


### PR DESCRIPTION
… refer to a location with in the string" for AD users

Fixing warning as an error build problem