### PR TITLE
CA-180128: ExpectDisruption flag not working correctly

### DIFF
--- a/XenModel/Actions/CancellingAction.cs
+++ b/XenModel/Actions/CancellingAction.cs
@@ -422,6 +422,14 @@ namespace XenAdmin.Actions
                     log.Error(xmlExcept, xmlExcept);
                     throw new Exception(Messages.INVALID_SESSION);
                 }
+                catch (XmlRpcIllFormedXmlException xmlRpcIllFormedXmlException)
+                {
+                    log.ErrorFormat("XmlRpcIllFormedXmlException in DoWithSessionRetry, retry {0}", retries);
+                    log.Error(xmlRpcIllFormedXmlException, xmlRpcIllFormedXmlException);
+
+                    if (!Connection.ExpectDisruption || retries <= 0)
+                        throw;
+                }
                 catch (WebException we)
                 {
                     log.ErrorFormat("WebException in DoWithSessionRetry, retry {0}", retries);

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -1278,9 +1278,17 @@ namespace XenAdmin.Network
                             XenObjectDownloader.GetEvents(eventNextSession, eventQueue, task.GetCancelled, legacyEventSystem, ref token);
                             eventsExceptionLogged = false;
                         }
-                        catch (WebException exn)
+                        catch (Exception exn)
                         {
-                            if (ExpectDisruption && (exn.Status == WebExceptionStatus.KeepAliveFailure || exn.Status == WebExceptionStatus.ConnectFailure))
+                            if (!ExpectDisruption)
+                                throw;
+
+                            log.DebugFormat("Exception (disruption is expected) in XenObjectDownloader.GetEvents: {0}", exn.GetType().Name);
+
+                            // ignoring some exceptions when disruption is expected
+                            if (exn is XmlRpcIllFormedXmlException || 
+                                exn is System.IO.IOException || 
+                                (exn is WebException && ((exn as WebException).Status == WebExceptionStatus.KeepAliveFailure || (exn as WebException).Status == WebExceptionStatus.ConnectFailure)))
                             {
                                 if (!eventsExceptionLogged)
                                 {

--- a/XenModel/XenAPI-Extensions/Task.cs
+++ b/XenModel/XenAPI-Extensions/Task.cs
@@ -219,6 +219,7 @@ namespace XenAPI
         {
             try
             {
+                remove_from_other_config(session, _task, "applies_to"); 
                 add_to_other_config(session, _task, "applies_to", string.Join(",", applies_to.ToArray()));
             }
             catch (XenAPI.Failure f)
@@ -259,6 +260,7 @@ namespace XenAPI
 
             try
             {
+                remove_from_other_config(session, task, XenCenterMeddlingActionTitleKey); 
                 add_to_other_config(session, task, XenCenterMeddlingActionTitleKey, title);
             }
             catch (Failure f)
@@ -284,6 +286,7 @@ namespace XenAPI
         {
             try
             {
+                remove_from_other_config(session, _task, "XenCenterUUID");
                 add_to_other_config(session, _task, "XenCenterUUID", uuid);
             }
             catch (XenAPI.Failure f)


### PR DESCRIPTION
CA-180128: Ignoring more exceptions on the connection thread when disruption is expected

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>