### PR TITLE
CA-181512: new RRDs xapi_open_fds, pool_task_count and pool_session_c…

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/DataSet.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataSet.cs
@@ -126,7 +126,10 @@ namespace XenAdmin.Controls.CustomDataGraph
         public static DataSet Create(string uuid, IXenObject xo, bool show, string settype)
         {
             var dataSet = new DataSet(uuid, xo, show, settype);
-
+            if(settype == "xapi_open_fds" || settype == "pool_task_count" || settype == "pool_session_count")
+            {
+                dataSet.NeverShow = true;
+            }
             if (settype.StartsWith("latency") || settype.EndsWith("latency"))
             {
                 if (settype.StartsWith("latency"))

--- a/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
+++ b/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
@@ -177,7 +177,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
             foreach (Data_source dataSource in dataSources)
             {
-                if (dataSource.name_label == "memory_total_kib" || dataSource.name_label == "memory")
+                if (dataSource.name_label == "memory_total_kib" || dataSource.name_label == "memory" || dataSource.name_label == "xapi_open_fds" || dataSource.name_label == "pool_task_count" || dataSource.name_label == "pool_session_count")
                     continue;
 
                 string friendlyName;

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -1717,6 +1717,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to I/O errors.
+        /// </summary>
+        public static string Label_performance_io_errors {
+            get {
+                return ResourceManager.GetString("Label-performance.io_errors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loopback Receive.
         /// </summary>
         public static string Label_performance_lo_rx {
@@ -1902,6 +1911,24 @@ namespace XenAdmin {
         public static string Label_performance_pif_aggr_tx {
             get {
                 return ResourceManager.GetString("Label-performance.pif_aggr_tx", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to pool_session_count.
+        /// </summary>
+        public static string Label_performance_pool_session_count {
+            get {
+                return ResourceManager.GetString("Label-performance.pool_session_count", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to pool_task_count.
+        /// </summary>
+        public static string Label_performance_pool_task_count {
+            get {
+                return ResourceManager.GetString("Label-performance.pool_task_count", resourceCulture);
             }
         }
         
@@ -2127,6 +2154,15 @@ namespace XenAdmin {
         public static string Label_performance_tap_tx_errors {
             get {
                 return ResourceManager.GetString("Label-performance.tap_tx_errors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tapdisks in low memory mode.
+        /// </summary>
+        public static string Label_performance_Tapdisks_in_low_memory_mode {
+            get {
+                return ResourceManager.GetString("Label-performance.Tapdisks_in_low_memory_mode", resourceCulture);
             }
         }
         
@@ -2361,6 +2397,15 @@ namespace XenAdmin {
         public static string Label_performance_xapi_memory_usage_kib {
             get {
                 return ResourceManager.GetString("Label-performance.xapi_memory_usage_kib", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to xapi_open_fds.
+        /// </summary>
+        public static string Label_performance_xapi_open_fds {
+            get {
+                return ResourceManager.GetString("Label-performance.xapi_open_fds", resourceCulture);
             }
         }
         

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1778,4 +1778,19 @@
   <data name="Label-SR.disk-space-allocations" xml:space="preserve">
     <value>Disk space allocations</value>
   </data>
+  <data name="Label-performance.pool_session_count" xml:space="preserve">
+    <value>pool_session_count</value>
+  </data>
+  <data name="Label-performance.pool_task_count" xml:space="preserve">
+    <value>pool_task_count</value>
+  </data>
+  <data name="Label-performance.Tapdisks_in_low_memory_mode" xml:space="preserve">
+    <value>Tapdisks in low memory mode</value>
+  </data>
+  <data name="Label-performance.xapi_open_fds" xml:space="preserve">
+    <value>xapi_open_fds</value>
+  </data>
+  <data name="Label-performance.io_errors" xml:space="preserve">
+    <value>I/O errors</value>
+  </data>
 </root>


### PR DESCRIPTION
…ount are now hidden from the XenCenter graphs.