### PR TITLE
CA-194940: WLB - Hide host disk IO settings for XenServer previous to Dundee.

### DIFF
--- a/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.cs
+++ b/XenAdmin/Dialogs/Wlb/WlbConfigurationDialog.cs
@@ -80,9 +80,11 @@ namespace XenAdmin.Dialogs.Wlb
                 }
 
                 verticalTabs.Items.Add(wlbThresholdsPage);
+                wlbThresholdsPage.Connection = _pool.Connection;
                 wlbThresholdsPage.PoolConfiguration = _poolConfiguration;
 
                 verticalTabs.Items.Add(wlbMetricWeightingPage);
+                wlbMetricWeightingPage.Connection = _pool.Connection;
                 wlbMetricWeightingPage.PoolConfiguration = _poolConfiguration;
 
                 if (_poolConfiguration.IsMROrLater)

--- a/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.Designer.cs
@@ -30,6 +30,7 @@ namespace XenAdmin.SettingsPanels
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WlbMetricWeightingPage));
             this.labelBlurb = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.decentGroupBox1 = new XenAdmin.Controls.DecentGroupBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.labelMoreImportant = new System.Windows.Forms.Label();
@@ -46,6 +47,7 @@ namespace XenAdmin.SettingsPanels
             this.trackbarNetReadPriority = new System.Windows.Forms.TrackBar();
             this.trackbarMemoryPriority = new System.Windows.Forms.TrackBar();
             this.trackbarCPUPriority = new System.Windows.Forms.TrackBar();
+            this.tableLayoutPanel1.SuspendLayout();
             this.decentGroupBox1.SuspendLayout();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackbarDiskWritePriority)).BeginInit();
@@ -60,6 +62,13 @@ namespace XenAdmin.SettingsPanels
             // 
             resources.ApplyResources(this.labelBlurb, "labelBlurb");
             this.labelBlurb.Name = "labelBlurb";
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.decentGroupBox1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.labelBlurb, 0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // decentGroupBox1
             // 
@@ -200,9 +209,10 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.Window;
-            this.Controls.Add(this.decentGroupBox1);
-            this.Controls.Add(this.labelBlurb);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "WlbMetricWeightingPage";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.decentGroupBox1.ResumeLayout(false);
             this.decentGroupBox1.PerformLayout();
             this.panel1.ResumeLayout(false);
@@ -220,6 +230,7 @@ namespace XenAdmin.SettingsPanels
         #endregion
 
         private XenAdmin.Controls.DecentGroupBox decentGroupBox1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Label labelMoreImportant;
         private System.Windows.Forms.Label labelLessImportant;

--- a/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.cs
@@ -52,6 +52,7 @@ namespace XenAdmin.SettingsPanels
         private WlbPoolConfiguration _poolConfiguration;
         private bool _loading = false;
         private bool _hasChanged = false;
+        private XenAdmin.Network.IXenConnection _connection;
 
         public WlbMetricWeightingPage()
         {
@@ -72,6 +73,17 @@ namespace XenAdmin.SettingsPanels
             }
         }
 
+        public XenAdmin.Network.IXenConnection Connection
+        {
+            set
+            {
+                if (null != value)
+                {
+                    _connection = value;
+                }
+            }
+        }
+
         private void InitializeControls()
         {
             _loading = true;
@@ -81,6 +93,16 @@ namespace XenAdmin.SettingsPanels
             trackbarNetWritePriority.Value = GetSafeTrackbarValue(trackbarNetWritePriority, _poolConfiguration.VmNetworkWriteWeightHigh / TRACKBAR_INTERVAL);
             trackbarDiskReadPriority.Value = GetSafeTrackbarValue(trackbarDiskReadPriority, _poolConfiguration.VmDiskReadWeightHigh / TRACKBAR_INTERVAL);
             trackbarDiskWritePriority.Value = GetSafeTrackbarValue(trackbarDiskWritePriority, _poolConfiguration.VmDiskWriteWeightHigh / TRACKBAR_INTERVAL);
+            // CA-194940:
+            // Host disk read/write threshold and weight settings work since Dundee.
+            // For previous XenServer, hide the host disk read/write settings.
+            if (!Helpers.DundeeOrGreater(_connection))
+            {
+                trackbarDiskReadPriority.Visible = false;
+                trackbarDiskWritePriority.Visible = false;
+                label10.Visible = false;
+                label11.Visible = false;
+            }
             _loading = false; ;
         }
 

--- a/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.resx
+++ b/XenAdmin/SettingsPanels/Wlb/WlbMetricWeightingPage.resx
@@ -145,13 +145,16 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelBlurb.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelBlurb.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="decentGroupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
+  </data>
+  <data name="decentGroupBox1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -580,10 +583,40 @@
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;decentGroupBox1.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;decentGroupBox1.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>587, 315</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>39</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="decentGroupBox1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelBlurb" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="labelMoreImportant.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/XenAdmin/SettingsPanels/Wlb/WlbThresholdsPage.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbThresholdsPage.cs
@@ -50,6 +50,7 @@ namespace XenAdmin.SettingsPanels
         private WlbPoolConfiguration _poolConfiguration;
         private bool _loading = false;
         private bool _hasChanged = false;
+        private XenAdmin.Network.IXenConnection _connection;
 
         public WlbThresholdsPage()
         {
@@ -70,6 +71,18 @@ namespace XenAdmin.SettingsPanels
             }
         }
 
+         public XenAdmin.Network.IXenConnection Connection
+         {
+             set
+             {
+                 if (null != value)
+                 {
+                     _connection = value;
+                 }
+             }
+         }
+
+
         private void InitializeControls()
         {
             _loading = true;
@@ -86,7 +99,19 @@ namespace XenAdmin.SettingsPanels
             labelDiskWriteUnits.Text = string.Format(labelDiskWriteUnits.Text, updownDiskWriteCriticalPoint.Minimum, updownDiskWriteCriticalPoint.Maximum);
             labelNetworkReadUnits.Text = string.Format(labelNetworkReadUnits.Text, updownNetworkReadCriticalPoint.Minimum, updownNetworkReadCriticalPoint.Maximum);
             labelNetworkWriteUnits.Text = string.Format(labelNetworkWriteUnits.Text, updownNetworkWriteCriticalPoint.Minimum, updownNetworkWriteCriticalPoint.Maximum);
-            
+
+            // CA-194940:
+            // Host disk read/write threshold and weight settings work since Dundee.
+            // For previous XenServer, hide the host disk read/write settings.
+            if (!Helpers.DundeeOrGreater(_connection))
+            {
+                updownDiskReadCriticalPoint.Visible = false;
+                updownDiskWriteCriticalPoint.Visible = false;
+                labelDiskReadUnits.Visible = false;
+                labelDiskWriteUnits.Visible = false;
+                labelDiskRead.Visible = false;
+                label1DiskWrite.Visible = false;
+            }
             _loading = false; ;
         }
 


### PR DESCRIPTION
1. Check the Xenserver platform version and display the host disk read/write
threshold and metric weighting for Dundee or later XenServer.
2. Update the metric weighting page to make it autosize-able.

Signed-off-by: Hui Zhang <hui.zhang@citrix.com>