### PR TITLE
CA-213414: Check feature-flag for ssl-legacy control switch

### DIFF
--- a/XenAdmin/Dialogs/PropertiesDialog.cs
+++ b/XenAdmin/Dialogs/PropertiesDialog.cs
@@ -197,7 +197,7 @@ namespace XenAdmin.Dialogs
                     ShowTab(PoolGpuEditPage = new PoolGpuEditPage());
                 }
 
-                if (is_pool_or_standalone && Helpers.DundeeOrGreater(xenObject.Connection))
+                if (is_pool_or_standalone && !Helpers.FeatureForbidden(xenObject.Connection, Host.RestrictSslLegacySwitch))
                     ShowTab(SecurityEditPage = new SecurityEditPage());
 
                 if (is_network)

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -502,6 +502,25 @@ namespace XenAPI
             return h._RestrictVss;
         }
 
+        /// <summary>
+        /// For Dundee and greater hosts: the feature is restricted only if the "restrict_ssl_legacy_switch" key exists and it is true
+        /// For pre-Dundee hosts: the feature is restricted if the "restrict_ssl_legacy_switch" key is absent or it is true
+        /// </summary>
+        private bool _RestrictSslLegacySwitch
+        {
+            get
+            {
+                return Helpers.DundeeOrGreater(this) 
+                    ? BoolKey(license_params, "restrict_ssl_legacy_switch") 
+                    : BoolKeyPreferTrue(license_params, "restrict_ssl_legacy_switch");
+            }
+        }
+
+        public static bool RestrictSslLegacySwitch(Host h)
+        {
+            return h._RestrictSslLegacySwitch;
+        }
+
         public bool HasPBDTo(SR sr)
         {
             foreach (XenRef<PBD> pbd in PBDs)


### PR DESCRIPTION
- For Dundee and newer hosts: the feature is restricted only if the "restrict_ssl_legacy_switch" flag exists and it is set to true
- For pre-Dundee hosts: the feature is restricted if the "restrict_ssl_legacy_switch" is absent or it is present and set to true

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>