### PR TITLE
CA-202371: Change wording on VM Advanced options page

### DIFF
--- a/XenAdmin/SettingsPanels/VMAdvancedEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/VMAdvancedEditPage.Designer.cs
@@ -31,15 +31,13 @@ namespace XenAdmin.SettingsPanels
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(VMAdvancedEditPage));
             this.GeneralOptimizationRadioButton = new System.Windows.Forms.RadioButton();
             this.CPSOptimizationRadioButton = new System.Windows.Forms.RadioButton();
-            this.ManualOptimizationRadioButton = new System.Windows.Forms.RadioButton();
             this.labelWarning = new System.Windows.Forms.Label();
-            this.ManualOptimizationGroupBox = new XenAdmin.Controls.DecentGroupBox();
-            this.ShadowMultiplierTextBox = new System.Windows.Forms.TextBox();
-            this.labelShadowMultiplier = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.iconWarning = new System.Windows.Forms.PictureBox();
-            this.ManualOptimizationGroupBox.SuspendLayout();
+            this.ManualOptimizationRadioButton = new System.Windows.Forms.RadioButton();
+            this.ShadowMultiplierTextBox = new System.Windows.Forms.TextBox();
+            this.labelShadowMultiplier = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.iconWarning)).BeginInit();
             this.SuspendLayout();
@@ -48,6 +46,7 @@ namespace XenAdmin.SettingsPanels
             // 
             resources.ApplyResources(this.GeneralOptimizationRadioButton, "GeneralOptimizationRadioButton");
             this.GeneralOptimizationRadioButton.Checked = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.GeneralOptimizationRadioButton, 3);
             this.GeneralOptimizationRadioButton.Name = "GeneralOptimizationRadioButton";
             this.GeneralOptimizationRadioButton.TabStop = true;
             this.GeneralOptimizationRadioButton.UseVisualStyleBackColor = true;
@@ -56,78 +55,72 @@ namespace XenAdmin.SettingsPanels
             // CPSOptimizationRadioButton
             // 
             resources.ApplyResources(this.CPSOptimizationRadioButton, "CPSOptimizationRadioButton");
+            this.tableLayoutPanel1.SetColumnSpan(this.CPSOptimizationRadioButton, 3);
             this.CPSOptimizationRadioButton.Name = "CPSOptimizationRadioButton";
             this.CPSOptimizationRadioButton.UseVisualStyleBackColor = true;
             this.CPSOptimizationRadioButton.CheckedChanged += new System.EventHandler(this.CPSOptimizationRadioButton_CheckedChanged);
             // 
-            // ManualOptimizationRadioButton
-            // 
-            resources.ApplyResources(this.ManualOptimizationRadioButton, "ManualOptimizationRadioButton");
-            this.ManualOptimizationRadioButton.Name = "ManualOptimizationRadioButton";
-            this.ManualOptimizationRadioButton.UseVisualStyleBackColor = true;
-            this.ManualOptimizationRadioButton.CheckedChanged += new System.EventHandler(this.ManualOptimizationRadioButton_CheckedChanged);
-            // 
             // labelWarning
             // 
             resources.ApplyResources(this.labelWarning, "labelWarning");
+            this.tableLayoutPanel1.SetColumnSpan(this.labelWarning, 2);
             this.labelWarning.Name = "labelWarning";
             // 
-            // ManualOptimizationGroupBox
+            // tableLayoutPanel1
             // 
-            resources.ApplyResources(this.ManualOptimizationGroupBox, "ManualOptimizationGroupBox");
-            this.ManualOptimizationGroupBox.Controls.Add(this.ShadowMultiplierTextBox);
-            this.ManualOptimizationGroupBox.Controls.Add(this.labelShadowMultiplier);
-            this.ManualOptimizationGroupBox.Name = "ManualOptimizationGroupBox";
-            this.ManualOptimizationGroupBox.TabStop = false;
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.GeneralOptimizationRadioButton, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.CPSOptimizationRadioButton, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.iconWarning, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.labelWarning, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.ManualOptimizationRadioButton, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.ShadowMultiplierTextBox, 2, 4);
+            this.tableLayoutPanel1.Controls.Add(this.labelShadowMultiplier, 1, 4);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.tableLayoutPanel1.SetColumnSpan(this.label1, 3);
+            this.label1.Name = "label1";
+            // 
+            // iconWarning
+            // 
+            this.iconWarning.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.iconWarning, "iconWarning");
+            this.iconWarning.Name = "iconWarning";
+            this.iconWarning.TabStop = false;
+            // 
+            // ManualOptimizationRadioButton
+            // 
+            resources.ApplyResources(this.ManualOptimizationRadioButton, "ManualOptimizationRadioButton");
+            this.tableLayoutPanel1.SetColumnSpan(this.ManualOptimizationRadioButton, 3);
+            this.ManualOptimizationRadioButton.Name = "ManualOptimizationRadioButton";
+            this.ManualOptimizationRadioButton.UseVisualStyleBackColor = true;
             // 
             // ShadowMultiplierTextBox
             // 
             resources.ApplyResources(this.ShadowMultiplierTextBox, "ShadowMultiplierTextBox");
             this.ShadowMultiplierTextBox.Name = "ShadowMultiplierTextBox";
+            this.ShadowMultiplierTextBox.Enter += new System.EventHandler(this.ShadowMultiplierTextBox_Enter);
             // 
             // labelShadowMultiplier
             // 
             resources.ApplyResources(this.labelShadowMultiplier, "labelShadowMultiplier");
             this.labelShadowMultiplier.Name = "labelShadowMultiplier";
             // 
-            // tableLayoutPanel1
-            // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // label1
-            // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
-            // 
-            // iconWarning
-            // 
-            resources.ApplyResources(this.iconWarning, "iconWarning");
-            this.iconWarning.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
-            this.iconWarning.Name = "iconWarning";
-            this.iconWarning.TabStop = false;
-            // 
             // VMAdvancedEditPage
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Controls.Add(this.labelWarning);
-            this.Controls.Add(this.iconWarning);
-            this.Controls.Add(this.ManualOptimizationRadioButton);
-            this.Controls.Add(this.CPSOptimizationRadioButton);
-            this.Controls.Add(this.GeneralOptimizationRadioButton);
-            this.Controls.Add(this.ManualOptimizationGroupBox);
             this.DoubleBuffered = true;
             this.Name = "VMAdvancedEditPage";
-            this.ManualOptimizationGroupBox.ResumeLayout(false);
-            this.ManualOptimizationGroupBox.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.iconWarning)).EndInit();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -136,7 +129,6 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.RadioButton GeneralOptimizationRadioButton;
         private System.Windows.Forms.RadioButton CPSOptimizationRadioButton;
         private System.Windows.Forms.RadioButton ManualOptimizationRadioButton;
-        private XenAdmin.Controls.DecentGroupBox ManualOptimizationGroupBox;
         private System.Windows.Forms.TextBox ShadowMultiplierTextBox;
         private System.Windows.Forms.Label labelShadowMultiplier;
         private System.Windows.Forms.PictureBox iconWarning;

--- a/XenAdmin/SettingsPanels/VMAdvancedEditPage.cs
+++ b/XenAdmin/SettingsPanels/VMAdvancedEditPage.cs
@@ -52,6 +52,7 @@ namespace XenAdmin.SettingsPanels
         private static double SHADOW_MULTIPLIER_CPS = 4.0;
         private readonly ToolTip m_invalidParamToolTip;
         private VM vm = null;
+        private bool showCpsOptimisation;
 
         public VMAdvancedEditPage()
         {
@@ -65,7 +66,7 @@ namespace XenAdmin.SettingsPanels
                     ToolTipIcon = ToolTipIcon.Warning,
                     ToolTipTitle = Messages.INVALID_PARAMETER
                 };
-            this.CPSOptimizationRadioButton.Visible = !HiddenFeatures.CPSOptimizationHidden;
+            this.CPSOptimizationRadioButton.Visible = showCpsOptimisation = !HiddenFeatures.CPSOptimizationHidden;
         }
 
         public String SubText
@@ -107,7 +108,7 @@ namespace XenAdmin.SettingsPanels
             if (vm.power_state == vm_power_state.Suspended || vm.power_state == vm_power_state.Paused)
             {
                 CPSOptimizationRadioButton.Enabled = GeneralOptimizationRadioButton.Enabled = ManualOptimizationRadioButton.Enabled = false;
-                ManualOptimizationGroupBox.Enabled = labelShadowMultiplier.Enabled = ShadowMultiplierTextBox.Enabled = false;
+                labelShadowMultiplier.Enabled = ShadowMultiplierTextBox.Enabled = false;
                 iconWarning.Visible = labelWarning.Visible = true;
             }
             else
@@ -118,7 +119,7 @@ namespace XenAdmin.SettingsPanels
             {
                 GeneralOptimizationRadioButton.Checked = true;
             }
-            else if (mul == SHADOW_MULTIPLIER_CPS)
+            else if (mul == SHADOW_MULTIPLIER_CPS && showCpsOptimisation)
             {
                 CPSOptimizationRadioButton.Checked = true;
             }
@@ -198,17 +199,19 @@ namespace XenAdmin.SettingsPanels
 
         private void GeneralOptimizationRadioButton_CheckedChanged(object sender, EventArgs e)
         {
-            ShadowValue = SHADOW_MULTIPLIER_GENERAL_USE;
+            if (GeneralOptimizationRadioButton.Checked) 
+                ShadowValue = SHADOW_MULTIPLIER_GENERAL_USE;
         }
 
         private void CPSOptimizationRadioButton_CheckedChanged(object sender, EventArgs e)
         {
-            ShadowValue = SHADOW_MULTIPLIER_CPS;
+            if (CPSOptimizationRadioButton.Checked)
+                ShadowValue = SHADOW_MULTIPLIER_CPS;
         }
 
-        private void ManualOptimizationRadioButton_CheckedChanged(object sender, EventArgs e)
+        private void ShadowMultiplierTextBox_Enter(object sender, EventArgs e)
         {
-            ManualOptimizationGroupBox.Enabled = ManualOptimizationRadioButton.Checked;
+            ManualOptimizationRadioButton.Checked = true;
         }
     }
 }

--- a/XenAdmin/SettingsPanels/VMAdvancedEditPage.resx
+++ b/XenAdmin/SettingsPanels/VMAdvancedEditPage.resx
@@ -118,309 +118,312 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="labelShadowMultiplier.AutoSize" type="System.Boolean, mscorlib">
+  <data name="GeneralOptimizationRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="GeneralOptimizationRadioButton.Text" xml:space="preserve">
-    <value>Optimize for &amp;general use</value>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="label1.AccessibleName" xml:space="preserve">
+    <value>c</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="ManualOptimizationRadioButton.Text" xml:space="preserve">
-    <value>Optimize manually (&amp;advanced use only)</value>
-  </data>
-  <data name="&gt;&gt;GeneralOptimizationRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ManualOptimizationRadioButton.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="&gt;&gt;labelShadowMultiplier.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ManualOptimizationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 17</value>
-  </data>
-  <data name="CPSOptimizationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 150</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>VMAdvancedEditPage</value>
-  </data>
-  <data name="&gt;&gt;ShadowMultiplierTextBox.Name" xml:space="preserve">
-    <value>ShadowMultiplierTextBox</value>
-  </data>
-  <data name="&gt;&gt;ShadowMultiplierTextBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ShadowMultiplierTextBox.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Verdana, 8.25pt</value>
-  </data>
-  <data name="&gt;&gt;iconWarning.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;labelWarning.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="CPSOptimizationRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;ManualOptimizationRadioButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CPSOptimizationRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="iconWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 185</value>
-  </data>
-  <data name="&gt;&gt;CPSOptimizationRadioButton.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="ShadowMultiplierTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ShadowMultiplierTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CPSOptimizationRadioButton.Text" xml:space="preserve">
-    <value>Optimize for [Citrix] &amp;XenApp</value>
-  </data>
-  <data name="iconWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 3</value>
   </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 3, 3, 12</value>
   </data>
-  <data name="&gt;&gt;ShadowMultiplierTextBox.Parent" xml:space="preserve">
-    <value>ManualOptimizationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;ManualOptimizationGroupBox.Name" xml:space="preserve">
-    <value>ManualOptimizationGroupBox</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ManualOptimizationGroupBox.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>507, 13</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>653, 41</value>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Use these options to optimize this VM for increased performance in different environments.</value>
   </data>
-  <data name="ManualOptimizationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 70</value>
-  </data>
-  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="GeneralOptimizationRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="ShadowMultiplierTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
-  </data>
-  <data name="ManualOptimizationGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>96, 96</value>
-  </data>
-  <data name="labelShadowMultiplier.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ManualOptimizationRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="iconWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 16</value>
-  </data>
-  <data name="GeneralOptimizationRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;GeneralOptimizationRadioButton.Name" xml:space="preserve">
-    <value>GeneralOptimizationRadioButton</value>
-  </data>
-  <data name="ManualOptimizationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 72</value>
-  </data>
-  <data name="labelWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 187</value>
-  </data>
-  <data name="&gt;&gt;iconWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ManualOptimizationRadioButton.Name" xml:space="preserve">
-    <value>ManualOptimizationRadioButton</value>
-  </data>
-  <data name="labelWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;CPSOptimizationRadioButton.Name" xml:space="preserve">
-    <value>CPSOptimizationRadioButton</value>
-  </data>
-  <data name="&gt;&gt;CPSOptimizationRadioButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="ManualOptimizationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>359, 72</value>
-  </data>
-  <data name="CPSOptimizationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 17</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;GeneralOptimizationRadioButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="GeneralOptimizationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 17</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
-  </data>
-  <data name="labelWarning.Text" xml:space="preserve">
-    <value>These settings cannot be adjusted when the VM is suspended</value>
-  </data>
-  <data name="&gt;&gt;iconWarning.Name" xml:space="preserve">
-    <value>iconWarning</value>
-  </data>
-  <data name="labelWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>301, 13</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;labelShadowMultiplier.Name" xml:space="preserve">
-    <value>labelShadowMultiplier</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GeneralOptimizationRadioButton.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CPSOptimizationRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ManualOptimizationGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="ShadowMultiplierTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 27</value>
-  </data>
-  <data name="iconWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>653, 423</value>
-  </data>
-  <data name="ManualOptimizationRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="GeneralOptimizationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 47</value>
-  </data>
-  <data name="labelWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;ManualOptimizationGroupBox.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="labelWarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50" /&gt;&lt;Rows Styles="Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="ManualOptimizationRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CPSOptimizationRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;labelWarning.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;labelWarning.Name" xml:space="preserve">
-    <value>labelWarning</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>653, 41</value>
-  </data>
-  <data name="&gt;&gt;labelWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="labelShadowMultiplier.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 30</value>
-  </data>
-  <data name="labelShadowMultiplier.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 13</value>
-  </data>
-  <data name="&gt;&gt;labelShadowMultiplier.Parent" xml:space="preserve">
-    <value>ManualOptimizationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;labelShadowMultiplier.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ManualOptimizationGroupBox.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="labelShadowMultiplier.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="CPSOptimizationRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="labelShadowMultiplier.Text" xml:space="preserve">
-    <value>Shadow memory &amp;multiplier:</value>
+  <data name="CPSOptimizationRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CPSOptimizationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 54</value>
+  </data>
+  <data name="CPSOptimizationRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 3, 3, 3</value>
+  </data>
+  <data name="CPSOptimizationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 17</value>
+  </data>
+  <data name="CPSOptimizationRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="CPSOptimizationRadioButton.Text" xml:space="preserve">
+    <value>Optimize for [Citrix] &amp;XenApp</value>
+  </data>
+  <data name="&gt;&gt;CPSOptimizationRadioButton.Name" xml:space="preserve">
+    <value>CPSOptimizationRadioButton</value>
+  </data>
+  <data name="&gt;&gt;CPSOptimizationRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CPSOptimizationRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;CPSOptimizationRadioButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="iconWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="iconWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 134</value>
+  </data>
+  <data name="iconWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 4, 3, 3</value>
+  </data>
+  <data name="iconWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="iconWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;iconWarning.Name" xml:space="preserve">
+    <value>iconWarning</value>
+  </data>
+  <data name="&gt;&gt;iconWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;iconWarning.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;iconWarning.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="labelWarning.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>32, 135</value>
+  </data>
+  <data name="labelWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 5, 3, 0</value>
+  </data>
+  <data name="labelWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>301, 13</value>
+  </data>
+  <data name="labelWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="labelWarning.Text" xml:space="preserve">
+    <value>These settings cannot be adjusted when the VM is suspended</value>
+  </data>
+  <data name="&gt;&gt;labelWarning.Name" xml:space="preserve">
+    <value>labelWarning</value>
+  </data>
+  <data name="&gt;&gt;labelWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelWarning.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelWarning.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="ManualOptimizationRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ManualOptimizationRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ManualOptimizationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 77</value>
+  </data>
+  <data name="ManualOptimizationRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 3, 3, 3</value>
+  </data>
+  <data name="ManualOptimizationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>208, 17</value>
+  </data>
+  <data name="ManualOptimizationRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
+  </data>
+  <data name="ManualOptimizationRadioButton.Text" xml:space="preserve">
+    <value>Optimize manually (&amp;advanced use only)</value>
+  </data>
+  <data name="&gt;&gt;ManualOptimizationRadioButton.Name" xml:space="preserve">
+    <value>ManualOptimizationRadioButton</value>
   </data>
   <data name="&gt;&gt;ManualOptimizationRadioButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;ManualOptimizationRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;ManualOptimizationRadioButton.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="ShadowMultiplierTextBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Verdana, 8.25pt</value>
+  </data>
+  <data name="ShadowMultiplierTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>182, 101</value>
+  </data>
+  <data name="ShadowMultiplierTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 4, 3, 8</value>
+  </data>
+  <data name="ShadowMultiplierTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 21</value>
+  </data>
+  <data name="ShadowMultiplierTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ShadowMultiplierTextBox.Name" xml:space="preserve">
+    <value>ShadowMultiplierTextBox</value>
+  </data>
+  <data name="&gt;&gt;ShadowMultiplierTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ShadowMultiplierTextBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;ShadowMultiplierTextBox.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="labelShadowMultiplier.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelShadowMultiplier.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelShadowMultiplier.Location" type="System.Drawing.Point, System.Drawing">
+    <value>45, 105</value>
+  </data>
+  <data name="labelShadowMultiplier.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>16, 8, 3, 8</value>
+  </data>
+  <data name="labelShadowMultiplier.Size" type="System.Drawing.Size, System.Drawing">
+    <value>131, 13</value>
+  </data>
+  <data name="labelShadowMultiplier.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="labelShadowMultiplier.Text" xml:space="preserve">
+    <value>Shadow memory &amp;multiplier:</value>
+  </data>
+  <data name="&gt;&gt;labelShadowMultiplier.Name" xml:space="preserve">
+    <value>labelShadowMultiplier</value>
+  </data>
+  <data name="&gt;&gt;labelShadowMultiplier.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelShadowMultiplier.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelShadowMultiplier.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>515, 299</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="GeneralOptimizationRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="CPSOptimizationRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="iconWarning" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelWarning" Row="5" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="ManualOptimizationRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="ShadowMultiplierTextBox" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="labelShadowMultiplier" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,29,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="GeneralOptimizationRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GeneralOptimizationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 31</value>
+  </data>
+  <data name="GeneralOptimizationRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 3, 3, 3</value>
+  </data>
+  <data name="GeneralOptimizationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 17</value>
+  </data>
   <data name="GeneralOptimizationRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>You can optimize this VM for increased performance in different environments. Use the preset choices to configure it for general use or to enhance Citrix XenApp performance. Alternatively, advanced users can select the manual setting for custom optimization.</value>
+  <data name="GeneralOptimizationRadioButton.Text" xml:space="preserve">
+    <value>Optimize for &amp;general use</value>
+  </data>
+  <data name="&gt;&gt;GeneralOptimizationRadioButton.Name" xml:space="preserve">
+    <value>GeneralOptimizationRadioButton</value>
+  </data>
+  <data name="&gt;&gt;GeneralOptimizationRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GeneralOptimizationRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;GeneralOptimizationRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>515, 299</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>VMAdvancedEditPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/XenAdmin/Wizards/NewVMWizard/Page_Name.ja.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Name.ja.resx
@@ -283,7 +283,7 @@
     <value>0</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>この新規仮想マシンを識別するための名前を入力します。ソフトウェアやハードウェアの違いがわかるような名前を使用すると便利です (RHEL DHCP Server、Win2K3 XenApp Server、Exchange 2007 Client Access Server など)。この名前は [XenCenter] のリソース ペインに表示され、後で変更することができます。
+    <value>この新規仮想マシンを識別するための名前を入力します。ソフトウェアやハードウェアの違いがわかるような名前を使用すると便利です (RHEL DHCP Server、Exchange 2007 Client Access Server など)。この名前は [XenCenter] のリソース ペインに表示され、後で変更することができます。
 
 必要に応じて、より詳細な情報を説明として追加することもできます。</value>
   </data>

--- a/XenAdmin/Wizards/NewVMWizard/Page_Name.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Name.resx
@@ -283,7 +283,7 @@
     <value>0</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>Enter a name that will help you to identify the virtual machine later. This could be a name that describes its software and hardware such as RHEL DHCP Server, Win2K3 XenApp Server or Exchange 2007 Client Access Server. This name will also be displayed in [XenCenter]'s Resources pane and can be changed later.
+    <value>Enter a name that will help you to identify the virtual machine later. This could be a name that describes its software and hardware such as RHEL DHCP Server or Exchange 2007 Client Access Server. This name will also be displayed in [XenCenter]'s Resources pane and can be changed later.
 
 You can also add a more detailed description of the VM, if you wish.</value>
   </data>

--- a/XenAdmin/Wizards/NewVMWizard/Page_Name.zh-CN.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Name.zh-CN.resx
@@ -283,7 +283,7 @@
     <value>0</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>输入有助于以后识别虚拟机的名称。此名称可以描述其软件和硬件，例如 RHEL DHCP Server、Win2K3 XenApp Server 或 Exchange 2007 Client Access Server。此名称还将显示在 [XenCenter] 的资源窗格中，以后可以更改。
+    <value>输入有助于以后识别虚拟机的名称。此名称可以描述其软件和硬件，例如 RHEL DHCP Server 或 Exchange 2007 Client Access Server。此名称还将显示在 [XenCenter] 的资源窗格中，以后可以更改。
 
 如果愿意，还可以添加更加详细的 VM 说明。</value>
   </data>


### PR DESCRIPTION
- Changes to the the layout: order of radio buttons, removed group box around the manual setting of shadow multiplier;
- Shadow multiplier edit box no longer disabled when "Optimize manually" not checked

- Also changed the wording on the Name page of the new VM wizard