### PR TITLE
CA-208495: XenCenter does not specify the NFS version when reattaching an existing SR

### DIFF
--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.Designer.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.Designer.cs
@@ -29,33 +29,41 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(VHDoNFS));
-            this.listBoxNfsSRs = new XenAdmin.Controls.SRListBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.radioButtonNfsReattach = new System.Windows.Forms.RadioButton();
             this.radioButtonNfsNew = new System.Windows.Forms.RadioButton();
             this.label2 = new System.Windows.Forms.Label();
-            this.serverOptionsTextBox = new System.Windows.Forms.TextBox();
-            this.labelAdvancedOptions = new System.Windows.Forms.Label();
+            this.nfsVersionLabel = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.NfsServerPathTextBox = new System.Windows.Forms.TextBox();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.label1 = new System.Windows.Forms.Label();
+            this.labelAdvancedOptions = new System.Windows.Forms.Label();
+            this.serverOptionsTextBox = new System.Windows.Forms.TextBox();
             this.NfsScanButton = new System.Windows.Forms.Button();
             this.nfsVersionSelectorTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-            this.nfsVersionLabel = new System.Windows.Forms.Label();
             this.nfsVersion3RadioButton = new System.Windows.Forms.RadioButton();
             this.nfsVersion4RadioButton = new System.Windows.Forms.RadioButton();
+            this.listBoxNfsSRs = new XenAdmin.Controls.SRListBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.nfsVersionSelectorTableLayoutPanel.SuspendLayout();
             this.SuspendLayout();
             // 
-            // listBoxNfsSRs
+            // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.listBoxNfsSRs, 3);
-            resources.ApplyResources(this.listBoxNfsSRs, "listBoxNfsSRs");
-            this.listBoxNfsSRs.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.listBoxNfsSRs.Name = "listBoxNfsSRs";
-            this.listBoxNfsSRs.Sorted = true;
-            this.listBoxNfsSRs.SelectedIndexChanged += new System.EventHandler(this.listBoxNfsSRs_SelectedIndexChanged);
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.nfsVersionLabel, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.NfsServerPathTextBox, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.labelAdvancedOptions, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.serverOptionsTextBox, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.radioButtonNfsNew, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.radioButtonNfsReattach, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.listBoxNfsSRs, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.NfsScanButton, 2, 1);
+            this.tableLayoutPanel1.Controls.Add(this.nfsVersionSelectorTableLayoutPanel, 1, 3);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // radioButtonNfsReattach
             // 
@@ -69,6 +77,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             // 
             resources.ApplyResources(this.radioButtonNfsNew, "radioButtonNfsNew");
             this.radioButtonNfsNew.Checked = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.radioButtonNfsNew, 2);
             this.radioButtonNfsNew.Name = "radioButtonNfsNew";
             this.radioButtonNfsNew.TabStop = true;
             this.radioButtonNfsNew.UseVisualStyleBackColor = true;
@@ -81,16 +90,17 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             this.label2.ForeColor = System.Drawing.SystemColors.WindowText;
             this.label2.Name = "label2";
             // 
-            // serverOptionsTextBox
+            // nfsVersionLabel
             // 
-            resources.ApplyResources(this.serverOptionsTextBox, "serverOptionsTextBox");
-            this.serverOptionsTextBox.Name = "serverOptionsTextBox";
+            resources.ApplyResources(this.nfsVersionLabel, "nfsVersionLabel");
+            this.nfsVersionLabel.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.nfsVersionLabel.Name = "nfsVersionLabel";
             // 
-            // labelAdvancedOptions
+            // label1
             // 
-            resources.ApplyResources(this.labelAdvancedOptions, "labelAdvancedOptions");
-            this.labelAdvancedOptions.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.labelAdvancedOptions.Name = "labelAdvancedOptions";
+            resources.ApplyResources(this.label1, "label1");
+            this.tableLayoutPanel1.SetColumnSpan(this.label1, 3);
+            this.label1.Name = "label1";
             // 
             // label3
             // 
@@ -104,27 +114,16 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             this.NfsServerPathTextBox.Name = "NfsServerPathTextBox";
             this.NfsServerPathTextBox.TextChanged += new System.EventHandler(this.NfsServerPathTextBox_TextChanged);
             // 
-            // tableLayoutPanel1
+            // labelAdvancedOptions
             // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.NfsServerPathTextBox, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label2, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.labelAdvancedOptions, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.serverOptionsTextBox, 1, 3);
-            this.tableLayoutPanel1.Controls.Add(this.radioButtonNfsNew, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.radioButtonNfsReattach, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.listBoxNfsSRs, 0, 7);
-            this.tableLayoutPanel1.Controls.Add(this.NfsScanButton, 2, 1);
-            this.tableLayoutPanel1.Controls.Add(this.nfsVersionSelectorTableLayoutPanel, 0, 5);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            resources.ApplyResources(this.labelAdvancedOptions, "labelAdvancedOptions");
+            this.labelAdvancedOptions.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.labelAdvancedOptions.Name = "labelAdvancedOptions";
             // 
-            // label1
+            // serverOptionsTextBox
             // 
-            resources.ApplyResources(this.label1, "label1");
-            this.tableLayoutPanel1.SetColumnSpan(this.label1, 3);
-            this.label1.Name = "label1";
+            resources.ApplyResources(this.serverOptionsTextBox, "serverOptionsTextBox");
+            this.serverOptionsTextBox.Name = "serverOptionsTextBox";
             // 
             // NfsScanButton
             // 
@@ -137,16 +136,9 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             // 
             resources.ApplyResources(this.nfsVersionSelectorTableLayoutPanel, "nfsVersionSelectorTableLayoutPanel");
             this.tableLayoutPanel1.SetColumnSpan(this.nfsVersionSelectorTableLayoutPanel, 2);
-            this.nfsVersionSelectorTableLayoutPanel.Controls.Add(this.nfsVersionLabel, 0, 0);
-            this.nfsVersionSelectorTableLayoutPanel.Controls.Add(this.nfsVersion3RadioButton, 1, 0);
-            this.nfsVersionSelectorTableLayoutPanel.Controls.Add(this.nfsVersion4RadioButton, 1, 1);
+            this.nfsVersionSelectorTableLayoutPanel.Controls.Add(this.nfsVersion3RadioButton, 0, 0);
+            this.nfsVersionSelectorTableLayoutPanel.Controls.Add(this.nfsVersion4RadioButton, 0, 1);
             this.nfsVersionSelectorTableLayoutPanel.Name = "nfsVersionSelectorTableLayoutPanel";
-            // 
-            // nfsVersionLabel
-            // 
-            resources.ApplyResources(this.nfsVersionLabel, "nfsVersionLabel");
-            this.nfsVersionLabel.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.nfsVersionLabel.Name = "nfsVersionLabel";
             // 
             // nfsVersion3RadioButton
             // 
@@ -161,6 +153,15 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             resources.ApplyResources(this.nfsVersion4RadioButton, "nfsVersion4RadioButton");
             this.nfsVersion4RadioButton.Name = "nfsVersion4RadioButton";
             this.nfsVersion4RadioButton.UseVisualStyleBackColor = true;
+            // 
+            // listBoxNfsSRs
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.listBoxNfsSRs, 3);
+            resources.ApplyResources(this.listBoxNfsSRs, "listBoxNfsSRs");
+            this.listBoxNfsSRs.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.listBoxNfsSRs.Name = "listBoxNfsSRs";
+            this.listBoxNfsSRs.Sorted = true;
+            this.listBoxNfsSRs.SelectedIndexChanged += new System.EventHandler(this.listBoxNfsSRs_SelectedIndexChanged);
             // 
             // VHDoNFS
             // 

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.cs
@@ -94,7 +94,6 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
         private void UpdateButtons()
         {
             NfsScanButton.Enabled = SrWizardHelpers.ValidateNfsSharename(NfsServerPathTextBox.Text);
-            nfsVersionSelectorTableLayoutPanel.Enabled = radioButtonNfsNew.Checked;
 
             OnPageUpdated();
         }
@@ -262,7 +261,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
                     dconf[SERVERPATH] = fullpath[1];
                 }
 
-                if (nfsVersion4RadioButton.Enabled && nfsVersion4RadioButton.Checked)
+                if (nfsVersion4RadioButton.Checked)
                     dconf[NFSVERSION] = "4";
 
                 return dconf;

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.resx
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.resx
@@ -121,14 +121,53 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+  <data name="nfsVersionLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="nfsVersionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="nfsVersionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 108</value>
+  </data>
+  <data name="nfsVersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 5, 3, 0</value>
+  </data>
+  <data name="nfsVersionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 13</value>
+  </data>
+  <data name="nfsVersionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="nfsVersionLabel.Text" xml:space="preserve">
+    <value>NFS Version:</value>
+  </data>
+  <data name="nfsVersionLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;nfsVersionLabel.Name" xml:space="preserve">
+    <value>nfsVersionLabel</value>
+  </data>
+  <data name="&gt;&gt;nfsVersionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nfsVersionLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;nfsVersionLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
@@ -154,7 +193,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -190,16 +229,16 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="NfsServerPathTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="NfsServerPathTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 50</value>
+    <value>107, 50</value>
   </data>
   <data name="NfsServerPathTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>306, 20</value>
+    <value>314, 20</value>
   </data>
   <data name="NfsServerPathTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -214,7 +253,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;NfsServerPathTextBox.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -226,7 +265,7 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 75</value>
+    <value>107, 75</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 15</value>
@@ -250,7 +289,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="labelAdvancedOptions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -262,13 +301,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelAdvancedOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 109</value>
+    <value>3, 157</value>
   </data>
   <data name="labelAdvancedOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>98, 13</value>
   </data>
   <data name="labelAdvancedOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="labelAdvancedOptions.Text" xml:space="preserve">
     <value>&amp;Advanced Options:</value>
@@ -286,19 +325,19 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelAdvancedOptions.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="serverOptionsTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="serverOptionsTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 106</value>
+    <value>107, 154</value>
   </data>
   <data name="serverOptionsTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>306, 20</value>
+    <value>314, 20</value>
   </data>
   <data name="serverOptionsTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;serverOptionsTextBox.Name" xml:space="preserve">
     <value>serverOptionsTextBox</value>
@@ -310,7 +349,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;serverOptionsTextBox.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="radioButtonNfsNew.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -319,7 +358,7 @@
     <value>NoControl</value>
   </data>
   <data name="radioButtonNfsNew.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 154</value>
+    <value>3, 202</value>
   </data>
   <data name="radioButtonNfsNew.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 25, 3, 3</value>
@@ -328,7 +367,7 @@
     <value>106, 17</value>
   </data>
   <data name="radioButtonNfsNew.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="radioButtonNfsNew.Text" xml:space="preserve">
     <value>&amp;Create a new SR</value>
@@ -343,7 +382,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;radioButtonNfsNew.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="radioButtonNfsReattach.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -352,13 +391,13 @@
     <value>NoControl</value>
   </data>
   <data name="radioButtonNfsReattach.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 222</value>
+    <value>3, 225</value>
   </data>
   <data name="radioButtonNfsReattach.Size" type="System.Drawing.Size, System.Drawing">
     <value>143, 17</value>
   </data>
   <data name="radioButtonNfsReattach.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="radioButtonNfsReattach.Text" xml:space="preserve">
     <value>&amp;Reattach an existing SR:</value>
@@ -373,7 +412,37 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;radioButtonNfsReattach.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
+  </data>
+  <data name="listBoxNfsSRs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="listBoxNfsSRs.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="listBoxNfsSRs.ItemHeight" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="listBoxNfsSRs.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 248</value>
+  </data>
+  <data name="listBoxNfsSRs.Size" type="System.Drawing.Size, System.Drawing">
+    <value>494, 210</value>
+  </data>
+  <data name="listBoxNfsSRs.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;listBoxNfsSRs.Name" xml:space="preserve">
+    <value>listBoxNfsSRs</value>
+  </data>
+  <data name="&gt;&gt;listBoxNfsSRs.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.SRListBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;listBoxNfsSRs.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;listBoxNfsSRs.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="NfsScanButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -406,10 +475,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;NfsScanButton.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="nfsVersionSelectorTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left</value>
+    <value>10</value>
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -419,42 +485,6 @@
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="nfsVersionLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="nfsVersionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="nfsVersionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 6</value>
-  </data>
-  <data name="nfsVersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>19, 6, 3, 6</value>
-  </data>
-  <data name="nfsVersionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
-  </data>
-  <data name="nfsVersionLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="nfsVersionLabel.Text" xml:space="preserve">
-    <value>NFS Version:</value>
-  </data>
-  <data name="nfsVersionLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;nfsVersionLabel.Name" xml:space="preserve">
-    <value>nfsVersionLabel</value>
-  </data>
-  <data name="&gt;&gt;nfsVersionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nfsVersionLabel.Parent" xml:space="preserve">
-    <value>nfsVersionSelectorTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;nfsVersionLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="nfsVersion3RadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -466,13 +496,13 @@
     <value>NoControl</value>
   </data>
   <data name="nfsVersion3RadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>94, 4</value>
+    <value>3, 3</value>
   </data>
   <data name="nfsVersion3RadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 17</value>
   </data>
   <data name="nfsVersion3RadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>1</value>
   </data>
   <data name="nfsVersion3RadioButton.Text" xml:space="preserve">
     <value>NFSv&amp;3</value>
@@ -487,7 +517,7 @@
     <value>nfsVersionSelectorTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;nfsVersion3RadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="nfsVersion4RadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -499,16 +529,13 @@
     <value>NoControl</value>
   </data>
   <data name="nfsVersion4RadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>94, 25</value>
-  </data>
-  <data name="nfsVersion4RadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 3</value>
+    <value>3, 26</value>
   </data>
   <data name="nfsVersion4RadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 17</value>
   </data>
   <data name="nfsVersion4RadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>2</value>
   </data>
   <data name="nfsVersion4RadioButton.Text" xml:space="preserve">
     <value>NFSv&amp;4</value>
@@ -523,22 +550,25 @@
     <value>nfsVersionSelectorTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;nfsVersion4RadioButton.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>1</value>
+  </data>
+  <data name="nfsVersionSelectorTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 174</value>
+    <value>104, 103</value>
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>0, 0, 0, 2</value>
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 45</value>
+    <value>396, 46</value>
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;nfsVersionSelectorTableLayoutPanel.Name" xml:space="preserve">
     <value>nfsVersionSelectorTableLayoutPanel</value>
@@ -550,10 +580,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;nfsVersionSelectorTableLayoutPanel.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="nfsVersionSelectorTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="nfsVersionLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="nfsVersion3RadioButton" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="nfsVersion4RadioButton" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="nfsVersion3RadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="nfsVersion4RadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -583,37 +613,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="label3" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NfsServerPathTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="2" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelAdvancedOptions" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="serverOptionsTextBox" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonNfsNew" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonNfsReattach" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="listBoxNfsSRs" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="NfsScanButton" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="nfsVersionSelectorTableLayoutPanel" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="listBoxNfsSRs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="listBoxNfsSRs.IntegralHeight" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="listBoxNfsSRs.ItemHeight" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="listBoxNfsSRs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 245</value>
-  </data>
-  <data name="listBoxNfsSRs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 213</value>
-  </data>
-  <data name="listBoxNfsSRs.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;listBoxNfsSRs.Name" xml:space="preserve">
-    <value>listBoxNfsSRs</value>
-  </data>
-  <data name="&gt;&gt;listBoxNfsSRs.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SRListBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;listBoxNfsSRs.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;listBoxNfsSRs.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="nfsVersionLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="label3" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NfsServerPathTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="2" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelAdvancedOptions" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="serverOptionsTextBox" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonNfsNew" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="radioButtonNfsReattach" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="listBoxNfsSRs" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="NfsScanButton" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="nfsVersionSelectorTableLayoutPanel" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION

- Re-position the version radio-buttons, so that is clear that the selected version applies to both Create and Reattach
- Pass the selected version to the attach command in the device_config parameter

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>