### PR TITLE
CA-196231: Don't confuse start-on with migration

### DIFF
--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) Citrix Systems Inc. 
+/* Copyright (c) Citrix Systems Inc. 
  * All rights reserved. 
  * 
  * Redistribution and use in source and binary forms, 
@@ -181,7 +181,7 @@ namespace XenAdmin.Commands
                 var firstItem = (VMOperationToolStripMenuSubItem)base.DropDownItems[0];
 
                 bool oldMigrateToHomeCmdCanRun = cmdHome.CanExecute();
-                if (affinityHost == null || !oldMigrateToHomeCmdCanRun && !cpmCmdHome.CanExecute())
+                if (affinityHost == null || _operation == vm_operations.start_on || !oldMigrateToHomeCmdCanRun && !cpmCmdHome.CanExecute())
                     firstItem.Command = cmdHome;
                 else
                     firstItem.Command = oldMigrateToHomeCmdCanRun ? cmdHome : cpmCmdHome;
@@ -207,7 +207,7 @@ namespace XenAdmin.Commands
                     Program.Invoke(Program.MainWindow, delegate
                                                            {
                                                                bool oldMigrateCmdCanRun = cmd.CanExecute();
-                                                               if (!oldMigrateCmdCanRun && !cpmCmd.CanExecute())
+                                                               if (_operation == vm_operations.start_on || !oldMigrateCmdCanRun && !cpmCmd.CanExecute())
                                                                    tempItem.Command = cmd;
                                                                else
                                                                    tempItem.Command = oldMigrateCmdCanRun ? cmd : cpmCmd;


### PR DESCRIPTION
The "Start on Server" VM context menu incorrectly enabled hosts that a VM can
only be started on after a storage migration.  This was due to the fact that
the VMOperationToolStripMenuItem class is used for both "Start on Server" as
well as "Migrate to Server".

This change ensures that start checks are done when a start is requested, and
migration checks otherwise.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>