### PR TITLE
CA-209502: Exception while deleting multiple folders

### DIFF
--- a/XenAdmin/Commands/DeleteFolderCommand.cs
+++ b/XenAdmin/Commands/DeleteFolderCommand.cs
@@ -66,14 +66,14 @@ namespace XenAdmin.Commands
 
         protected override void ExecuteCore(SelectedItemCollection selection)
         {
-            List<Folder> folders = new List<Folder>(selection.AsXenObjects<Folder>(CanExecute));
+            List<IXenObject> folders = new List<IXenObject>(selection.AsXenObjects<Folder>(CanExecute));
 
-            folders.RemoveAll((Predicate<Folder>)delegate(Folder folder)
+            folders.RemoveAll((Predicate<IXenObject>)delegate(IXenObject folder)
             {
                 // if the list contains any folders that are children to others in the list then
                 // they will automatically get deleted, so remove them here.
 
-                foreach (Folder f in folders)
+                foreach (var f in folders)
                 {
                     if (folder.opaque_ref.StartsWith(f.opaque_ref + "/"))
                     {
@@ -83,12 +83,7 @@ namespace XenAdmin.Commands
                 return false;
             });
 
-            List<AsyncAction> actions = new List<AsyncAction>();
-            foreach (Folder folder in folders)
-            {
-                actions.Add(new FolderAction((IXenObject)folder, null, FolderAction.Kind.Delete));
-            }
-            RunMultipleActions(actions, Messages.DELETING_FOLDERS, Messages.DELETING_FOLDERS, Messages.DELETED_FOLDERS, true);
+            new FolderAction(folders, null, FolderAction.Kind.Delete).RunAsync();
         }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)

--- a/XenAdmin/Commands/DeleteFolderCommand.cs
+++ b/XenAdmin/Commands/DeleteFolderCommand.cs
@@ -83,7 +83,7 @@ namespace XenAdmin.Commands
                 return false;
             });
 
-            new FolderAction(folders, null, FolderAction.Kind.Delete).RunAsync();
+            new DeleteFolderAction(folders).RunAsync();
         }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)

--- a/XenAdmin/Commands/DragDropIntoFolderCommand.cs
+++ b/XenAdmin/Commands/DragDropIntoFolderCommand.cs
@@ -174,7 +174,7 @@ namespace XenAdmin.Commands
                 }
             }
 
-            new FolderAction(GetItemsNotAlreadyInTargetFolder(), targetFolder, FolderAction.Kind.Move).RunAsync();
+            new MoveToFolderAction(GetItemsNotAlreadyInTargetFolder(), targetFolder).RunAsync();
 
             // need to now wait until the operation has finished... then we can expand the node.
             ThreadPool.QueueUserWorkItem(delegate

--- a/XenAdmin/Commands/DragDropIntoFolderCommand.cs
+++ b/XenAdmin/Commands/DragDropIntoFolderCommand.cs
@@ -162,12 +162,6 @@ namespace XenAdmin.Commands
         protected override void ExecuteCore()
         {
             Folder targetFolder = GetTargetNodeAncestorAsXenObjectOrGroupingTag<Folder>();
-            List<AsyncAction> actions = new List<AsyncAction>();
-
-            foreach (IXenObject draggedItem in GetItemsNotAlreadyInTargetFolder())
-            {
-                actions.Add(new FolderAction(draggedItem, targetFolder, FolderAction.Kind.Move));
-            }
 
             if (DraggedNodes != null)
             {
@@ -180,8 +174,7 @@ namespace XenAdmin.Commands
                 }
             }
 
-            MultipleActionLauncher launcher = new MultipleActionLauncher(actions, string.Format(Messages.MOVE_OBJECTS_TO_FOLDER, targetFolder.Name), Messages.MOVING, Messages.MOVED, true);
-            launcher.Run();
+            new FolderAction(GetItemsNotAlreadyInTargetFolder(), targetFolder, FolderAction.Kind.Move).RunAsync();
 
             // need to now wait until the operation has finished... then we can expand the node.
             ThreadPool.QueueUserWorkItem(delegate

--- a/XenAdmin/Commands/NewFolderCommand.cs
+++ b/XenAdmin/Commands/NewFolderCommand.cs
@@ -116,7 +116,7 @@ namespace XenAdmin.Commands
 
             if (newPaths.Count > 0)
             {
-                FolderAction action = new FolderAction(connection, FolderAction.Kind.New, newPaths.ToArray());
+                var action = new CreateFolderAction(connection, newPaths.ToArray());
 
                 Action<ActionBase> completed = null;
                 completed = delegate

--- a/XenAdmin/Commands/RemoveFromFolderCommand.cs
+++ b/XenAdmin/Commands/RemoveFromFolderCommand.cs
@@ -37,6 +37,7 @@ using XenAdmin.Actions;
 using XenAdmin.Controls;
 using XenAdmin.Model;
 using XenAPI;
+using System.Linq;
 
 
 namespace XenAdmin.Commands
@@ -77,18 +78,12 @@ namespace XenAdmin.Commands
 
         protected override void ExecuteCore(SelectedItemCollection selection)
         {
-            var actions = new List<AsyncAction>();
+            var objectsToBeRemoved = (from VirtualTreeNode node in _nodes
+                                    let xenObject = node.Tag as IXenObject
+                                    where xenObject != null
+                                    select xenObject).ToList();
 
-            foreach (VirtualTreeNode node in _nodes)
-            {
-                IXenObject xenObject = node.Tag as IXenObject;
-
-                if (xenObject != null)
-                    actions.Add(new FolderAction(xenObject, null, FolderAction.Kind.Delete));
-            }
-
-            if (actions.Count != 0)
-                RunMultipleActions(actions, Messages.REMOVE_FROM_FOLDER, Messages.REMOVING_FROM_FOLDER, Messages.REMOVED_FROM_FOLDER, true);
+            new FolderAction(objectsToBeRemoved, null, FolderAction.Kind.Delete).RunAsync();
         }
 
         public override string MenuText

--- a/XenAdmin/Commands/RemoveFromFolderCommand.cs
+++ b/XenAdmin/Commands/RemoveFromFolderCommand.cs
@@ -83,7 +83,7 @@ namespace XenAdmin.Commands
                                     where xenObject != null
                                     select xenObject).ToList();
 
-            new FolderAction(objectsToBeRemoved, null, FolderAction.Kind.Delete).RunAsync();
+            new DeleteFolderAction(objectsToBeRemoved).RunAsync();
         }
 
         public override string MenuText

--- a/XenAdmin/Commands/RenameFolderCommand.cs
+++ b/XenAdmin/Commands/RenameFolderCommand.cs
@@ -71,7 +71,7 @@ namespace XenAdmin.Commands
             string newName = _newName;
             Folders.FixupRelativePath(ref newName);
 
-            FolderAction action = new FolderAction(_folder, newName, FolderAction.Kind.Rename);
+            FolderAction action = new RenameFolderAction(_folder, newName);
             action.Completed += action_Completed;
             action.RunAsync();
         }

--- a/XenModel/Folders.cs
+++ b/XenModel/Folders.cs
@@ -415,7 +415,7 @@ namespace XenAdmin.Model
         public static void Create(IXenConnection connection, params string[] paths)
         {
             if (paths.Length > 0)
-                new FolderAction(connection, FolderAction.Kind.New, paths).RunAsync();
+                new CreateFolderAction(connection, paths).RunAsync();
         }
 
         public static void Move(Session session, IXenObject ixmo, Folder target)
@@ -434,7 +434,7 @@ namespace XenAdmin.Model
                     return;
             }
 
-            FolderAction action = new FolderAction(ixmo, target, FolderAction.Kind.Move);
+            FolderAction action = new MoveToFolderAction(ixmo, target);
             if (session == null)
                 action.RunAsync();
             else
@@ -457,7 +457,7 @@ namespace XenAdmin.Model
             if (folder == null)
                 return;
 
-            new FolderAction(folder, new_name, FolderAction.Kind.Rename).RunAsync();
+            new RenameFolderAction(folder, new_name).RunAsync();
         }
 
         public static void Unfolder(Session session, IXenObject ixmo)
@@ -465,7 +465,7 @@ namespace XenAdmin.Model
             if (ixmo == null)
                 return;
 
-            FolderAction action = new FolderAction(ixmo, null, FolderAction.Kind.Delete);
+            var action = new DeleteFolderAction(ixmo);
             if (session == null)
                 action.RunAsync();
             else


### PR DESCRIPTION
- Changed the FolderAction class so that it can be used to delete or move multiple folders across connections, instead of having multiple actions (one for each holder) which can not run in parallel.
- The api calls that update the EMPTY_FOLDERS entry in pool's other_config are preformed last for all connections, avoiding cross-thread exceptions when two threads try to add/remove the same key.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>