### PR TITLE
CA-214622: Confusing info shown on Install Update screen

### DIFF
--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -11364,7 +11364,7 @@ Check your settings and try again.</value>
     <value>Rebooting {0} ... </value>
   </data>
   <data name="UPDATES_WIZARD_REMOVING_UPDATE" xml:space="preserve">
-    <value>Removing update file {0} from {1}... </value>
+    <value>Deleting update installation file {0} from {1}... </value>
   </data>
   <data name="UPDATES_WIZARD_REPAIR_SR" xml:space="preserve">
     <value>Click here to repair</value>


### PR DESCRIPTION
Changed message to "Deleting update installation file ..." to match wording in previous page of the wizard.

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>