### PR TITLE
CA-189084: Control domain memory alerts not getting generated in Xencenter.

### DIFF
--- a/XenAdmin/SettingsPanels/PerfmonAlertEditPage.cs
+++ b/XenAdmin/SettingsPanels/PerfmonAlertEditPage.cs
@@ -50,6 +50,8 @@ namespace XenAdmin.SettingsPanels
 {
     public partial class PerfmonAlertEditPage : UserControl, IEditPage
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         private IXenObject _XenObject;
 
         private readonly ToolTip m_invalidParamToolTip;
@@ -242,6 +244,7 @@ namespace XenAdmin.SettingsPanels
         {
             if (_XenObject == null)
                 return;
+            
             try
             {
                 var perfmonDefinitions = PerfmonDefinition.GetPerfmonDefinitions(_XenObject);
@@ -260,13 +263,40 @@ namespace XenAdmin.SettingsPanels
                         memoryAlert.Populate(perfmonDefinition);
                     else if (perfmonDefinition.IsSrUsage)
                         srAlert.Populate(perfmonDefinition);
-                    else if (perfmonDefinition.IsDom0MemoryUsage)
-                        dom0MemoryAlert.Populate(perfmonDefinition);
                     else if (perfmonDefinition.IsSrPhysicalUtilisation)
                         physicalUtilisationAlert.Populate(perfmonDefinition);
                 }
             }
             catch { }
+
+            // Dom0 memory usage is stored in the other_config of the Dom0 vm not on the host (or any other XenObject)
+            try
+            {
+                if (_XenObject is Host)
+                {
+                    var controlDomain = (_XenObject as Host).ControlDomain;
+
+                    if (controlDomain != null)
+                    {
+                        var controlDomainPerfmonDefinitions = PerfmonDefinition.GetPerfmonDefinitions(controlDomain);
+
+                        if (controlDomainPerfmonDefinitions != null)
+                        {
+                            for (int ii = 0; ii < controlDomainPerfmonDefinitions.Length; ii++)
+                            {
+                                var def = controlDomainPerfmonDefinitions[ii];
+
+                                if (def != null && def.IsDom0MemoryUsage)
+                                    dom0MemoryAlert.Populate(def);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error("Unexpected error during populating controls for Dom0 Memory Usage alert. Leaving it as is.", ex);    
+            }
         }
 
         public bool HasChanged
@@ -436,9 +466,13 @@ namespace XenAdmin.SettingsPanels
         {
             Debug.Assert(XapiToGuiTriggerLevel != null && XapiToGuiTriggerPeriod != null && XapiToGuiAlertInterval != null);
 
-            m_checkBox.Checked = true;
-            m_upDownTriggerLevel.Value = XapiToGuiTriggerLevel(perfmon.AlarmTriggerLevel);
-            m_upDownTriggerPeriod.Value = XapiToGuiTriggerPeriod(perfmon.AlarmTriggerPeriod);
+            if (perfmon.HasValueSet)
+            {
+                m_checkBox.Checked = true;
+                m_upDownTriggerLevel.Value = XapiToGuiTriggerLevel(perfmon.AlarmTriggerLevel);
+                m_upDownTriggerPeriod.Value = XapiToGuiTriggerPeriod(perfmon.AlarmTriggerPeriod);
+            }
+
             try
             {
                 m_upDownAlertInterval.Value = XapiToGuiAlertInterval(perfmon.AlarmAutoInhibitPeriod);

--- a/XenAdmin/SettingsPanels/PerfmonAlertEditPage.cs
+++ b/XenAdmin/SettingsPanels/PerfmonAlertEditPage.cs
@@ -267,7 +267,10 @@ namespace XenAdmin.SettingsPanels
                         physicalUtilisationAlert.Populate(perfmonDefinition);
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                log.Error("Unexpected error during populating controls for Alerts. Exception swallowed.", ex); //Adding this to pre-existing empty catch block to log it at least
+            }
 
             // Dom0 memory usage is stored in the other_config of the Dom0 vm not on the host (or any other XenObject)
             try
@@ -295,7 +298,7 @@ namespace XenAdmin.SettingsPanels
             }
             catch (Exception ex)
             {
-                log.Error("Unexpected error during populating controls for Dom0 Memory Usage alert. Leaving it as is.", ex);    
+                log.Error("Unexpected error during populating controls for Dom0 Memory Usage alert. Exception swallowed.", ex);     //Any error here will cause the controls not being populated, but they will be still usable.
             }
         }
 

--- a/XenModel/Actions/Perfmon/PerfmonDefinitionAction.cs
+++ b/XenModel/Actions/Perfmon/PerfmonDefinitionAction.cs
@@ -115,9 +115,6 @@ namespace XenAdmin.Actions
                 }
             }
 
-            if (dom0_memory_usage != null && perfmonDefinitions.Contains(dom0_memory_usage))
-                perfmonDefinitions.Remove(dom0_memory_usage);
-
             if (perfmonDefinitions == null || perfmonDefinitions.Count == 0)
             {
                 Helpers.RemoveFromOtherConfig(Session, xo, PerfmonDefinition.PERFMON_KEY_NAME);

--- a/XenModel/Alerts/PerfmonDefinition.cs
+++ b/XenModel/Alerts/PerfmonDefinition.cs
@@ -82,12 +82,15 @@ namespace XenAdmin.Alerts
         private readonly decimal alarmTriggerPeriod;
         private readonly decimal alarmAutoInhibitPeriod;
 
+        public bool HasValueSet { private set; get; }
+
         public PerfmonDefinition(string name, decimal alarmTriggerLevel, decimal alarmTriggerPeriod, decimal alarmAutoInhibitPeriod)
         {
             this.name = name;
             this.alarmTriggerLevel = alarmTriggerLevel;
             this.alarmTriggerPeriod = alarmTriggerPeriod;
             this.alarmAutoInhibitPeriod = alarmAutoInhibitPeriod;
+            HasValueSet = true;
         }
 
         public bool IsCPUUsage
@@ -184,6 +187,7 @@ namespace XenAdmin.Alerts
                         NumberStyles.Any,
                         CultureInfo.InvariantCulture,
                         out alarmTriggerLevel);
+                    HasValueSet = HasValueSet || success;
                 }
                 else if (node.Name.Equals(ALARM_TRIGGER_PERIOD_ELEMENT_NAME))
                 {
@@ -192,6 +196,7 @@ namespace XenAdmin.Alerts
                         NumberStyles.Any,
                         CultureInfo.InvariantCulture,
                         out alarmTriggerPeriod);
+                    HasValueSet = HasValueSet || success;
                 }
                 else if (node.Name.Equals(ALARM_AUTO_INHIBIT_PERIOD_ELEMENT_NAME))
                 {
@@ -200,6 +205,7 @@ namespace XenAdmin.Alerts
                         NumberStyles.Any,
                         CultureInfo.InvariantCulture,
                         out alarmAutoInhibitPeriod);
+                    HasValueSet = HasValueSet || success;
                 }
 
                 if (!success)


### PR DESCRIPTION
Dom0 memory alerts have to be configured in the other_config of the Control Domain (Dom0) and not of the the host. This changeset implements this exception.