### PR TITLE
CA-188554: XenCenter Error Uncaught exception System.NullReferenceException

### DIFF
--- a/XenAdmin/TabPages/GeneralTabLicenseStatusStringifier.cs
+++ b/XenAdmin/TabPages/GeneralTabLicenseStatusStringifier.cs
@@ -48,7 +48,7 @@ namespace XenAdmin.TabPages
         {
             get
             {
-                if (Status != null && Status.LicencedHost != null && Status.LicenseExpiresIn.TotalDays < 3653)
+                if (Status != null && Status.LicencedHost != null && Status.LicenseExpiresIn != null && Status.LicenseExpiresIn.TotalDays < 3653)
                     return HelpersGUI.DateTimeToString(Status.LicencedHost.LicenseExpiryUTC.ToLocalTime(),
                                                         Messages.DATEFORMAT_DMY_LONG, true);
 

--- a/XenAdmin/TabPages/GeneralTabPage.Designer.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.Designer.cs
@@ -15,7 +15,9 @@ namespace XenAdmin.TabPages
         {
             if (disposing && (components != null))
             {
-                licenseStatus.Dispose();
+                if (licenseStatus != null)
+                    licenseStatus.Dispose();
+
                 components.Dispose();
             }
             base.Dispose(disposing);

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -102,20 +102,18 @@ namespace XenAdmin.TabPages
             GeneralTabLicenseStatusStringifier ss = new GeneralTabLicenseStatusStringifier(licenseStatus);
             Program.Invoke(Program.MainWindow, () => 
             {
-                if (pdSectionLicense != null)
-                    pdSectionLicense.UpdateEntryValueWithKey(
-                        FriendlyName("host.license_params-expiry"),
-                        ss.ExpiryDate, 
-                        ss.ShowExpiryDate);
+                pdSectionLicense.UpdateEntryValueWithKey(
+                    FriendlyName("host.license_params-expiry"),
+                    ss.ExpiryDate, 
+                    ss.ShowExpiryDate);
             });
 
             Program.Invoke(Program.MainWindow, () =>
             {
-                if (pdSectionLicense != null)
-                    pdSectionLicense.UpdateEntryValueWithKey(
-                        Messages.LICENSE_STATUS,
-                        ss.ExpiryStatus,
-                        true);
+                pdSectionLicense.UpdateEntryValueWithKey(
+                    Messages.LICENSE_STATUS,
+                    ss.ExpiryStatus,
+                    true);
             });
         }
 
@@ -166,10 +164,7 @@ namespace XenAdmin.TabPages
                 if (value == null)
                     return;
 
-                UnregisterLicenseStatusUpdater();
-
-                if (value is Host || value is Pool)
-                    SetupAndStartLicenseStatus(value);
+                RegisterLicenseStatusUpdater(xenObject);
 
                 if (xenObject != value)
                 {
@@ -191,19 +186,17 @@ namespace XenAdmin.TabPages
             }
         }
 
-        private void SetupAndStartLicenseStatus(IXenObject xo)
-        {
-            System.Diagnostics.Debug.Assert(xo is Host || xo is Pool);
-
-            licenseStatus = new LicenseStatus(xo);
-            licenseStatus.ItemUpdated += licenseStatus_ItemUpdated;
-            licenseStatus.BeginUpdate();
-        }
-
-        private void UnregisterLicenseStatusUpdater()
+        private void RegisterLicenseStatusUpdater(IXenObject xenObject)
         {
             if (licenseStatus != null)
                 licenseStatus.ItemUpdated -= licenseStatus_ItemUpdated;
+
+            if (xenObject is Host || xenObject is Pool)
+            {
+                licenseStatus = new LicenseStatus(xenObject);
+                licenseStatus.ItemUpdated += licenseStatus_ItemUpdated;
+                licenseStatus.BeginUpdate();
+            }
         }
 
         void s_ExpandedEventHandler(PDSection pdSection)

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -195,7 +195,7 @@ namespace XenAPI
         {
             get
             {
-                if (license_params.ContainsKey("expiry"))
+                if (license_params != null && license_params.ContainsKey("expiry"))
                     return TimeUtil.ParseISO8601DateTime(license_params["expiry"]);
                 return new DateTime(2030, 1, 1);
             }


### PR DESCRIPTION
Fixed the exception that was caused by a missing null reference check and also the fact that the license status had to be watched only for pools and hosts, so added a check before starting watching the license status of the IXenObject (on GeneralTabPage)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>