### PR TITLE
CA-184560: Fix the issue when the RPU wizard cannot check the host version after reboot

### DIFF
--- a/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/AutomaticBackgroundThread.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/AutomaticBackgroundThread.cs
@@ -81,6 +81,11 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
                                 if (planAction is UpgradeHostPlanAction)
                                 {
                                     Host hostAfterReboot = host.Connection.Resolve(new XenRef<Host>(host.opaque_ref));
+                                    if (hostAfterReboot == null)
+                                    {
+                                        log.InfoFormat("Host '{0}' cannot be resolved. Try to resolve it again with timeout", host.Name);
+                                        hostAfterReboot = (planAction as UpgradeHostPlanAction).Host;
+                                    }
                                     if (hostAfterReboot != null && Helpers.SameServerVersion(hostAfterReboot, hostVersion))
                                     {
                                         log.ErrorFormat("Host '{0}' rebooted with the same version '{1}'", hostAfterReboot.Name, hostAfterReboot.LongProductVersion);

--- a/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/AutomaticBackgroundThread.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/AutomaticBackgroundThread.cs
@@ -80,12 +80,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
                                 
                                 if (planAction is UpgradeHostPlanAction)
                                 {
-                                    Host hostAfterReboot = host.Connection.Resolve(new XenRef<Host>(host.opaque_ref));
-                                    if (hostAfterReboot == null)
-                                    {
-                                        log.InfoFormat("Host '{0}' cannot be resolved. Try to resolve it again with timeout", host.Name);
-                                        hostAfterReboot = (planAction as UpgradeHostPlanAction).Host;
-                                    }
+                                    Host hostAfterReboot = (planAction as UpgradeHostPlanAction).Host;
                                     if (hostAfterReboot != null && Helpers.SameServerVersion(hostAfterReboot, hostVersion))
                                     {
                                         log.ErrorFormat("Host '{0}' rebooted with the same version '{1}'", hostAfterReboot.Name, hostAfterReboot.LongProductVersion);


### PR DESCRIPTION

In the RPU wizard, after we notice that the host has been rebooted we try to resolve the host from cache, but sometimes the cache is not populated at that point.
Then, because we cannot resolve the host, we cannot check the host version and we assume is a newer version (which might not be true).
This commit adds a call to retry to resolve the host (with timeout).

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>