### PR TITLE
CA-217232: Batch updates: Install Dundee released hotfixes in Batch f…

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -477,11 +477,11 @@ namespace XenAdmin.Core
                 // Take all the hotfixes for this version
                 allPatches.AddRange(serverVersions[0].Patches);
 
-                var minimumPatches = serverVersions[0].MinimalPatches;
+                uSeq.MinimalPatches = serverVersions[0].MinimalPatches;
 
                 foreach (Host h in hosts)
                 {
-                    uSeq[h] = GetUpgradeSequenceForHost(h, allPatches, minimumPatches);
+                    uSeq[h] = GetUpgradeSequenceForHost(h, allPatches, uSeq.MinimalPatches);
                 }
             }
 
@@ -547,7 +547,17 @@ namespace XenAdmin.Core
             {
                 get
                 {
-                    return AllPatches.Distinct().ToList();
+                    var uniquePatches = new List<XenServerPatch>();
+
+                    foreach (var mp in MinimalPatches)
+                    {
+                        if (AllPatches.Any(p => p.Uuid == mp.Uuid))
+                        {
+                            uniquePatches.Add(mp);
+                        }
+                    }
+
+                    return uniquePatches;
                 }
             }
 
@@ -566,6 +576,12 @@ namespace XenAdmin.Core
 
                     return true;
                 }
+            }
+
+            public List<XenServerPatch> MinimalPatches
+            {
+                set;
+                get;
             }
         }
 


### PR DESCRIPTION
…ails with wrong message in hotfix wizard

Despite the update sequences are correct by host, when they are flattened, the original order (order in minimal patches) was not considered properly, so a missing patch was scheduled for later in the sequence than it should have been, thus the upgrade failed with a precheck-error.

This bug occurs when we are given
* a pool of more than one host,
* with (at least) patchA not installed on 2 or more hosts
* patchA requires patchR that is not installed on at least one of the above hosts (but not not on all)
* the host that is missing patchR is ahead of other hosts in pool.Hosts.Cache

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>