### PR TITLE
CA-198956: VM.set_snapshot_schedule throws exception "Object deleted: VMSS" in xapi

### DIFF
--- a/XenAdmin/Dialogs/VMProtectionRecovery/PolicyHistory.cs
+++ b/XenAdmin/Dialogs/VMProtectionRecovery/PolicyHistory.cs
@@ -72,6 +72,31 @@ namespace XenAdmin.Dialogs.VMProtectionRecovery
         }
 
         private IVMPolicy _policy;
+        public void StartRefreshTab()
+        {
+            /* hoursFromNow has 3 possible values:
+                1) 0 -> top 10 messages (default)
+                2) 24 -> messages from past 24 Hrs
+                3) 7 * 24 -> messages from lst 7 days */
+
+            var hoursFromNow = 0;
+            switch (comboBox1.SelectedIndex)
+            {
+                case 0: /* default value*/
+                    break;
+                case 1:
+                    hoursFromNow = 24;
+                    break;
+                case 2:
+                    hoursFromNow = 7 * 24;
+                    break;
+            }
+
+            PureAsyncAction action = _policy.getAlertsAction(_policy, hoursFromNow);
+            action.Completed += action_Completed;
+            action.RunAsync();
+        }
+
         public void RefreshTab(IVMPolicy policy)
         {
             _policy = policy;
@@ -83,23 +108,7 @@ namespace XenAdmin.Dialogs.VMProtectionRecovery
             else
             {
                 comboBox1.Enabled = true;
-                int hoursFromNow = 0;
-                switch (comboBox1.SelectedIndex)
-                {
-                    case 0: /* default value*/
-                        break;
-                    case 1:
-                        hoursFromNow = 24;
-                        break;
-                    case 2:
-                        hoursFromNow = 7 * 24;
-                        break;
-                }
-        
-                PureAsyncAction action = _policy.getAlertsAction(_policy, hoursFromNow);
-                action.Completed += action_Completed;
-                action.RunAsync();
-                RefreshGrid(_policy.PolicyAlerts);
+                StartRefreshTab();
             }
 
         }
@@ -184,30 +193,7 @@ namespace XenAdmin.Dialogs.VMProtectionRecovery
         {
             if (_policy != null)
             {
-                /* hoursFromNow has 3 possible values:
-                    1) 0 -> top 10 messages (default)
-                    2) 24 -> messages from past 24 Hrs
-                    3) 7 * 24 -> messages from lst 7 days */
-
-                int hoursFromNow = 0 ;
-
-                switch (comboBox1.SelectedIndex)
-                {
-                    case 0: /* default value*/
-                        break;
-                    case 1:
-                        hoursFromNow = 24;
-                        break;
-                    case 2:
-                        hoursFromNow = 7 * 24;
-                        break;
-                }
-
-                dataGridView1.Rows.Clear();
-                panelLoading.Visible = true;
-                PureAsyncAction action = _policy.getAlertsAction(_policy, hoursFromNow);                
-                action.Completed += action_Completed;
-                action.RunAsync(); 
+               StartRefreshTab();  
             }
         }
 

--- a/XenAdmin/Dialogs/VMProtectionRecovery/PolicyHistory.cs
+++ b/XenAdmin/Dialogs/VMProtectionRecovery/PolicyHistory.cs
@@ -83,6 +83,22 @@ namespace XenAdmin.Dialogs.VMProtectionRecovery
             else
             {
                 comboBox1.Enabled = true;
+                int hoursFromNow = 0;
+                switch (comboBox1.SelectedIndex)
+                {
+                    case 0: /* default value*/
+                        break;
+                    case 1:
+                        hoursFromNow = 24;
+                        break;
+                    case 2:
+                        hoursFromNow = 7 * 24;
+                        break;
+                }
+        
+                PureAsyncAction action = _policy.getAlertsAction(_policy, hoursFromNow);
+                action.Completed += action_Completed;
+                action.RunAsync();
                 RefreshGrid(_policy.PolicyAlerts);
             }
 
@@ -168,30 +184,30 @@ namespace XenAdmin.Dialogs.VMProtectionRecovery
         {
             if (_policy != null)
             {
-                if (comboBox1.SelectedIndex == 0)
-		{
-                    dataGridView1.Rows.Clear();
-                    panelLoading.Visible = true;
-                    PureAsyncAction action = _policy.getAlertsAction(_policy, 0) ;
-                    action.Completed += action_Completed;
-                    action.RunAsync();
-		}
-                else if (comboBox1.SelectedIndex == 1)
+                /* hoursFromNow has 3 possible values:
+                    1) 0 -> top 10 messages (default)
+                    2) 24 -> messages from past 24 Hrs
+                    3) 7 * 24 -> messages from lst 7 days */
+
+                int hoursFromNow = 0 ;
+
+                switch (comboBox1.SelectedIndex)
                 {
-                    dataGridView1.Rows.Clear();
-                    panelLoading.Visible = true;
-                    PureAsyncAction action = _policy.getAlertsAction(_policy, 24) ;                
-                    action.Completed += action_Completed;
-                    action.RunAsync();                   
+                    case 0: /* default value*/
+                        break;
+                    case 1:
+                        hoursFromNow = 24;
+                        break;
+                    case 2:
+                        hoursFromNow = 7 * 24;
+                        break;
                 }
-                else if (comboBox1.SelectedIndex == 2)
-                {
-                    dataGridView1.Rows.Clear();
-                    panelLoading.Visible = true;
-                    PureAsyncAction action = _policy.getAlertsAction(_policy, 7 * 24);
-                    action.Completed += action_Completed;
-                    action.RunAsync();
-                }
+
+                dataGridView1.Rows.Clear();
+                panelLoading.Visible = true;
+                PureAsyncAction action = _policy.getAlertsAction(_policy, hoursFromNow);                
+                action.Completed += action_Completed;
+                action.RunAsync(); 
             }
         }
 

--- a/XenAdmin/Dialogs/VMProtectionRecovery/PolicyHistory.cs
+++ b/XenAdmin/Dialogs/VMProtectionRecovery/PolicyHistory.cs
@@ -169,7 +169,13 @@ namespace XenAdmin.Dialogs.VMProtectionRecovery
             if (_policy != null)
             {
                 if (comboBox1.SelectedIndex == 0)
-                    RefreshGrid(_policy.PolicyAlerts);
+		{
+                    dataGridView1.Rows.Clear();
+                    panelLoading.Visible = true;
+                    PureAsyncAction action = _policy.getAlertsAction(_policy, 0) ;
+                    action.Completed += action_Completed;
+                    action.RunAsync();
+		}
                 else if (comboBox1.SelectedIndex == 1)
                 {
                     dataGridView1.Rows.Clear();

--- a/XenAdmin/Dialogs/VMProtectionRecovery/VMProtectionPoliciesDialog.cs
+++ b/XenAdmin/Dialogs/VMProtectionRecovery/VMProtectionPoliciesDialog.cs
@@ -201,43 +201,54 @@ namespace XenAdmin.Dialogs.VMPolicies
             dataGridView1.SuspendLayout();
             var selectedPolicy = currentSelected;
             dataGridView1.Rows.Clear();
+	    var policyList = VMGroup<T>.VMPolicies(Pool.Connection.Cache);
 
-            /* filter out the messages for VMSS as the VMSS does not have recent alerts and that need to be populated below*/
-            List<XenAPI.Message> vmssMessages = new List<XenAPI.Message>();
+            /* creating a dictionary to hold (policy_uuid, message list) */
+
+            Dictionary<string, List<XenAPI.Message>> policyMessage = new Dictionary<string, List<XenAPI.Message>>();
+    
+            /* populate the dictionary with policy uuid */
+
+            foreach (var policy in policyList)
+            {
+                policy.PolicyAlerts.Clear();
+                List<XenAPI.Message> messageList = new List<XenAPI.Message>();
+                policyMessage.Add(policy.uuid, messageList);
+            }
+       
+            /* iterate through all messages and populate the dictionary with message list */
+
             if (!VMGroup<T>.isVMPolicyVMPP)
             {
                 var messages = Pool.Connection.Cache.Messages;
+                List<XenAPI.Message> value = new List<XenAPI.Message>();
+
                 foreach (var message in messages)
                 {
                     if (message.cls == cls.VMSS)
                     {
-                        vmssMessages.Add(message);
-                    }
-                }
-            }
-            foreach (var policy in VMGroup<T>.VMPolicies(Pool.Connection.Cache))
-            {
-                if (!VMGroup<T>.isVMPolicyVMPP)
-                {
-                    policy.PolicyAlerts.Clear();
-                    List<XenAPI.Message> processedMessages = new List<XenAPI.Message>();
-                    /*for VMSS: Populate the alerts from Messages by filtering out the alerts for this schedule
-                     This is not required in VMPP as the VMPP record itself has the recentAlerts */
-                    foreach (var message in vmssMessages)
-                    {
-                        if (message.obj_uuid == policy.uuid)
+                        if (policyMessage.TryGetValue(message.obj_uuid, out value))
                         {
-                            policy.PolicyAlerts.Add(new PolicyAlert(message.priority, message.name, message.timestamp));
-                            processedMessages.Add(message);
+                            value.Add(message);
                         }
-                    }
-                    vmssMessages.RemoveAll(message => processedMessages.Contains(message));
-                }
 
-                if (dataGridView1.ColumnCount > 0)
-                    dataGridView1.Rows.Add(new PolicyRow(policy));
+                    }
+                }
             }
-            RefreshButtons();
+
+            /* add only 10 messages for each policy and referesh the rows*/
+
+            foreach (var policy in policyList)
+            {
+                for (int messageCount = 0; messageCount < 10 && messageCount < policyMessage[policy.uuid].Count; messageCount++)
+                {
+                    policy.PolicyAlerts.Add(new PolicyAlert(policyMessage[policy.uuid][messageCount].priority, policyMessage[policy.uuid][messageCount].name, policyMessage[policy.uuid][messageCount].timestamp));
+                }
+                    if (dataGridView1.ColumnCount > 0)
+                        dataGridView1.Rows.Add(new PolicyRow(policy));
+            }
+
+           RefreshButtons();
             if (selectedPolicy != null)
             {
                 foreach (PolicyRow row in dataGridView1.Rows)

--- a/XenAdmin/Dialogs/VMProtectionRecovery/VMProtectionPoliciesDialog.cs
+++ b/XenAdmin/Dialogs/VMProtectionRecovery/VMProtectionPoliciesDialog.cs
@@ -44,7 +44,7 @@ using XenAdmin.Core;
 using XenAdmin.Dialogs.VMProtectionRecovery;
 using XenCenterLib;
 using XenAdmin.Alerts;
-
+using System.Linq;
 
 namespace XenAdmin.Dialogs.VMProtection_Recovery
 {
@@ -237,15 +237,18 @@ namespace XenAdmin.Dialogs.VMPolicies
             }
 
             /* add only 10 messages for each policy and referesh the rows*/
-
+            
             foreach (var policy in policyList)
             {
-                for (int messageCount = 0; messageCount < 10 && messageCount < policyMessage[policy.uuid].Count; messageCount++)
+                /* message list need not be always sorted */
+
+                var messageListSorted = policyMessage[policy.uuid].OrderByDescending(message => message.timestamp).ToList();
+                for (int messageCount = 0; messageCount < 10 && messageCount < messageListSorted.Count; messageCount++)
                 {
-                    policy.PolicyAlerts.Add(new PolicyAlert(policyMessage[policy.uuid][messageCount].priority, policyMessage[policy.uuid][messageCount].name, policyMessage[policy.uuid][messageCount].timestamp));
+                    policy.PolicyAlerts.Add(new PolicyAlert(messageListSorted[messageCount].priority, messageListSorted[messageCount].name, messageListSorted[messageCount].timestamp));
                 }
-                    if (dataGridView1.ColumnCount > 0)
-                        dataGridView1.Rows.Add(new PolicyRow(policy));
+                if (dataGridView1.ColumnCount > 0)
+                    dataGridView1.Rows.Add(new PolicyRow(policy));
             }
 
            RefreshButtons();

--- a/XenModel/Actions/VMSS/GetVMSSAlertsAction.cs
+++ b/XenModel/Actions/VMSS/GetVMSSAlertsAction.cs
@@ -35,6 +35,7 @@ using System.Text;
 using XenAdmin.Alerts;
 using XenAPI;
 using System.Diagnostics;
+using System.Linq;
 
 namespace XenAdmin.Actions
 {
@@ -52,7 +53,7 @@ namespace XenAdmin.Actions
         protected override void Run()
         {
             var now = DateTime.Now;
-            var messages = Pool.Connection.Cache.Messages;
+ 	    var messages = Pool.Connection.Cache.Messages.OrderByDescending(message => message.timestamp).ToList();
             var listAlerts = new List<PolicyAlert>();
  	    DateTime currentTime = DateTime.Now;
             DateTime offset = currentTime.Add(new TimeSpan(- _hoursFromNow, 0, 0));
@@ -84,6 +85,11 @@ namespace XenAdmin.Actions
                     {
                         listAlerts.Add(new PolicyAlert(message.priority, message.name, message.timestamp));
                     }
+
+                    /* since the messages are sorted on timestamp you need not scan the entire message list */
+
+                    else if (message.timestamp < offset)
+                        break;
                 }
 	    }
 

--- a/XenModel/Actions/VMSS/GetVMSSAlertsAction.cs
+++ b/XenModel/Actions/VMSS/GetVMSSAlertsAction.cs
@@ -54,16 +54,38 @@ namespace XenAdmin.Actions
             var now = DateTime.Now;
             var messages = Pool.Connection.Cache.Messages;
             var listAlerts = new List<PolicyAlert>();
+ 	    DateTime currentTime = DateTime.Now;
+            DateTime offset = currentTime.Add(new TimeSpan(- _hoursFromNow, 0, 0));
+          
+            /* _hoursFromNow has 3 possible values:
+                1) 0 -> top 10 messages
+                2) 24 -> messages from past 24 Hrs
+                3) 7 * 24 -> messages from lst 7 days */
 
-            /*for VMSS: Populate the alerts from Messages by filtering out the alerts for this schedule
-                This is not required in VMPP as the VMPP record itself has the recentAlerts */
-            foreach (var message in messages)
+            if (_hoursFromNow == 0)
             {
-                if (message.cls == cls.VMSS && message.obj_uuid == VMSS.uuid)
+                int messageCounter = 0;
+                foreach (var message in messages)
                 {
-                    listAlerts.Add(new PolicyAlert(message.priority, message.name, message.timestamp));
+                    if (message.cls == cls.VMSS && message.obj_uuid == VMSS.uuid && messageCounter < 10)
+                    {
+                        listAlerts.Add(new PolicyAlert(message.priority, message.name, message.timestamp));
+                        messageCounter++;
+                    }
+                    else if (messageCounter >= 10)
+                        break;
                 }
-            }
+            } 
+            else
+            {
+                foreach (var message in messages)
+                {
+                    if (message.cls == cls.VMSS && message.obj_uuid == VMSS.uuid && message.timestamp > offset)
+                    {
+                        listAlerts.Add(new PolicyAlert(message.priority, message.name, message.timestamp));
+                    }
+                }
+	    }
 
             VMSS.Alerts = new List<PolicyAlert>(listAlerts);
             Debug.WriteLine(string.Format("GetAlerts took: {0}", DateTime.Now - now));

--- a/XenModel/XenAPI-Extensions/VMSS.cs
+++ b/XenModel/XenAPI-Extensions/VMSS.cs
@@ -306,11 +306,6 @@ namespace XenAPI
         {
             get
             {
-                foreach (var recent in _alerts)
-                {
-                    if (!_alerts.Contains(recent))
-                        _alerts.Add(recent);
-                }
                 return _alerts;
             }
             set { _alerts = value; }

--- a/XenModel/XenAPI/VM.cs
+++ b/XenModel/XenAPI/VM.cs
@@ -3590,7 +3590,7 @@ namespace XenAPI
         /// <param name="_value">The value</param>
         public static void set_snapshot_schedule(Session session, string _vm, string _value)
         {
-            session.proxy.vm_set_snapshot_schedule(session.uuid, (_vm != null) ? _vm : "", (_value != null) ? _value : "").parse();
+            session.proxy.vm_set_snapshot_schedule(session.uuid, (_vm != null) ? _vm : "", (_value != null) ? _value : Helper.NullOpaqueRef).parse();
         }
 
         /// <summary>

--- a/XenModel/XenAPI/VM.cs
+++ b/XenModel/XenAPI/VM.cs
@@ -3590,7 +3590,7 @@ namespace XenAPI
         /// <param name="_value">The value</param>
         public static void set_snapshot_schedule(Session session, string _vm, string _value)
         {
-            session.proxy.vm_set_snapshot_schedule(session.uuid, (_vm != null) ? _vm : "", (_value != null) ? _value : Helper.NullOpaqueRef).parse();
+            session.proxy.vm_set_snapshot_schedule(session.uuid, (_vm != null) ? _vm : "", (_value != null) ? _value : "").parse();
         }
 
         /// <summary>


### PR DESCRIPTION
XAPI expects "OpaqueRef:NULL" in the value field to unassign a VM from
a particular policy, however XC is sending an empty string "". As a fix
the empty string is replaced with Helper.NullOpaqueRef.

Signed-off-by: Sharath Babu <Sharath.Babu@citrix.com>