### PR TITLE
CA-182884: Fixed typo which caused the wrong severity icon to be displayed on the Health Check dialog

### DIFF
--- a/XenModel/HealthCheckSettings.cs
+++ b/XenModel/HealthCheckSettings.cs
@@ -379,7 +379,7 @@ namespace XenAdmin.Model
         {
             switch (severity)
             {
-                case "Eror":
+                case "Error":
                     return DiagnosticAlertSeverity.Error;
                 case "Warning":
                     return DiagnosticAlertSeverity.Warning;


### PR DESCRIPTION

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>