### PR TITLE
CP-13165: Make quiescing into a licensed feature

### DIFF
--- a/XenAdmin/Dialogs/VmSnapshotDialog.cs
+++ b/XenAdmin/Dialogs/VmSnapshotDialog.cs
@@ -49,7 +49,8 @@ namespace XenAdmin.Dialogs
             _VM = vm;
             diskRadioButton.Enabled = _VM.allowed_operations.Contains(vm_operations.snapshot);
             pictureBoxSnapshotsInfo.Visible = !diskRadioButton.Enabled;
-            quiesceCheckBox.Enabled = _VM.allowed_operations.Contains(vm_operations.snapshot_with_quiesce);
+            quiesceCheckBox.Enabled = _VM.allowed_operations.Contains(vm_operations.snapshot_with_quiesce) 
+                && !Helpers.FeatureForbidden(_VM, Host.RestrictVss);
             pictureBoxQuiesceInfo.Visible = !quiesceCheckBox.Enabled;
             memoryRadioButton.Enabled = _VM.allowed_operations.Contains(vm_operations.checkpoint)
                 && !Helpers.FeatureForbidden(_VM, Host.RestrictCheckpoint);
@@ -146,6 +147,8 @@ namespace XenAdmin.Dialogs
             string tt;
             if (!Helpers.MidnightRideOrGreater(_VM.Connection))
                 tt = string.Format(Messages.FEATURE_NOT_AVAILABLE_NEED_MR_PLURAL, Messages.QUIESCED_SNAPSHOTS);
+            else if (Helpers.FeatureForbidden(_VM, Host.RestrictVss))
+                tt = Messages.FIELD_DISABLED;
             else if (_VM.power_state != vm_power_state.Running)
                 tt = Messages.INFO_QUIESCE_MODE_POWER_STATE.Replace("\\n", "\n");
             else if (_VM.virtualisation_status != VM.VirtualisationStatus.OPTIMIZED)

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -484,6 +484,19 @@ namespace XenAPI
             return h._RestrictHealthCheck;
         }
 
+        /// <summary>
+        /// Vss feature is restricted only if the "restrict_vss" key exists and it is true
+        /// </summary>
+        private bool _RestrictVss
+        {
+            get { return BoolKey(license_params, "restrict_vss"); }
+        }
+
+        public static bool RestrictVss(Host h)
+        {
+            return h._RestrictVss;
+        }
+
         public bool HasPBDTo(SR sr)
         {
             foreach (XenRef<PBD> pbd in PBDs)


### PR DESCRIPTION
- Add code to check license before offering quiescing on the VM Snapshot dialog
- If the feature is not available, the message displayed is: "This feature is disabled due to license restrictions on the server."

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>