### PR TITLE
CA-210732: XenCenter VM properties GPU always shows "None"

### DIFF
--- a/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
@@ -195,6 +195,9 @@ namespace XenAdmin.Controls
                     if (!VgpuTypes[i].Equals(other.VgpuTypes[i]))
                         return false;
                 }
+
+                if (IsGpuHeaderItem && other.IsVgpuSubitem)
+                    return false;
             }
 
             return result;

--- a/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
@@ -196,7 +196,8 @@ namespace XenAdmin.Controls
                         return false;
                 }
 
-                if (IsGpuHeaderItem && other.IsVgpuSubitem)
+                if ((IsGpuHeaderItem && other.IsVgpuSubitem) ||
+                    (IsVgpuSubitem && other.IsGpuHeaderItem))
                     return false;
             }
 

--- a/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/VgpuComboBox.cs
@@ -170,6 +170,9 @@ namespace XenAdmin.Controls
 
         public bool Equals(GpuTuple other)
         {
+            if (other == null)
+                return false;
+
             if (GpuGroup == null && other.GpuGroup == null)
                 return true;
             if (GpuGroup == null || other.GpuGroup == null)


### PR DESCRIPTION
The error occurs when there is a gpu group with only one vgpu type: When setting the selected item in the vGPU combobox, XenCenter tries to select the group header instead of the vGPU type; because the group header is not selectable, we then default to "None".
With this fix, we ensure that two items are not equal if one is a group header and the other is a subitem.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>