### PR TITLE
CA-217862: Batch Updates: handle partially upgraded pools

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -492,7 +492,7 @@ namespace XenAdmin.Core
         }
 
         /// <summary>
-        /// Returns a XenServerVersion if all hosts of the pool has the same version
+        /// Returns a XenServerVersion if all hosts of the pool have the same version
         /// Returns null if it is unknown or they don't match
         /// </summary>
         /// <returns></returns>

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -193,6 +193,15 @@ namespace XenAdmin.Wizards.PatchingWizard
                     return;
                 }
 
+                var pool = Helpers.GetPool(host.Connection);
+                if (pool != null && !pool.IsPoolFullyUpgraded) //partially upgraded pool is not supported
+                {
+                    row.Enabled = false;
+                    row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_PARTIALLY_UPGRADED;
+
+                    return;
+                }
+
                 //if there is a host missing from the upgrade sequence
                 if (host.Connection.Cache.Hosts.Any(h => !us.Keys.Contains(h)))
                 {

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -175,6 +175,15 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             if (IsInAutomaticMode)
             {
+                var pool = Helpers.GetPool(host.Connection);
+                if (pool != null && !pool.IsPoolFullyUpgraded) //partially upgraded pool is not supported
+                {
+                    row.Enabled = false;
+                    row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_PARTIALLY_UPGRADED;
+
+                    return;
+                }
+
                 //check updgrade sequences
                 Updates.UpgradeSequence us = Updates.GetUpgradeSequence(host.Connection, AutoDownloadedXenServerVersions);
 
@@ -191,15 +200,6 @@ namespace XenAdmin.Wizards.PatchingWizard
                 {
                     row.Enabled = false;
                     row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED_FOR_BATCH_UPDATING;
-
-                    return;
-                }
-
-                var pool = Helpers.GetPool(host.Connection);
-                if (pool != null && !pool.IsPoolFullyUpgraded) //partially upgraded pool is not supported
-                {
-                    row.Enabled = false;
-                    row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_PARTIALLY_UPGRADED;
 
                     return;
                 }

--- a/XenAdminTests/UnitTests/BatchUpdatesTests/BatchUpdatesTests.cs
+++ b/XenAdminTests/UnitTests/BatchUpdatesTests/BatchUpdatesTests.cs
@@ -387,7 +387,7 @@ namespace XenAdminTests.UnitTests
 
         /// <summary>
         /// Version does not exist
-        /// Result: update sequence does not have the host
+        /// Result: update sequence is null
         /// </summary>
         [Test]
         public void NoInfoForCurrentVersion()
@@ -404,7 +404,7 @@ namespace XenAdminTests.UnitTests
 
             // Assert
 
-            Assert.NotNull(upgradeSequence);
+            Assert.Null(upgradeSequence);
             Assert.AreEqual(0, upgradeSequence.Count);
         }
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26081,6 +26081,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Automatic update is not supported on partially upgraded [XenServer] pools..
+        /// </summary>
+        public static string PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_PARTIALLY_UPGRADED {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_PARTIALLY_UPGRADED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot install supplemental packs on this [XenServer] version.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_SUPP_PACKS {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9015,6 +9015,9 @@ However, there is not enough space to perform the repartitioning, so the current
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_HOST_VERSION" xml:space="preserve">
     <value>Automatic update is not supported on this [XenServer] version</value>
   </data>
+  <data name="PATCHINGWIZARD_SELECTSERVERPAGE_AUTO_UPDATE_NOT_SUPPORTED_PARTIALLY_UPGRADED" xml:space="preserve">
+    <value>Automatic update is not supported on partially upgraded [XenServer] pools.</value>
+  </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_SUPP_PACKS" xml:space="preserve">
     <value>Cannot install supplemental packs on this [XenServer] version</value>
   </data>


### PR DESCRIPTION
Partially upgraded pools and mixed version pools are not supported, XenCenter will display a proper error message.