### PR TITLE
CA-202417: New VM Wizard Memory Modify button is not working reliably…

### DIFF
--- a/XenAdmin/Controls/Ballooning/VMMemoryControlsAdvanced.cs
+++ b/XenAdmin/Controls/Ballooning/VMMemoryControlsAdvanced.cs
@@ -98,7 +98,7 @@ namespace XenAdmin.Controls.Ballooning
 
         private void SetIncrements()
         {
-             memorySpinnerDynMin.Increment =  memorySpinnerDynMax.Increment = memorySpinnerStatMax.Increment = CalcIncrement(memorySpinnerDynMax.Units);
+             memorySpinnerDynMin.Increment =  memorySpinnerDynMax.Increment = memorySpinnerStatMax.Increment = CalcIncrement(static_max, memorySpinnerDynMax.Units);
         }
 
         private void Spinners_ValueChanged(object sender, EventArgs e)

--- a/XenAdmin/Controls/Ballooning/VMMemoryControlsBasic.cs
+++ b/XenAdmin/Controls/Ballooning/VMMemoryControlsBasic.cs
@@ -175,7 +175,7 @@ namespace XenAdmin.Controls.Ballooning
 
         private void SetIncrements()
         {
-            vmShinyBar.Increment = memorySpinnerDynMin.Increment = memorySpinnerDynMax.Increment = memorySpinnerFixed.Increment = CalcIncrement(memorySpinnerDynMax.Units);
+            vmShinyBar.Increment = memorySpinnerDynMin.Increment = memorySpinnerDynMax.Increment = memorySpinnerFixed.Increment = CalcIncrement(static_max, memorySpinnerDynMax.Units);
         }
 
         private void DynamicSpinners_ValueChanged(object sender, EventArgs e)

--- a/XenAdmin/Controls/Ballooning/VMMemoryControlsEdit.cs
+++ b/XenAdmin/Controls/Ballooning/VMMemoryControlsEdit.cs
@@ -214,14 +214,15 @@ namespace XenAdmin.Controls.Ballooning
             }
         }
 
-        protected double CalcIncrement(string units)
+        public static double CalcIncrement(double static_max, string units)
         {
             if (units == "MB")
             {
-                // Calculate a suitable increment for dynamic_min and dynamic_max, if static_max small
-                int i;
-                for (i = 1; i < static_max / Util.BINARY_MEGA / 8 && i < 128; i *= 2)
-                    ;
+                // Calculate a suitable increment if the static_max is small
+                int i = 1;
+                while (i < static_max / Util.BINARY_MEGA / 8 && i < 128)
+                    i *= 2;
+                
                 return i * Util.BINARY_MEGA;
             }
             else

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -109,7 +109,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             comboBoxTopology.Populate(Template.VCPUs_at_startup, Template.VCPUs_max, Template.CoresPerSocket, Template.MaxCoresPerSocket);
             PopulateVCPUs(Template.MaxVCPUsAllowed, Template.VCPUs_at_startup);
 
-            SetSpinnerLimits();
+            SetSpinnerLimitsAndIncrement();
 
             ValuesUpdated();
 
@@ -153,8 +153,10 @@ namespace XenAdmin.Wizards.NewVMWizard
             spinnerStatMax.SetRange(0, maxMemAllowed);
         }
 
-        private void SetSpinnerLimits()
+        private void SetSpinnerLimitsAndIncrement()
         {
+            spinnerDynMin.Increment = spinnerDynMax.Increment = spinnerStatMax.Increment = VMMemoryControlsEdit.CalcIncrement(Template.memory_static_max, spinnerDynMin.Units);
+            
             long maxMemAllowed = MaxMemAllowed;
             double min = Template.memory_static_min;
             if (memoryMode == 1)
@@ -329,7 +331,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             if (initialising)
                 return;
 
-            SetSpinnerLimits();
+            SetSpinnerLimitsAndIncrement();
             ValuesUpdated();
         }
 


### PR DESCRIPTION
… when specified in MB

Now we set Increment exactly as on other pages
when the unit is MB: the increment it will be calculated dynamically (1, 2, 4,...)
when GB, increment will be 1 GB for values >=10GB, 0.1GB otherwise

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>