### PR TITLE
CA-159790: [XSO-208] MeddlingActions don't show location information

### DIFF
--- a/XenAdmin/Core/ActionBaseExtensions.cs
+++ b/XenAdmin/Core/ActionBaseExtensions.cs
@@ -153,6 +153,9 @@ namespace XenAdmin.Core
             if (action.Pool != null)
                 return action.Pool.Name;
 
+            if (action.Connection != null)
+                return action.Connection.FriendlyName;
+
             return string.Empty;
         }
 

--- a/XenAdmin/Diagnostics/Problems/VmApplianceProblem/RunningVmApplianceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VmApplianceProblem/RunningVmApplianceProblem.cs
@@ -102,8 +102,8 @@ namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
                 else
                     actions.Add(new VMHardShutdown(vm));
             }
-            return new MultipleAction(VmAppliance.Connection, Messages.ACTION_VM_SHUTTING_DOWN,
-                                      Messages.ACTION_VM_SHUTTING_DOWN, Messages.ACTION_VM_SHUT_DOWN, actions);
+            return new MultipleAction(VmAppliance.Connection, Messages.ACTION_SHUTTING_DOWN,
+                                      Messages.ACTION_SHUTTING_DOWN, Messages.ACTION_SHUT_DOWN, actions);
         }
     }
 }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -1726,6 +1726,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shut down.
+        /// </summary>
+        public static string ACTION_SHUT_DOWN {
+            get {
+                return ResourceManager.GetString("ACTION_SHUT_DOWN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete VM.
         /// </summary>
         public static string ACTION_SHUTDOWN_AND_DESTROY_VM_TITLE {
@@ -1740,6 +1749,15 @@ namespace XenAdmin {
         public static string ACTION_SHUTDOWN_AND_DESTROY_VMS_TITLE {
             get {
                 return ResourceManager.GetString("ACTION_SHUTDOWN_AND_DESTROY_VMS_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shutting down.
+        /// </summary>
+        public static string ACTION_SHUTTING_DOWN {
+            get {
+                return ResourceManager.GetString("ACTION_SHUTTING_DOWN", resourceCulture);
             }
         }
         
@@ -2860,7 +2878,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rebooting.
+        ///   Looks up a localized string similar to Rebooting VM.
         /// </summary>
         public static string ACTION_VM_REBOOTING {
             get {
@@ -2887,7 +2905,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resuming.
+        ///   Looks up a localized string similar to Resuming VM.
         /// </summary>
         public static string ACTION_VM_RESUMING {
             get {
@@ -2950,7 +2968,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Shutting down.
+        ///   Looks up a localized string similar to Shutting down VM.
         /// </summary>
         public static string ACTION_VM_SHUTTING_DOWN {
             get {
@@ -2995,7 +3013,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starting.
+        ///   Looks up a localized string similar to Starting VM.
         /// </summary>
         public static string ACTION_VM_STARTING {
             get {
@@ -3058,7 +3076,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Suspending.
+        ///   Looks up a localized string similar to Suspending VM.
         /// </summary>
         public static string ACTION_VM_SUSPENDING {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -678,6 +678,12 @@
   <data name="ACTION_SHUTDOWN_AND_DESTROY_VM_TITLE" xml:space="preserve">
     <value>Delete VM</value>
   </data>
+  <data name="ACTION_SHUTTING_DOWN" xml:space="preserve">
+    <value>Shutting down</value>
+  </data>
+  <data name="ACTION_SHUT_DOWN" xml:space="preserve">
+    <value>Shut down</value>
+  </data>
   <data name="ACTION_SRS_DESTROYING" xml:space="preserve">
     <value>Destroying SRs</value>
   </data>
@@ -1063,7 +1069,7 @@
     <value>Rebooted</value>
   </data>
   <data name="ACTION_VM_REBOOTING" xml:space="preserve">
-    <value>Rebooting</value>
+    <value>Rebooting VM</value>
   </data>
   <data name="ACTION_VM_REBOOTING_TITLE" xml:space="preserve">
     <value>Rebooting VM '{0}' on '{1}'</value>
@@ -1072,7 +1078,7 @@
     <value>Resumed</value>
   </data>
   <data name="ACTION_VM_RESUMING" xml:space="preserve">
-    <value>Resuming</value>
+    <value>Resuming VM</value>
   </data>
   <data name="ACTION_VM_RESUMING_ON_TITLE" xml:space="preserve">
     <value>Resuming VM '{0}' on '{1}'</value>
@@ -1090,7 +1096,7 @@
     <value>Revert snapshot '{0}'</value>
   </data>
   <data name="ACTION_VM_SHUTTING_DOWN" xml:space="preserve">
-    <value>Shutting down</value>
+    <value>Shutting down VM</value>
   </data>
   <data name="ACTION_VM_SHUTTING_DOWN_TITLE" xml:space="preserve">
     <value>Shutting down VM '{0}' on '{1}'</value>
@@ -1108,7 +1114,7 @@
     <value>Started paused</value>
   </data>
   <data name="ACTION_VM_STARTING" xml:space="preserve">
-    <value>Starting</value>
+    <value>Starting VM</value>
   </data>
   <data name="ACTION_VM_STARTING_ON_TITLE" xml:space="preserve">
     <value>Starting VM '{0}' on '{1}'</value>
@@ -1129,7 +1135,7 @@
     <value>Suspended</value>
   </data>
   <data name="ACTION_VM_SUSPENDING" xml:space="preserve">
-    <value>Suspending</value>
+    <value>Suspending VM</value>
   </data>
   <data name="ACTION_VM_SUSPENDING_TITLE" xml:space="preserve">
     <value>Suspending VM '{0}'</value>


### PR DESCRIPTION
Updated the GetLocation extension method for ActionBase objects to return action.Connection.FriendlyName should it have no Host or Pool set up. This way we see location for MeddlingActions.
Also changed some messages (Task Names) to include "VM" in them too, because xe command line initiated VM lifecycle actions looked really misleading after the above fix in XenCenter (Eg. restarting a VM would show up as "Restarting", "server" which would suggest that not just the VM, but the host is being restarted.)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>