### PR TITLE
CA-217388: Hotfix Install wizard shows update as already uploaded whe…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizardModeGuidanceBuilder.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizardModeGuidanceBuilder.cs
@@ -40,7 +40,7 @@ namespace XenAdmin.Wizards.PatchingWizard
     {
         public static string ModeRetailPatch(List<Host> servers, Pool_patch patch)
         {
-            return Build(servers, patch.after_apply_guidance);
+            return Build(servers, patch != null ? patch.after_apply_guidance : new List<after_apply_guidance>());
         }
 
         public static string ModeSuppPack(List<Host> servers)


### PR DESCRIPTION
…n it is not actually uploaded because there wasn't enough space

- Add a new update to the list of uploaded updates only when the upload action has completed successfully.
- Do not perform the disk space check if there is nothing to upload (update has already been uploaded).

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>