### PR TITLE
CA-217847: Fixed issue where servers were marked as unable to be upda…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -113,6 +113,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 var fileFromDiskAlertPatch = wizardModeAutomatic ? null : PatchingWizard_SelectPatchPage.FileFromDiskAlert;
 
                 PatchingWizard_SelectServers.IsInAutomaticMode = wizardModeAutomatic;
+                PatchingWizard_SelectServers.AutoDownloadedXenServerVersions = PatchingWizard_SelectPatchPage.AutoDownloadedXenServerVersions;
                 PatchingWizard_SelectServers.SelectedUpdateType = updateType;
                 PatchingWizard_SelectServers.Patch = existPatch;
                 PatchingWizard_SelectServers.SelectedUpdateAlert = alertPatch;
@@ -155,19 +156,21 @@ namespace XenAdmin.Wizards.PatchingWizard
             else if (prevPageType == typeof(PatchingWizard_SelectServers))
             {
                 var selectedServers = PatchingWizard_SelectServers.SelectedServers;
-                
+                var selectedPools = PatchingWizard_SelectServers.SelectedPools;
+                var selectedMasters = PatchingWizard_SelectServers.SelectedMasters;
+
                 PatchingWizard_PrecheckPage.SelectedServers = selectedServers;
 
                 PatchingWizard_ModePage.SelectedServers = selectedServers;
 
-                PatchingWizard_PatchingPage.SelectedMasters = PatchingWizard_SelectServers.SelectedMasters;
+                PatchingWizard_PatchingPage.SelectedMasters = selectedMasters;
                 PatchingWizard_PatchingPage.SelectedServers = selectedServers;
-                PatchingWizard_PatchingPage.SelectedPools = PatchingWizard_SelectServers.SelectedPools;
+                PatchingWizard_PatchingPage.SelectedPools = selectedPools;
 
-                PatchingWizard_UploadPage.SelectedMasters = PatchingWizard_SelectServers.SelectedMasters;
+                PatchingWizard_UploadPage.SelectedMasters = selectedMasters;
                 PatchingWizard_UploadPage.SelectedServers = selectedServers;
 
-                PatchingWizard_AutoUpdatingPage.SelectedPools = PatchingWizard_SelectServers.SelectedPools;
+                PatchingWizard_AutoUpdatingPage.SelectedPools = selectedPools;
             }
             else if (prevPageType == typeof(PatchingWizard_UploadPage))
             {

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -164,6 +164,8 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         public bool IsInAutomaticMode { get { return AutomaticRadioButton.Visible && AutomaticRadioButton.Checked; } }
 
+        public List<XenServerVersion> AutoDownloadedXenServerVersions { get; private set; }
+
         public override void PageLeave(PageLoadedDirection direction, ref bool cancel)
         {
             if (direction == PageLoadedDirection.Forward)
@@ -218,6 +220,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                     {
                         cancel = true;
                     }
+                    AutoDownloadedXenServerVersions = downloadUpdatesAction.XenServerVersions;
                 }
             }
 

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -167,6 +167,8 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         public bool IsInAutomaticMode { set; get; }
 
+        public List<XenServerVersion> AutoDownloadedXenServerVersions { private get; set; }
+
         private void EnabledRow(Host host, UpdateType type, int index)
         {
             var row = (PatchingHostsDataGridViewRow)dataGridViewHosts.Rows[index];
@@ -174,7 +176,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             if (IsInAutomaticMode)
             {
                 //check updgrade sequences
-                Updates.UpgradeSequence us = Updates.GetUpgradeSequence(host.Connection);
+                Updates.UpgradeSequence us = Updates.GetUpgradeSequence(host.Connection, AutoDownloadedXenServerVersions);
 
                 if (us == null) //version not supported
                 {

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -74,7 +74,7 @@ namespace XenAdmin.Actions
         private readonly bool _checkForPatches;
         private readonly string _checkForUpdatesUrl;
 
-        public DownloadUpdatesXmlAction(bool checkForXenCenter, bool checkForServerVersion, bool checkForPatches, string checkForUpdatesUrl)
+        public DownloadUpdatesXmlAction(bool checkForXenCenter, bool checkForServerVersion, bool checkForPatches, string checkForUpdatesUrl = null)
             : base(null, "_get_updates", "_get_updates", true)
         {
             Debug.Assert(checkForUpdatesUrl != null, "Parameter checkForUpdatesUrl should not be null. This class does not default its value anymore.");
@@ -88,10 +88,6 @@ namespace XenAdmin.Actions
             _checkForPatches = checkForPatches;
             _checkForUpdatesUrl = checkForUpdatesUrl;
         }
-
-        protected DownloadUpdatesXmlAction(bool checkForXenCenter, bool checkForServerVersion, bool checkForPatches)
-            : this(checkForXenCenter, checkForServerVersion, checkForPatches, null)
-        { }
 
         protected override void Run()
         {


### PR DESCRIPTION
…ted automatically

even when automatic mode was supported for them. The problem was that the xenserver
versions were not retrieved from the DownloadUpdatesXmlAction once the latter had run.
Also, minor refactoring.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>