### PR TITLE
[CA-207306] Select box is not in line with pGPU bar on GPU tab of host

### DIFF
--- a/XenAdmin/Controls/GPU/GpuRow.cs
+++ b/XenAdmin/Controls/GPU/GpuRow.cs
@@ -116,8 +116,8 @@ namespace XenAdmin.Controls.GPU
             if (checkBox != null)
             {
                 shinyBarsContainerPanel.Controls.Add(checkBox, 0, index);
-                checkBox.Dock = DockStyle.Fill;
-                checkBox.Margin = new Padding(3, 14, 0, 0);
+                checkBox.Dock = DockStyle.Top;
+                checkBox.Margin = new Padding(6, 32, 0, 0);
                 checkBox.CheckedChanged += CheckedChanged;
                 checkBox.Checked = true;
             }


### PR DESCRIPTION
The last pGPU's row was stretching to the bottom, causing the lowest select box to fill its space and go down too much.
Changed the select boxs' dock style and margin.

Signed-off-by: Frederico Mazzone <fredericom@citrite.net>