### PR TITLE
CA-148491: XenServer breaks if any XenAPI client leaks sessions

### DIFF
--- a/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
@@ -68,7 +68,7 @@ namespace XenServerHealthCheck
 
             try
             {
-                session.login_with_password(connection.Username, connection.Password);
+                session.login_with_password(connection.Username, connection.Password, Helper.APIVersionString(API_Version.LATEST), Session.UserAgent);
                 connection.LoadCache(session);
                 var pool = Helpers.GetPoolOfOne(connection);
                 if (pool != null)
@@ -187,7 +187,7 @@ namespace XenServerHealthCheck
         public void updateHealthCheckSettings(bool success, DateTime time, string uploadUuid = "")
         {
             Session session = new Session(connection.Hostname, 80);
-            session.login_with_password(connection.Username, connection.Password);
+            session.login_with_password(connection.Username, connection.Password, Helper.APIVersionString(API_Version.LATEST), Session.UserAgent);
             connection.LoadCache(session);
 
             // Round-trip format time

--- a/XenServerHealthCheck/XenServerHealthCheckService.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckService.cs
@@ -48,6 +48,9 @@ namespace XenServerHealthCheck
         {
             InitializeComponent();
             AutoLog = false;
+
+            XenAPI.Session.UserAgent = string.Format("XenServerHealthCheck/API-{0}", API_Version.LATEST);
+
             if (!System.Diagnostics.EventLog.SourceExists("XenServerHealthCheck"))
             {
                 System.Diagnostics.EventLog.CreateEventSource(
@@ -131,7 +134,7 @@ namespace XenServerHealthCheck
                 session.APIVersion = API_Version.LATEST;
                 try
                 {
-                    session.login_with_password(server.UserName, server.Password);
+                    session.login_with_password(server.UserName, server.Password, Helper.APIVersionString(API_Version.LATEST), Session.UserAgent);
                 }
                 catch (Exception exn)
                 {
@@ -171,7 +174,7 @@ namespace XenServerHealthCheck
                         log.InfoFormat("Reconnect to master {0}", server.HostName);
                         session = new Session(server.HostName, 80);
                         session.APIVersion = API_Version.LATEST;
-                        session.login_with_password(server.UserName, server.Password);
+                        session.login_with_password(server.UserName, server.Password, Helper.APIVersionString(API_Version.LATEST), Session.UserAgent);
                     }
                     XenConnection connectionInfo = new XenConnection();
                     connectionInfo.Hostname = server.HostName;


### PR DESCRIPTION
Fixing XenServerHealthCheck to use the modern overload of session.login_with_password. With this change XC and all its components are now sending an originator field (with some version added to it).

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>