### PR TITLE
CP-15405: Copy all DotNetInstaller files to the local folder before b…

### DIFF
--- a/mk/archive-unsigned.sh
+++ b/mk/archive-unsigned.sh
@@ -34,11 +34,6 @@ set -eu
 
 ZIP="zip -q"
 
-#copy all dotNetInstaller files
-DOTNETINSTALLER_FILEPATH="$(which dotNetInstaller.exe)"
-DOTNETINSTALLER_DIRPATH=${DOTNETINSTALLER_FILEPATH%/*}
-cp -R "${DOTNETINSTALLER_DIRPATH}"/* ${DOTNETINST}
-
 #archive unsigned artifacts 
 mkdir_clean ${OUTPUT_DIR}/XenAdminUnsigned
 cp -R ${REPO}/* ${OUTPUT_DIR}/XenAdminUnsigned

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -166,8 +166,9 @@ version_vnccontrol_installer ${WIX}/vnccontrol.wxs
 #copy dotNetInstaller files
 DOTNETINST=${REPO}/dotNetInstaller
 cp ${MICROSOFT_DOTNET_FRAMEWORK_INSTALLER_DIR}/NDP452-KB2901954-Web.exe ${DOTNETINST}
-cp "$(which dotNetInstaller.exe)" ${DOTNETINST}
-cp "$(which InstallerLinker.exe)" ${DOTNETINST}
+DOTNETINSTALLER_FILEPATH="$(which dotNetInstaller.exe)"
+DOTNETINSTALLER_DIRPATH=${DOTNETINSTALLER_FILEPATH%/*}
+cp -R "${DOTNETINSTALLER_DIRPATH}"/* ${DOTNETINST}
 
 # Collect the unsigned files, if the COLLECT_UNSIGNED_FILES is defined 
 # (the variable can be set from the jenkins ui by putting "export COLLECT_UNSIGNED_FILES=1" above the call for build script)


### PR DESCRIPTION
…uilding the installer

- Fixes build error "build-installers.sh: line 134: ./InstallerLinker.exe: Accessing a corrupted shared library"

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>