### PR TITLE
CA-213500: Revert To, Actions and Delete buttons are enabled even if there is no manual snapshot.

### DIFF
--- a/XenAdmin/TabPages/SnapshotsPage.cs
+++ b/XenAdmin/TabPages/SnapshotsPage.cs
@@ -1115,7 +1115,11 @@ namespace XenAdmin.TabPages
                     {
                         VM snap = (VM)item.Tag;
                         if (snap != null && snap.is_a_snapshot)
-                            snapshots.Add(snap);
+                        {
+                            if(!(snap.is_snapshot_from_vmpp || snap.is_vmss_snapshot) || toolStripMenuItemScheduledSnapshots.Checked)
+                                snapshots.Add(snap);
+                        }
+                            
                     }
                     return snapshots;
                 }
@@ -1129,7 +1133,10 @@ namespace XenAdmin.TabPages
                     {
                         VM snap = (VM)row.Tag;
                         if (snap != null && snap.is_a_snapshot)
-                            snapshots.Add(snap);
+                        {
+                            if (!(snap.is_snapshot_from_vmpp || snap.is_vmss_snapshot) || toolStripMenuItemScheduledSnapshots.Checked)
+                                snapshots.Add(snap);
+                        }
                     }
                     return snapshots;
                 }


### PR DESCRIPTION
 CA-213500: Revert To, Actions and Delete buttons are enabled even
 if there is no manual snapshot.

Signed-off-by: Sharath Babu <Sharath.Babu@citrix.com>