### PR TITLE
CA-214622: XenCenter Install update Wizard Confusing Info shown on Install update screen

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -32852,7 +32852,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Removing update {0} from {1}... .
+        ///   Looks up a localized string similar to Removing update file {0} from {1}... .
         /// </summary>
         public static string UPDATES_WIZARD_REMOVING_UPDATE {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -11364,7 +11364,7 @@ Check your settings and try again.</value>
     <value>Rebooting {0} ... </value>
   </data>
   <data name="UPDATES_WIZARD_REMOVING_UPDATE" xml:space="preserve">
-    <value>Removing update {0} from {1}... </value>
+    <value>Removing update file {0} from {1}... </value>
   </data>
   <data name="UPDATES_WIZARD_REPAIR_SR" xml:space="preserve">
     <value>Click here to repair</value>


### PR DESCRIPTION
Changed confusing message from "Removing update ..." to "Removing update file ...".

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>