### PR TITLE
CA-213281, CA-213278: OK fixed

### DIFF
--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.Designer.cs
@@ -245,6 +245,7 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.existingAuthenticationRadioButton.Name = "existingAuthenticationRadioButton";
             this.existingAuthenticationRadioButton.TabStop = true;
             this.existingAuthenticationRadioButton.UseVisualStyleBackColor = true;
+            this.existingAuthenticationRadioButton.CheckedChanged += new System.EventHandler(this.existingAuthenticationRadioButton_CheckedChanged);
             // 
             // newAuthenticationRadioButton
             // 

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.cs
@@ -409,5 +409,10 @@ namespace XenAdmin.Dialogs.HealthCheck
         {
             Program.OpenURL(e.LinkText);
         }
+
+        private void existingAuthenticationRadioButton_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateButtons();
+        }
     }
 }


### PR DESCRIPTION
Bugs fixed:
* OK button not re-enabling when switching back to using existing credentials in Health Check Enrollment dialog
* Using empty credentials to authenticate with Citrix Insight Services does not disable OK button in Health Check Enrollment dialog

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>