### PR TITLE
CA-202076: Some logs in Server Status Report don't have description

### DIFF
--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -142,6 +142,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Tests for connectivity between [XenServer] and the internet.
+        /// </summary>
+        public static string Description_host_system_status_conntest {
+            get {
+                return ResourceManager.GetString("Description-host.system_status-conntest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Information and statistics about the system&apos;s control groups.
         /// </summary>
         public static string Description_host_system_status_control_slice {
@@ -1245,6 +1254,15 @@ namespace XenAdmin {
         public static string Label_host_system_status_client_logs {
             get {
                 return ResourceManager.GetString("Label-host.system_status-client-logs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Connection test.
+        /// </summary>
+        public static string Label_host_system_status_conntest {
+            get {
+                return ResourceManager.GetString("Label-host.system_status-conntest", resourceCulture);
             }
         }
         

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1850,4 +1850,10 @@
   <data name="Label-host.system_status-xscontainer" xml:space="preserve">
     <value>Container management logs</value>
   </data>
+  <data name="Description-host.system_status-conntest" xml:space="preserve">
+    <value>Tests for connectivity between [XenServer] and the internet</value>
+  </data>
+  <data name="Label-host.system_status-conntest" xml:space="preserve">
+    <value>Connection test</value>
+  </data>
 </root>


### PR DESCRIPTION
Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>