### PR TITLE
CP-13077: Changes to the Health Check feature to work properly with RBAC

### DIFF
--- a/XenAdmin/Core/HealthCheck.cs
+++ b/XenAdmin/Core/HealthCheck.cs
@@ -103,10 +103,8 @@ namespace XenAdmin.Core
 
             if (healthCheckSettings.Status == HealthCheckStatus.Enabled && !healthCheckSettings.HasAnalysisResult)
             {
-                var action = new GetHealthCheckAnalysisResultAction(pool, Registry.HealthCheckDiagnosticDomainName, suppressHistory);
-
                 if (PassedRbacChecks(pool.Connection))
-                    return action;
+                    return new GetHealthCheckAnalysisResultAction(pool, Registry.HealthCheckDiagnosticDomainName, suppressHistory);
             }
             return null;
         }

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.cs
@@ -207,6 +207,8 @@ namespace XenAdmin.Dialogs.HealthCheck
             scheduleLabel.Text = GetScheduleDescription(poolRow.Pool.HealthCheckSettings);
             lastUploadLabel.Visible = lastUploadDateLabel.Visible = !string.IsNullOrEmpty(poolRow.Pool.HealthCheckSettings.LastSuccessfulUpload);
             lastUploadDateLabel.Text = GetLastUploadDescription(poolRow.Pool.HealthCheckSettings);
+            
+            UpdateButtonsVisibility(poolRow.Pool);
 
             healthCheckStatusPanel.Visible = poolRow.Pool.HealthCheckSettings.Status == HealthCheckStatus.Enabled;
             notEnrolledPanel.Visible = poolRow.Pool.HealthCheckSettings.Status != HealthCheckStatus.Enabled;
@@ -297,6 +299,16 @@ namespace XenAdmin.Dialogs.HealthCheck
             {
                 previousUploadPanel.Visible = false;
             }
+        }
+
+        public void UpdateButtonsVisibility(Pool pool)
+        {
+            refreshLinkLabel.Visible =
+                editLinkLabel.Visible =
+                disableLinkLabel.Visible =
+                uploadRequestLinkLabel.Visible =
+                enrollNowLinkLabel.Visible = Core.HealthCheck.PassedRbacChecks(pool.Connection);
+
         }
 
         private void HealthCheckOverviewDialog_Load(object sender, EventArgs e)
@@ -450,7 +462,7 @@ namespace XenAdmin.Dialogs.HealthCheck
             if (poolRow.Pool == null)
                 return;
             
-            Core.HealthCheck.CheckForAnalysisResults(poolRow.Pool.Connection);
+            Core.HealthCheck.CheckForAnalysisResults(poolRow.Pool.Connection, false);
         }
 
         private void HealthCheck_CheckForUpdatesCompleted(bool succeeded)

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.cs
@@ -266,9 +266,9 @@ namespace XenAdmin.Dialogs.HealthCheck
             if (!CheckCredentialsEntered())
                 return false;
 
-            var action = new HealthCheckAuthenticationAction(pool, textBoxMyCitrixUsername.Text.Trim(), textBoxMyCitrixPassword.Text.Trim(),
+            var action = new HealthCheckAuthenticationAction(textBoxMyCitrixUsername.Text.Trim(), textBoxMyCitrixPassword.Text.Trim(),
                 Registry.HealthCheckIdentityTokenDomainName, Registry.HealthCheckUploadGrantTokenDomainName, Registry.HealthCheckUploadTokenDomainName,
-                Registry.HealthCheckDiagnosticDomainName, Registry.HealthCheckProductKey, true, 0, false);
+                Registry.HealthCheckDiagnosticDomainName, Registry.HealthCheckProductKey, 0, false);
 
             try
             {
@@ -283,7 +283,8 @@ namespace XenAdmin.Dialogs.HealthCheck
             }
 
             authenticationToken = action.UploadToken;  // curent upload token
-            authenticated = pool.HealthCheckSettings.TryGetExistingTokens(pool.Connection, out authenticationToken, out diagnosticToken);
+            diagnosticToken = action.DiagnosticToken;  // curent diagnostic token
+            authenticated = !String.IsNullOrEmpty(authenticationToken) && !String.IsNullOrEmpty(diagnosticToken);
             return authenticated;
         }
 

--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageDestination.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageDestination.cs
@@ -183,10 +183,10 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
             if (string.IsNullOrEmpty(usernameTextBox.Text) || string.IsNullOrEmpty(passwordTextBox.Text))
                 return false;
 
-            var action = new HealthCheckAuthenticationAction(null, usernameTextBox.Text.Trim(), passwordTextBox.Text.Trim(),
+            var action = new HealthCheckAuthenticationAction(usernameTextBox.Text.Trim(), passwordTextBox.Text.Trim(),
                 Registry.HealthCheckIdentityTokenDomainName, Registry.HealthCheckUploadGrantTokenDomainName,
                 Registry.HealthCheckUploadTokenDomainName, Registry.HealthCheckDiagnosticDomainName, Registry.HealthCheckProductKey, 
-                false, TokenExpiration, false);
+                TokenExpiration, false);
 
             new ActionProgressDialog(action, ProgressBarStyle.Blocks).ShowDialog(Parent);
 

--- a/XenModel/Actions/HealthCheck/GetHealthCheckAnalysisResultAction.cs
+++ b/XenModel/Actions/HealthCheck/GetHealthCheckAnalysisResultAction.cs
@@ -49,7 +49,11 @@ namespace XenAdmin.Actions
         public GetHealthCheckAnalysisResultAction(Pool pool, bool suppressHistory)
             : base(pool.Connection, Messages.ACTION_GET_HEALTH_CHECK_RESULT, Messages.ACTION_GET_HEALTH_CHECK_RESULT_PROGRESS, suppressHistory)
         {
-            
+            #region RBAC Dependencies
+            ApiMethodsToRoleCheck.Add("secret.get_by_uuid");
+            ApiMethodsToRoleCheck.Add("secret.get_value");
+            ApiMethodsToRoleCheck.Add("pool.set_health_check_config");
+            #endregion
         }
 
         public GetHealthCheckAnalysisResultAction(Pool pool, string diagnosticDomainName, bool suppressHistory)
@@ -63,7 +67,7 @@ namespace XenAdmin.Actions
         {
             try
             {
-                var diagnosticToken = Pool.HealthCheckSettings.GetSecretyInfo(Pool.Connection, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET);
+                var diagnosticToken = Pool.HealthCheckSettings.GetSecretyInfo(Session, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET);
                 if (string.IsNullOrEmpty(diagnosticToken))
                 {
                     log.InfoFormat("Cannot get the diagnostic result for {0}, because couldn't retrieve the diagnostic token", Pool.Name);

--- a/XenModel/Actions/HealthCheck/SaveHealthCheckSettingsAction.cs
+++ b/XenModel/Actions/HealthCheck/SaveHealthCheckSettingsAction.cs
@@ -29,7 +29,9 @@
  * SUCH DAMAGE.
  */
 
+using System;
 using System.Collections.Generic;
+using System.Net;
 using XenAdmin.Model;
 using XenAPI;
 
@@ -37,6 +39,8 @@ namespace XenAdmin.Actions
 {
     public class SaveHealthCheckSettingsAction : PureAsyncAction
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         private readonly Pool pool;
         HealthCheckSettings healthCheckSettings;
         private string authenticationToken;
@@ -59,12 +63,67 @@ namespace XenAdmin.Actions
         {
             Dictionary<string, string> newConfig = healthCheckSettings.ToDictionary(pool.health_check_config);
             if (!string.IsNullOrEmpty(authenticationToken))
-                HealthCheckAuthenticationAction.SetSecretInfo(Connection, newConfig, HealthCheckSettings.UPLOAD_TOKEN_SECRET, authenticationToken);
+            {
+                log.Info("Saving upload token as xapi secret"); 
+                SetSecretInfo(Session, newConfig, HealthCheckSettings.UPLOAD_TOKEN_SECRET, authenticationToken);
+            }
             if (!string.IsNullOrEmpty(diagnosticToken))
-            HealthCheckAuthenticationAction.SetSecretInfo(Connection, newConfig, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET, diagnosticToken);
-            HealthCheckAuthenticationAction.SetSecretInfo(Connection, newConfig, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET, username);
-            HealthCheckAuthenticationAction.SetSecretInfo(Connection, newConfig, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET, password);
-            Pool.set_health_check_config(Connection.Session, pool.opaque_ref, newConfig);
+            {
+                log.Info("Saving diagnostic token as xapi secret"); 
+                SetSecretInfo(Session, newConfig, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET, diagnosticToken);
+            }
+            SetSecretInfo(Session, newConfig, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET, username);
+            SetSecretInfo(Session, newConfig, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET, password);
+            Pool.set_health_check_config(Session, pool.opaque_ref, newConfig);
+        }
+
+        public static void SetSecretInfo(Session session, Dictionary<string, string> config, string infoKey, string infoValue)
+        {
+            if (string.IsNullOrEmpty(infoKey))
+                return;
+
+            if (infoValue == null)
+            {
+                if (config.ContainsKey(infoKey))
+                {
+                    TryToDestroySecret(session, config[infoKey]);
+                    config.Remove(infoKey);
+                }
+            }
+            else if (config.ContainsKey(infoKey))
+            {
+                try
+                {
+                    string secretRef = Secret.get_by_uuid(session, config[infoKey]);
+                    Secret.set_value(session, secretRef, infoValue);
+                }
+                catch (Failure)
+                {
+                    config[infoKey] = Secret.CreateSecret(session, infoValue);
+                }
+                catch (WebException)
+                {
+                    config[infoKey] = Secret.CreateSecret(session, infoValue);
+                }
+            }
+            else
+            {
+                config[infoKey] = Secret.CreateSecret(session, infoValue);
+            }
+        }
+
+        private static void TryToDestroySecret(Session session, string secret_uuid)
+        {
+            try
+            {
+                var secret = Secret.get_by_uuid(session, secret_uuid);
+                Secret.destroy(session, secret.opaque_ref);
+                log.DebugFormat("Successfully destroyed secret {0}", secret_uuid);
+            }
+            catch (Exception exn)
+            {
+                log.Error(string.Format("Failed to destroy secret {0}", secret_uuid), exn);
+            }
         }
     }
 }

--- a/XenModel/HealthCheckSettings.cs
+++ b/XenModel/HealthCheckSettings.cs
@@ -272,7 +272,7 @@ namespace XenAdmin.Model
 
         #endregion
 
-        public string GetSecretyInfo(IXenConnection connection, string secretType)
+        public string GetSecretyInfo(Session session, string secretType)
         {
             string UUID = string.Empty;
             switch (secretType)
@@ -294,18 +294,25 @@ namespace XenAdmin.Model
                     break;
             }
 
-            if (connection == null || string.IsNullOrEmpty(UUID))
+            if (session == null || string.IsNullOrEmpty(UUID))
                 return null;
             try
             {
-                string opaqueref = Secret.get_by_uuid(connection.Session, UUID);
-                return Secret.get_value(connection.Session, opaqueref);
+                string opaqueref = Secret.get_by_uuid(session, UUID);
+                return Secret.get_value(session, opaqueref);
             }
             catch (Exception e)
             {
                 log.Error("Exception getting the upload token from the xapi secret", e);
                 return null;
             }
+        }
+
+        public string GetSecretyInfo(IXenConnection connection, string secretType)
+        {
+            if (connection == null)
+                return null;
+            return GetSecretyInfo(connection.Session, secretType);
         }
 
         public bool TryGetExistingTokens(IXenConnection connection, out string uploadToken, out string diagnosticToken)


### PR DESCRIPTION
Changed all the health check actions to perform the necessary role checks
- HealthCheckAuthenticationAction: changed so it does not save the tokens, so no role checks required in this action (all the checks are performed in SaveHealthCheckSettingsAction)
- GetHealthCheckAnalysisActions: added role checks

On the Health Check Overview dialog, a pool is displayed as read-only if connected as a user with roles that don't permit changing the health check settings:
- the following actions are not available: enroll, edit settings, disable health check, request upload, get analysis result