### PR TITLE
CA-214953: Multiple connection dialogs while attempting to connect

### DIFF
--- a/XenAdmin/Dialogs/ConnectingToServerDialog.cs
+++ b/XenAdmin/Dialogs/ConnectingToServerDialog.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Windows.Forms;
+using System.Collections.Generic;
 using XenAdmin.Core;
 using XenAdmin.Network;
 
@@ -41,6 +42,7 @@ namespace XenAdmin.Dialogs
     {
         private readonly IXenConnection _connection;
         private Form ownerForm;
+        private static Dictionary<IXenConnection, ConnectingToServerDialog> openDialogs = new Dictionary<IXenConnection, ConnectingToServerDialog>();
 
         public ConnectingToServerDialog(IXenConnection connection)
             : base(connection)
@@ -98,6 +100,9 @@ namespace XenAdmin.Dialogs
                 return;
             }
 
+            if (_connection != null)
+                openDialogs.Remove(_connection);
+
             base.OnFormClosing(e);
         }
 
@@ -123,6 +128,16 @@ namespace XenAdmin.Dialogs
         {
             if (_connection != null && _connection is XenConnection)
             {
+                // CA-214953 - Focus on existing dialog for this connection, instead of creating a new one
+                ConnectingToServerDialog dlg;
+                if (openDialogs.TryGetValue(_connection, out dlg))
+                {
+                    dlg.Focus();
+                    this.Close();
+                    return;
+                }
+                openDialogs.Add(_connection, this);
+
                 ownerForm = owner;
 
                 RegisterEventHandlers();

--- a/XenAdmin/Dialogs/ConnectingToServerDialog.cs
+++ b/XenAdmin/Dialogs/ConnectingToServerDialog.cs
@@ -31,7 +31,6 @@
 
 using System;
 using System.Windows.Forms;
-using System.Collections.Generic;
 using XenAdmin.Core;
 using XenAdmin.Network;
 
@@ -42,7 +41,6 @@ namespace XenAdmin.Dialogs
     {
         private readonly IXenConnection _connection;
         private Form ownerForm;
-        private static Dictionary<IXenConnection, ConnectingToServerDialog> openDialogs = new Dictionary<IXenConnection, ConnectingToServerDialog>();
 
         public ConnectingToServerDialog(IXenConnection connection)
             : base(connection)
@@ -101,7 +99,7 @@ namespace XenAdmin.Dialogs
             }
 
             if (_connection != null)
-                openDialogs.Remove(_connection);
+                XenConnectionUI.connectionDialogs.Remove(_connection);
 
             base.OnFormClosing(e);
         }
@@ -128,16 +126,6 @@ namespace XenAdmin.Dialogs
         {
             if (_connection != null && _connection is XenConnection)
             {
-                // CA-214953 - Focus on existing dialog for this connection, instead of creating a new one
-                ConnectingToServerDialog dlg;
-                if (openDialogs.TryGetValue(_connection, out dlg))
-                {
-                    dlg.Focus();
-                    this.Close();
-                    return;
-                }
-                openDialogs.Add(_connection, this);
-
                 ownerForm = owner;
 
                 RegisterEventHandlers();


### PR DESCRIPTION
ConnectingToServerDialog now keeps track of the dialogs for each connection and focuses on them if they already exist, instead of creating new ones.

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>