### PR TITLE
CA-210549: Make MultipleAction and ParallelAction cancellable

### DIFF
--- a/XenModel/Actions/MultipleAction.cs
+++ b/XenModel/Actions/MultipleAction.cs
@@ -148,7 +148,7 @@ namespace XenAdmin.Actions
             }
         }
 
-        private void RecalculatePercentComplete()
+        protected virtual void RecalculatePercentComplete()
         {
             int total = 0;
             int n = subActions.Count;


### PR DESCRIPTION
- The multiple action is cancellable if is at least one sub action is not completed
- When a multiple action is cancelled, we try to cancel all sub actions that are not completed
- Also changed the way we calculate the percent complete for the parent action, to report partial progress of the sub actions

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>