### PR TITLE
CA-33357: Improvements: show the disk name on the New VM storage page…

### DIFF
--- a/XenAdmin/Wizards/NewVMWizard/Page_Networking.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Networking.resx
@@ -112,23 +112,23 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 4</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
     <value>561, 46</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -139,7 +139,7 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -166,7 +166,7 @@
     <value>AddButton</value>
   </data>
   <data name="&gt;&gt;AddButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AddButton.Parent" xml:space="preserve">
     <value>toolTipContainerAddButton</value>
@@ -178,7 +178,7 @@
     <value>Top, Right</value>
   </data>
   <data name="PropertiesButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>490, 134</value>
+    <value>490, 105</value>
   </data>
   <data name="PropertiesButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -187,13 +187,13 @@
     <value>5</value>
   </data>
   <data name="PropertiesButton.Text" xml:space="preserve">
-    <value>P&amp;roperties</value>
+    <value>&amp;Edit...</value>
   </data>
   <data name="&gt;&gt;PropertiesButton.Name" xml:space="preserve">
     <value>PropertiesButton</value>
   </data>
   <data name="&gt;&gt;PropertiesButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;PropertiesButton.Parent" xml:space="preserve">
     <value>$this</value>
@@ -205,7 +205,7 @@
     <value>Top, Right</value>
   </data>
   <data name="DeleteButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>489, 105</value>
+    <value>490, 134</value>
   </data>
   <data name="DeleteButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -220,7 +220,7 @@
     <value>DeleteButton</value>
   </data>
   <data name="&gt;&gt;DeleteButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DeleteButton.Parent" xml:space="preserve">
     <value>$this</value>
@@ -247,7 +247,7 @@
     <value>BoxTitle</value>
   </data>
   <data name="&gt;&gt;BoxTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BoxTitle.Parent" xml:space="preserve">
     <value>$this</value>
@@ -258,7 +258,7 @@
   <data name="NetworksGridView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <metadata name="ImageColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ImageColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ImageColumn.HeaderText" xml:space="preserve">
@@ -267,7 +267,7 @@
   <data name="ImageColumn.Width" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <metadata name="MacColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="MacColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="MacColumn.HeaderText" xml:space="preserve">
@@ -276,7 +276,7 @@
   <data name="MacColumn.Width" type="System.Int32, mscorlib">
     <value>55</value>
   </data>
-  <metadata name="NetworkColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="NetworkColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="NetworkColumn.HeaderText" xml:space="preserve">
@@ -325,7 +325,7 @@
     <value>labelDefaultTemplateInfo</value>
   </data>
   <data name="&gt;&gt;labelDefaultTemplateInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelDefaultTemplateInfo.Parent" xml:space="preserve">
     <value>panelDefaultTemplateInfo</value>
@@ -349,7 +349,7 @@
     <value>pictureBox1</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
     <value>panelDefaultTemplateInfo</value>
@@ -373,7 +373,7 @@
     <value>panelDefaultTemplateInfo</value>
   </data>
   <data name="&gt;&gt;panelDefaultTemplateInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panelDefaultTemplateInfo.Parent" xml:space="preserve">
     <value>$this</value>
@@ -405,7 +405,7 @@
   <data name="&gt;&gt;toolTipContainerAddButton.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -418,19 +418,19 @@
     <value>ImageColumn</value>
   </data>
   <data name="&gt;&gt;ImageColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MacColumn.Name" xml:space="preserve">
     <value>MacColumn</value>
   </data>
   <data name="&gt;&gt;MacColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;NetworkColumn.Name" xml:space="preserve">
     <value>NetworkColumn</value>
   </data>
   <data name="&gt;&gt;NetworkColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>Page_Networking</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.Designer.cs
@@ -30,62 +30,27 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_Storage));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.label1 = new System.Windows.Forms.Label();
-            this.DisksRadioButton = new System.Windows.Forms.RadioButton();
-            this.DisklessVMRadioButton = new System.Windows.Forms.RadioButton();
-            this.AddButton = new System.Windows.Forms.Button();
-            this.PropertiesButton = new System.Windows.Forms.Button();
-            this.DeleteButton = new System.Windows.Forms.Button();
+            this.CloneCheckBox = new System.Windows.Forms.CheckBox();
             this.DisksGridView = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
+            this.DeleteButton = new System.Windows.Forms.Button();
+            this.PropertiesButton = new System.Windows.Forms.Button();
+            this.AddButton = new System.Windows.Forms.Button();
+            this.DisklessVMRadioButton = new System.Windows.Forms.RadioButton();
+            this.DisksRadioButton = new System.Windows.Forms.RadioButton();
+            this.label1 = new System.Windows.Forms.Label();
             this.ImageColumn = new System.Windows.Forms.DataGridViewImageColumn();
+            this.NameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SrColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SizeColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SharedColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.CloneCheckBox = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.DisksGridView)).BeginInit();
             this.SuspendLayout();
             // 
-            // label1
+            // CloneCheckBox
             // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
-            // 
-            // DisksRadioButton
-            // 
-            resources.ApplyResources(this.DisksRadioButton, "DisksRadioButton");
-            this.DisksRadioButton.Name = "DisksRadioButton";
-            this.DisksRadioButton.TabStop = true;
-            this.DisksRadioButton.UseVisualStyleBackColor = true;
-            this.DisksRadioButton.CheckedChanged += new System.EventHandler(this.DisksRadioButton_CheckedChanged);
-            // 
-            // DisklessVMRadioButton
-            // 
-            resources.ApplyResources(this.DisklessVMRadioButton, "DisklessVMRadioButton");
-            this.DisklessVMRadioButton.Name = "DisklessVMRadioButton";
-            this.DisklessVMRadioButton.TabStop = true;
-            this.DisklessVMRadioButton.UseVisualStyleBackColor = true;
-            this.DisklessVMRadioButton.CheckedChanged += new System.EventHandler(this.DisklessVMRadioButton_CheckedChanged);
-            // 
-            // AddButton
-            // 
-            resources.ApplyResources(this.AddButton, "AddButton");
-            this.AddButton.Name = "AddButton";
-            this.AddButton.UseVisualStyleBackColor = true;
-            this.AddButton.Click += new System.EventHandler(this.AddButton_Click);
-            // 
-            // PropertiesButton
-            // 
-            resources.ApplyResources(this.PropertiesButton, "PropertiesButton");
-            this.PropertiesButton.Name = "PropertiesButton";
-            this.PropertiesButton.UseVisualStyleBackColor = true;
-            this.PropertiesButton.Click += new System.EventHandler(this.PropertiesButton_Click);
-            // 
-            // DeleteButton
-            // 
-            resources.ApplyResources(this.DeleteButton, "DeleteButton");
-            this.DeleteButton.Name = "DeleteButton";
-            this.DeleteButton.UseVisualStyleBackColor = true;
-            this.DeleteButton.Click += new System.EventHandler(this.DeleteButton_Click);
+            resources.ApplyResources(this.CloneCheckBox, "CloneCheckBox");
+            this.CloneCheckBox.Name = "CloneCheckBox";
+            this.CloneCheckBox.UseVisualStyleBackColor = true;
             // 
             // DisksGridView
             // 
@@ -95,6 +60,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.DisksGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.DisksGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ImageColumn,
+            this.NameColumn,
             this.SrColumn,
             this.SizeColumn,
             this.SharedColumn});
@@ -109,17 +75,67 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.DisksGridView.Name = "DisksGridView";
             this.DisksGridView.SelectionChanged += new System.EventHandler(this.DisksGridView_SelectionChanged);
             // 
+            // DeleteButton
+            // 
+            resources.ApplyResources(this.DeleteButton, "DeleteButton");
+            this.DeleteButton.Name = "DeleteButton";
+            this.DeleteButton.UseVisualStyleBackColor = true;
+            this.DeleteButton.Click += new System.EventHandler(this.DeleteButton_Click);
+            // 
+            // PropertiesButton
+            // 
+            resources.ApplyResources(this.PropertiesButton, "PropertiesButton");
+            this.PropertiesButton.Name = "PropertiesButton";
+            this.PropertiesButton.UseVisualStyleBackColor = true;
+            this.PropertiesButton.Click += new System.EventHandler(this.PropertiesButton_Click);
+            // 
+            // AddButton
+            // 
+            resources.ApplyResources(this.AddButton, "AddButton");
+            this.AddButton.Name = "AddButton";
+            this.AddButton.UseVisualStyleBackColor = true;
+            this.AddButton.Click += new System.EventHandler(this.AddButton_Click);
+            // 
+            // DisklessVMRadioButton
+            // 
+            resources.ApplyResources(this.DisklessVMRadioButton, "DisklessVMRadioButton");
+            this.DisklessVMRadioButton.Name = "DisklessVMRadioButton";
+            this.DisklessVMRadioButton.TabStop = true;
+            this.DisklessVMRadioButton.UseVisualStyleBackColor = true;
+            this.DisklessVMRadioButton.CheckedChanged += new System.EventHandler(this.DisklessVMRadioButton_CheckedChanged);
+            // 
+            // DisksRadioButton
+            // 
+            resources.ApplyResources(this.DisksRadioButton, "DisksRadioButton");
+            this.DisksRadioButton.Name = "DisksRadioButton";
+            this.DisksRadioButton.TabStop = true;
+            this.DisksRadioButton.UseVisualStyleBackColor = true;
+            this.DisksRadioButton.CheckedChanged += new System.EventHandler(this.DisksRadioButton_CheckedChanged);
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
+            // 
             // ImageColumn
             // 
             this.ImageColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.ImageColumn.HeaderText = global::XenAdmin.Messages.SOLUTION_UNKNOWN;
+            resources.ApplyResources(this.ImageColumn, "ImageColumn");
             this.ImageColumn.Name = "ImageColumn";
             this.ImageColumn.ReadOnly = true;
-            resources.ApplyResources(this.ImageColumn, "ImageColumn");
+            // 
+            // NameColumn
+            // 
+            this.NameColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.NameColumn.FillWeight = 40F;
+            resources.ApplyResources(this.NameColumn, "NameColumn");
+            this.NameColumn.Name = "NameColumn";
+            this.NameColumn.ReadOnly = true;
             // 
             // SrColumn
             // 
             this.SrColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.SrColumn.FillWeight = 60F;
             resources.ApplyResources(this.SrColumn, "SrColumn");
             this.SrColumn.Name = "SrColumn";
             this.SrColumn.ReadOnly = true;
@@ -137,12 +153,6 @@ namespace XenAdmin.Wizards.NewVMWizard
             resources.ApplyResources(this.SharedColumn, "SharedColumn");
             this.SharedColumn.Name = "SharedColumn";
             this.SharedColumn.ReadOnly = true;
-            // 
-            // CloneCheckBox
-            // 
-            resources.ApplyResources(this.CloneCheckBox, "CloneCheckBox");
-            this.CloneCheckBox.Name = "CloneCheckBox";
-            this.CloneCheckBox.UseVisualStyleBackColor = true;
             // 
             // Page_Storage
             // 
@@ -172,10 +182,11 @@ namespace XenAdmin.Wizards.NewVMWizard
         private System.Windows.Forms.Button PropertiesButton;
         private System.Windows.Forms.Button DeleteButton;
         private XenAdmin.Controls.DataGridViewEx.DataGridViewEx DisksGridView;
+        private System.Windows.Forms.CheckBox CloneCheckBox;
         private System.Windows.Forms.DataGridViewImageColumn ImageColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn NameColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn SrColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn SizeColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn SharedColumn;
-        private System.Windows.Forms.CheckBox CloneCheckBox;
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
@@ -356,12 +356,13 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             get
             {
-                List<KeyValuePair<string, string>> sum = new List<KeyValuePair<string, string>>();
-                int i = 0;
+                var sum = new List<KeyValuePair<string, string>>();
+
                 foreach (DiskDescription d in SelectedDisks)
                 {
-                    sum.Add(new KeyValuePair<string, string>(string.Format(Messages.NEWVMWIZARD_STORAGEPAGE_DISK, i), Util.DiskSizeString(d.Disk.virtual_size)));
-                    i++;
+                    sum.Add(new KeyValuePair<string, string>(
+                        string.Format(Messages.NEWVMWIZARD_STORAGEPAGE_DISK, Helpers.GetName(d.Disk).Ellipsise(30)),
+                        Util.DiskSizeString(d.Disk.virtual_size)));
                 }
                 return sum;
             }
@@ -411,6 +412,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private DataGridViewImageCell ImageCell;
         private DataGridViewTextBoxCell SizeCell;
+        private DataGridViewTextBoxCell NameCell;
         private DataGridViewTextBoxCell SrCell;
         private DataGridViewTextBoxCell SharedCell;
 
@@ -469,13 +471,13 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void AddCells()
         {
-            ImageCell = new DataGridViewImageCell(false);
-            ImageCell.ValueType = typeof(Image);
+            ImageCell = new DataGridViewImageCell(false) {ValueType = typeof(Image)};
+            NameCell = new DataGridViewTextBoxCell();
             SizeCell = new DataGridViewTextBoxCell();
             SrCell = new DataGridViewTextBoxCell();
             SharedCell = new DataGridViewTextBoxCell();
 
-            Cells.AddRange(new DataGridViewCell[] { ImageCell, SrCell, SizeCell, SharedCell });
+            Cells.AddRange(ImageCell, NameCell, SrCell, SizeCell, SharedCell);
 
             UpdateDetails();
         }
@@ -496,6 +498,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
             ImageCell.ToolTipText = ImageToolTip;
             SizeCell.ToolTipText = ImageToolTip;
+            NameCell.ToolTipText = ImageToolTip;
             SrCell.ToolTipText = ImageToolTip;
             SharedCell.ToolTipText = ImageToolTip;
 
@@ -505,10 +508,12 @@ namespace XenAdmin.Wizards.NewVMWizard
             else
                 SizeCell.Value = sr.HBALunPerVDI ? String.Empty : Util.DiskSizeString(Disk.virtual_size);
 
+            NameCell.Value = Helpers.GetName(Disk);
+
             if (Disk.SR.opaque_ref != Helper.NullOpaqueRef)
             {
-                SrCell.Value = Helpers.GetName(Connection.Resolve<SR>(Disk.SR));
-                SharedCell.Value = (Connection.Resolve<SR>(Disk.SR).shared ? Messages.TRUE : Messages.FALSE);
+                SrCell.Value = Helpers.GetName(sr);
+                SharedCell.Value = sr.shared ? Messages.TRUE : Messages.FALSE;
             }
             else
             {

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.resx
@@ -112,196 +112,75 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 128</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>The virtual machine template you selected earlier provides the virtual disks listed below. You can change the properties of these virtual disks, and add more disks if required.
-
-Alternatively, you can select the second option below to create a diskless VM that can be booted from the network and does not use any virtual disks.
-
-When you have finished configuring disks for the new virtual machine, click Next to continue to the next step.</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="DisksRadioButton.AutoSize" type="System.Boolean, mscorlib">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="CloneCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="DisksRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 131</value>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="CloneCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="DisksRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 17</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="CloneCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 275</value>
   </data>
-  <data name="DisksRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="CloneCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 17</value>
   </data>
-  <data name="DisksRadioButton.Text" xml:space="preserve">
-    <value>Use these &amp;virtual disks:</value>
-  </data>
-  <data name="&gt;&gt;DisksRadioButton.Name" xml:space="preserve">
-    <value>DisksRadioButton</value>
-  </data>
-  <data name="&gt;&gt;DisksRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DisksRadioButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;DisksRadioButton.ZOrder" xml:space="preserve">
+  <data name="CloneCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
-  <data name="DisklessVMRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="CloneCheckBox.Text" xml:space="preserve">
+    <value>Use storage-level &amp;fast disk clone</value>
   </data>
-  <data name="DisklessVMRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 317</value>
+  <data name="&gt;&gt;CloneCheckBox.Name" xml:space="preserve">
+    <value>CloneCheckBox</value>
   </data>
-  <data name="DisklessVMRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 17</value>
+  <data name="&gt;&gt;CloneCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="DisklessVMRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="DisklessVMRadioButton.Text" xml:space="preserve">
-    <value>Create a diskles&amp;s VM that boots from the network</value>
-  </data>
-  <data name="&gt;&gt;DisklessVMRadioButton.Name" xml:space="preserve">
-    <value>DisklessVMRadioButton</value>
-  </data>
-  <data name="&gt;&gt;DisklessVMRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DisklessVMRadioButton.Parent" xml:space="preserve">
+  <data name="&gt;&gt;CloneCheckBox.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;DisklessVMRadioButton.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="AddButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="AddButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>428, 154</value>
-  </data>
-  <data name="AddButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="AddButton.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="AddButton.Text" xml:space="preserve">
-    <value>&amp;Add...</value>
-  </data>
-  <data name="&gt;&gt;AddButton.Name" xml:space="preserve">
-    <value>AddButton</value>
-  </data>
-  <data name="&gt;&gt;AddButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AddButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;AddButton.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="PropertiesButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="PropertiesButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>428, 212</value>
-  </data>
-  <data name="PropertiesButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="PropertiesButton.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="PropertiesButton.Text" xml:space="preserve">
-    <value>P&amp;roperties</value>
-  </data>
-  <data name="&gt;&gt;PropertiesButton.Name" xml:space="preserve">
-    <value>PropertiesButton</value>
-  </data>
-  <data name="&gt;&gt;PropertiesButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PropertiesButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;PropertiesButton.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="DeleteButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="DeleteButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>428, 183</value>
-  </data>
-  <data name="DeleteButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="DeleteButton.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="DeleteButton.Text" xml:space="preserve">
-    <value>&amp;Delete</value>
-  </data>
-  <data name="&gt;&gt;DeleteButton.Name" xml:space="preserve">
-    <value>DeleteButton</value>
-  </data>
-  <data name="&gt;&gt;DeleteButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DeleteButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;DeleteButton.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;CloneCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="DisksGridView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <metadata name="ImageColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ImageColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="ImageColumn.HeaderText" xml:space="preserve">
+    <value />
+  </data>
   <data name="ImageColumn.Width" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <metadata name="SrColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="NameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="NameColumn.HeaderText" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NameColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <metadata name="SrColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="SrColumn.HeaderText" xml:space="preserve">
     <value>Location</value>
   </data>
-  <metadata name="SizeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="SrColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <metadata name="SizeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="SizeColumn.HeaderText" xml:space="preserve">
@@ -310,7 +189,7 @@ When you have finished configuring disks for the new virtual machine, click Next
   <data name="SizeColumn.Width" type="System.Int32, mscorlib">
     <value>52</value>
   </data>
-  <metadata name="SharedColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="SharedColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="SharedColumn.HeaderText" xml:space="preserve">
@@ -340,34 +219,191 @@ When you have finished configuring disks for the new virtual machine, click Next
   <data name="&gt;&gt;DisksGridView.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="CloneCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="DeleteButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
-  <data name="CloneCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>25, 275</value>
+  <data name="DeleteButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="CloneCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 17</value>
+  <data name="DeleteButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>428, 212</value>
   </data>
-  <data name="CloneCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="DeleteButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
-  <data name="CloneCheckBox.Text" xml:space="preserve">
-    <value>Use storage-level &amp;fast disk clone</value>
+  <data name="DeleteButton.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="&gt;&gt;CloneCheckBox.Name" xml:space="preserve">
-    <value>CloneCheckBox</value>
+  <data name="DeleteButton.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
   </data>
-  <data name="&gt;&gt;CloneCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;DeleteButton.Name" xml:space="preserve">
+    <value>DeleteButton</value>
   </data>
-  <data name="&gt;&gt;CloneCheckBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;DeleteButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DeleteButton.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;CloneCheckBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;DeleteButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="PropertiesButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="PropertiesButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="PropertiesButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>428, 183</value>
+  </data>
+  <data name="PropertiesButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="PropertiesButton.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="PropertiesButton.Text" xml:space="preserve">
+    <value>&amp;Edit...</value>
+  </data>
+  <data name="&gt;&gt;PropertiesButton.Name" xml:space="preserve">
+    <value>PropertiesButton</value>
+  </data>
+  <data name="&gt;&gt;PropertiesButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PropertiesButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;PropertiesButton.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="AddButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="AddButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="AddButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>428, 154</value>
+  </data>
+  <data name="AddButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="AddButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="AddButton.Text" xml:space="preserve">
+    <value>&amp;Add...</value>
+  </data>
+  <data name="&gt;&gt;AddButton.Name" xml:space="preserve">
+    <value>AddButton</value>
+  </data>
+  <data name="&gt;&gt;AddButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AddButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;AddButton.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="DisklessVMRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="DisklessVMRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="DisklessVMRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 317</value>
+  </data>
+  <data name="DisklessVMRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 17</value>
+  </data>
+  <data name="DisklessVMRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="DisklessVMRadioButton.Text" xml:space="preserve">
+    <value>Create a diskles&amp;s VM that boots from the network</value>
+  </data>
+  <data name="&gt;&gt;DisklessVMRadioButton.Name" xml:space="preserve">
+    <value>DisklessVMRadioButton</value>
+  </data>
+  <data name="&gt;&gt;DisklessVMRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DisklessVMRadioButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;DisklessVMRadioButton.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="DisksRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="DisksRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="DisksRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 131</value>
+  </data>
+  <data name="DisksRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 17</value>
+  </data>
+  <data name="DisksRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="DisksRadioButton.Text" xml:space="preserve">
+    <value>Use these &amp;virtual disks:</value>
+  </data>
+  <data name="&gt;&gt;DisksRadioButton.Name" xml:space="preserve">
+    <value>DisksRadioButton</value>
+  </data>
+  <data name="&gt;&gt;DisksRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DisksRadioButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;DisksRadioButton.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>500, 128</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="label1.Text" xml:space="preserve">
+    <value>The virtual machine template you selected earlier provides the virtual disks listed below. You can change the properties of these virtual disks, and add more disks if required.
+
+Alternatively, you can select the second option below to create a diskless VM that can be booted from the network and does not use any virtual disks.
+
+When you have finished configuring disks for the new virtual machine, click Next to continue to the next step.</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -380,25 +416,31 @@ When you have finished configuring disks for the new virtual machine, click Next
     <value>ImageColumn</value>
   </data>
   <data name="&gt;&gt;ImageColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Name" xml:space="preserve">
+    <value>NameColumn</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SrColumn.Name" xml:space="preserve">
     <value>SrColumn</value>
   </data>
   <data name="&gt;&gt;SrColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SizeColumn.Name" xml:space="preserve">
     <value>SizeColumn</value>
   </data>
   <data name="&gt;&gt;SizeColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SharedColumn.Name" xml:space="preserve">
     <value>SharedColumn</value>
   </data>
   <data name="&gt;&gt;SharedColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>Page_Storage</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -24307,7 +24307,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disk {0}.
+        ///   Looks up a localized string similar to Disk &apos;{0}&apos;.
         /// </summary>
         public static string NEWVMWIZARD_STORAGEPAGE_DISK {
             get {
@@ -32906,7 +32906,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Removing update file {0} from {1}... .
+        ///   Looks up a localized string similar to Deleting update installation file {0} from {1}... .
         /// </summary>
         public static string UPDATES_WIZARD_REMOVING_UPDATE {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8325,7 +8325,7 @@ Review these settings, then click Previous if you need to change anything. Other
     <value>Locate the operating system installation media</value>
   </data>
   <data name="NEWVMWIZARD_STORAGEPAGE_DISK" xml:space="preserve">
-    <value>Disk {0}</value>
+    <value>Disk '{0}'</value>
   </data>
   <data name="NEWVMWIZARD_STORAGEPAGE_DISK_DESCRIPTION" xml:space="preserve">
     <value>Created by template provisioner</value>


### PR DESCRIPTION
… so it is

more obvious to the user that they can edit it. To this purpose change the button
Properties to Edit (and do the same on the Networking page for consistence). Also
show the name of the disk (ellipsized if too long) on the wizard's finish page.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>