### PR TITLE
CA-213728: Going to Home Server tab can change home server

### DIFF
--- a/XenAdmin/Controls/AffinityPicker.Designer.cs
+++ b/XenAdmin/Controls/AffinityPicker.Designer.cs
@@ -109,6 +109,7 @@ namespace XenAdmin.Controls
             this.ReasonColumn});
             resources.ApplyResources(this.ServersGridView, "ServersGridView");
             this.ServersGridView.Name = "ServersGridView";
+            this.ServersGridView.VisibleChanged += new System.EventHandler(this.ServersGridView_VisibleChanged);
             // 
             // ImageColumn
             // 

--- a/XenAdmin/Controls/AffinityPicker.cs
+++ b/XenAdmin/Controls/AffinityPicker.cs
@@ -216,6 +216,17 @@ namespace XenAdmin.Controls
             else
                 ServersGridView.Select();
         }
+
+        bool selectedOnVisibleChanged = false;
+
+        private void ServersGridView_VisibleChanged(object sender, EventArgs e)
+        {
+            if (!selectedOnVisibleChanged)
+            {
+                selectedOnVisibleChanged = true;
+                SelectSomething();//CA-213728
+            }
+        }
     }
 
     internal class ServerGridRow : DataGridViewExRow


### PR DESCRIPTION
Even though the correct row have been selected by the time the grid becomes visible, it is not displayed properly. This change set fixes the problem by selecting the row again.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>