### PR TITLE
Text corrections in the Health Check dialogs

### DIFF
--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.resx
@@ -1189,7 +1189,7 @@
     <value>12</value>
   </data>
   <data name="rubricLabel.Text" xml:space="preserve">
-    <value>Health Check will automatically upload a server status report to the Citrix Insight Services, based on a predefined schedule configured on your XenServer pools.</value>
+    <value>Health Check will automatically upload a server status report to Citrix Insight Services, based on a predefined schedule configured on your XenServer pools.</value>
   </data>
   <data name="&gt;&gt;rubricLabel.Name" xml:space="preserve">
     <value>rubricLabel</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
@@ -895,7 +895,7 @@
     <value>10</value>
   </data>
   <data name="rubricLabel.Text" xml:space="preserve">
-    <value>Health Check will automatically upload a server status report to the Citrix Insight Services, based on a predefined schedule configured on your XenServer pool.</value>
+    <value>Health Check will automatically upload a server status report to Citrix Insight Services, based on a predefined schedule configured on your XenServer pool.</value>
   </data>
   <data name="&gt;&gt;rubricLabel.Name" xml:space="preserve">
     <value>rubricLabel</value>

--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageDestination.resx
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageDestination.resx
@@ -607,7 +607,7 @@
     <value>8</value>
   </data>
   <data name="uploadCheckBox.Text" xml:space="preserve">
-    <value>&amp;Upload the status report to the Citrix Insight Services</value>
+    <value>&amp;Upload the status report to Citrix Insight Services</value>
   </data>
   <data name="&gt;&gt;uploadCheckBox.Name" xml:space="preserve">
     <value>uploadCheckBox</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -16299,7 +16299,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Authentication with Citrix Insight Services is required in order to enable this feature. Please register by  providing MyCitrix credentials. These credentials will only be used to obtain a Call Home upload grant token and will not be stored on this machine or on your server..
+        ///   Looks up a localized string similar to Authentication with Citrix Insight Services is required in order to enable this feature. Please register by  providing MyCitrix credentials. These credentials will only be used to obtain an upload token and will not be stored on this machine or on your server..
         /// </summary>
         public static string HEALTHCHECK_AUTHENTICATION_RUBRIC_NO_TOKEN {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5702,7 +5702,7 @@ Click Configure HA to alter the settings displayed below.</value>
     <value>Authentication with Citrix Insight Services is required in order to enable this feature. XenCenter detected a previous successful authentication for one of other connected pools. You can choose to re-use it or authenticate again.</value>
   </data>
   <data name="HEALTHCHECK_AUTHENTICATION_RUBRIC_NO_TOKEN" xml:space="preserve">
-    <value>Authentication with Citrix Insight Services is required in order to enable this feature. Please register by  providing MyCitrix credentials. These credentials will only be used to obtain a Call Home upload grant token and will not be stored on this machine or on your server.</value>
+    <value>Authentication with Citrix Insight Services is required in order to enable this feature. Please register by  providing MyCitrix credentials. These credentials will only be used to obtain an upload token and will not be stored on this machine or on your server.</value>
   </data>
   <data name="HEALTHCHECK_ENROLLMENT_CONFIRMATION_BUTTON_LABEL" xml:space="preserve">
     <value>OK, Enable Health Check</value>


### PR DESCRIPTION
- no “the” is needed in front of “Citrix Insight Services”  (e.g. “…authenticate with Citrix Insight Services…” and not “…authenticate with the Citrix Insight Services…”)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>