### PR TITLE
Cp 18011: [XenCenter] Add live patching checkbox

### DIFF
--- a/XenAdmin/Dialogs/PropertiesDialog.cs
+++ b/XenAdmin/Dialogs/PropertiesDialog.cs
@@ -201,7 +201,7 @@ namespace XenAdmin.Dialogs
                 if (is_pool_or_standalone && !Helpers.FeatureForbidden(xenObject.Connection, Host.RestrictSslLegacySwitch))
                     ShowTab(SecurityEditPage = new SecurityEditPage());
 
-                if (is_pool_or_standalone)
+                if (is_pool_or_standalone && !Helpers.FeatureForbidden(xenObject.Connection, Host.RestrictLivePatching))
                     ShowTab(LivePatchingEditPage = new LivePatchingEditPage());
 
                 if (is_network)

--- a/XenAdmin/Dialogs/PropertiesDialog.cs
+++ b/XenAdmin/Dialogs/PropertiesDialog.cs
@@ -79,6 +79,7 @@ namespace XenAdmin.Dialogs
         private VMEnlightenmentEditPage VMEnlightenmentEditPage;
         private Page_CloudConfigParameters CloudConfigParametersPage;
         private SecurityEditPage SecurityEditPage;
+        private LivePatchingEditPage LivePatchingEditPage;
         #endregion
 
         private IXenObject xenObject, xenObjectBefore, xenObjectCopy;
@@ -199,6 +200,9 @@ namespace XenAdmin.Dialogs
 
                 if (is_pool_or_standalone && !Helpers.FeatureForbidden(xenObject.Connection, Host.RestrictSslLegacySwitch))
                     ShowTab(SecurityEditPage = new SecurityEditPage());
+
+                if (is_pool_or_standalone)
+                    ShowTab(LivePatchingEditPage = new LivePatchingEditPage());
 
                 if (is_network)
                     ShowTab(editNetworkPage = new EditNetworkPage());

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.Designer.cs
@@ -29,30 +29,49 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LivePatchingEditPage));
-            this.labelLivePatching = new System.Windows.Forms.Label();
-            this.checkLivePatchingAllowed = new System.Windows.Forms.CheckBox();
+            this.radioButtonDisable = new System.Windows.Forms.RadioButton();
+            this.radioButtonEnable = new System.Windows.Forms.RadioButton();
+            this.labelRubric = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // labelLivePatching
+            // radioButtonDisable
             // 
-            resources.ApplyResources(this.labelLivePatching, "labelLivePatching");
-            this.labelLivePatching.Name = "labelLivePatching";
+            resources.ApplyResources(this.radioButtonDisable, "radioButtonDisable");
+            this.radioButtonDisable.Name = "radioButtonDisable";
+            this.radioButtonDisable.TabStop = true;
+            this.radioButtonDisable.UseVisualStyleBackColor = true;
             // 
-            // checkLivePatching
+            // radioButtonEnable
             // 
-            resources.ApplyResources(this.checkLivePatchingAllowed, "checkLivePatching");
-            this.checkLivePatchingAllowed.Checked = true;
-            this.checkLivePatchingAllowed.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkLivePatchingAllowed.Name = "checkLivePatching";
-            this.checkLivePatchingAllowed.UseVisualStyleBackColor = true;
+            resources.ApplyResources(this.radioButtonEnable, "radioButtonEnable");
+            this.radioButtonEnable.Name = "radioButtonEnable";
+            this.radioButtonEnable.TabStop = true;
+            this.radioButtonEnable.UseVisualStyleBackColor = true;
+            // 
+            // labelRubric
+            // 
+            resources.ApplyResources(this.labelRubric, "labelRubric");
+            this.labelRubric.BackColor = System.Drawing.Color.Transparent;
+            this.labelRubric.Name = "labelRubric";
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.labelRubric, 0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // LivePatchingEditPage
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.checkLivePatchingAllowed);
-            this.Controls.Add(this.labelLivePatching);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.radioButtonDisable);
+            this.Controls.Add(this.radioButtonEnable);
             this.Name = "LivePatchingEditPage";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -60,7 +79,10 @@
 
         #endregion
 
-        private System.Windows.Forms.Label labelLivePatching;
-        private System.Windows.Forms.CheckBox checkLivePatchingAllowed;
+        private System.Windows.Forms.RadioButton radioButtonDisable;
+        private System.Windows.Forms.RadioButton radioButtonEnable;
+        private System.Windows.Forms.Label labelRubric;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+
     }
 }

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.Designer.cs
@@ -1,0 +1,66 @@
+﻿namespace XenAdmin.SettingsPanels
+{
+    partial class LivePatchingEditPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LivePatchingEditPage));
+            this.labelLivePatching = new System.Windows.Forms.Label();
+            this.checkLivePatchingAllowed = new System.Windows.Forms.CheckBox();
+            this.SuspendLayout();
+            // 
+            // labelLivePatching
+            // 
+            resources.ApplyResources(this.labelLivePatching, "labelLivePatching");
+            this.labelLivePatching.Name = "labelLivePatching";
+            // 
+            // checkLivePatching
+            // 
+            resources.ApplyResources(this.checkLivePatchingAllowed, "checkLivePatching");
+            this.checkLivePatchingAllowed.Checked = true;
+            this.checkLivePatchingAllowed.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkLivePatchingAllowed.Name = "checkLivePatching";
+            this.checkLivePatchingAllowed.UseVisualStyleBackColor = true;
+            // 
+            // LivePatchingEditPage
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.checkLivePatchingAllowed);
+            this.Controls.Add(this.labelLivePatching);
+            this.Name = "LivePatchingEditPage";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelLivePatching;
+        private System.Windows.Forms.CheckBox checkLivePatchingAllowed;
+    }
+}

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.cs
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.cs
@@ -1,0 +1,110 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms;
+using XenAdmin;
+using XenAdmin.Actions;
+using XenAdmin.Core;
+using XenAPI;
+
+namespace XenAdmin.SettingsPanels
+{
+    public partial class LivePatchingEditPage : UserControl, IEditPage
+    {
+        private Pool pool;
+
+        public LivePatchingEditPage()
+        {
+            InitializeComponent();
+            Text = Messages.LIVE_PATCHING;
+        }
+
+        #region IEditPage Members
+
+        public AsyncAction SaveSettings()
+        {
+            bool now_allowed = checkLivePatchingAllowed.Checked;
+            string title = now_allowed ?
+                String.Format(Messages.ACTION_ALLOW_LIVE_PATCHING, pool.Name) :
+                String.Format(Messages.ACTION_DISALLOW_LIVE_PATCHING, pool.Name);
+
+            return new DelegatedAsyncAction(pool.Connection, title, null, null,
+                delegate(Session session) { Pool.set_live_patching_disabled(session, pool.opaque_ref, !checkLivePatchingAllowed.Checked); }, true);
+        }
+
+        public void SetXenObjects(IXenObject orig, IXenObject clone)
+        {
+            pool = Helpers.GetPoolOfOne(clone.Connection);  // clone could be a pool or a host
+
+            if (pool.live_patching_disabled)
+                checkLivePatchingAllowed.Checked = false;
+            else
+                checkLivePatchingAllowed.Checked = true;
+        }
+
+        public bool ValidToSave
+        {
+            get { return true; }
+        }
+
+        public void ShowLocalValidationMessages()
+        { }
+
+        public void Cleanup()
+        { }
+
+        public bool HasChanged
+        {
+            // Changed if pool disabled = UI allowed
+            get { return pool.live_patching_disabled.Equals(checkLivePatchingAllowed.Checked); }
+        }
+
+        #endregion
+
+        #region VerticalTab Members
+
+        public string SubText
+        {
+            get { return checkLivePatchingAllowed.Checked? Messages.ALLOWED : Messages.NOT_ALLOWED; }
+        }
+
+        public Image Image
+        {
+            get { return Properties.Resources._000_Patch_h32bit_16; }
+        }
+
+        #endregion
+    }
+}

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.cs
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.cs
@@ -30,11 +30,8 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
-using XenAdmin;
 using XenAdmin.Actions;
 using XenAdmin.Core;
 using XenAPI;
@@ -55,8 +52,8 @@ namespace XenAdmin.SettingsPanels
 
         public AsyncAction SaveSettings()
         {
-            bool now_allowed = checkLivePatchingAllowed.Checked;
-            string title = now_allowed ?
+            bool nowAllowed = checkLivePatchingAllowed.Checked;
+            string title = nowAllowed ?
                 String.Format(Messages.ACTION_ALLOW_LIVE_PATCHING, pool.Name) :
                 String.Format(Messages.ACTION_DISALLOW_LIVE_PATCHING, pool.Name);
 

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.ja.resx
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.ja.resx
@@ -1,0 +1,273 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element msdata:IsDataSet="true" name="root">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="labelRubric.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <data name="labelRubric.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 4</value>
+  </data>
+  <data name="labelRubric.Size" type="System.Drawing.Size, System.Drawing">
+    <value>473, 17</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="labelRubric.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelRubric.Text" xml:space="preserve">
+    <value>このプールとの通信に使用できるセキュリティ プロトコルを選択します。</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Name" xml:space="preserve">
+    <value>labelRubric</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="radioButtonTLS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonTLS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 31</value>
+  </data>
+  <data name="radioButtonTLS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 17</value>
+  </data>
+  <data name="radioButtonTLS.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="radioButtonTLS.Text" xml:space="preserve">
+    <value>最大セキュリティ: TLS 1.2 のみ(&amp;M)</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.Name" xml:space="preserve">
+    <value>radioButtonTLS</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="radioButtonSSL.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonSSL.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 54</value>
+  </data>
+  <data name="radioButtonSSL.Size" type="System.Drawing.Size, System.Drawing">
+    <value>292, 17</value>
+  </data>
+  <data name="radioButtonSSL.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="radioButtonSSL.Text" xml:space="preserve">
+    <value>後方互換性: SSL 3.0 および TLS 1.0, 1.1 &amp;&amp; 1.2(&amp;B)</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.Name" xml:space="preserve">
+    <value>radioButtonSSL</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="pictureBoxDisruption.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 88</value>
+  </data>
+  <data name="pictureBoxDisruption.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBoxDisruption.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="pictureBoxDisruption.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.Name" xml:space="preserve">
+    <value>pictureBoxDisruption</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelDisruption.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelDisruption.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 90</value>
+  </data>
+  <data name="labelDisruption.Size" type="System.Drawing.Size, System.Drawing">
+    <value>363, 13</value>
+  </data>
+  <data name="labelDisruption.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="labelDisruption.Text" xml:space="preserve">
+    <value>この設定を変更すると、一時的に [XenServer] にアクセスできなくなります</value>
+  </data>
+  <data name="labelDisruption.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.Name" xml:space="preserve">
+    <value>labelDisruption</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>477, 198</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SecurityEditPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.resx
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.resx
@@ -1,0 +1,195 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="labelLivePatching.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="labelLivePatching.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 10</value>
+  </data>
+  <data name="labelLivePatching.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
+  </data>
+  <data name="labelLivePatching.Size" type="System.Drawing.Size, System.Drawing">
+    <value>373, 60</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="labelLivePatching.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelLivePatching.Text" xml:space="preserve">
+    <value>Allow live patching</value>
+  </data>
+  <data name="&gt;&gt;labelLivePatching.Name" xml:space="preserve">
+    <value>labelLivePatching</value>
+  </data>
+  <data name="&gt;&gt;labelLivePatching.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelLivePatching.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelLivePatching.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="checkLivePatching.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkLivePatching.Location" type="System.Drawing.Point, System.Drawing">
+    <value>301, 10</value>
+  </data>
+  <data name="checkLivePatching.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 33</value>
+  </data>
+  <data name="checkLivePatching.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;checkLivePatching.Name" xml:space="preserve">
+    <value>checkLivePatching</value>
+  </data>
+  <data name="&gt;&gt;checkLivePatching.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkLivePatching.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;checkLivePatching.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>240, 240</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1192, 495</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>LivePatchingEditPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.resx
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.resx
@@ -117,62 +117,137 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="labelLivePatching.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="labelLivePatching.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 10</value>
-  </data>
-  <data name="labelLivePatching.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 0, 8, 0</value>
-  </data>
-  <data name="labelLivePatching.Size" type="System.Drawing.Size, System.Drawing">
-    <value>373, 60</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="labelLivePatching.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="labelLivePatching.Text" xml:space="preserve">
-    <value>Allow live patching</value>
-  </data>
-  <data name="&gt;&gt;labelLivePatching.Name" xml:space="preserve">
-    <value>labelLivePatching</value>
-  </data>
-  <data name="&gt;&gt;labelLivePatching.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelLivePatching.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;labelLivePatching.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="checkLivePatching.AutoSize" type="System.Boolean, mscorlib">
+  <data name="radioButtonDisable.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="checkLivePatching.Location" type="System.Drawing.Point, System.Drawing">
-    <value>301, 10</value>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="radioButtonDisable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="checkLivePatching.Size" type="System.Drawing.Size, System.Drawing">
-    <value>34, 33</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="radioButtonDisable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 156</value>
   </data>
-  <data name="checkLivePatching.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="radioButtonDisable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
-  <data name="&gt;&gt;checkLivePatching.Name" xml:space="preserve">
-    <value>checkLivePatching</value>
+  <data name="radioButtonDisable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>337, 36</value>
   </data>
-  <data name="&gt;&gt;checkLivePatching.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="radioButtonDisable.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="&gt;&gt;checkLivePatching.Parent" xml:space="preserve">
+  <data name="radioButtonDisable.Text" xml:space="preserve">
+    <value>&amp;Don't use live patching</value>
+  </data>
+  <data name="&gt;&gt;radioButtonDisable.Name" xml:space="preserve">
+    <value>radioButtonDisable</value>
+  </data>
+  <data name="&gt;&gt;radioButtonDisable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonDisable.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;checkLivePatching.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;radioButtonDisable.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="radioButtonEnable.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonEnable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="radioButtonEnable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 104</value>
+  </data>
+  <data name="radioButtonEnable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="radioButtonEnable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 36</value>
+  </data>
+  <data name="radioButtonEnable.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="radioButtonEnable.Text" xml:space="preserve">
+    <value>&amp;Use live patching when possible</value>
+  </data>
+  <data name="&gt;&gt;radioButtonEnable.Name" xml:space="preserve">
+    <value>radioButtonEnable</value>
+  </data>
+  <data name="&gt;&gt;radioButtonEnable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonEnable.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;radioButtonEnable.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="labelRubric.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelRubric.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="labelRubric.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1186, 64</value>
+  </data>
+  <data name="labelRubric.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
+  </data>
+  <data name="labelRubric.Text" xml:space="preserve">
+    <value>Live patching allows some Linux kernel and Xen updates to be installed without rebooting the server. Select whether you wish to use live patches when they are available.</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Name" xml:space="preserve">
+    <value>labelRubric</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1192, 64</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelRubric" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,50,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/SettingsPanels/LivePatchingEditPage.zh-CN.resx
+++ b/XenAdmin/SettingsPanels/LivePatchingEditPage.zh-CN.resx
@@ -1,0 +1,273 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element msdata:IsDataSet="true" name="root">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="labelRubric.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <data name="labelRubric.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 4</value>
+  </data>
+  <data name="labelRubric.Size" type="System.Drawing.Size, System.Drawing">
+    <value>473, 17</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="labelRubric.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelRubric.Text" xml:space="preserve">
+    <value>选择与此池进行通信时可以使用的安全协议。</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Name" xml:space="preserve">
+    <value>labelRubric</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelRubric.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="radioButtonTLS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonTLS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 31</value>
+  </data>
+  <data name="radioButtonTLS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 17</value>
+  </data>
+  <data name="radioButtonTLS.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="radioButtonTLS.Text" xml:space="preserve">
+    <value>最大安全性(&amp;M): 仅限 TLS 1.2</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.Name" xml:space="preserve">
+    <value>radioButtonTLS</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;radioButtonTLS.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="radioButtonSSL.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonSSL.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 54</value>
+  </data>
+  <data name="radioButtonSSL.Size" type="System.Drawing.Size, System.Drawing">
+    <value>292, 17</value>
+  </data>
+  <data name="radioButtonSSL.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="radioButtonSSL.Text" xml:space="preserve">
+    <value>向后兼容性(&amp;B): SSL 3.0 以及 TLS 1.0、1.1 和 1.2</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.Name" xml:space="preserve">
+    <value>radioButtonSSL</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;radioButtonSSL.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="pictureBoxDisruption.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 88</value>
+  </data>
+  <data name="pictureBoxDisruption.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBoxDisruption.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="pictureBoxDisruption.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.Name" xml:space="preserve">
+    <value>pictureBoxDisruption</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxDisruption.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelDisruption.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelDisruption.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 90</value>
+  </data>
+  <data name="labelDisruption.Size" type="System.Drawing.Size, System.Drawing">
+    <value>363, 13</value>
+  </data>
+  <data name="labelDisruption.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="labelDisruption.Text" xml:space="preserve">
+    <value>更改此设置将导致您暂时失去对 [XenServer] 的访问权限</value>
+  </data>
+  <data name="labelDisruption.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.Name" xml:space="preserve">
+    <value>labelDisruption</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelDisruption.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>477, 198</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SecurityEditPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -293,6 +293,12 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="SettingsPanels\LivePatchingEditPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="SettingsPanels\LivePatchingEditPage.Designer.cs">
+      <DependentUpon>LivePatchingEditPage.cs</DependentUpon>
+    </Compile>
     <Compile Include="SettingsPanels\SecurityEditPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -1739,6 +1745,15 @@
     <EmbeddedResource Include="SettingsPanels\EditNetworkPage.resx">
       <DependentUpon>EditNetworkPage.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SettingsPanels\LivePatchingEditPage.ja.resx">
+      <DependentUpon>LivePatchingEditPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SettingsPanels\LivePatchingEditPage.resx">
+      <DependentUpon>LivePatchingEditPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SettingsPanels\LivePatchingEditPage.zh-CN.resx">
+      <DependentUpon>LivePatchingEditPage.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="SettingsPanels\SecurityEditPage.ja.resx">
       <DependentUpon>SecurityEditPage.cs</DependentUpon>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -79,6 +79,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allowing live patching for &apos;{0}&apos;.
+        /// </summary>
+        public static string ACTION_ALLOW_LIVE_PATCHING {
+            get {
+                return ResourceManager.GetString("ACTION_ALLOW_LIVE_PATCHING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change disk size.
         /// </summary>
         public static string ACTION_CHANGE_DISK_SIZE {
@@ -516,6 +525,15 @@ namespace XenAdmin {
         public static string ACTION_DISABLE_VM_ENLIGHTENMENT_TITLE {
             get {
                 return ResourceManager.GetString("ACTION_DISABLE_VM_ENLIGHTENMENT_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disallowing live patching for &apos;{0}&apos;.
+        /// </summary>
+        public static string ACTION_DISALLOW_LIVE_PATCHING {
+            get {
+                return ResourceManager.GetString("ACTION_DISALLOW_LIVE_PATCHING", resourceCulture);
             }
         }
         
@@ -4747,6 +4765,15 @@ namespace XenAdmin {
         public static string ALLOW_TO_CONTINUE {
             get {
                 return ResourceManager.GetString("ALLOW_TO_CONTINUE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allowed.
+        /// </summary>
+        public static string ALLOWED {
+            get {
+                return ResourceManager.GetString("ALLOWED", resourceCulture);
             }
         }
         
@@ -19660,6 +19687,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Live Patching.
+        /// </summary>
+        public static string LIVE_PATCHING {
+            get {
+                return ResourceManager.GetString("LIVE_PATCHING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading &apos;{0}&apos;....
         /// </summary>
         public static string LOADING {
@@ -24861,6 +24897,15 @@ namespace XenAdmin {
         public static string NOT_AGILE_VM_HAS_VGPU {
             get {
                 return ResourceManager.GetString("NOT_AGILE_VM_HAS_VGPU", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not allowed.
+        /// </summary>
+        public static string NOT_ALLOWED {
+            get {
+                return ResourceManager.GetString("NOT_ALLOWED", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -79,15 +79,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allowing live patching for &apos;{0}&apos;.
-        /// </summary>
-        public static string ACTION_ALLOW_LIVE_PATCHING {
-            get {
-                return ResourceManager.GetString("ACTION_ALLOW_LIVE_PATCHING", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Change disk size.
         /// </summary>
         public static string ACTION_CHANGE_DISK_SIZE {
@@ -511,6 +502,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Disable live patching.
+        /// </summary>
+        public static string ACTION_DISABLE_LIVE_PATCHING {
+            get {
+                return ResourceManager.GetString("ACTION_DISABLE_LIVE_PATCHING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disabling .
         /// </summary>
         public static string ACTION_DISABLE_VM_ENLIGHTENMENT_DESCRIPTION {
@@ -529,11 +529,11 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disallowing live patching for &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Disabling live patching for &apos;{0}&apos;.
         /// </summary>
-        public static string ACTION_DISALLOW_LIVE_PATCHING {
+        public static string ACTION_DISABLING_LIVE_PATCHING {
             get {
-                return ResourceManager.GetString("ACTION_DISALLOW_LIVE_PATCHING", resourceCulture);
+                return ResourceManager.GetString("ACTION_DISABLING_LIVE_PATCHING", resourceCulture);
             }
         }
         
@@ -826,6 +826,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable live patching.
+        /// </summary>
+        public static string ACTION_ENABLE_LIVE_PATCHING {
+            get {
+                return ResourceManager.GetString("ACTION_ENABLE_LIVE_PATCHING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enabling.
         /// </summary>
         public static string ACTION_ENABLE_VM_ENLIGHTENMENT_DESCRIPTION {
@@ -840,6 +849,15 @@ namespace XenAdmin {
         public static string ACTION_ENABLE_VM_ENLIGHTENMENT_TITLE {
             get {
                 return ResourceManager.GetString("ACTION_ENABLE_VM_ENLIGHTENMENT_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enabling live patching for &apos;{0}&apos;.
+        /// </summary>
+        public static string ACTION_ENABLING_LIVE_PATCHING {
+            get {
+                return ResourceManager.GetString("ACTION_ENABLING_LIVE_PATCHING", resourceCulture);
             }
         }
         
@@ -4765,15 +4783,6 @@ namespace XenAdmin {
         public static string ALLOW_TO_CONTINUE {
             get {
                 return ResourceManager.GetString("ALLOW_TO_CONTINUE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Allowed.
-        /// </summary>
-        public static string ALLOWED {
-            get {
-                return ResourceManager.GetString("ALLOWED", resourceCulture);
             }
         }
         
@@ -24897,15 +24906,6 @@ namespace XenAdmin {
         public static string NOT_AGILE_VM_HAS_VGPU {
             get {
                 return ResourceManager.GetString("NOT_AGILE_VM_HAS_VGPU", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Not allowed.
-        /// </summary>
-        public static string NOT_ALLOWED {
-            get {
-                return ResourceManager.GetString("NOT_ALLOWED", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.ja.resx
+++ b/XenModel/Messages.ja.resx
@@ -12948,4 +12948,19 @@ To learn more about the [XenServer] Active Directory feature or to start a [XenS
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>現在の位置</value>
   </data>
+  <data name="ACTION_DISABLE_LIVE_PATCHING" xml:space="preserve">
+    <value>Disable live patching</value>
+  </data>
+  <data name="ACTION_DISABLING_LIVE_PATCHING" xml:space="preserve">
+    <value>Disabling live patching for '{0}'</value>
+  </data>
+  <data name="ACTION_ENABLE_LIVE_PATCHING" xml:space="preserve">
+    <value>Enable live patching</value>
+  </data>
+  <data name="ACTION_ENABLING_LIVE_PATCHING" xml:space="preserve">
+    <value>Enabling live patching for '{0}'</value>
+  </data>
+  <data name="LIVE_PATCHING" xml:space="preserve">
+    <value>Live Patching</value>
+  </data>
 </root>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -123,6 +123,9 @@
   <data name="ACTION_ACTIVATING_MULTIPLE_VDIS_TITLE" xml:space="preserve">
     <value>Activating Multiple Virtual Disks</value>
   </data>
+  <data name="ACTION_ALLOW_LIVE_PATCHING" xml:space="preserve">
+    <value>Allowing live patching for '{0}'</value>
+  </data>
   <data name="ACTION_CHANGED_DISK_SIZE_FOR" xml:space="preserve">
     <value>Disk size changed for '{0}'.</value>
   </data>
@@ -269,6 +272,9 @@
   </data>
   <data name="ACTION_DISABLE_VM_ENLIGHTENMENT_TITLE" xml:space="preserve">
     <value>Disable container management on VM '{0}'</value>
+  </data>
+  <data name="ACTION_DISALLOW_LIVE_PATCHING" xml:space="preserve">
+    <value>Disallowing live patching for '{0}'</value>
   </data>
   <data name="ACTION_DISK_ACTIVATED" xml:space="preserve">
     <value>Activated disk...</value>
@@ -1725,6 +1731,9 @@ Note that if RBAC is enabled, only alerts which you have privileges to dismiss w
   </data>
   <data name="ALERT_SR_SUB_TEXT" xml:space="preserve">
     <value>When storage throughput exceeds {0} for {1} min(s)</value>
+  </data>
+  <data name="ALLOWED" xml:space="preserve">
+    <value>Allowed</value>
   </data>
   <data name="ALLOWED_MTU_RANGE" xml:space="preserve">
     <value>Allowed MTU range: {0} to {1}</value>
@@ -6862,6 +6871,9 @@ Standard features only</value>
   <data name="LIST_SEPARATOR" xml:space="preserve">
     <value>, </value>
   </data>
+  <data name="LIVE_PATCHING" xml:space="preserve">
+    <value>Live Patching</value>
+  </data>
   <data name="LOADING" xml:space="preserve">
     <value>Loading '{0}'...</value>
   </data>
@@ -8658,6 +8670,9 @@ It is strongly recommended that you Cancel and apply the latest version of the p
   </data>
   <data name="NOT_AGILE_VM_HAS_VGPU" xml:space="preserve">
     <value>The VM has one or more virtual GPUs. Restart cannot be guaranteed.</value>
+  </data>
+  <data name="NOT_ALLOWED" xml:space="preserve">
+    <value>Not allowed</value>
   </data>
   <data name="NOT_APPLIED" xml:space="preserve">
     <value>Not applied</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -123,9 +123,6 @@
   <data name="ACTION_ACTIVATING_MULTIPLE_VDIS_TITLE" xml:space="preserve">
     <value>Activating Multiple Virtual Disks</value>
   </data>
-  <data name="ACTION_ALLOW_LIVE_PATCHING" xml:space="preserve">
-    <value>Allowing live patching for '{0}'</value>
-  </data>
   <data name="ACTION_CHANGED_DISK_SIZE_FOR" xml:space="preserve">
     <value>Disk size changed for '{0}'.</value>
   </data>
@@ -267,14 +264,17 @@
   <data name="ACTION_DETATCHING_MULTIPLE_VDIS_TITLE" xml:space="preserve">
     <value>Detaching Multiple Storage Items</value>
   </data>
+  <data name="ACTION_DISABLE_LIVE_PATCHING" xml:space="preserve">
+    <value>Disable live patching</value>
+  </data>
   <data name="ACTION_DISABLE_VM_ENLIGHTENMENT_DESCRIPTION" xml:space="preserve">
     <value>Disabling </value>
   </data>
   <data name="ACTION_DISABLE_VM_ENLIGHTENMENT_TITLE" xml:space="preserve">
     <value>Disable container management on VM '{0}'</value>
   </data>
-  <data name="ACTION_DISALLOW_LIVE_PATCHING" xml:space="preserve">
-    <value>Disallowing live patching for '{0}'</value>
+  <data name="ACTION_DISABLING_LIVE_PATCHING" xml:space="preserve">
+    <value>Disabling live patching for '{0}'</value>
   </data>
   <data name="ACTION_DISK_ACTIVATED" xml:space="preserve">
     <value>Activated disk...</value>
@@ -372,11 +372,17 @@
   <data name="ACTION_DR_TASK_DESTROY_TITLE" xml:space="preserve">
     <value>DR cleanup ({0})</value>
   </data>
+  <data name="ACTION_ENABLE_LIVE_PATCHING" xml:space="preserve">
+    <value>Enable live patching</value>
+  </data>
   <data name="ACTION_ENABLE_VM_ENLIGHTENMENT_DESCRIPTION" xml:space="preserve">
     <value>Enabling</value>
   </data>
   <data name="ACTION_ENABLE_VM_ENLIGHTENMENT_TITLE" xml:space="preserve">
     <value>Enable container management on VM '{0}'</value>
+  </data>
+  <data name="ACTION_ENABLING_LIVE_PATCHING" xml:space="preserve">
+    <value>Enabling live patching for '{0}'</value>
   </data>
   <data name="ACTION_EXPORT_DESCRIPTION_BLOCK_CHECKSUM_FAILED" xml:space="preserve">
     <value>Export failed due to a block checksum mismatch.  Please retry the export.</value>
@@ -1731,9 +1737,6 @@ Note that if RBAC is enabled, only alerts which you have privileges to dismiss w
   </data>
   <data name="ALERT_SR_SUB_TEXT" xml:space="preserve">
     <value>When storage throughput exceeds {0} for {1} min(s)</value>
-  </data>
-  <data name="ALLOWED" xml:space="preserve">
-    <value>Allowed</value>
   </data>
   <data name="ALLOWED_MTU_RANGE" xml:space="preserve">
     <value>Allowed MTU range: {0} to {1}</value>
@@ -8670,9 +8673,6 @@ It is strongly recommended that you Cancel and apply the latest version of the p
   </data>
   <data name="NOT_AGILE_VM_HAS_VGPU" xml:space="preserve">
     <value>The VM has one or more virtual GPUs. Restart cannot be guaranteed.</value>
-  </data>
-  <data name="NOT_ALLOWED" xml:space="preserve">
-    <value>Not allowed</value>
   </data>
   <data name="NOT_APPLIED" xml:space="preserve">
     <value>Not applied</value>

--- a/XenModel/Messages.zh-CN.resx
+++ b/XenModel/Messages.zh-CN.resx
@@ -12947,4 +12947,19 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>您在此处</value>
   </data>
+  <data name="ACTION_DISABLE_LIVE_PATCHING" xml:space="preserve">
+    <value>Disable live patching</value>
+  </data>
+  <data name="ACTION_DISABLING_LIVE_PATCHING" xml:space="preserve">
+    <value>Disabling live patching for '{0}'</value>
+  </data>
+  <data name="ACTION_ENABLE_LIVE_PATCHING" xml:space="preserve">
+    <value>Enable live patching</value>
+  </data>
+  <data name="ACTION_ENABLING_LIVE_PATCHING" xml:space="preserve">
+    <value>Enabling live patching for '{0}'</value>
+  </data>
+  <data name="LIVE_PATCHING" xml:space="preserve">
+    <value>Live Patching</value>
+  </data>
 </root>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -521,6 +521,16 @@ namespace XenAPI
             return h._RestrictSslLegacySwitch;
         }
 
+        private bool _RestrictLivePatching
+        {
+            get { return BoolKey(license_params, "restrict_live_patching"); }
+        }
+
+        public static bool RestrictLivePatching(Host h)
+        {
+            return h._RestrictLivePatching;
+        }
+
         public bool HasPBDTo(SR sr)
         {
             foreach (XenRef<PBD> pbd in PBDs)

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -523,7 +523,7 @@ namespace XenAPI
 
         private bool _RestrictLivePatching
         {
-            get { return BoolKey(license_params, "restrict_live_patching"); }
+            get { return BoolKeyPreferTrue(license_params, "restrict_live_patching"); }
         }
 
         public static bool RestrictLivePatching(Host h)


### PR DESCRIPTION
Add a live patching tab with a checkbox to toggle whether live patching is allowed for a licensed pool or standalone host. 