### PR TITLE
CA-191315: Storage motion from XenCenter should no longer be blocked …

### DIFF
--- a/XenAdmin/Commands/Controls/MigrateVMToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/MigrateVMToolStripMenuItem.cs
@@ -57,7 +57,7 @@ namespace XenAdmin.Commands
 
         protected override void AddAdditionalMenuItems(SelectedItemCollection selection)
         {
-            if (selection.ToList().All(item => Helpers.TampaOrGreater(item.Connection)))
+            if (selection.ToList().All(item => Helpers.TampaOrGreater(item.Connection) && !Helpers.CrossPoolMigrationRestrictedWithWlb(item.Connection)))
             {
                 VMOperationCommand cmd = new CrossPoolMigrateCommand(Command.MainWindowCommandInterface, selection);
                 DropDownItems.Add(new ToolStripSeparator());

--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -162,6 +162,8 @@ namespace XenAdmin.Commands
                     base.DropDownItems.Insert(hostMenuItems.IndexOf(menuItem) + 1, menuItem);
                 }
             });
+
+            Program.Invoke(Program.MainWindow, () => AddAdditionalMenuItems(selection));
         }
 
         private void EnableAppropriateHostsNoWlb(Session session)

--- a/XenAdmin/Commands/CrossPoolMigrateCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMigrateCommand.cs
@@ -114,7 +114,7 @@ namespace XenAdmin.Commands
             return !failureFound &&
                    vm.allowed_operations != null &&
                    vm.allowed_operations.Contains(vm_operations.migrate_send) &&
-                   !Helpers.WlbEnabledAndConfigured(vm.Connection) &&
+                   !Helpers.CrossPoolMigrationRestrictedWithWlb(vm.Connection) &&
                    vm.SRs.ToList().All(sr=> sr != null && !sr.HBALunPerVDI) &&
                    (preselectedHost == null || vm.Connection.Resolve(vm.resident_on) != preselectedHost); //Not the same as the pre-selected host
         }

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/WlbEnabledFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/WlbEnabledFilter.cs
@@ -58,9 +58,9 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                 bool targetWlb = false;
 
                 if(ItemToFilterOn != null)
-                    targetWlb = Helpers.WlbEnabledAndConfigured(ItemToFilterOn.Connection);
+                    targetWlb = Helpers.CrossPoolMigrationRestrictedWithWlb(ItemToFilterOn.Connection);
 
-                bool sourceWlb = preSelectedVMs.Any(vm => Helpers.WlbEnabledAndConfigured(vm.Connection));
+                bool sourceWlb = preSelectedVMs.Any(vm => Helpers.CrossPoolMigrationRestrictedWithWlb(vm.Connection));
 
                 reason = targetWlb ? Messages.CPM_WLB_ENABLED_ON_HOST_FAILURE_REASON : Messages.CPM_WLB_ENABLED_ON_VM_FAILURE_REASON;
 

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -491,6 +491,11 @@ namespace XenAdmin.Core
             return (p != null && !String.IsNullOrEmpty(p.wlb_url));
         }
 
+        public static bool CrossPoolMigrationRestrictedWithWlb(IXenConnection conn)
+        {
+            return WlbEnabledAndConfigured(conn) && !DundeeOrGreater(conn);
+        }
+
         #region AllocationBoundsStructAndMethods
         public struct AllocationBounds
         {


### PR DESCRIPTION
…on WLB-enabled pools

The restriction that Storage Motion was not possible in the presence of WLB has been removed in Dundee. This commit removes the check in XenCenter.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>