### PR TITLE
[CA-213410] XenCenter ignores proxy settings in some places

### DIFF
--- a/XenAdmin/Core/WebBrowser2.cs
+++ b/XenAdmin/Core/WebBrowser2.cs
@@ -181,7 +181,8 @@ namespace XenAdmin.Core
 
             // test each url with a WebClient to see if it works.
             _webClients.Clear();
-            _webClients.AddRange(uriList.ConvertAll(u => new WebClient()));
+            var proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null, false);
+            _webClients.AddRange(uriList.ConvertAll(u => new WebClient() { Proxy = proxy }));
 
             // start all urls downloading in parallel.
             for (int i = 0; i < _webClients.Count; i++)

--- a/XenAdmin/Dialogs/DownloadApplianceDialog.cs
+++ b/XenAdmin/Dialogs/DownloadApplianceDialog.cs
@@ -60,6 +60,7 @@ namespace XenAdmin.Dialogs
 			m_uri = new Uri(uri);
 
 			m_webClient = new WebClient();
+            m_webClient.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null, false);
 			m_webClient.DownloadFileCompleted += webclient_DownloadFileCompleted;
 			m_webClient.DownloadProgressChanged += webclient_DownloadProgressChanged;
 		}
@@ -204,16 +205,6 @@ namespace XenAdmin.Dialogs
 				m_tlpProgress.Visible = true;
 				m_progressBar.Value = 0;
 				m_buttonDownload.Enabled = false;
-
-				Uri proxyUri = m_webClient.Proxy.GetProxy(m_uri);
-
-				if (proxyUri != m_uri)
-				{
-					DownloadedPath = null;
-					m_tlpProgress.Visible = false;
-					ShowDownloadError(Messages.PROXY_SERVERS_NOT_SUPPORTED);
-					return;
-				}
 
 				DownloadedPath = Path.Combine(m_textBoxWorkspace.Text, Path.GetFileName(m_uri.AbsolutePath));
 				

--- a/XenAdmin/Plugins/Features/TabPageFeature.cs
+++ b/XenAdmin/Plugins/Features/TabPageFeature.cs
@@ -961,6 +961,7 @@ namespace XenAdmin.Plugins
                 request.ContentType = "xml";
                 request.ContentLength = Encoding.UTF8.GetBytes(jsCallbackAndData[1]).Length;
                 request.UserAgent = Branding.BRAND_CONSOLE + "\\Plugin";
+                request.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(connection, false);
 
                 using (StreamWriter xmlstream = new StreamWriter(request.GetRequestStream()))
                 {

--- a/XenAdmin/Plugins/Features/TabPageFeature.cs
+++ b/XenAdmin/Plugins/Features/TabPageFeature.cs
@@ -961,7 +961,7 @@ namespace XenAdmin.Plugins
                 request.ContentType = "xml";
                 request.ContentLength = Encoding.UTF8.GetBytes(jsCallbackAndData[1]).Length;
                 request.UserAgent = Branding.BRAND_CONSOLE + "\\Plugin";
-                request.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(connection, false);
+                request.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(connection, true);
 
                 using (StreamWriter xmlstream = new StreamWriter(request.GetRequestStream()))
                 {

--- a/XenModel/Actions/HealthCheck/GetHealthCheckAnalysisResultAction.cs
+++ b/XenModel/Actions/HealthCheck/GetHealthCheckAnalysisResultAction.cs
@@ -153,6 +153,7 @@ namespace XenAdmin.Actions
                 var httpWebRequest = (HttpWebRequest)WebRequest.Create(urlString);
                 httpWebRequest.Headers.Add("Authorization", authorizationHeader);
                 httpWebRequest.Method = "GET";
+                httpWebRequest.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null, false);
 
                 string result;
                 var httpResponse = (HttpWebResponse)httpWebRequest.GetResponse();
@@ -201,6 +202,7 @@ namespace XenAdmin.Actions
             var httpWebRequest = (HttpWebRequest)WebRequest.Create(urlString);
             httpWebRequest.Headers.Add("Authorization", authorizationHeader);
             httpWebRequest.Method = "GET";
+            httpWebRequest.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null, false);
 
             string result;
             var httpResponse = (HttpWebResponse)httpWebRequest.GetResponse();

--- a/XenModel/Actions/HealthCheck/HealthCheckAuthenticationAction.cs
+++ b/XenModel/Actions/HealthCheck/HealthCheckAuthenticationAction.cs
@@ -219,6 +219,7 @@ namespace XenAdmin.Actions
             }
             httpWebRequest.ContentType = "application/json";
             httpWebRequest.Method = "POST";
+            httpWebRequest.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null, false);
 
             using (var streamWriter = new StreamWriter(httpWebRequest.GetRequestStream()))
             {

--- a/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
+++ b/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
@@ -74,6 +74,7 @@ namespace XenAdmin.Actions
         private void DownloadFile()
         {
             WebClient client = new WebClient();
+            client.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null, false);
             //register download events
             client.DownloadProgressChanged += client_DownloadProgressChanged;
             client.DownloadFileCompleted += client_DownloadFileCompleted;

--- a/XenOvfTransport/Import.cs
+++ b/XenOvfTransport/Import.cs
@@ -2584,6 +2584,7 @@ namespace XenOvfTransport
                 _downloadexception = null;
                 OnUpdate(new XenOvfTranportEventArgs(XenOvfTranportEventType.FileStart, "Web Download Start", downloadupdatemsg, 0, _filedownloadsize));
                 WebClient wc = new WebClient();
+                wc.Proxy = XenAdmin.XenAdminConfigManager.Provider.GetProxyFromSettings(null, false);
                 wc.DownloadFileCompleted += new System.ComponentModel.AsyncCompletedEventHandler(wc_DownloadFileCompleted);
                 wc.DownloadProgressChanged += new DownloadProgressChangedEventHandler(wc_DownloadProgressChanged);
                 wc.DownloadFileAsync(filetodownload, tmpfilename);


### PR DESCRIPTION
Assigned Proxy property in all WebClient, WebRequest and HttpWebRequest instances.
Removed "proxy not supported" message from Download Appliance dialog, since the download does work with a proxy.

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>