### PR TITLE
CP-14085: Feature leveling not needed on pool-join

### DIFF
--- a/XenModel/Actions/Pool/PoolAction.cs
+++ b/XenModel/Actions/Pool/PoolAction.cs
@@ -86,6 +86,10 @@ namespace XenAdmin.Actions
             // Mask the CPUs, and reboot the hosts (simultaneously, as they must all be on separate connections)
             foreach (Host host in hostsToCpuMask)
             {
+                // No CPU masking is needed for Dundee or greater hosts 
+                if (Helpers.DundeeOrGreater(host))
+                    continue;
+
                 Host.set_cpu_features(host.Connection.Session, host.opaque_ref, poolMaster.cpu_info["features"]);
                 RebootHostAction action = new RebootHostAction(host, acceptNTolChanges);
                 rebootActions.Add(action);

--- a/XenModel/Actions/Pool/PoolAction.cs
+++ b/XenModel/Actions/Pool/PoolAction.cs
@@ -88,7 +88,10 @@ namespace XenAdmin.Actions
             {
                 // No CPU masking is needed for Dundee or greater hosts 
                 if (Helpers.DundeeOrGreater(host))
+                {
+                    System.Diagnostics.Trace.Assert(false, "No CPU masking should be done for Dundee or greater hosts");
                     continue;
+                }
 
                 Host.set_cpu_features(host.Connection.Session, host.opaque_ref, poolMaster.cpu_info["features"]);
                 RebootHostAction action = new RebootHostAction(host, acceptNTolChanges);

--- a/XenModel/PoolJoinRules.cs
+++ b/XenModel/PoolJoinRules.cs
@@ -270,6 +270,10 @@ namespace XenAdmin.Core
                 if (slave_cpu_info["vendor"] != master_cpu_info["vendor"])
                     return false;
 
+                // No feature checks are needed for Dundee or greater hosts
+                if (Helpers.DundeeOrGreater(master))
+                    return true;
+
                 if (slave_cpu_info["features"] == master_cpu_info["features"])
                     return true;
 


### PR DESCRIPTION
 Feature leveling should "just work" for Dundee and higher hosts, without the need for us to level them explicitly

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>