### PR TITLE
CA-209198: Allowed to attempt to install hotfix when it is already applied

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
@@ -171,7 +171,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 List<Host> poolHosts = new List<Host>(pool.Connection.Cache.Hosts);
                 Host master = SelectedServers.Find(host => host.IsMaster() && poolHosts.Contains(host));
-                if (master != null)
+                if (master != null && poolPatch != null && poolPatch.AppliedOn(master) == DateTime.MaxValue)
                     planActions.AddRange(CompileActionList(master, poolPatch));
                 foreach (Host server in SelectedServers)
                 {

--- a/XenModel/Actions/Pool_Patch/ApplyPatchAction.cs
+++ b/XenModel/Actions/Pool_Patch/ApplyPatchAction.cs
@@ -130,7 +130,8 @@ namespace XenAdmin.Actions
             {
                 foreach (Host host in hosts)
                 {
-                    ApplyPatch(host, patch);
+                    if (patch.AppliedOn(host) == DateTime.MaxValue)
+                        ApplyPatch(host, patch);
                 }
             }
         


### PR DESCRIPTION
XenCenter no longer ignores checking if the master host already has the specified patch applied; it now checks before trying to apply it, which means we get no error in the Patching Wizard's Patching Page.

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>