### PR TITLE
CA-198895: Have parameter Languages back in xencenter.l10n.diff

### DIFF
--- a/WixInstaller/XenCenter.l10n.diff
+++ b/WixInstaller/XenCenter.l10n.diff
@@ -28,8 +28,17 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
 # SUCH DAMAGE.
 
---- XenCenter.wxs	Thu Feb 11 17:06:22 2016
-+++ XenCenter.l10n.wxs	Thu Feb 11 17:00:41 2016
+--- XenCenter.wxs	2016-02-16 11:09:24.524929500 +0800
++++ XenCenter.l10n.wxs	2016-02-16 11:50:37.348205900 +0800
+@@ -38,7 +38,7 @@
+     <?define UpgradeCode="{[BRANDING_XENCENTER_UPGRADE_CODE_GUID]}"?>
+     <?define ProductCode="{65AE1345-A520-456D-8A19-2F52D43D3A09}"?>
+     <Product Id="$(var.ProductCode)" Name="[Citrix] [XenCenter]" Language="$(env.WixLangId)" Version="$(var.ProductVersion)" Manufacturer="[BRANDING_COMPANY_NAME_LEGAL]" UpgradeCode="$(var.UpgradeCode)">
+-        <Package Description="[Citrix] [XenCenter]" Comments="none." InstallerVersion="200" Compressed="yes" />
++        <Package Languages="1033,1041,2052,1028" Description="[Citrix] [XenCenter]" Comments="none." InstallerVersion="200" Compressed="yes" />
+         <Media Id="1" Cabinet="XenCenter.cab" EmbedCab="yes" />
+         <Directory Id="TARGETDIR" Name="SourceDir">
+             <Directory Id="ProgramFilesFolder">
 @@ -86,64 +86,64 @@
                              <File Id="XslicIcon" Source="..\Branding\Images\file_license.ico" />
                              <File Id="XkbIcon" Source="..\Branding\Images\file_backup.ico" />
@@ -174,7 +183,7 @@
              <ComponentRef Id="SchemasFilesComponent" />
              <ComponentRef Id="ExternalToolsComponent" />
              <ComponentRef Id="RegistryEntries" />
-@@ -302,7 +324,7 @@
+@@ -302,7 +326,7 @@
          <Property Id="ARPPRODUCTICON" Value="XenCenterICO" />
          <MajorUpgrade AllowDowngrades="no" AllowSameVersionUpgrades="yes" DowngradeErrorMessage="!(loc.ErrorNewerProduct)" Schedule="afterInstallInitialize"/>
          <PropertyRef Id="NETFRAMEWORK45" />


### PR DESCRIPTION
This fix is to have CN version wizard back in XenCenter installer
Without Language, the l10n installer can only show EN wizard in CN environment.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>