### PR TITLE
CA-181390: Solved issue related to taking a file from disk that is no…

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -629,8 +629,6 @@ namespace XenAdmin.TabPages
             }
 
             var poolNotAppPatches = poolNotAppliedPatches();
-            if (!string.IsNullOrEmpty(poolNotAppPatches))
-                s.AddEntry(FriendlyName("Pool_patch.not_applied"), poolNotAppPatches, menuItems, Color.Red);
         }
 
         private void generateHostPatchesBox()

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -34,11 +34,12 @@ namespace XenAdmin.Wizards.PatchingWizard
         public List<Host> SelectedMasters { private get; set; }
         public List<Host> SelectedServers { private get; set; }
         public UpdateType SelectedUpdateType { private get; set; }
-        public string SelectedNewPatch { get; set; }
+        public string SelectedNewPatchPath { get; set; }
         public Pool_patch SelectedExistingPatch { private get; set; }
         public Alert SelectedUpdateAlert { private get; set; }
 
         public readonly List<Pool_patch> NewUploadedPatches = new List<Pool_patch>();
+        private Dictionary<string, List<Host>> uploadedUpdates = new Dictionary<string, List<Host>>();
         private Pool_patch _patch = null;
         public Pool_patch Patch
         {
@@ -66,7 +67,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             {
                 flickerFreeListBox1.Items.Clear();
                 var selectedPatch = SelectedUpdateAlert != null ? ((XenServerPatchAlert)SelectedUpdateAlert).Patch : null;
-                if (selectedPatch != null && String.IsNullOrEmpty(SelectedNewPatch) &&
+                if (selectedPatch != null && String.IsNullOrEmpty(SelectedNewPatchPath) &&
                     (!AllDownloadedPatches.Any(kvp => kvp.Key == selectedPatch.Uuid)
                         || String.IsNullOrEmpty(AllDownloadedPatches[selectedPatch.Uuid]) 
                         || !File.Exists(AllDownloadedPatches[selectedPatch.Uuid])))
@@ -76,7 +77,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 else
                 {
                     if (selectedPatch != null && AllDownloadedPatches.ContainsKey(selectedPatch.Uuid))
-                        SelectedNewPatch = AllDownloadedPatches[selectedPatch.Uuid];
+                        SelectedNewPatchPath = AllDownloadedPatches[selectedPatch.Uuid];
                     PrepareUploadActions();
                     TryUploading();
                 }
@@ -156,9 +157,10 @@ namespace XenAdmin.Wizards.PatchingWizard
                 switch (SelectedUpdateType)
                 {
                     case UpdateType.NewRetail:
-                        if (_patch == null || !PatchExistsOnPool(_patch, selectedServer))
+                        if (CanUploadUpdateOnHost(SelectedNewPatchPath, selectedServer))
                         {
-                            action = new UploadPatchAction(selectedServer.Connection, SelectedNewPatch, true);
+                            action = new UploadPatchAction(selectedServer.Connection, SelectedNewPatchPath, true);
+                            AddToUploadedUpdates(SelectedNewPatchPath, selectedServer);
                         }
                         break;
                     case UpdateType.Existing:
@@ -170,11 +172,16 @@ namespace XenAdmin.Wizards.PatchingWizard
                         }
                         break;
                     case UpdateType.NewSuppPack:
-                        action = new UploadSupplementalPackAction(
+                        if (CanUploadUpdateOnHost(SelectedNewPatchPath, selectedServer))
+                        {
+                            action = new UploadSupplementalPackAction(
                             selectedServer.Connection,
                             SelectedServers.Where(s => s.Connection == selectedServer.Connection).ToList(),
-                            SelectedNewPatch,
+                            SelectedNewPatchPath,
                             true);
+
+                            AddToUploadedUpdates(SelectedNewPatchPath, selectedServer);
+                        }
                         break;
                 }
                 if (action != null)
@@ -198,6 +205,25 @@ namespace XenAdmin.Wizards.PatchingWizard
         private bool canDownload = true;
         private DiskSpaceRequirements diskSpaceRequirements;
 
+        private bool CanUploadUpdateOnHost(string patchPath, Host host)
+        {
+            return !uploadedUpdates.ContainsKey(patchPath) || !uploadedUpdates[patchPath].Contains(host);
+        }
+
+        private void AddToUploadedUpdates(string patchPath, Host host)
+        {
+            if(!uploadedUpdates.ContainsKey(patchPath))
+            {
+                List<Host> hosts = new List<Host>();
+                hosts.Add(host);
+                uploadedUpdates.Add(patchPath, hosts);
+            }
+            else if(!uploadedUpdates[patchPath].Contains(host))
+            {
+                uploadedUpdates[patchPath].Add(host);
+            }
+        }
+
         private void TryUploading()
         {
             // reset progress bar and action progress description
@@ -216,7 +242,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 switch (SelectedUpdateType)
                 {
                     case UpdateType.NewRetail:
-                        action = new CheckDiskSpaceForPatchUploadAction(master, SelectedNewPatch, true);
+                        action = new CheckDiskSpaceForPatchUploadAction(master, SelectedNewPatchPath, true);
                         break;
                     case UpdateType.Existing:
                         if (SelectedExistingPatch != null && !PatchExistsOnPool(SelectedExistingPatch, master))
@@ -376,10 +402,10 @@ namespace XenAdmin.Wizards.PatchingWizard
                     }
                     if (action is DownloadAndUnzipXenServerPatchAction)
                     {
-                        SelectedNewPatch = ((DownloadAndUnzipXenServerPatchAction)action).PatchPath;
+                        SelectedNewPatchPath = ((DownloadAndUnzipXenServerPatchAction)action).PatchPath;
                         if (SelectedUpdateAlert is XenServerPatchAlert && (SelectedUpdateAlert as XenServerPatchAlert).Patch != null)
                         {
-                            AllDownloadedPatches.Add((SelectedUpdateAlert as XenServerPatchAlert).Patch.Uuid, SelectedNewPatch);
+                            AllDownloadedPatches.Add((SelectedUpdateAlert as XenServerPatchAlert).Patch.Uuid, SelectedNewPatchPath);
                         }
                         _patch = null;
                         PrepareUploadActions();

--- a/XenModel/Actions/Pool_Patch/RemovePatchAction.cs
+++ b/XenModel/Actions/Pool_Patch/RemovePatchAction.cs
@@ -48,7 +48,7 @@ namespace XenAdmin.Actions
         private readonly Pool_patch patch;
 
         /// <summary>
-        /// This constructor is used to upload a single 'normal' patch
+        /// This constructor is used to remove a single 'normal' patch
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="path"></param>


### PR DESCRIPTION
…t in the list of updates taken from the Citrix website. Created a dictionary that contains all the uploaded updates(the patch path) and on which hosts they were applied.

- Not applied updates do not appear anymore in the General Tab of a pool. (Related to CA-180577)
- If we apply a patch that was already applied (happens when we take a file from disk that is not in the updates list taken from the Citrix website -> no metadata), on cancel we are now removing the uploaded patch from the host.