### PR TITLE
CA-198767: Add only-physical-PIFs pool-join constraint

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -23080,7 +23080,7 @@ namespace XenAdmin {
         ///
         ///All configuration required to expose a LUN to the host must be completed manually, including configuring your FCoE fabric, and allocating LUN(s) to your CNA’s public world wide name (PWWN). 
         ///
-        ///Once this configuration has been carried out, this wizard will walk you through discovering and mounting a LUN available to the hosts CNA’s as a SCSI device.  [rest of string was truncated]&quot;;.
+        ///Once this configuration has been carried out, this wizard will walk you through discovering and mounting a LUN available to the hosts CNA’s as a SCSI device. The SC [rest of string was truncated]&quot;;.
         /// </summary>
         public static string NEWSR_LVMOFCOE_BLURB {
             get {
@@ -23102,7 +23102,7 @@ namespace XenAdmin {
         ///
         ///All configuration required to expose a LUN to the host must be completed manually, including storage devices, network devices, and the HBA within the [XenServer] host.
         ///
-        ///Once all configuration is complete the HBA will expose a SCSI device backed by the LUN to the host. The SCSI device can then be used to access the [rest of string was truncated]&quot;;.
+        ///Once all configuration is complete the HBA will expose a SCSI device backed by the LUN to the host. The SCSI device can then be used to access the LUN as if i [rest of string was truncated]&quot;;.
         /// </summary>
         public static string NEWSR_LVMOHBA_BLURB {
             get {
@@ -26488,6 +26488,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This server may not have any bonds, VLANs or cross-server private networks.
+        /// </summary>
+        public static string POOL_JOIN_NOT_PHYSICAL_PIF {
+            get {
+                return ResourceManager.GetString("POOL_JOIN_NOT_PHYSICAL_PIF", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Pool License.
         /// </summary>
         public static string POOL_LICENSE {
@@ -28236,7 +28245,7 @@ namespace XenAdmin {
         ///2. Click the Reboot Now button below to reboot the server and begin the installation.
         ///3. Go to the server’s console and follow the on-screen instructions to install the upgrade.
         ///
-        ///To skip this server and continue to the next server in the pool, click Skip This Server. Note that running a pool with servers on different ve [rest of string was truncated]&quot;;.
+        ///To skip this server and continue to the next server in the pool, click Skip This Server. Note that running a pool with servers on different versions of [X [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ROLLING_UPGRADE_REBOOT_MESSAGE {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9250,6 +9250,9 @@ The VM protection policy for this VM does not have automatic archiving configure
   <data name="POOL_JOIN_IMPOSSIBLE" xml:space="preserve">
     <value>Pool join not possible</value>
   </data>
+  <data name="POOL_JOIN_NOT_PHYSICAL_PIF" xml:space="preserve">
+    <value>This server may not have any bonds, VLANs or cross-server private networks</value>
+  </data>
   <data name="POOL_LICENSE" xml:space="preserve">
     <value>Pool License</value>
   </data>

--- a/XenModel/PoolJoinRules.cs
+++ b/XenModel/PoolJoinRules.cs
@@ -33,7 +33,7 @@ using System;
 using System.Collections.Generic;
 using XenAdmin.Network;
 using XenAPI;
-
+using System.Linq;
 
 namespace XenAdmin.Core
 {
@@ -65,6 +65,7 @@ namespace XenAdmin.Core
             DifferentCPUs,
             DifferentNetworkBackends,
             MasterHasHA,
+            NotPhysicalPif,
             WrongRoleOnMaster,
             WrongRoleOnSlave,
             NotConnected,
@@ -151,6 +152,9 @@ namespace XenAdmin.Core
             if (HaEnabled(masterConnection))
                 return Reason.MasterHasHA;
 
+            if (HasSlaveAnyNonPhysicalPif(slaveConnection))
+                return Reason.NotPhysicalPif;
+
             return Reason.Allowed;
         }
 
@@ -200,6 +204,8 @@ namespace XenAdmin.Core
                     return Messages.DISCONNECTED;
                 case Reason.MasterHasHA:
                     return Messages.POOL_JOIN_FORBIDDEN_BY_HA;
+                case Reason.NotPhysicalPif :
+                    return Messages.POOL_JOIN_NOT_PHYSICAL_PIF;
                 case Reason.WrongRoleOnMaster:
                     return Messages.NEWPOOL_MASTER_ROLE;
                 case Reason.WrongRoleOnSlave:
@@ -604,6 +610,12 @@ namespace XenAdmin.Core
                     return true;
             }
             return false;
+        }
+
+        public static bool HasSlaveAnyNonPhysicalPif(IXenConnection slaveConnection)
+        {
+            return
+                slaveConnection.Cache.PIFs.Any(p => !p.IsPhysical);
         }
     }
 }


### PR DESCRIPTION
There is a new pool join rule in xapi: the joining host may only have physical PIFs, i.e. no bonds, VLANs and tunnels (cross-server private networks). This is checked by asserting that for all PIFs of the joining host, PIF.physical = true. When this occurs, people should be encouraged to manually remove any existing bonds, VLANs or tunnels and try again.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>