### PR TITLE
[CA-208810]: I18n:JA/SC:  Lost Scrollbar for the long strings...

### DIFF
--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckPolicyStatementDialog.ja.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckPolicyStatementDialog.ja.resx
@@ -129,12 +129,12 @@
     <value>NoControl</value>
   </data>
   <data name="OKButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>353, 94</value>
+    <value>353, 127</value>
   </data>
   <data name="OKButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>79, 23</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="OKButton.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
@@ -166,7 +166,7 @@
     <value>None</value>
   </data>
   <data name="policyStatementTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 93</value>
+    <value>424, 113</value>
   </data>
   <data name="policyStatementTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -186,14 +186,14 @@
   <data name="&gt;&gt;policyStatementTextBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>444, 129</value>
+    <value>444, 162</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckPolicyStatementDialog.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckPolicyStatementDialog.resx
@@ -129,7 +129,7 @@
     <value>NoControl</value>
   </data>
   <data name="OKButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>353, 94</value>
+    <value>353, 127</value>
   </data>
   <data name="OKButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>79, 23</value>
@@ -166,7 +166,7 @@
     <value>None</value>
   </data>
   <data name="policyStatementTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 80</value>
+    <value>424, 113</value>
   </data>
   <data name="policyStatementTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -193,7 +193,7 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>444, 129</value>
+    <value>444, 162</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckPolicyStatementDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckPolicyStatementDialog.zh-CN.resx
@@ -129,12 +129,12 @@
     <value>NoControl</value>
   </data>
   <data name="OKButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>353, 94</value>
+    <value>353, 127</value>
   </data>
   <data name="OKButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>79, 23</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="OKButton.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
@@ -166,7 +166,7 @@
     <value>None</value>
   </data>
   <data name="policyStatementTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 90</value>
+    <value>424, 113</value>
   </data>
   <data name="policyStatementTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -186,14 +186,14 @@
   <data name="&gt;&gt;policyStatementTextBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>444, 129</value>
+    <value>444, 162</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.Designer.cs
@@ -211,6 +211,7 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.tableLayoutPanel2.SetColumnSpan(this.authenticationRubricTextBox, 2);
             this.authenticationRubricTextBox.Cursor = System.Windows.Forms.Cursors.Default;
             this.authenticationRubricTextBox.Name = "authenticationRubricTextBox";
+            this.authenticationRubricTextBox.ReadOnly = true;
             this.authenticationRubricTextBox.ShortcutsEnabled = false;
             this.authenticationRubricTextBox.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.authenticationRubricTextBox_LinkClicked);
             // 

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.ja.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.ja.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
-    <xsd:element msdata:IsDataSet="true" name="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
-                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
-              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
-              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -117,15 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="okButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="okButton.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -487,7 +487,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="frequencyLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="frequencyNumericBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="weeksLabel" Row="0" RowSpan="1" Column="2" ColumnSpan="1" />&lt;Control Name="dayOfweekLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="timeOfDayLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="timeOfDayComboBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" />&lt;Control Name="dayOfWeekComboBox" Row="2" RowSpan="1" Column="1" ColumnSpan="2" />&lt;/Controls>&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="frequencyLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="frequencyNumericBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="weeksLabel" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="dayOfweekLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="timeOfDayLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="timeOfDayComboBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="dayOfWeekComboBox" Row="2" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBox2.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
@@ -553,7 +553,7 @@
     <value>None</value>
   </data>
   <data name="authenticationRubricTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>589, 46</value>
+    <value>589, 72</value>
   </data>
   <data name="authenticationRubricTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -586,13 +586,13 @@
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 106</value>
+    <value>20, 132</value>
   </data>
   <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -628,13 +628,13 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 135</value>
+    <value>20, 161</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -661,7 +661,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 138</value>
+    <value>89, 164</value>
   </data>
   <data name="textBoxMyCitrixPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -685,7 +685,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 109</value>
+    <value>89, 135</value>
   </data>
   <data name="textBoxMyCitrixUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -715,7 +715,7 @@
     <value>NoControl</value>
   </data>
   <data name="existingAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 59</value>
+    <value>3, 85</value>
   </data>
   <data name="existingAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>167, 19</value>
@@ -748,7 +748,7 @@
     <value>NoControl</value>
   </data>
   <data name="newAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 84</value>
+    <value>3, 110</value>
   </data>
   <data name="newAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>232, 19</value>
@@ -787,7 +787,7 @@
     <value>5</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>591, 167</value>
+    <value>591, 193</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -805,7 +805,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="authenticationRubricTextBox" Row="0" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="label1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="label2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="textBoxMyCitrixPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="textBoxMyCitrixUsername" Row="3" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="existingAuthenticationRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="newAuthenticationRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="2" />&lt;/Controls>&lt;Columns Styles="AutoSize,0,Percent,100,Absolute,20" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="authenticationRubricTextBox" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="label1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixUsername" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="existingAuthenticationRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="newAuthenticationRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBox1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
@@ -814,7 +814,7 @@
     <value>11, 402</value>
   </data>
   <data name="decentGroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>597, 188</value>
+    <value>597, 218</value>
   </data>
   <data name="decentGroupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -910,7 +910,7 @@
     <value>3</value>
   </data>
   <data name="m_ctrlError.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
   <data name="m_ctrlError.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -919,19 +919,19 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="m_ctrlError.Error" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="m_ctrlError.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="m_ctrlError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 593</value>
+    <value>11, 623</value>
   </data>
   <data name="m_ctrlError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
   </data>
   <data name="m_ctrlError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>434, 42</value>
+    <value>434, 22</value>
   </data>
   <data name="m_ctrlError.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -952,7 +952,7 @@
     <value>4</value>
   </data>
   <data name="flowLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>Bottom, Left, Right</value>
   </data>
   <data name="flowLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -964,13 +964,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>448, 593</value>
+    <value>421, 627</value>
   </data>
   <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 42</value>
+    <value>190, 36</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1054,13 +1054,13 @@
     <value>NoControl</value>
   </data>
   <data name="errorLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>216, 138</value>
+    <value>213, 138</value>
   </data>
   <data name="errorLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 0</value>
   </data>
   <data name="errorLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 20</value>
+    <value>378, 20</value>
   </data>
   <data name="errorLabel.TabIndex" type="System.Int32, mscorlib">
     <value>120</value>
@@ -1087,7 +1087,7 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsStatusImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>197, 138</value>
+    <value>194, 138</value>
   </data>
   <data name="testCredentialsStatusImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>
@@ -1174,7 +1174,7 @@
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -1216,7 +1216,7 @@
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -1243,7 +1243,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 107</value>
+    <value>89, 107</value>
   </data>
   <data name="textboxXSPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1267,7 +1267,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSUserName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 78</value>
+    <value>89, 78</value>
   </data>
   <data name="textboxXSUserName.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1366,7 +1366,7 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 133</value>
+    <value>89, 133</value>
   </data>
   <data name="testCredentialsButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
@@ -1426,7 +1426,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="errorLabel" Row="5" RowSpan="1" Column="3" ColumnSpan="1" />&lt;Control Name="testCredentialsStatusImage" Row="5" RowSpan="1" Column="2" ColumnSpan="1" />&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="4" />&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="textboxXSPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="3" />&lt;Control Name="textboxXSUserName" Row="3" RowSpan="1" Column="1" ColumnSpan="3" />&lt;Control Name="currentXsCredentialsRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="4" />&lt;Control Name="newXsCredentialsRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="4" />&lt;Control Name="testCredentialsButton" Row="5" RowSpan="1" Column="1" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="AutoSize,0,AutoSize,100,AutoSize,50,Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,25" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="errorLabel" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="testCredentialsStatusImage" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textboxXSPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="textboxXSUserName" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="currentXsCredentialsRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="newXsCredentialsRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="testCredentialsButton" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,100,AutoSize,50,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
@@ -1471,7 +1471,7 @@
     <value>11</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>619, 632</value>
+    <value>619, 671</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1489,16 +1489,16 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="decentGroupBox2" Row="3" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="decentGroupBox1" Row="8" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="rubricLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="PolicyStatementLinkLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="m_ctrlError" Row="10" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="flowLayoutPanel1" Row="10" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="enrollmentCheckBox" Row="2" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="decentGroupBoxXSCredentials" Row="7" RowSpan="1" Column="0" ColumnSpan="2" />&lt;/Controls>&lt;Columns Styles="Percent,100,AutoSize,0" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="decentGroupBox2" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="decentGroupBox1" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="rubricLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="PolicyStatementLinkLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="m_ctrlError" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="flowLayoutPanel1" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="enrollmentCheckBox" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="decentGroupBoxXSCredentials" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>619, 632</value>
+    <value>619, 671</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
@@ -133,7 +133,7 @@
     <value>NoControl</value>
   </data>
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 3</value>
+    <value>31, 3</value>
   </data>
   <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 25</value>
@@ -166,7 +166,7 @@
     <value>NoControl</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>85, 3</value>
+    <value>112, 3</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 25</value>
@@ -553,7 +553,7 @@
     <value>None</value>
   </data>
   <data name="authenticationRubricTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>589, 46</value>
+    <value>589, 72</value>
   </data>
   <data name="authenticationRubricTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -586,19 +586,19 @@
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 106</value>
+    <value>20, 132</value>
   </data>
   <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>U&amp;ser name:</value>
+    <value>U&amp;sername:</value>
   </data>
   <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -628,13 +628,13 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 135</value>
+    <value>20, 161</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -661,7 +661,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 138</value>
+    <value>89, 164</value>
   </data>
   <data name="textBoxMyCitrixPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -685,7 +685,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 109</value>
+    <value>89, 135</value>
   </data>
   <data name="textBoxMyCitrixUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -715,7 +715,7 @@
     <value>NoControl</value>
   </data>
   <data name="existingAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 59</value>
+    <value>3, 85</value>
   </data>
   <data name="existingAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>167, 19</value>
@@ -748,7 +748,7 @@
     <value>NoControl</value>
   </data>
   <data name="newAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 84</value>
+    <value>3, 110</value>
   </data>
   <data name="newAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>232, 19</value>
@@ -787,7 +787,7 @@
     <value>5</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>591, 167</value>
+    <value>591, 193</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -814,7 +814,7 @@
     <value>11, 402</value>
   </data>
   <data name="decentGroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>597, 188</value>
+    <value>597, 218</value>
   </data>
   <data name="decentGroupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -910,7 +910,7 @@
     <value>3</value>
   </data>
   <data name="m_ctrlError.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
   <data name="m_ctrlError.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -925,13 +925,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="m_ctrlError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 593</value>
+    <value>11, 623</value>
   </data>
   <data name="m_ctrlError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
   </data>
   <data name="m_ctrlError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>434, 42</value>
+    <value>407, 22</value>
   </data>
   <data name="m_ctrlError.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -952,7 +952,7 @@
     <value>4</value>
   </data>
   <data name="flowLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>Bottom, Left, Right</value>
   </data>
   <data name="flowLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -964,13 +964,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>448, 593</value>
+    <value>421, 627</value>
   </data>
   <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 42</value>
+    <value>190, 36</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1054,13 +1054,13 @@
     <value>NoControl</value>
   </data>
   <data name="errorLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>216, 138</value>
+    <value>213, 138</value>
   </data>
   <data name="errorLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 0</value>
   </data>
   <data name="errorLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 20</value>
+    <value>378, 20</value>
   </data>
   <data name="errorLabel.TabIndex" type="System.Int32, mscorlib">
     <value>120</value>
@@ -1087,7 +1087,7 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsStatusImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>197, 138</value>
+    <value>194, 138</value>
   </data>
   <data name="testCredentialsStatusImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>
@@ -1174,13 +1174,13 @@
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
   </data>
   <data name="label4.Text" xml:space="preserve">
-    <value>&amp;User name:</value>
+    <value>&amp;Username:</value>
   </data>
   <data name="label4.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -1216,7 +1216,7 @@
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -1243,7 +1243,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 107</value>
+    <value>89, 107</value>
   </data>
   <data name="textboxXSPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1267,7 +1267,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSUserName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 78</value>
+    <value>89, 78</value>
   </data>
   <data name="textboxXSUserName.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1303,7 +1303,7 @@
     <value>3, 28</value>
   </data>
   <data name="currentXsCredentialsRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>351, 19</value>
+    <value>231, 19</value>
   </data>
   <data name="currentXsCredentialsRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -1366,7 +1366,7 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 133</value>
+    <value>89, 133</value>
   </data>
   <data name="testCredentialsButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
@@ -1471,7 +1471,7 @@
     <value>11</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>619, 632</value>
+    <value>619, 671</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1498,7 +1498,7 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>619, 632</value>
+    <value>619, 671</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.zh-CN.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
-    <xsd:element msdata:IsDataSet="true" name="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
-                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
-              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
-              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -117,15 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="okButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="okButton.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -487,7 +487,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="frequencyLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="frequencyNumericBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="weeksLabel" Row="0" RowSpan="1" Column="2" ColumnSpan="1" />&lt;Control Name="dayOfweekLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="timeOfDayLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="timeOfDayComboBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" />&lt;Control Name="dayOfWeekComboBox" Row="2" RowSpan="1" Column="1" ColumnSpan="2" />&lt;/Controls>&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="frequencyLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="frequencyNumericBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="weeksLabel" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="dayOfweekLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="timeOfDayLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="timeOfDayComboBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="dayOfWeekComboBox" Row="2" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBox2.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
@@ -553,7 +553,7 @@
     <value>None</value>
   </data>
   <data name="authenticationRubricTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>589, 46</value>
+    <value>589, 72</value>
   </data>
   <data name="authenticationRubricTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -586,13 +586,13 @@
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 106</value>
+    <value>20, 132</value>
   </data>
   <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -628,13 +628,13 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 135</value>
+    <value>20, 161</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -661,7 +661,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 138</value>
+    <value>89, 164</value>
   </data>
   <data name="textBoxMyCitrixPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -685,7 +685,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 109</value>
+    <value>89, 135</value>
   </data>
   <data name="textBoxMyCitrixUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -715,7 +715,7 @@
     <value>NoControl</value>
   </data>
   <data name="existingAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 59</value>
+    <value>3, 85</value>
   </data>
   <data name="existingAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>167, 19</value>
@@ -748,7 +748,7 @@
     <value>NoControl</value>
   </data>
   <data name="newAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 84</value>
+    <value>3, 110</value>
   </data>
   <data name="newAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>232, 19</value>
@@ -787,7 +787,7 @@
     <value>5</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>591, 167</value>
+    <value>591, 193</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -805,7 +805,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="authenticationRubricTextBox" Row="0" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="label1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="label2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="textBoxMyCitrixPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="textBoxMyCitrixUsername" Row="3" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="existingAuthenticationRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="newAuthenticationRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="2" />&lt;/Controls>&lt;Columns Styles="AutoSize,0,Percent,100,Absolute,20" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="authenticationRubricTextBox" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="label1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixUsername" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="existingAuthenticationRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="newAuthenticationRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBox1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
@@ -814,7 +814,7 @@
     <value>11, 402</value>
   </data>
   <data name="decentGroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>597, 188</value>
+    <value>597, 218</value>
   </data>
   <data name="decentGroupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -910,7 +910,7 @@
     <value>3</value>
   </data>
   <data name="m_ctrlError.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
   <data name="m_ctrlError.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -919,19 +919,19 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="m_ctrlError.Error" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="m_ctrlError.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="m_ctrlError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 593</value>
+    <value>11, 623</value>
   </data>
   <data name="m_ctrlError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
   </data>
   <data name="m_ctrlError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>434, 42</value>
+    <value>434, 22</value>
   </data>
   <data name="m_ctrlError.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -952,7 +952,7 @@
     <value>4</value>
   </data>
   <data name="flowLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>Bottom, Left, Right</value>
   </data>
   <data name="flowLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -964,13 +964,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>448, 593</value>
+    <value>421, 627</value>
   </data>
   <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 42</value>
+    <value>190, 36</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1054,13 +1054,13 @@
     <value>NoControl</value>
   </data>
   <data name="errorLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>216, 138</value>
+    <value>213, 138</value>
   </data>
   <data name="errorLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 0</value>
   </data>
   <data name="errorLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 20</value>
+    <value>378, 20</value>
   </data>
   <data name="errorLabel.TabIndex" type="System.Int32, mscorlib">
     <value>120</value>
@@ -1087,7 +1087,7 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsStatusImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>197, 138</value>
+    <value>194, 138</value>
   </data>
   <data name="testCredentialsStatusImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>
@@ -1174,7 +1174,7 @@
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -1216,7 +1216,7 @@
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 29</value>
+    <value>63, 29</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -1243,7 +1243,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 107</value>
+    <value>89, 107</value>
   </data>
   <data name="textboxXSPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1267,7 +1267,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSUserName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 78</value>
+    <value>89, 78</value>
   </data>
   <data name="textboxXSUserName.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1366,7 +1366,7 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 133</value>
+    <value>89, 133</value>
   </data>
   <data name="testCredentialsButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 0</value>
@@ -1426,7 +1426,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="errorLabel" Row="5" RowSpan="1" Column="3" ColumnSpan="1" />&lt;Control Name="testCredentialsStatusImage" Row="5" RowSpan="1" Column="2" ColumnSpan="1" />&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="4" />&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="textboxXSPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="3" />&lt;Control Name="textboxXSUserName" Row="3" RowSpan="1" Column="1" ColumnSpan="3" />&lt;Control Name="currentXsCredentialsRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="4" />&lt;Control Name="newXsCredentialsRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="4" />&lt;Control Name="testCredentialsButton" Row="5" RowSpan="1" Column="1" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="AutoSize,0,AutoSize,100,AutoSize,50,Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,25" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="errorLabel" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="testCredentialsStatusImage" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textboxXSPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="textboxXSUserName" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="currentXsCredentialsRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="newXsCredentialsRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="testCredentialsButton" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,100,AutoSize,50,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
@@ -1471,7 +1471,7 @@
     <value>11</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>619, 632</value>
+    <value>619, 671</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1489,16 +1489,16 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="decentGroupBox2" Row="3" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="decentGroupBox1" Row="8" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="rubricLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="PolicyStatementLinkLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="m_ctrlError" Row="10" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="flowLayoutPanel1" Row="10" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="enrollmentCheckBox" Row="2" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="decentGroupBoxXSCredentials" Row="7" RowSpan="1" Column="0" ColumnSpan="2" />&lt;/Controls>&lt;Columns Styles="Percent,100,AutoSize,0" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" />&lt;/TableLayoutSettings></value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="decentGroupBox2" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="decentGroupBox1" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="rubricLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="PolicyStatementLinkLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="m_ctrlError" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="flowLayoutPanel1" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="enrollmentCheckBox" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="decentGroupBoxXSCredentials" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>619, 632</value>
+    <value>619, 671</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>


### PR DESCRIPTION
Made textbox bigger in health check policy dialog.
Made textbox bigger in the 'Authentication with Citrix Insight Services'
section of the health check enrollment dialog.
Adjusted some control properties to correct the position of OK/Cancel
buttons.
Changed 'User name:' labels to 'Username:' in health check enrollment
dialog.
Changed Chinese and Japanese resource files to match English changes.

Signed-off-by: Frederico Mazzone <fredericom@citrite.net>