### PR TITLE
CA-214063: Batch Updates: Name of the master is shown instead of the …

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -167,7 +167,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 PatchingWizard_UploadPage.SelectedMasters = PatchingWizard_SelectServers.SelectedMasters;
                 PatchingWizard_UploadPage.SelectedServers = selectedServers;
 
-                PatchingWizard_AutoUpdatingPage.SelectedMasters = PatchingWizard_SelectServers.SelectedMasters;
+                PatchingWizard_AutoUpdatingPage.SelectedPools = PatchingWizard_SelectServers.SelectedPools;
             }
             else if (prevPageType == typeof(PatchingWizard_UploadPage))
             {

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutoUpdatingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutoUpdatingPage.cs
@@ -59,7 +59,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         public List<Problem> ProblemsResolvedPreCheck { private get; set; }
 
-        public List<Host> SelectedMasters { private get; set; }
+        public List<Pool> SelectedPools { private get; set; }
 
         private List<PoolPatchMapping> patchMappings = new List<PoolPatchMapping>();
         public Dictionary<XenServerPatch, string> AllDownloadedPatches = new Dictionary<XenServerPatch, string>();
@@ -136,21 +136,23 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             Dictionary<Host, List<PlanAction>> planActionsPerPool = new Dictionary<Host, List<PlanAction>>();
 
-            foreach (var master in SelectedMasters)
+            foreach (var pool in SelectedPools)
             {
+                var master = Helpers.GetMaster(pool.Connection);
+
                 Dictionary<Host, List<PlanAction>> planActionsByHost = new Dictionary<Host, List<PlanAction>>();
                 Dictionary<Host, List<PlanAction>> delayedActionsByHost = new Dictionary<Host, List<PlanAction>>();
                 planActionsPerPool.Add(master, new List<PlanAction>());
 
-                foreach (var host in master.Connection.Cache.Hosts)
+                foreach (var host in pool.Connection.Cache.Hosts)
                 {
                     planActionsByHost.Add(host, new List<PlanAction>());
                     delayedActionsByHost.Add(host, new List<PlanAction>());
                 }
 
-                var hosts = master.Connection.Cache.Hosts;
+                var hosts = pool.Connection.Cache.Hosts;
 
-                var us = Updates.GetUpgradeSequence(master.Connection);
+                var us = Updates.GetUpgradeSequence(pool.Connection);
 
                 foreach (var patch in us.UniquePatches)
                 {
@@ -288,6 +290,9 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
 
             textBoxLog.Text = sb.ToString();
+
+            textBoxLog.SelectionStart = textBoxLog.Text.Length;
+            textBoxLog.ScrollToCaret();
         }
 
         private void WorkerDoWork(object sender, DoWorkEventArgs doWorkEventArgs)

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -118,7 +118,17 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                         var pool = Helpers.GetPoolOfOne(xenConnection);
                         Host master = pool.Connection.Resolve(pool.master);
-                        int index = dataGridViewHosts.Rows.Add(new PatchingHostsDataGridViewRow(pool, true));
+
+                        int index = -1;
+                        if (Helpers.GetPool(xenConnection) != null) //pools
+                        {
+                            index = dataGridViewHosts.Rows.Add(new PatchingHostsDataGridViewRow(pool, true));
+                        }
+                        else //standalone hosts
+                        {
+                            index = dataGridViewHosts.Rows.Add(new PatchingHostsDataGridViewRow(master, false));
+                        }
+
                         EnabledRow(master, SelectedUpdateType, index);
                     }
                     else

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -122,7 +122,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                         int index = -1;
                         if (Helpers.GetPool(xenConnection) != null) //pools
                         {
-                            index = dataGridViewHosts.Rows.Add(new PatchingHostsDataGridViewRow(pool, true));
+                            index = dataGridViewHosts.Rows.Add(new PatchingHostsDataGridViewRow(pool));
                         }
                         else //standalone hosts
                         {
@@ -644,8 +644,6 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         private class PatchingHostsDataGridViewRow : CollapsingPoolHostDataGridViewRow
         {
-            public bool AutomaticMode = false;
-
             private class DataGridViewNameCell : DataGridViewExNameCell
             {
                 protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates cellState, object value, object formattedValue, string errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts)
@@ -737,10 +735,9 @@ namespace XenAdmin.Wizards.PatchingWizard
             private DataGridViewCell _poolIconHostCheckCell;
             private DataGridViewTextBoxCell _versionCell;
 
-            public PatchingHostsDataGridViewRow(Pool pool, bool automaticMode = false)
+            public PatchingHostsDataGridViewRow(Pool pool)
                 : base(pool)
             {
-                AutomaticMode = automaticMode;
                 SetupCells();
             }
 


### PR DESCRIPTION
…pool's name on Select Servers Page

Fixed display issue, now showing pools (and standalone hosts at the same level), not masters.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>