### PR TITLE
CA-198962: Fix compile error of rebranding

### DIFF
--- a/mk/declarations.sh
+++ b/mk/declarations.sh
@@ -154,9 +154,11 @@ if [ "${BUILD_KIND:+$BUILD_KIND}" = production ]
 then
     WEB_LIB="http://admin/linux/distfiles/windows-build"
     WEB_LATEST_BUILD="http://admin/builds/carbon/${XS_BRANCH}/xe-phase-2-latest"
+    REBRANDING_WEB_LATEST_BUILD="http://admin/builds/carbon/${XS_BRANCH}/xe-phase-rebrand-latest"
 else
     WEB_LIB="http://files.uk.xensource.com/linux/distfiles/windows-build"
     WEB_LATEST_BUILD="http://www.uk.xensource.com/carbon/${XS_BRANCH}/xe-phase-2-latest"
+    REBRANDING_WEB_LATEST_BUILD="http://www.uk.xensource.com/carbon/${XS_BRANCH}/xe-phase-rebrand-latest"
 fi
 WEB_XE_PHASE_1=${WEB_LATEST_BUILD}/xe-phase-1
 WEB_XE_PHASE_2=${WEB_LATEST_BUILD}/xe-phase-2

--- a/mk/package-and-sign.sh
+++ b/mk/package-and-sign.sh
@@ -39,7 +39,8 @@ REPO=${XENADMIN_DIR}
 OUTPUT_DIR=${ROOT}/output
 DOTNETINST=${REPO}/dotNetInstaller
 	
-source ${REPO}/Branding/branding.sh
+BRANDING_BRAND_CONSOLE=[XenCenter]
+BRANDING_COMPANY_NAME_SHORT=[Citrix]
 
 WIX=${REPO}/WixInstaller
 WIX_BIN=${WIX}/bin

--- a/mk/re-branding.sh
+++ b/mk/re-branding.sh
@@ -171,6 +171,7 @@ rebranding_global ${REPO}/dotNetInstaller/XenCenterSetupBootstrapper_l10n.xml
 
 #mk
 rebranding_global ${REPO}/mk/ISO_files/AUTORUN.INF
+rebranding_global ${REPO}/mk/package-and-sign.sh
 
 #WixInstaller
 rebranding_global ${REPO}/WixInstaller/en-us.wxl


### PR DESCRIPTION
After this code change, we also need to modify branding.sh for non-citrix build to use:
REBRANDING_WEB_LATEST_BUILD
instead of 
WEB_LATEST_BUILD
Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>