### PR TITLE
CA-150200: EN: Duplicate hotkeys for “Storage” and “Show Columns” under Citrix XenCenter

### DIFF
--- a/XenAdmin/Controls/XenSearch/SearchOutput.resx
+++ b/XenAdmin/Controls/XenSearch/SearchOutput.resx
@@ -217,7 +217,6 @@
     <value>2</value>
   </data>
   <data name="buttonColumns.Text" xml:space="preserve">
-    <value>Sh&amp;ow Columns</value>
     <value>Show &amp;Columns</value>
   </data>
   <data name="&gt;&gt;buttonColumns.Name" xml:space="preserve">


### PR DESCRIPTION
Remove the old value, leaving only the new one

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>