### PR TITLE
CA-203345: Exporting snapshot jams and cant be cancelled (when export…

### DIFF
--- a/XenModel/Actions/VM/ExportVmAction.cs
+++ b/XenModel/Actions/VM/ExportVmAction.cs
@@ -131,7 +131,7 @@ namespace XenAdmin.Actions
                     // which probably means there was an exception in the GUI code before the
                     // action got going. Kill the task so that we don't block forever on
                     // taskThread.Join(). Brought to light by CA-11100.
-                    XenAPI.Task.destroy(this.Session, this.RelatedTask.opaque_ref);
+                    DestroyTask();
                 }
                 // Test for null: don't overwrite a previous exception
                 if (_exception == null)

--- a/XenModel/WLB/WlbReportAction.cs
+++ b/XenModel/WLB/WlbReportAction.cs
@@ -117,7 +117,7 @@ namespace XenAdmin.Actions.Wlb
                     // which probably means there was an exception in the GUI code before the
                     // action got going. Kill the task so that we don't block forever on
                     // taskThread.Join(). Brought to light by CA-11100.
-                    XenAPI.Task.destroy(Session, RelatedTask.opaque_ref);
+                    DestroyTask();
                 }
                 if (exception == null)
                     exception = e;


### PR DESCRIPTION
…ing 2 snapshots to the same file)

Replaced the call to Task.destroy() with the DestroyTask() method, which additionally sets RelatedTask to null. This ensures that we stop polling the task for its progress and report the error.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>