### PR TITLE
CP-15407: Update the function that calculates pool license

### DIFF
--- a/XenModel/XenAPI-Extensions/Pool.cs
+++ b/XenModel/XenAPI-Extensions/Pool.cs
@@ -117,7 +117,7 @@ namespace XenAPI
                 foreach (Host.Edition edition in Enum.GetValues(typeof(Host.Edition)))
                 {
                     Host.Edition edition1 = edition;
-                    Host host = hosts.Find(h => h.edition == Host.GetEditionText(edition1));
+                    Host host = hosts.Find(h => Host.GetEdition(h.edition) == edition1);
 
                     if (host != null)
                     {


### PR DESCRIPTION
Cherry-picked from cream-indigo:
CA-190393: Update the function that calculates pool license
- use Host.GetEdition function, as this function interprets xapi license string "basic" as Free license in XenCenter

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>