### PR TITLE
CA-205204: Uncaught exception during RPU

### DIFF
--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
@@ -330,11 +330,18 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
         private void ReportException(Exception exception, PlanAction planAction, Host host)
         {
             Program.Invoke(this, () =>
-                                     {
-                                         if (host != null && !host.enabled && host.Connection != null && host.Connection.Session != null)
-                                             new EnableHostAction(host, false,
-                                                                  AddHostToPoolCommand.EnableNtolDialog).RunExternal(host.Connection.Session);
-                                     });
+                                    {
+                                        if (host != null && !host.enabled && host.Connection != null && host.Connection.Session != null)
+                                            try
+                                            {
+                                                new EnableHostAction(host, false,
+                                                                AddHostToPoolCommand.EnableNtolDialog).RunExternal(host.Connection.Session);
+                                            }
+                                            catch (Exception e)
+                                            {
+                                                log.Error("Exception while trying to re-enable the host", e);
+                                            }
+                                    });
             Program.BeginInvoke(this, () =>
                                           {
                                               var row = planAction is UnwindProblemsAction


### PR DESCRIPTION
When an exception is reported during the RPU, XenCenter tries to re-enable the host. But when this fails, we should just ignore it and report the original exception.

Signed-off-by: Mihaela Stoica <Mihaela.Stoica@citrix.com>