### PR TITLE
CA-217844: Handling Automatic update not supported

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -442,6 +442,9 @@ namespace XenAdmin.Core
                 var minimumPatches = new List<XenServerPatch>();
                 minimumPatches = serverVersions[0].MinimalPatches;
 
+                if (minimumPatches == null) //unknown
+                    return recommendedPatches;
+
                 var appliedPatches = host.AppliedPatches();
                 recommendedPatches = minimumPatches.FindAll(p => !appliedPatches.Any(ap => string.Equals(ap.uuid, p.Uuid, StringComparison.OrdinalIgnoreCase)));
 
@@ -477,12 +480,19 @@ namespace XenAdmin.Core
                 // Take all the hotfixes for this version
                 allPatches.AddRange(serverVersions[0].Patches);
 
+                if (serverVersions[0].MinimalPatches == null)
+                    return null;
+
                 uSeq.MinimalPatches = serverVersions[0].MinimalPatches;
 
                 foreach (Host h in hosts)
                 {
                     uSeq[h] = GetUpgradeSequenceForHost(h, allPatches, uSeq.MinimalPatches);
                 }
+            }
+            else
+            {
+                return null;
             }
 
             return uSeq;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -173,6 +173,17 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             if (IsInAutomaticMode)
             {
+                //check updgrade sequences
+                Updates.UpgradeSequence us = Updates.GetUpgradeSequence(host.Connection);
+
+                if (us == null) //version not supported
+                {
+                    row.Enabled = false;
+                    row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_HOST_VERSION;
+
+                    return;
+                }
+
                 //unlicensed servers are not enabled
                 if (Host.RestrictBatchHotfixApply(host))
                 {
@@ -181,9 +192,6 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                     return;
                 }
-                
-                //check updgrade sequences
-                Updates.UpgradeSequence us = Updates.GetUpgradeSequence(host.Connection);
 
                 //if there is a host missing from the upgrade sequence
                 if (host.Connection.Cache.Hosts.Any(h => !us.Keys.Contains(h)))

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -254,12 +254,14 @@ namespace XenAdmin.Actions
                     }
 
                     List<XenServerPatch> patches = new List<XenServerPatch>();
-                    List<XenServerPatch> minimalPatches = new List<XenServerPatch>();
+                    List<XenServerPatch> minimalPatches = null; //keep it null to indicate that there is no a minimalpatches tag
 
                     foreach (XmlNode childnode in version.ChildNodes)
                     {
                         if (childnode.Name == "minimalpatches")
                         {
+                            minimalPatches = new List<XenServerPatch>();
+
                             foreach (XmlNode minimalpatch in childnode.ChildNodes)
                             {
                                 if (minimalpatch.Name != "patch")

--- a/XenModel/Actions/Updates/XenServerVersion.cs
+++ b/XenModel/Actions/Updates/XenServerVersion.cs
@@ -44,11 +44,28 @@ namespace XenAdmin.Core
         public string Url;
         public string Oem;
         public List<XenServerPatch> Patches;
+        
+        /// <summary>
+        /// A host of this version is considered up-to-date when it has all the patches in this list installed on it
+        /// <value>null</value> means that the list is not known (batch updates/automatic updating is not supported)
+        /// </summary>
         public List<XenServerPatch> MinimalPatches;
+        
         public DateTime TimeStamp;
         public const string UpdateRoot = @"http://updates.xensource.com";
         public string BuildNumber;
 
+        /// <summary>
+        /// Defines metadata for a XenServer version
+        /// </summary>
+        /// <param name="version_oem"></param>
+        /// <param name="name"></param>
+        /// <param name="latest"></param>
+        /// <param name="url"></param>
+        /// <param name="patches"></param>
+        /// <param name="minimumPatches">can be null (see <paramref name="MinimalPatches"/></param>
+        /// <param name="timestamp"></param>
+        /// <param name="buildNumber"></param>
         public XenServerVersion(string version_oem, string name, bool latest, string url, List<XenServerPatch> patches, List<XenServerPatch> minimumPatches,
             string timestamp, string buildNumber)
         {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26054,7 +26054,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Automatic update is not supported on this [XenServer] version..
+        ///   Looks up a localized string similar to Automatic update is not supported on this [XenServer] version.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_HOST_VERSION {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26054,6 +26054,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Automatic update is not supported on this [XenServer] version..
+        /// </summary>
+        public static string PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_HOST_VERSION {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_HOST_VERSION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot install supplemental packs on this [XenServer] version.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_SUPP_PACKS {
@@ -26135,7 +26144,8 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Select one or more pools or standalone hosts that you want to have automatically updated.
+        ///Greyed out servers cannot be updated automatically..
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGGE_RUBRIC_AUTOMATIC_MODE {
             get {
@@ -26144,7 +26154,8 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Select one or more servers from the list of available servers.
+        ///Servers where the selected update cannot be applied appear disabled in this list..
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGGE_RUBRIC_DEFAULT {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9006,6 +9006,9 @@ However, there is not enough space to perform the repartitioning, so the current
   <data name="PATCHINGWIZARD_SELECTPATCHPAGE_UPDATESEXT" xml:space="preserve">
     <value>[XenServer] Updates and Supplemental Packs (*.{0}, *.iso)|*.{0};*.iso</value>
   </data>
+  <data name="PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_HOST_VERSION" xml:space="preserve">
+    <value>Automatic update is not supported on this [XenServer] version.</value>
+  </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_SUPP_PACKS" xml:space="preserve">
     <value>Cannot install supplemental packs on this [XenServer] version</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9007,7 +9007,7 @@ However, there is not enough space to perform the repartitioning, so the current
     <value>[XenServer] Updates and Supplemental Packs (*.{0}, *.iso)|*.{0};*.iso</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_HOST_VERSION" xml:space="preserve">
-    <value>Automatic update is not supported on this [XenServer] version.</value>
+    <value>Automatic update is not supported on this [XenServer] version</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_SUPP_PACKS" xml:space="preserve">
     <value>Cannot install supplemental packs on this [XenServer] version</value>


### PR DESCRIPTION
If there is no <minimalpatches /> tag, the version is not supported. This check has priority over licensed state when displaying the reason why a server is not supported.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>