### PR TITLE
CA-196643: Check the CPU feature compatibility in StartDiagnosisForm

### DIFF
--- a/XenAdmin/Actions/GUIActions/Wlb/WlbOptimizePoolAction.cs
+++ b/XenAdmin/Actions/GUIActions/Wlb/WlbOptimizePoolAction.cs
@@ -312,7 +312,7 @@ namespace XenAdmin.Actions.Wlb
 
             if (failure.ErrorDescription[0] == Failure.NO_HOSTS_AVAILABLE)
             {
-                VMOperationCommand.StartDiagnosisForm(vm);
+                VMOperationCommand.StartDiagnosisForm(vm, vm.power_state == vm_power_state.Halted);
             }
             else if (failure.ErrorDescription[0] == Failure.HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN)
             {

--- a/XenAdmin/Commands/VMOperationCommand.cs
+++ b/XenAdmin/Commands/VMOperationCommand.cs
@@ -224,7 +224,7 @@ namespace XenAdmin.Commands
         }
 
 
-        public static void StartDiagnosisForm(VM vm)
+        public static void StartDiagnosisForm(VM vm, bool isStart)
         {
             ThreadPool.QueueUserWorkItem(delegate
             {
@@ -246,6 +246,11 @@ namespace XenAdmin.Commands
                     foreach (Host host in connection.Cache.Hosts)
                     {
                         reasons[host] = string.Empty;
+                        if (!isStart && VMOperationHostCommand.VmCpuFeaturesIncompatibleWithHost(host, vm))
+                        {
+                            reasons[host] = FriendlyErrorNames.VM_INCOMPATIBLE_WITH_THIS_HOST;
+                            continue;
+                        }
                         try
                         {
                             VM.assert_can_boot_here(session, vm.opaque_ref, host.opaque_ref);
@@ -276,7 +281,7 @@ namespace XenAdmin.Commands
             if (failure.ErrorDescription[0] == Failure.NO_HOSTS_AVAILABLE)
             {
                 // Show a dialog displaying why the VM couldn't be started on each host
-                StartDiagnosisForm(VMStartAction.VM);
+                StartDiagnosisForm(VMStartAction.VM, VMStartAction.IsStart);
             }
             else if (failure.ErrorDescription[0] == Failure.HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN)
             {


### PR DESCRIPTION
- The StartDiagnosisForm dialog shows the reasons why a VM cannot be started or resumed. XenCenter tries to get these reasons from a call to VM.assert_can_boot_here, but his function does not perform a CPU feature compatibility check.
- This commit adds the CPU feature compatibility check for resume operations.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>