### PR TITLE
CA-211418: Exception in XenCenter while attaching vdi to a VM on a p…

### DIFF
--- a/XenAdmin/Dialogs/AttachDiskDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AttachDiskDialog.Designer.cs
@@ -97,6 +97,7 @@ namespace XenAdmin.Dialogs
             this.Controls.Add(this.DiskListTreeView);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.Name = "AttachDiskDialog";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.AttachDiskDialog_FormClosing);
             this.readonlyCheckboxToolTipContainer.ResumeLayout(false);
             this.readonlyCheckboxToolTipContainer.PerformLayout();
             this.ResumeLayout(false);

--- a/XenAdmin/Dialogs/AttachDiskDialog.cs
+++ b/XenAdmin/Dialogs/AttachDiskDialog.cs
@@ -161,9 +161,11 @@ namespace XenAdmin.Dialogs
                             DiskListVdiItem VDIitem = new DiskListVdiItem(TheVDI);
                             if (VDIitem.Show)
                                 DiskListTreeView.AddChildNode(item, VDIitem);
+                            TheVDI.PropertyChanged -= new PropertyChangedEventHandler(Server_Changed);
                             TheVDI.PropertyChanged += new PropertyChangedEventHandler(Server_Changed);
                         }
                     }
+                    sr.PropertyChanged -= new PropertyChangedEventHandler(Server_Changed);
                     sr.PropertyChanged += new PropertyChangedEventHandler(Server_Changed);
                 }
             }


### PR DESCRIPTION
…ool with an SR with 20,000 VDIs

All event handlers are now unsubscribed when AttachDiskDialog is closed, allowing its memory to be garbage collected.
Image for each VDI now references an existing image instead of creating a new object.

Signed-off-by: Frederico Mazzone <fredericom@citrite.net>