### PR TITLE
CP-17933: Add feature flag for proxy authentication

### DIFF
--- a/XenAdmin/Core/Registry.cs
+++ b/XenAdmin/Core/Registry.cs
@@ -80,6 +80,14 @@ namespace XenAdmin.Core
             }
         }
 
+        internal static bool ProxyAuthenticationEnabled
+        {
+            get
+            {
+                return ReadBool(PROXY_AUTHENTICATION_ENABLED, false);
+            }
+        }
+
         public static SSLCertificateTypes AlwaysShowSSLCertificates
         {
             get
@@ -402,6 +410,7 @@ namespace XenAdmin.Core
         private const string HEALTH_CHECK_PRODUCT_KEY = "HealthCheckProductKey";
         private const string HIDDEN_FEATURES = "HiddenFeatures";
         private const string ADDITIONAL_FEATURES = "AdditionalFeatures";
+        private const string PROXY_AUTHENTICATION_ENABLED = "ProxyAuthenticationEnabled";
     }
 
     public enum SSLCertificateTypes { None, Changed, All }

--- a/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.cs
@@ -52,7 +52,7 @@ namespace XenAdmin.Dialogs.OptionsPages
         private OptionsDialog optionsDialog;
 
         // used for preventing the event handlers from doing anything when changing controls through code
-        private bool freezeEventHandling = true;
+        private bool eventsDisabled = true;
 
         public ConnectionOptionsPage()
         {
@@ -111,42 +111,84 @@ namespace XenAdmin.Dialogs.OptionsPages
             
             ConnectionTimeoutNud.Value = Properties.Settings.Default.ConnectionTimeout / 1000;
 
-            freezeEventHandling = false;
+            eventsDisabled = false;
         }
 
         private void UseProxyRadioButton_CheckedChanged(object sender, EventArgs e)
         {
+            if (eventsDisabled)
+                return;
+
             enableOK();
         }
 
         private void AuthenticationCheckBox_CheckedChanged(object sender, EventArgs e)
         {
-            CallWithFreezeAwareness(AuthenticationCheckBoxChanged);
+            if (eventsDisabled)
+                return;
+
+            eventsDisabled = true;
+
+            if (!AuthenticationCheckBox.Checked)
+            {
+                ProxyUsernameTextBox.Clear();
+                ProxyPasswordTextBox.Clear();
+            }
+            SelectUseThisProxyServer();
+
+            eventsDisabled = false;
+
+            enableOK();
         }
 
         private void ProxyAddressTextBox_TextChanged(object sender, EventArgs e)
         {
-            CallWithFreezeAwareness(SelectUseThisProxyServer);
+            if (eventsDisabled)
+                return;
+
+            SelectUseThisProxyServer();
+
+            enableOK();
         }
 
         private void ProxyPortTextBox_TextChanged(object sender, EventArgs e)
         {
-            CallWithFreezeAwareness(SelectUseThisProxyServer);
+            if (eventsDisabled)
+                return;
+
+            SelectUseThisProxyServer();
+
+            enableOK();
         }
 
         private void ProxyUsernameTextBox_TextChanged(object sender, EventArgs e)
         {
-            CallWithFreezeAwareness(SelectProvideCredentials);
+            if (eventsDisabled)
+                return;
+
+            SelectProvideCredentials();
+
+            enableOK();
         }
 
         private void ProxyPasswordTextBox_TextChanged(object sender, EventArgs e)
         {
-            CallWithFreezeAwareness(SelectProvideCredentials);
+            if (eventsDisabled)
+                return;
+
+            SelectProvideCredentials();
+
+            enableOK();
         }
 
         private void BypassForServersCheckbox_CheckedChanged(object sender, EventArgs e)
         {
-            CallWithFreezeAwareness(SelectUseThisProxyServer);
+            if (eventsDisabled)
+                return;
+
+            SelectUseThisProxyServer();
+
+            enableOK();
         }
 
         private void SelectUseThisProxyServer()
@@ -156,39 +198,8 @@ namespace XenAdmin.Dialogs.OptionsPages
 
         private void SelectProvideCredentials()
         {
-            SelectUseThisProxyServer();
             AuthenticationCheckBox.Checked = true;
-        }
-
-        private void AuthenticationCheckBoxChanged()
-        {
-            SelectUseThisProxyServer();
-            if (!AuthenticationCheckBox.Checked)
-            {
-                ProxyUsernameTextBox.Clear();
-                ProxyPasswordTextBox.Clear();
-            }
-        }
-
-        private void CallWithFreezeAwareness(Action func)
-        {
-            if (freezeEventHandling)
-                return;
-            freezeEventHandling = true;
-
-            try
-            {
-                func();
-            }
-            catch
-            {
-                throw;
-            }
-            finally
-            {
-                freezeEventHandling = false;
-                enableOK();
-            }
+            UseProxyRadioButton.Checked = true;
         }
 
         private void enableOK()

--- a/XenAdmin/Program.cs
+++ b/XenAdmin/Program.cs
@@ -985,6 +985,11 @@ namespace XenAdmin
 
         public static void ReconfigureConnectionSettings()
         {
+            if (!Registry.ProxyAuthenticationEnabled)
+            {
+                Properties.Settings.Default.ProvideProxyAuthentication = false;
+                Properties.Settings.Default.Save();
+            }
             XenAPI.Session.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null);
         }
 


### PR DESCRIPTION
Added Registry.ProxyAuthenticationEnabled boolean property to enable/disable proxy authentication UI controls in Connection Options page.
Cleaned up event handler logic in Connection Options page to return from multiple/unnecessary calls to event handlers when manually changing controls through code.

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>