### PR TITLE
CA-187681: Improvement for VM.IsWindows property

### DIFF
--- a/XenModel/XenAPI-Extensions/VM_guest_metrics.cs
+++ b/XenModel/XenAPI-Extensions/VM_guest_metrics.cs
@@ -29,16 +29,46 @@
  * SUCH DAMAGE.
  */
 
+using System.Linq;
+
 namespace XenAPI
 {
     public partial class VM_guest_metrics
     {
+        /// <summary>
+        /// List of distro values that we treat as Linux/Non-Windows (written by Linux Guest Agent, evaluating xe-linux-distribution)
+        /// </summary>
+        private readonly string[] linuxDistros = { "debian", "rhel", "fedora", "centos", "scientific", "oracle", "sles", "lsb", "boot2docker", "freebsd" };
+        
         //This will tell if they are install (but they may not be upto date!)
         public bool PV_drivers_installed
         {
             get
             {
                 return PV_drivers_version.ContainsKey("major") && PV_drivers_version.ContainsKey("minor");
+            }
+        }
+
+        /// <summary>
+        /// Returns true if (it is known that) this VM_guest_metrics belongs to a non-Windows VM.
+        /// (Returns false if the VM is Windows or unknown)
+        /// </summary>
+        /// <param name="gm"></param>
+        /// <returns></returns>
+        public bool IsVmNotWindows
+        {
+            get
+            {
+                if (this.os_version != null)
+                {
+                    if (this.os_version.ContainsKey("distro") && !string.IsNullOrEmpty(this.os_version["distro"]) && linuxDistros.Contains(this.os_version["distro"].ToLowerInvariant()))
+                        return true;
+
+                    if (this.os_version.ContainsKey("uname") && this.os_version["uname"].ToLowerInvariant().Contains("netscaler"))
+                        return true;
+                }
+
+                return false;
             }
         }
     }


### PR DESCRIPTION
VM.IsWindows  will try to use guest_metrics referenced by the last_booted_record when the guest_metrics on the VM is not available.
This gives some extra chance to detect a Non-Windows VM.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>