### PR TITLE
CA-150200: EN: Duplicate hotkeys for “Storage” and “Show Columns” under Citrix XenCenter.

### DIFF
--- a/XenAdmin/Controls/XenSearch/SearchOutput.resx
+++ b/XenAdmin/Controls/XenSearch/SearchOutput.resx
@@ -218,6 +218,7 @@
   </data>
   <data name="buttonColumns.Text" xml:space="preserve">
     <value>Sh&amp;ow Columns</value>
+    <value>Show &amp;Columns</value>
   </data>
   <data name="&gt;&gt;buttonColumns.Name" xml:space="preserve">
     <value>buttonColumns</value>


### PR DESCRIPTION
New hotkey for "Show columns" is alt+C

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>