### PR TITLE
CA-183958: Committed percentage for thinly provisioned SRs should not…

### DIFF
--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -1135,7 +1135,7 @@ namespace XenAPI
         {
             get
             {
-                return (long)Math.Round(virtual_allocation / (double)physical_size * 100.0);
+                return (long)Math.Round(Math.Abs(virtual_allocation) / (double)physical_size * 100.0);
             }
         }
 


### PR DESCRIPTION
… be displayed as negative value

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>