### PR TITLE
CA-184563: Do not show Provisioning method for SRs other than iSCSI and LVM

### DIFF
--- a/XenAdmin/Commands/ConvertToThinSRCommand.cs
+++ b/XenAdmin/Commands/ConvertToThinSRCommand.cs
@@ -98,7 +98,7 @@ namespace XenAdmin.Commands
             {
                 var sr = item.XenObject as SR;
 
-                if (sr != null && Helpers.DundeeOrGreater(sr.Connection) && sr.Provisioning == SrProvisioning.Thick && (sr.type == "lvmohba" || sr.type == "lvmoiscsi"))
+                if (sr != null && Helpers.DundeeOrGreater(sr.Connection) && (sr.type == "lvmohba" || sr.type == "lvmoiscsi") && !sr.IsThinProvisioned)
                     return sr;
             }
 

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1233,20 +1233,24 @@ namespace XenAdmin.TabPages
                 {
                     s.AddEntry(FriendlyName("SR.size"), sr.SizeString);
 
-                    IEnumerable<CommandToolStripMenuItem> menuItems = null;
-                    if (sr.Provisioning == SrProvisioning.Thick && (sr.type == "lvmohba" || sr.type == "lvmoiscsi"))
+                    if (sr.type == "lvmohba" || sr.type == "lvmoiscsi")
                     {
-                        menuItems = new[] { new CommandToolStripMenuItem(new ConvertToThinSRCommand(Program.MainWindow, new List<SelectedItem> () { new SelectedItem(xenObject)} ), true) };
-                    }
-                    s.AddEntry(FriendlyName("SR.provisioning"), sr.IsThinProvisioned 
-                        ? string.Format(Messages.SR_THIN_PROVISIONING_COMMITTED, sr.PercentageCommitted) 
-                        : Messages.SR_THICK_PROVISIONING, menuItems);
-
-                    if(sr.IsThinProvisioned && sr.sm_config.ContainsKey("initial_allocation") && sr.sm_config.ContainsKey("allocation_quantum"))
-                    {
-                        s.AddEntry(FriendlyName("SR.disk-space-allocations"), 
-                                   Helpers.GetAllocationProperties(sr.sm_config["initial_allocation"], sr.sm_config["allocation_quantum"]));
-                    }
+                        // add entries related to thin lvhd SRs
+                        IEnumerable<CommandToolStripMenuItem> menuItems = null;
+                        if (!sr.IsThinProvisioned)
+                        {
+                            menuItems = new[] { new CommandToolStripMenuItem(new ConvertToThinSRCommand(Program.MainWindow, new List<SelectedItem>() { new SelectedItem(xenObject) }), true) };
+                        }
+                        s.AddEntry(FriendlyName("SR.provisioning"), sr.IsThinProvisioned 
+                            ? string.Format(Messages.SR_THIN_PROVISIONING_COMMITTED, sr.PercentageCommitted) 
+                            : Messages.SR_THICK_PROVISIONING, menuItems);
+                        
+                        if(sr.IsThinProvisioned && sr.sm_config.ContainsKey("initial_allocation") && sr.sm_config.ContainsKey("allocation_quantum"))
+                        {
+                            s.AddEntry(FriendlyName("SR.disk-space-allocations"), 
+                                       Helpers.GetAllocationProperties(sr.sm_config["initial_allocation"], sr.sm_config["allocation_quantum"]));
+                        }
+                    }                    
                 }
 
                 if (sr.GetScsiID() != null)

--- a/XenAdminTests/TabsAndMenus/TabsAndMenus.cs
+++ b/XenAdminTests/TabsAndMenus/TabsAndMenus.cs
@@ -343,7 +343,7 @@ namespace XenAdminTests.TabsAndMenus
 
         protected static bool CanConvertSR(SR sr)
         {
-            return sr != null && Helpers.DundeeOrGreater(sr.Connection) && sr.Provisioning == SrProvisioning.Thick && (sr.type == "lvmohba" || sr.type == "lvmoiscsi");
+            return sr != null && Helpers.DundeeOrGreater(sr.Connection) && (sr.type == "lvmohba" || sr.type == "lvmoiscsi") && !sr.IsThinProvisioned;
         }
 
         /// <summary>

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -959,17 +959,6 @@ namespace XenAPI
             }
         }
 
-        public SrProvisioning Provisioning
-        {
-            get
-            {
-                string allocation = Get(sm_config, "allocation");
-                return string.IsNullOrEmpty(allocation) || allocation == "thick"
-                           ? SrProvisioning.Thick
-                           : SrProvisioning.Thin;
-            }
-        }
-
         public Icons GetIcon
         {
             get
@@ -1151,11 +1140,5 @@ namespace XenAPI
         }
 
         #endregion
-    }
-
-    public enum SrProvisioning
-    {
-        Thick,
-        Thin
     }
 }


### PR DESCRIPTION

- display the Provisioning entries in the General Tab only for iSCSI and LVM SRs
- also changed the checks in the ConvertToThinSRCommand to use SR.IsThinProvisioned property instead of SR.Provisioning

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>