### PR TITLE
CA-202374: XC greyed out 'Install Tools' menu for imported VM from Cream

### DIFF
--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -830,7 +830,7 @@ namespace XenAPI
             {
                 Debug.Assert(HasNewVirtualisationStates);
 
-                var flags = !Helpers.DundeeOrGreater(Connection) && HasRDP || HasStaticIP
+                var flags = HasStaticIP
                     ? VirtualisationStatus.MANAGEMENT_INSTALLED 
                     : 0;
 

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -424,6 +424,18 @@ namespace XenAPI
             get { return HVM_boot_policy != ""; }
         }
 
+        public bool HasStaticIP
+        {
+            get
+            {
+                var metrics = Connection.Resolve(this.guest_metrics);
+                if (metrics == null)
+                    return false;
+
+                return 0 != IntKey(metrics.other, "feature-static-ip-setting", 0);
+            }
+        }
+
         public bool HasRDP
         {
             get
@@ -818,7 +830,9 @@ namespace XenAPI
             {
                 Debug.Assert(HasNewVirtualisationStates);
 
-                var flags = HasRDP ? VirtualisationStatus.MANAGEMENT_INSTALLED : 0;
+                var flags = !Helpers.DundeeOrGreater(Connection) && HasRDP || HasStaticIP
+                    ? VirtualisationStatus.MANAGEMENT_INSTALLED 
+                    : 0;
 
                 var vm_guest_metrics = Connection.Resolve(guest_metrics);
                 if (vm_guest_metrics != null && vm_guest_metrics.storage_paths_optimized && vm_guest_metrics.network_paths_optimized)


### PR DESCRIPTION
Check different feature flag for Windows VMs on Dundee to detect Dundee guest agent. For earlier versions nothing is changed.
This will cause XC to report "Management not installed" for Windows VMs on Dundee hosts with Cream guest agent (This is the case when a host has been upgraded from Cream to Dundee).

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>