### PR TITLE
CP-15922: Investigate and fix WiX installer for InstallDir Extension UI

### DIFF
--- a/mk/patches/wix_src_patch
+++ b/mk/patches/wix_src_patch
@@ -62,6 +62,21 @@ diff -ru wixlib/Common.wxs wixlib/Common.wxs
          <WixVariable Id="WixUICostingPopupOptOut" Value="1" Overridable="yes" />
  
          <UI Id="WixUI_Common">
+@@ -71,5 +71,13 @@
+             <UIText Id="VolumeCostSize">!(loc.UITextVolumeCostSize)</UIText>
+             <UIText Id="VolumeCostVolume">!(loc.UITextVolumeCostVolume)</UIText>
+         </UI>
+-    </Fragment>
++ </Fragment>
++<Fragment>
++    <!-- Validate install directory -->
++    <CustomAction Id="WixUIValidatePath" BinaryKey="WixUIWixca" DllEntry="ValidatePath" Return="ignore" Execute="immediate" />
++</Fragment>
++<Fragment>
++    <Binary Id="WixUIWixca" SourceFile="PrintEula.dll" />
++</Fragment>
++    
+ </Wix>
 diff -ru wixlib/InstallDirDlg.wxs wixlib/InstallDirDlg.wxs
 --- wixlib/InstallDirDlg.wxs	Thu Jan 20 06:13:28 2011 -0800
 +++ wixlib/InstallDirDlg.wxs	Mon Feb 20 18:18:06 2012 +0000

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -148,7 +148,7 @@ cp -r ${WIX_SRC}/src/ext/UIExtension/wixlib ${REPO}/WixInstaller
 
 mkdir_clean ${WIX_BIN}
 ${UNZIP} ${SCRATCH_DIR}/wix39-binaries.zip -d ${WIX_BIN}
-#cp ${WIX_BIN}/PrintEula.dll ${REPO}/WixInstaller
+touch ${REPO}/WixInstaller/PrintEula.dll
 
 #compile_wix
 


### PR DESCRIPTION
This changeset makes it possible to use InstallDir again - it hasn't worked since we changed to 3.9 from 3.5.