### PR TITLE
CP-15714: UI: Change Select Servers Page

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -45,6 +45,7 @@ using XenAdmin.Dialogs;
 using System.Drawing;
 using XenAdmin.Alerts;
 using System.Linq;
+using XenAdmin.Actions;
 
 
 namespace XenAdmin.Wizards.PatchingWizard
@@ -181,9 +182,25 @@ namespace XenAdmin.Wizards.PatchingWizard
                         PageLeaveCancelled(string.Format(Messages.UPDATES_WIZARD_FILE_NOT_FOUND, SelectedNewPatch));
                     }
                 }
+                else //In Automatic Mode
+                {
+                    var downloadUpdatesAction = new DownloadUpdatesXmlAction(false, true, true);
+                    var dialog = new ActionProgressDialog(downloadUpdatesAction, ProgressBarStyle.Marquee);
+
+                    dialog.ShowDialog(this.Parent); //Will block until dialog closes, action completed
+
+                    if (!downloadUpdatesAction.Succeeded)
+                    {
+                        cancel = true;
+
+                    }
+                }
             }
 
-            Updates.CheckForUpdatesCompleted -= CheckForUpdates_CheckForUpdatesCompleted;
+            if (!cancel) //unsubscribe only if we are really leaving this page
+            {
+                Updates.CheckForUpdatesCompleted -= CheckForUpdates_CheckForUpdatesCompleted;
+            }
             base.PageLeave(direction, ref cancel);
         }
 
@@ -583,13 +600,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         private void AutomaticRadioButton_CheckedChanged(object sender, EventArgs e)
         {
-            if (AutomaticRadioButton.Checked)
-            {
-                CheckForUpdatesInProgress = true;
-                Updates.CheckForUpdates(true);
-
-                UpdateEnablement();
-            }
+            UpdateEnablement();
         }
 
         private void downloadUpdateRadioButton_CheckedChanged(object sender, EventArgs e)

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -156,13 +156,13 @@ namespace XenAdmin.Wizards.PatchingWizard
                     if (us[host].Count == 0)
                     {
                         row.Enabled = false;
-                        //add tooltip  why not
+                        row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_UP_TO_DATE;
                     }
                 }
                 else
                 {
                     row.Enabled = false;
-                    //add tooltip why not
+                    row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_NOT_AUTO_UPGRADABLE;
                 }
 
                 return;

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -25991,6 +25991,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This server cannot be updated automatically..
+        /// </summary>
+        public static string PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_NOT_AUTO_UPGRADABLE {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_NOT_AUTO_UPGRADABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This server is already up-to-date..
+        /// </summary>
+        public static string PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_UP_TO_DATE {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_UP_TO_DATE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select Servers.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_TEXT {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8985,6 +8985,12 @@ However, there is not enough space to perform the repartitioning, so the current
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_PATCH_NOT_APPLICABLE" xml:space="preserve">
     <value>Update not applicable</value>
   </data>
+  <data name="PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_NOT_AUTO_UPGRADABLE" xml:space="preserve">
+    <value>This server cannot be updated automatically.</value>
+  </data>
+  <data name="PATCHINGWIZARD_SELECTSERVERPAGE_SERVER_UP_TO_DATE" xml:space="preserve">
+    <value>This server is already up-to-date.</value>
+  </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_TEXT" xml:space="preserve">
     <value>Select Servers</value>
   </data>


### PR DESCRIPTION
DownloadUpdatesXmlAction is now called on PageLeave and not when the user selects Automatic Mode. This way we get the error message at the right time, also showing a progress dialog what makes the UX much better.
New tooltips for servers on the Select Server Page to to cover two more cases

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>