### PR TITLE
CA-187909: Special characters should be URLencoded on HTTP calls

### DIFF
--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard_SelectInstallMethod.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard_SelectInstallMethod.cs
@@ -179,7 +179,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
                 if (InstallMethod != RollingUpgradeInstallMethod.nfs && textBoxUser.Text != string.Empty && textBoxPassword.Text != string.Empty)
                 {
-                    dict.Add("url", string.Format("{0}://{1}:{2}@{3}", InstallMethod, HttpUtility.UrlEncode(textBoxUser.Text), HttpUtility.UrlEncode(textBoxPassword.Text), url));
+                    dict.Add("url", string.Format("{0}://{1}:{2}@{3}", InstallMethod, textBoxUser.Text.UrlEncode(), textBoxPassword.Text.UrlEncode(), url));
                 }
                 else
                     dict.Add("url", string.Format("{0}://{1}", InstallMethod,  url));

--- a/XenModel/Actions/HealthCheck/XenServerHealthCheckUpload.cs
+++ b/XenModel/Actions/HealthCheck/XenServerHealthCheckUpload.cs
@@ -37,7 +37,7 @@ using System.Text;
 using System.Web.Script.Serialization;
 using XenAdmin;
 using XenAdmin.Network;
-
+using XenAdmin.Core;
 
 namespace XenServerHealthCheck
 {
@@ -71,7 +71,7 @@ namespace XenServerHealthCheck
             // Request a new bundle upload to CIS server.
             string FULL_URL = UPLOAD_URL + "bundle/?size=" + size.ToString() + "&name=" + fileName.UrlEncode();
             if (!string.IsNullOrEmpty(caseNumber))
-                FULL_URL += "&sr=" + caseNumber.UrlEncode();
+                FULL_URL += "&sr=" + caseNumber;
             log.InfoFormat("InitiateUpload, UPLOAD_URL: {0}", FULL_URL);
             Uri uri = new Uri(FULL_URL);
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
@@ -188,7 +188,7 @@ namespace XenServerHealthCheck
             long offset = 0;
             while (offset < size)
             {
-                StringBuilder url = new StringBuilder(UPLOAD_URL + "upload_raw_chunk/?id=" + uploadUuid.UrlEncode());
+                StringBuilder url = new StringBuilder(UPLOAD_URL + "upload_raw_chunk/?id=" + uploadUuid);
                 url.Append(String.Format("&offset={0}", offset));
                 long remainingSize = size - offset;
                 long thisChunkSize = (remainingSize > CHUNK_SIZE) ? CHUNK_SIZE : remainingSize;
@@ -228,18 +228,9 @@ namespace XenServerHealthCheck
 
             log.InfoFormat("Succeed to upload bundle {0}", fileName);
             return uploadUuid;
-
+            
         }
     }
 
-    public static class Extensions
-    {
-        public static string UrlEncode(this string str)
-        {
-            if (string.IsNullOrEmpty(str))
-                return str;
 
-            return WebUtility.UrlEncode(str);
-        }
-    }
 }

--- a/XenModel/Actions/HealthCheck/XenServerHealthCheckUpload.cs
+++ b/XenModel/Actions/HealthCheck/XenServerHealthCheckUpload.cs
@@ -69,9 +69,9 @@ namespace XenServerHealthCheck
         public string InitiateUpload(string fileName, long size, string caseNumber)
         {
             // Request a new bundle upload to CIS server.
-            string FULL_URL = UPLOAD_URL + "bundle/?size=" + size.ToString() + "&name=" + fileName;
+            string FULL_URL = UPLOAD_URL + "bundle/?size=" + size.ToString() + "&name=" + fileName.UrlEncode();
             if (!string.IsNullOrEmpty(caseNumber))
-                FULL_URL += "&sr=" + caseNumber;
+                FULL_URL += "&sr=" + caseNumber.UrlEncode();
             log.InfoFormat("InitiateUpload, UPLOAD_URL: {0}", FULL_URL);
             Uri uri = new Uri(FULL_URL);
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
@@ -188,7 +188,7 @@ namespace XenServerHealthCheck
             long offset = 0;
             while (offset < size)
             {
-                StringBuilder url = new StringBuilder(UPLOAD_URL + "upload_raw_chunk/?id=" + uploadUuid);
+                StringBuilder url = new StringBuilder(UPLOAD_URL + "upload_raw_chunk/?id=" + uploadUuid.UrlEncode());
                 url.Append(String.Format("&offset={0}", offset));
                 long remainingSize = size - offset;
                 long thisChunkSize = (remainingSize > CHUNK_SIZE) ? CHUNK_SIZE : remainingSize;
@@ -230,6 +230,16 @@ namespace XenServerHealthCheck
             return uploadUuid;
 
         }
+    }
 
+    public static class Extensions
+    {
+        public static string UrlEncode(this string str)
+        {
+            if (string.IsNullOrEmpty(str))
+                return str;
+
+            return WebUtility.UrlEncode(str);
+        }
     }
 }

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -2071,5 +2071,13 @@ namespace XenAdmin.Core
 
            return vdi.virtual_size;
        }
+
+        public static string UrlEncode(this string str)
+        {
+            if (string.IsNullOrEmpty(str))
+                return str;
+
+            return System.Net.WebUtility.UrlEncode(str);
+        }
     }
 }


### PR DESCRIPTION
UrlEncoded all the strings that are used when creating URLs. (Such as untrusted user input: string fileName)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>