### PR TITLE
CA-216697: MTU message present on the Network Settings page when crea…

### DIFF
--- a/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.cs
+++ b/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWDetails.cs
@@ -136,7 +136,7 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             comboBoxNICList.Visible = external;
             labelVLAN.Visible = external;
             numericUpDownVLAN.Visible = external;
-            numericUpDownMTU.Visible = labelMTU.Visible = external;
+            numericUpDownMTU.Visible = labelMTU.Visible = infoMtuPanel.Visible = external;
             labelNIC.Visible = external;
             if (comboBoxNICList.Items.Count > 0)
                 comboBoxNICList.SelectedIndex = external ? comboBoxNICList.Items.Count - 1 : -1;


### PR DESCRIPTION
…ting an internal network

In the New Network wizard, when the "Single-Server Private Network" type is selected, the Network settings page should not display the MTU hint message, because it is not relevant to any controls on the page

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>