### PR TITLE
CP-13100: Fixed unit tests and fixed a bug in code

### DIFF
--- a/XenAdmin/Commands/ConvertToThinSRCommand.cs
+++ b/XenAdmin/Commands/ConvertToThinSRCommand.cs
@@ -98,7 +98,7 @@ namespace XenAdmin.Commands
             {
                 var sr = item.XenObject as SR;
 
-                if (sr != null && sr.Provisioning == SrProvisioning.Thick && (sr.type == "lvmohba" || sr.type == "lvmoiscsi"))
+                if (sr != null && Helpers.DundeeOrGreater(sr.Connection) && sr.Provisioning == SrProvisioning.Thick && (sr.type == "lvmohba" || sr.type == "lvmoiscsi"))
                     return sr;
             }
 

--- a/XenAdminTests/TabsAndMenus/MainMenuGeorge.cs
+++ b/XenAdminTests/TabsAndMenus/MainMenuGeorge.cs
@@ -149,6 +149,7 @@ namespace XenAdminTests.TabsAndMenus
 	            new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	            new ExpectedTextMenuItem("&Forget", false, false  ),
 	            new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	            new ExpectedSeparator(),
 	            new ExpectedTextMenuItem("P&roperties", false, false  )
             };
@@ -259,6 +260,7 @@ namespace XenAdminTests.TabsAndMenus
 	            new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	            new ExpectedTextMenuItem("&Forget", false, false  ),
 	            new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	            new ExpectedSeparator(),
 	            new ExpectedTextMenuItem("P&roperties", false, false  )
             };
@@ -370,6 +372,7 @@ namespace XenAdminTests.TabsAndMenus
 	                new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	                new ExpectedTextMenuItem("&Forget", false, false  ),
 	                new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+	                new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	                new ExpectedSeparator(),
 	                new ExpectedTextMenuItem("P&roperties", false, false  )
                 };
@@ -482,6 +485,7 @@ namespace XenAdminTests.TabsAndMenus
 	            new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	            new ExpectedTextMenuItem("&Forget", false, false  ),
 	            new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+                new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	            new ExpectedSeparator(),
 	            new ExpectedTextMenuItem("P&roperties", false, false  )
             };
@@ -596,6 +600,7 @@ namespace XenAdminTests.TabsAndMenus
 	                new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	                new ExpectedTextMenuItem("&Forget", false, false  ),
 	                new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+    	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	                new ExpectedSeparator(),
 	                new ExpectedTextMenuItem("P&roperties", false, false  )
                 };
@@ -711,6 +716,7 @@ namespace XenAdminTests.TabsAndMenus
 	                new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	                new ExpectedTextMenuItem("&Forget", CanForget(sr), false  ),
 	                new ExpectedTextMenuItem("Destr&oy...", CanDestroy(sr), false  ),
+    	            new ExpectedTextMenuItem("&Convert SR...", CanConvertSR(sr), false  ),
 	                new ExpectedSeparator(),
 	                new ExpectedTextMenuItem("P&roperties", true, false  )
                 };
@@ -827,6 +833,7 @@ namespace XenAdminTests.TabsAndMenus
 	                    new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	                    new ExpectedTextMenuItem("&Forget", false, false  ),
 	                    new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+        	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	                    new ExpectedSeparator(),
 	                    new ExpectedTextMenuItem("P&roperties", false, false  )
                     };
@@ -946,6 +953,7 @@ namespace XenAdminTests.TabsAndMenus
                     new ExpectedTextMenuItem("R&eattach...", false, false  ),
                     new ExpectedTextMenuItem("&Forget", false, false  ),
                     new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+    	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
                     new ExpectedSeparator(),
                     new ExpectedTextMenuItem("P&roperties", false, false  )
                 };
@@ -1066,6 +1074,7 @@ namespace XenAdminTests.TabsAndMenus
 	                    new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	                    new ExpectedTextMenuItem("&Forget", false, false  ),
 	                    new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+        	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	                    new ExpectedSeparator(),
 	                    new ExpectedTextMenuItem("P&roperties", false, false  )
                     };
@@ -1187,6 +1196,7 @@ namespace XenAdminTests.TabsAndMenus
                     new ExpectedTextMenuItem("R&eattach...", false, false  ),
                     new ExpectedTextMenuItem("&Forget", false, false  ),
                     new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+    	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
                     new ExpectedSeparator(),
                     new ExpectedTextMenuItem("P&roperties", false, false  )
                 };
@@ -1309,6 +1319,7 @@ namespace XenAdminTests.TabsAndMenus
 	                    new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	                    new ExpectedTextMenuItem("&Forget", false, false  ),
 	                    new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+        	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	                    new ExpectedSeparator(),
 	                    new ExpectedTextMenuItem("P&roperties", false, false  )
                     };
@@ -1426,6 +1437,7 @@ namespace XenAdminTests.TabsAndMenus
 	            new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	            new ExpectedTextMenuItem("&Forget", false, false  ),
 	            new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+   	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	            new ExpectedSeparator(),
 	            new ExpectedTextMenuItem("P&roperties", false, false  )
             };
@@ -1536,6 +1548,7 @@ namespace XenAdminTests.TabsAndMenus
 	            new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	            new ExpectedTextMenuItem("&Forget", false, false  ),
 	            new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+   	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	            new ExpectedSeparator(),
 	            new ExpectedTextMenuItem("P&roperties", false, false  )
             };
@@ -1676,6 +1689,7 @@ namespace XenAdminTests.TabsAndMenus
 	                new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	                new ExpectedTextMenuItem("&Forget", false, false  ),
 	                new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+    	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	                new ExpectedSeparator(),
 	                new ExpectedTextMenuItem("P&roperties", false, false  )
                 };
@@ -1801,6 +1815,7 @@ namespace XenAdminTests.TabsAndMenus
 	            new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	            new ExpectedTextMenuItem("&Forget", false, false  ),
 	            new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+   	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	            new ExpectedSeparator(),
 	            new ExpectedTextMenuItem("P&roperties", false, false  )
             };
@@ -1936,6 +1951,7 @@ namespace XenAdminTests.TabsAndMenus
 	            new ExpectedTextMenuItem("R&eattach...", false, false  ),
 	            new ExpectedTextMenuItem("&Forget", false, false  ),
 	            new ExpectedTextMenuItem("Destr&oy...", false, false  ),
+   	            new ExpectedTextMenuItem("&Convert SR...", false, false  ),
 	            new ExpectedSeparator(),
 	            new ExpectedTextMenuItem("P&roperties", false, false  )
             };

--- a/XenAdminTests/TabsAndMenus/TabsAndMenus.cs
+++ b/XenAdminTests/TabsAndMenus/TabsAndMenus.cs
@@ -341,6 +341,11 @@ namespace XenAdminTests.TabsAndMenus
             return sr.HasPBDs && !SR.IsDefaultSr(sr) && sr.SupportsVdiCreate() && (sr.shared || sr.Connection.Cache.HostCount <= 1) && !HelpersGUI.GetActionInProgress(sr);
         }
 
+        protected static bool CanConvertSR(SR sr)
+        {
+            return sr != null && Helpers.DundeeOrGreater(sr.Connection) && sr.Provisioning == SrProvisioning.Thick && (sr.type == "lvmohba" || sr.type == "lvmoiscsi");
+        }
+
         /// <summary>
         /// Adds the "Expand All" and "Collapse Children" expected items to the specified list for the specified node.
         /// </summary>


### PR DESCRIPTION
Fixing the unit tests pointed me at the command's CanExecuteCore where the check for Dundee or higher was missing. Fixed that as well.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>