### PR TITLE
CA-187932: Cancelled tasks are reported as errors in XenCenter

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -456,7 +456,7 @@ namespace XenAdmin
                                                    : null);
             }
 
-            int errors = ConnectionsManager.History.Count(a => a.IsCompleted && !a.Succeeded);
+            int errors = ConnectionsManager.History.Count(a => a.IsCompleted && !a.Succeeded && !((a is CancellingAction) && ((CancellingAction)a).Cancelled));
             navigationPane.UpdateNotificationsButton(NotificationsSubMode.Events, errors);
 
             if (eventsPage.Visible)


### PR DESCRIPTION
Fixed: "User tasks (e.g. VM import) are reported as errors in XenCenter, when they are cancelled tasks."
Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>