### PR TITLE
CA-209290: "Virtualization state" label displayed twice on General Tab of newly created VM

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1347,7 +1347,7 @@ namespace XenAdmin.TabPages
                     {
                         if (vm.virtualisation_status.HasFlag(XenAPI.VM.VirtualisationStatus.UNKNOWN))
                         {
-                            s.AddEntry(FriendlyName("VM.VirtualizationState"), vm.VirtualisationStatusString);
+                            sb.AppendLine(vm.VirtualisationStatusString);
                         }
                         else
                         {


### PR DESCRIPTION
Fixed duplicated headers.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>