### PR TITLE
Removes the extra line in the Disk Space Allocation Message in the Ge…

### DIFF
--- a/XenAdmin/SettingsPanels/VDISizeLocationPage.cs
+++ b/XenAdmin/SettingsPanels/VDISizeLocationPage.cs
@@ -102,8 +102,8 @@ namespace XenAdmin.SettingsPanels
             
             if(sr.IsThinProvisioned && vdi.sm_config.ContainsKey("initial_allocation") && vdi.sm_config.ContainsKey("allocation_quantum"))
             {
-                initial_alloc_value.Text = Util.MemorySizeStringSuitableUnits(Convert.ToDouble(vdi.sm_config["initial_allocation"]), true);
-                incr_alloc_value.Text = Util.MemorySizeStringSuitableUnits(Convert.ToDouble(vdi.sm_config["allocation_quantum"]), true);
+                initial_alloc_value.Text = Util.MemorySizeStringSuitableUnits(Convert.ToDouble(vdi.sm_config["initial_allocation"]), true, Messages.VAL_MB);
+                incr_alloc_value.Text = Util.MemorySizeStringSuitableUnits(Convert.ToDouble(vdi.sm_config["allocation_quantum"]), true, Messages.VAL_MB);
             }
 
             if (vdi.allowed_operations.Contains(vdi_operations.resize) ||

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -30163,7 +30163,6 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to Initial allocation: {0}
-        ///
         ///Incremental allocation: {1}.
         /// </summary>
         public static string SR_DISK_SPACE_ALLOCATION {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10505,7 +10505,6 @@ Do you want to connect to the pool master '{1}'?</value>
   </data>
   <data name="SR_DISK_SPACE_ALLOCATION" xml:space="preserve">
     <value>Initial allocation: {0}
-
 Incremental allocation: {1}</value>
   </data>
   <data name="SR_DOES_NOT_NEED_UPGRADE" xml:space="preserve">

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -897,8 +897,8 @@ namespace XenAdmin.Core
         public static string GetAllocationProperties(string initial_allocation, string quantum_allocation)
         {
             return string.Format(Messages.SR_DISK_SPACE_ALLOCATION,
-                   Util.MemorySizeStringSuitableUnits(Convert.ToDouble(initial_allocation), true),
-                   Util.MemorySizeStringSuitableUnits(Convert.ToDouble(quantum_allocation), true));
+                   Util.MemorySizeStringSuitableUnits(Convert.ToDouble(initial_allocation), true, Messages.VAL_MB),
+                   Util.MemorySizeStringSuitableUnits(Convert.ToDouble(quantum_allocation), true, Messages.VAL_MB));
         }
 
         public static string GetHostRestrictions(Host host)

--- a/XenModel/Utils/Util.cs
+++ b/XenModel/Utils/Util.cs
@@ -95,7 +95,27 @@ namespace XenAdmin
             {
                 return string.Format(Messages.VAL_B, bytes);
             }
-        }      
+        }
+
+        /// <summary>
+        /// Returns the string in suitable units and when the number of bytes is 0 the units are the ones given in formatStringWhenZero.
+        /// E.g. : if bytes = 0, showPoint0Decimal = false, formatStringWhenZero = Messages.VAL_MB, then the function will return "0 MB".
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <param name="showPoint0Decimal"></param>
+        /// <param name="formatStringWhenZero"></param>
+        /// <returns></returns>
+        public static string MemorySizeStringSuitableUnits(double bytes, bool showPoint0Decimal, string formatStringWhenZero)
+        {
+            if(bytes == 0)
+            {
+                return string.Format(formatStringWhenZero, bytes);
+            }
+            else
+            {
+                return MemorySizeStringSuitableUnits(bytes, showPoint0Decimal);
+            }
+        }
 
         public static string DataRateString(double bytesPerSec)
         {


### PR DESCRIPTION
…neral Tab.

Creates a new function MemorySizeStringSuitableUnits that takes one more parameter that specifies the units that must be used when the number of bytes is 0.