### PR TITLE
CA-187150: Dundee XenCenter cannot create iSCSI SRs on older hosts

### DIFF
--- a/XenAdmin/Wizards/NewSRWizard.cs
+++ b/XenAdmin/Wizards/NewSRWizard.cs
@@ -415,6 +415,9 @@ namespace XenAdmin.Wizards
                 {
                     xenTabPageStorageProvisioningMethod.ResetControls();
                 }
+
+                m_srWizardType.UUID = xenTabPageLvmoIscsi.UUID;
+                m_srWizardType.DeviceConfig = xenTabPageLvmoIscsi.DeviceConfig;
             }
             else if (senderPagetype == typeof(NFS_ISO))
             {


### PR DESCRIPTION
Fixed regression that was caused by hiding the Storage Provisioning page

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>