### PR TITLE
CP-14472: Remove the lock in the License Manager and ensure that all the updates are done on the main thread.

### DIFF
--- a/XenAdmin/Dialogs/LicenseManager/LicenseCheckableDataGridView/LicenseCheckableDataGridViewController.cs
+++ b/XenAdmin/Dialogs/LicenseManager/LicenseCheckableDataGridView/LicenseCheckableDataGridViewController.cs
@@ -99,32 +99,31 @@ namespace XenAdmin.Controls
             if (comparer == null || columnIndex < 0)
                 return;
 
-            lock (StoredRowsLock)
+            Program.AssertOnEventThread();
+
+            View.SuspendDrawing();
+            try
             {
-                View.SuspendDrawing();
-                try
-                {
-                    View.DrawAllRowsAsClearedMW();
-                    storedRows.Sort(comparer);
+                View.DrawAllRowsAsClearedMW();
+                storedRows.Sort(comparer);
 
-                    if(CurrentSortDirection == SortDirection.Descending)
-                        storedRows.Reverse();
+                if(CurrentSortDirection == SortDirection.Descending)
+                    storedRows.Reverse();
 
-                    foreach (CheckableDataGridViewRow row in storedRows)
-                    {
-                        View.DrawRowMW(row);
-                        LicenseDataGridViewRow lRow = row as LicenseDataGridViewRow;
-                        if (lRow == null)
-                            continue;
-                        LicenseView.DrawStatusIcon(row.Index, lRow.RowStatus);
-                        if (row.Highlighted)
-                            View.DrawRowAsHighlightedMW(true, row.Index);
-                    }
-                }
-                finally
+                foreach (CheckableDataGridViewRow row in storedRows)
                 {
-                    View.ResumeDrawing();
+                    View.DrawRowMW(row);
+                    LicenseDataGridViewRow lRow = row as LicenseDataGridViewRow;
+                    if (lRow == null)
+                        continue;
+                    LicenseView.DrawStatusIcon(row.Index, lRow.RowStatus);
+                    if (row.Highlighted)
+                        View.DrawRowAsHighlightedMW(true, row.Index);
                 }
+            }
+            finally
+            {
+                View.ResumeDrawing();
             }
         }
 

--- a/XenAdmin/Dialogs/LicenseManager/LicenseDataGridViewRow.cs
+++ b/XenAdmin/Dialogs/LicenseManager/LicenseDataGridViewRow.cs
@@ -83,10 +83,10 @@ namespace XenAdmin.Dialogs
             if (RowShouldBeExpanded(XenObject) && DataGridView is LicenseCheckableDataGridView)
             {
                 refreshing = true;
-                TriggerRefreshAllEvent();  
+                Program.Invoke(Program.MainWindow, TriggerRefreshAllEvent);  
             }
             else
-                TriggerCellTextUpdatedEvent();
+                Program.Invoke(Program.MainWindow, TriggerCellTextUpdatedEvent);
         }
 
         public static bool RowShouldBeExpanded(IXenObject xenObject)


### PR DESCRIPTION

- changed the licenseStatus_ItemUpdated event handler to invoke on the main thread, as this is the only case when a background thread needs to update the storedRows list..All the other reads and writes are taken place on the main (UI) thread
- removed the storedRowsLock as it is not needed since we do all the updates to storedRows on one thread.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>