### PR TITLE
CA-134554: Re-enable WLB Disk Read/Write configuration since WLB VPX is ready

### DIFF
--- a/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.cs
@@ -81,10 +81,6 @@ namespace XenAdmin.SettingsPanels
             trackbarNetWritePriority.Value = GetSafeTrackbarValue(trackbarNetWritePriority, _poolConfiguration.VmNetworkWriteWeightHigh / TRACKBAR_INTERVAL);
             trackbarDiskReadPriority.Value = GetSafeTrackbarValue(trackbarDiskReadPriority, _poolConfiguration.VmDiskReadWeightHigh / TRACKBAR_INTERVAL);
             trackbarDiskWritePriority.Value = GetSafeTrackbarValue(trackbarDiskWritePriority, _poolConfiguration.VmDiskWriteWeightHigh / TRACKBAR_INTERVAL);
-            //CA-134554 - Hide Disk Read/Write until the backend server side is ready
-            trackbarDiskReadPriority.Visible = false;
-            trackbarDiskWritePriority.Visible = false;
-
             _loading = false; ;
         }
 

--- a/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.resx
+++ b/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.resx
@@ -225,9 +225,6 @@
   <data name="&gt;&gt;label11.Name" xml:space="preserve">
     <value>label11</value>
   </data>
-  <data name="label11.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
   <data name="&gt;&gt;label11.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
@@ -260,9 +257,6 @@
   </data>
   <data name="&gt;&gt;label10.Name" xml:space="preserve">
     <value>label10</value>
-  </data>
-  <data name="label10.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
   </data>
   <data name="&gt;&gt;label10.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -571,7 +565,7 @@
     <value>6, 46</value>
   </data>
   <data name="decentGroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>578, 196</value>
+    <value>578, 266</value>
   </data>
   <data name="decentGroupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>

--- a/XenAdmin/SettingsPanels/Wlb/WlbThresholdsPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbThresholdsPage.Designer.cs
@@ -34,10 +34,6 @@ namespace XenAdmin.SettingsPanels
             this.decentGroupBox1 = new XenAdmin.Controls.DecentGroupBox();
             this.label1DiskWrite = new System.Windows.Forms.Label();
             this.labelDiskRead = new System.Windows.Forms.Label();
-            //CA-134554 - Hide Disk Read/Write until the backend server side is ready
-            this.label1DiskWrite.Visible = false;
-            this.labelDiskRead.Visible = false;
-
             this.labelNetworkWrite = new System.Windows.Forms.Label();
             this.labelNetworkRead = new System.Windows.Forms.Label();
             this.labelFreeMemory = new System.Windows.Forms.Label();

--- a/XenAdmin/SettingsPanels/Wlb/WlbThresholdsPage.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbThresholdsPage.cs
@@ -86,13 +86,7 @@ namespace XenAdmin.SettingsPanels
             labelDiskWriteUnits.Text = string.Format(labelDiskWriteUnits.Text, updownDiskWriteCriticalPoint.Minimum, updownDiskWriteCriticalPoint.Maximum);
             labelNetworkReadUnits.Text = string.Format(labelNetworkReadUnits.Text, updownNetworkReadCriticalPoint.Minimum, updownNetworkReadCriticalPoint.Maximum);
             labelNetworkWriteUnits.Text = string.Format(labelNetworkWriteUnits.Text, updownNetworkWriteCriticalPoint.Minimum, updownNetworkWriteCriticalPoint.Maximum);
-
-            //CA-134554 - Hide Disk Read/Write until the backend server side is ready
-            updownDiskReadCriticalPoint.Visible = false;
-            updownDiskWriteCriticalPoint.Visible = false;
-            labelDiskReadUnits.Visible = false;
-            labelDiskWriteUnits.Visible = false;
-
+            
             _loading = false; ;
         }
 


### PR DESCRIPTION

Revert commit 32c945e104d755b0c172760846ffe57de6d3ad25 which was used to
"Hide Disk Read/Write configuration until the backend server side is ready."