### PR TITLE
CA-218304: Text cut off in Properties dialog, Alerts tab

### DIFF
--- a/XenAdmin/SettingsPanels/PerfmonAlertEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/PerfmonAlertEditPage.Designer.cs
@@ -33,6 +33,7 @@ namespace XenAdmin.SettingsPanels
             this.AlertIntervalMinutesLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.nudAlertInterval = new XenAdmin.SettingsPanels.AlertNumericUpDown();
             this.PhysicalUtilisationGroupBox = new XenAdmin.Controls.DecentGroupBox();
             this.physicalUtilisationMinutesLabel = new System.Windows.Forms.Label();
@@ -91,6 +92,7 @@ namespace XenAdmin.SettingsPanels
             this.CPUUsagePercentLabel = new System.Windows.Forms.Label();
             this.CPUDurationThresholdLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudAlertInterval)).BeginInit();
             this.PhysicalUtilisationGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudPhysicalUtilisationDurationThreshold)).BeginInit();
@@ -141,6 +143,12 @@ namespace XenAdmin.SettingsPanels
             // 
             resources.ApplyResources(this.label1, "label1");
             this.label1.Name = "label1";
+            // 
+            // tableLayoutPanel2
+            // 
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
             // nudAlertInterval
             // 
@@ -746,13 +754,15 @@ namespace XenAdmin.SettingsPanels
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.tableLayoutPanel2);
             this.Controls.Add(this.AlertIntervalLabel);
             this.Controls.Add(this.nudAlertInterval);
             this.Controls.Add(this.AlertIntervalMinutesLabel);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "PerfmonAlertEditPage";
             this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudAlertInterval)).EndInit();
             this.PhysicalUtilisationGroupBox.ResumeLayout(false);
             this.PhysicalUtilisationGroupBox.PerformLayout();
@@ -850,5 +860,6 @@ namespace XenAdmin.SettingsPanels
         private AlertCheckBox physicalUtilisationAlertCheckBox;
         private System.Windows.Forms.Label physicalUtilisationDurationLabel;
         private System.Windows.Forms.Label physicalUtilisationLabel;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
     }
 }

--- a/XenAdmin/SettingsPanels/PerfmonAlertEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/PerfmonAlertEditPage.Designer.cs
@@ -32,9 +32,8 @@ namespace XenAdmin.SettingsPanels
             this.AlertIntervalLabel = new System.Windows.Forms.Label();
             this.AlertIntervalMinutesLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.label1 = new System.Windows.Forms.Label();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.nudAlertInterval = new XenAdmin.SettingsPanels.AlertNumericUpDown();
+            this.labelRubric = new System.Windows.Forms.Label();
+            this.panel1 = new System.Windows.Forms.Panel();
             this.PhysicalUtilisationGroupBox = new XenAdmin.Controls.DecentGroupBox();
             this.physicalUtilisationMinutesLabel = new System.Windows.Forms.Label();
             this.nudPhysicalUtilisationDurationThreshold = new XenAdmin.SettingsPanels.AlertNumericUpDown();
@@ -91,9 +90,9 @@ namespace XenAdmin.SettingsPanels
             this.CPUAlertCheckBox = new XenAdmin.SettingsPanels.AlertCheckBox();
             this.CPUUsagePercentLabel = new System.Windows.Forms.Label();
             this.CPUDurationThresholdLabel = new System.Windows.Forms.Label();
+            this.nudAlertInterval = new XenAdmin.SettingsPanels.AlertNumericUpDown();
             this.tableLayoutPanel1.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudAlertInterval)).BeginInit();
+            this.panel1.SuspendLayout();
             this.PhysicalUtilisationGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudPhysicalUtilisationDurationThreshold)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudPhysicalUtilisation)).BeginInit();
@@ -115,6 +114,7 @@ namespace XenAdmin.SettingsPanels
             this.CpuGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudCPUUsagePercent)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudCPUDurationThreshold)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAlertInterval)).BeginInit();
             this.SuspendLayout();
             // 
             // AlertIntervalLabel
@@ -130,53 +130,33 @@ namespace XenAdmin.SettingsPanels
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.PhysicalUtilisationGroupBox, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.Dom0MemoryUsageGroupBox, 0, 5);
-            this.tableLayoutPanel1.Controls.Add(this.MemoryGroupBox, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.SrGroupBox, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.DiskGroupBox, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.NetGroupBox, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.CpuGroupBox, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.labelRubric, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.PhysicalUtilisationGroupBox, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.Dom0MemoryUsageGroupBox, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.MemoryGroupBox, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.SrGroupBox, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.DiskGroupBox, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.NetGroupBox, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.CpuGroupBox, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
-            // label1
+            // labelRubric
             // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
+            resources.ApplyResources(this.labelRubric, "labelRubric");
+            this.labelRubric.Name = "labelRubric";
             // 
-            // tableLayoutPanel2
+            // panel1
             // 
-            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            // 
-            // nudAlertInterval
-            // 
-            this.nudAlertInterval.Increment = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            resources.ApplyResources(this.nudAlertInterval, "nudAlertInterval");
-            this.nudAlertInterval.Maximum = new decimal(new int[] {
-            86400,
-            0,
-            0,
-            0});
-            this.nudAlertInterval.Minimum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            this.nudAlertInterval.Name = "nudAlertInterval";
-            this.nudAlertInterval.Value = new decimal(new int[] {
-            60,
-            0,
-            0,
-            0});
+            resources.ApplyResources(this.panel1, "panel1");
+            this.panel1.Controls.Add(this.AlertIntervalLabel);
+            this.panel1.Controls.Add(this.AlertIntervalMinutesLabel);
+            this.panel1.Controls.Add(this.nudAlertInterval);
+            this.panel1.Name = "panel1";
             // 
             // PhysicalUtilisationGroupBox
             // 
+            resources.ApplyResources(this.PhysicalUtilisationGroupBox, "PhysicalUtilisationGroupBox");
             this.PhysicalUtilisationGroupBox.Controls.Add(this.physicalUtilisationMinutesLabel);
             this.PhysicalUtilisationGroupBox.Controls.Add(this.nudPhysicalUtilisationDurationThreshold);
             this.PhysicalUtilisationGroupBox.Controls.Add(this.physicalUtilisationPercentLabel);
@@ -184,7 +164,6 @@ namespace XenAdmin.SettingsPanels
             this.PhysicalUtilisationGroupBox.Controls.Add(this.physicalUtilisationAlertCheckBox);
             this.PhysicalUtilisationGroupBox.Controls.Add(this.physicalUtilisationDurationLabel);
             this.PhysicalUtilisationGroupBox.Controls.Add(this.physicalUtilisationLabel);
-            resources.ApplyResources(this.PhysicalUtilisationGroupBox, "PhysicalUtilisationGroupBox");
             this.PhysicalUtilisationGroupBox.Name = "PhysicalUtilisationGroupBox";
             this.PhysicalUtilisationGroupBox.TabStop = false;
             // 
@@ -257,6 +236,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // Dom0MemoryUsageGroupBox
             // 
+            resources.ApplyResources(this.Dom0MemoryUsageGroupBox, "Dom0MemoryUsageGroupBox");
             this.Dom0MemoryUsageGroupBox.Controls.Add(this.nudDom0MemUsage);
             this.Dom0MemoryUsageGroupBox.Controls.Add(this.Dom0MemoryDurationThresholdLabel);
             this.Dom0MemoryUsageGroupBox.Controls.Add(this.nudDom0MemoryDurationThreshold);
@@ -264,7 +244,6 @@ namespace XenAdmin.SettingsPanels
             this.Dom0MemoryUsageGroupBox.Controls.Add(this.Dom0MemoryAlertCheckBox);
             this.Dom0MemoryUsageGroupBox.Controls.Add(this.dom0MemoryMinutesLabel);
             this.Dom0MemoryUsageGroupBox.Controls.Add(this.dom0MemoryPercentLabel);
-            resources.ApplyResources(this.Dom0MemoryUsageGroupBox, "Dom0MemoryUsageGroupBox");
             this.Dom0MemoryUsageGroupBox.Name = "Dom0MemoryUsageGroupBox";
             this.Dom0MemoryUsageGroupBox.TabStop = false;
             // 
@@ -337,6 +316,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // MemoryGroupBox
             // 
+            resources.ApplyResources(this.MemoryGroupBox, "MemoryGroupBox");
             this.MemoryGroupBox.Controls.Add(this.memoryMinutesLabel);
             this.MemoryGroupBox.Controls.Add(this.nudMemoryDurationThreshold);
             this.MemoryGroupBox.Controls.Add(this.memoryUnitsLabel);
@@ -344,7 +324,6 @@ namespace XenAdmin.SettingsPanels
             this.MemoryGroupBox.Controls.Add(this.MemoryAlertCheckBox);
             this.MemoryGroupBox.Controls.Add(this.memoryDurationThresholdLabel);
             this.MemoryGroupBox.Controls.Add(this.memoryUsageLabel);
-            resources.ApplyResources(this.MemoryGroupBox, "MemoryGroupBox");
             this.MemoryGroupBox.Name = "MemoryGroupBox";
             this.MemoryGroupBox.TabStop = false;
             // 
@@ -422,6 +401,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // SrGroupBox
             // 
+            resources.ApplyResources(this.SrGroupBox, "SrGroupBox");
             this.SrGroupBox.Controls.Add(this.srMinutesLabel);
             this.SrGroupBox.Controls.Add(this.nudSrMinutes);
             this.SrGroupBox.Controls.Add(this.srUnitsLabel);
@@ -429,7 +409,6 @@ namespace XenAdmin.SettingsPanels
             this.SrGroupBox.Controls.Add(this.SrAlertCheckBox);
             this.SrGroupBox.Controls.Add(this.SrDurationThresholdLabel);
             this.SrGroupBox.Controls.Add(this.SrUsageLabel);
-            resources.ApplyResources(this.SrGroupBox, "SrGroupBox");
             this.SrGroupBox.Name = "SrGroupBox";
             this.SrGroupBox.TabStop = false;
             // 
@@ -507,6 +486,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // DiskGroupBox
             // 
+            resources.ApplyResources(this.DiskGroupBox, "DiskGroupBox");
             this.DiskGroupBox.Controls.Add(this.DiskMinutesLabel);
             this.DiskGroupBox.Controls.Add(this.nudDiskDurationThreshold);
             this.DiskGroupBox.Controls.Add(this.DiskPercentLabel);
@@ -514,7 +494,6 @@ namespace XenAdmin.SettingsPanels
             this.DiskGroupBox.Controls.Add(this.DiskAlertCheckBox);
             this.DiskGroupBox.Controls.Add(this.DiskDurationThresholdLabel);
             this.DiskGroupBox.Controls.Add(this.DiskUsagePercentLabel);
-            resources.ApplyResources(this.DiskGroupBox, "DiskGroupBox");
             this.DiskGroupBox.Name = "DiskGroupBox";
             this.DiskGroupBox.TabStop = false;
             // 
@@ -592,6 +571,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // NetGroupBox
             // 
+            resources.ApplyResources(this.NetGroupBox, "NetGroupBox");
             this.NetGroupBox.Controls.Add(this.NetPercentLabel);
             this.NetGroupBox.Controls.Add(this.nudNetUsagePercent);
             this.NetGroupBox.Controls.Add(this.NetMinutesLabel);
@@ -599,7 +579,6 @@ namespace XenAdmin.SettingsPanels
             this.NetGroupBox.Controls.Add(this.NetAlertCheckBox);
             this.NetGroupBox.Controls.Add(this.NetDurationThresholdLabel);
             this.NetGroupBox.Controls.Add(this.NetUsagePercentLabel);
-            resources.ApplyResources(this.NetGroupBox, "NetGroupBox");
             this.NetGroupBox.Name = "NetGroupBox";
             this.NetGroupBox.TabStop = false;
             // 
@@ -672,6 +651,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // CpuGroupBox
             // 
+            resources.ApplyResources(this.CpuGroupBox, "CpuGroupBox");
             this.CpuGroupBox.Controls.Add(this.cpuPercentLabel);
             this.CpuGroupBox.Controls.Add(this.nudCPUUsagePercent);
             this.CpuGroupBox.Controls.Add(this.cpuMinutesLabel);
@@ -679,7 +659,6 @@ namespace XenAdmin.SettingsPanels
             this.CpuGroupBox.Controls.Add(this.CPUAlertCheckBox);
             this.CpuGroupBox.Controls.Add(this.CPUUsagePercentLabel);
             this.CpuGroupBox.Controls.Add(this.CPUDurationThresholdLabel);
-            resources.ApplyResources(this.CpuGroupBox, "CpuGroupBox");
             this.CpuGroupBox.Name = "CpuGroupBox";
             this.CpuGroupBox.TabStop = false;
             // 
@@ -750,20 +729,41 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.CPUDurationThresholdLabel, "CPUDurationThresholdLabel");
             this.CPUDurationThresholdLabel.Name = "CPUDurationThresholdLabel";
             // 
+            // nudAlertInterval
+            // 
+            this.nudAlertInterval.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            resources.ApplyResources(this.nudAlertInterval, "nudAlertInterval");
+            this.nudAlertInterval.Maximum = new decimal(new int[] {
+            86400,
+            0,
+            0,
+            0});
+            this.nudAlertInterval.Minimum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.nudAlertInterval.Name = "nudAlertInterval";
+            this.nudAlertInterval.Value = new decimal(new int[] {
+            60,
+            0,
+            0,
+            0});
+            // 
             // PerfmonAlertEditPage
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.tableLayoutPanel2);
-            this.Controls.Add(this.AlertIntervalLabel);
-            this.Controls.Add(this.nudAlertInterval);
-            this.Controls.Add(this.AlertIntervalMinutesLabel);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "PerfmonAlertEditPage";
             this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudAlertInterval)).EndInit();
+            this.tableLayoutPanel1.PerformLayout();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.PhysicalUtilisationGroupBox.ResumeLayout(false);
             this.PhysicalUtilisationGroupBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudPhysicalUtilisationDurationThreshold)).EndInit();
@@ -792,6 +792,7 @@ namespace XenAdmin.SettingsPanels
             this.CpuGroupBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudCPUUsagePercent)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudCPUDurationThreshold)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAlertInterval)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -843,7 +844,7 @@ namespace XenAdmin.SettingsPanels
         private AlertCheckBox SrAlertCheckBox;
         private System.Windows.Forms.Label SrDurationThresholdLabel;
         private System.Windows.Forms.Label SrUsageLabel;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label labelRubric;
         private Controls.DecentGroupBox Dom0MemoryUsageGroupBox;
         private AlertNumericUpDown nudDom0MemUsage;
         private System.Windows.Forms.Label Dom0MemoryDurationThresholdLabel;
@@ -860,6 +861,6 @@ namespace XenAdmin.SettingsPanels
         private AlertCheckBox physicalUtilisationAlertCheckBox;
         private System.Windows.Forms.Label physicalUtilisationDurationLabel;
         private System.Windows.Forms.Label physicalUtilisationLabel;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Panel panel1;
     }
 }

--- a/XenAdmin/SettingsPanels/PerfmonAlertEditPage.resx
+++ b/XenAdmin/SettingsPanels/PerfmonAlertEditPage.resx
@@ -127,13 +127,16 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="AlertIntervalLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 145</value>
+    <value>8, 8</value>
   </data>
   <data name="AlertIntervalLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 38, 8</value>
   </data>
+  <data name="AlertIntervalLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 38</value>
+  </data>
   <data name="AlertIntervalLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>270, 32</value>
+    <value>270, 70</value>
   </data>
   <data name="AlertIntervalLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -151,10 +154,10 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AlertIntervalLabel.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>panel1</value>
   </data>
   <data name="&gt;&gt;AlertIntervalLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="AlertIntervalMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -163,7 +166,7 @@
     <value>NoControl</value>
   </data>
   <data name="AlertIntervalMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>545, 145</value>
+    <value>559, 10</value>
   </data>
   <data name="AlertIntervalMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -184,10 +187,10 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AlertIntervalMinutesLabel.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>panel1</value>
   </data>
   <data name="&gt;&gt;AlertIntervalMinutesLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -198,329 +201,47 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Name" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Name" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;MemoryGroupBox.Name" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;MemoryGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;MemoryGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;MemoryGroupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;SrGroupBox.Name" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;SrGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;SrGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;SrGroupBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;DiskGroupBox.Name" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;DiskGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;DiskGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;DiskGroupBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;NetGroupBox.Name" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;NetGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;NetGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;NetGroupBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.Name" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 208</value>
-  </data>
-  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 25, 8, 8</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1128, 1477</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="PhysicalUtilisationGroupBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Dom0MemoryUsageGroupBox" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemoryGroupBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="SrGroupBox" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="DiskGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NetGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CpuGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+  <data name="labelRubric.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1127, 96</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>[XenServer] can notify you when your resource usage crosses certain thresholds. These notifications are generated as system alerts and can be forwarded  to an email server the same as any other System Alert.</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="labelRubric.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+  <data name="labelRubric.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="labelRubric.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
   </data>
-  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1143, 112</value>
-  </data>
-  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50" /&gt;&lt;Rows Styles="Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="nudAlertInterval.Location" type="System.Drawing.Point, System.Drawing">
-    <value>342, 140</value>
-  </data>
-  <data name="nudAlertInterval.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="labelRubric.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
   </data>
-  <data name="nudAlertInterval.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 38</value>
+  <data name="labelRubric.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 38</value>
   </data>
-  <data name="nudAlertInterval.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="labelRubric.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 294</value>
   </data>
-  <data name="&gt;&gt;nudAlertInterval.Name" xml:space="preserve">
-    <value>nudAlertInterval</value>
-  </data>
-  <data name="&gt;&gt;nudAlertInterval.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudAlertInterval.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;nudAlertInterval.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationMinutesLabel.Name" xml:space="preserve">
-    <value>physicalUtilisationMinutesLabel</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationMinutesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationMinutesLabel.Parent" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationMinutesLabel.ZOrder" xml:space="preserve">
+  <data name="labelRubric.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.Name" xml:space="preserve">
-    <value>nudPhysicalUtilisationDurationThreshold</value>
+  <data name="labelRubric.Text" xml:space="preserve">
+    <value>[XenServer] can notify you when your resource usage crosses certain thresholds. These notifications are generated as system alerts and can be forwarded  to an email server the same as any other System Alert.</value>
   </data>
-  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;labelRubric.Name" xml:space="preserve">
+    <value>labelRubric</value>
   </data>
-  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.Parent" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationPercentLabel.Name" xml:space="preserve">
-    <value>physicalUtilisationPercentLabel</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationPercentLabel.Type" xml:space="preserve">
+  <data name="&gt;&gt;labelRubric.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;physicalUtilisationPercentLabel.Parent" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationPercentLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudPhysicalUtilisation.Name" xml:space="preserve">
-    <value>nudPhysicalUtilisation</value>
-  </data>
-  <data name="&gt;&gt;nudPhysicalUtilisation.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudPhysicalUtilisation.Parent" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudPhysicalUtilisation.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.Name" xml:space="preserve">
-    <value>physicalUtilisationAlertCheckBox</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.Parent" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationDurationLabel.Name" xml:space="preserve">
-    <value>physicalUtilisationDurationLabel</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationDurationLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationDurationLabel.Parent" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationDurationLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationLabel.Name" xml:space="preserve">
-    <value>physicalUtilisationLabel</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationLabel.Parent" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;physicalUtilisationLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="PhysicalUtilisationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 1274</value>
-  </data>
-  <data name="PhysicalUtilisationGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
-  </data>
-  <data name="PhysicalUtilisationGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 0</value>
-  </data>
-  <data name="PhysicalUtilisationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1112, 195</value>
-  </data>
-  <data name="PhysicalUtilisationGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="PhysicalUtilisationGroupBox.Text" xml:space="preserve">
-    <value>                              </value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Name" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;labelRubric.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;labelRubric.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="PhysicalUtilisationGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="physicalUtilisationMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -744,119 +465,38 @@
   <data name="&gt;&gt;physicalUtilisationLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;nudDom0MemUsage.Name" xml:space="preserve">
-    <value>nudDom0MemUsage</value>
+  <data name="PhysicalUtilisationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 1640</value>
   </data>
-  <data name="&gt;&gt;nudDom0MemUsage.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudDom0MemUsage.Parent" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudDom0MemUsage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.Name" xml:space="preserve">
-    <value>Dom0MemoryDurationThresholdLabel</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.Parent" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.Name" xml:space="preserve">
-    <value>nudDom0MemoryDurationThreshold</value>
-  </data>
-  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.Parent" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.Name" xml:space="preserve">
-    <value>Dom0MemoryUsagePercentLabel</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.Parent" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.Name" xml:space="preserve">
-    <value>Dom0MemoryAlertCheckBox</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.Parent" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryMinutesLabel.Name" xml:space="preserve">
-    <value>dom0MemoryMinutesLabel</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryMinutesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryMinutesLabel.Parent" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryMinutesLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryPercentLabel.Name" xml:space="preserve">
-    <value>dom0MemoryPercentLabel</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryPercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryPercentLabel.Parent" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;dom0MemoryPercentLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Dom0MemoryUsageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 1063</value>
-  </data>
-  <data name="Dom0MemoryUsageGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="PhysicalUtilisationGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="PhysicalUtilisationGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 0</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1112, 195</value>
+  <data name="PhysicalUtilisationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 189</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+  <data name="PhysicalUtilisationGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.Text" xml:space="preserve">
+  <data name="PhysicalUtilisationGroupBox.Text" xml:space="preserve">
     <value>                              </value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Name" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Name" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="Dom0MemoryUsageGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="nudDom0MemUsage.Location" type="System.Drawing.Point, System.Drawing">
     <value>725, 55</value>
@@ -1080,119 +720,38 @@
   <data name="&gt;&gt;dom0MemoryPercentLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;memoryMinutesLabel.Name" xml:space="preserve">
-    <value>memoryMinutesLabel</value>
+  <data name="Dom0MemoryUsageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 1435</value>
   </data>
-  <data name="&gt;&gt;memoryMinutesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryMinutesLabel.Parent" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;memoryMinutesLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryDurationThreshold.Name" xml:space="preserve">
-    <value>nudMemoryDurationThreshold</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryDurationThreshold.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryDurationThreshold.Parent" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryDurationThreshold.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;memoryUnitsLabel.Name" xml:space="preserve">
-    <value>memoryUnitsLabel</value>
-  </data>
-  <data name="&gt;&gt;memoryUnitsLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryUnitsLabel.Parent" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;memoryUnitsLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryUsage.Name" xml:space="preserve">
-    <value>nudMemoryUsage</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryUsage.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryUsage.Parent" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudMemoryUsage.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;MemoryAlertCheckBox.Name" xml:space="preserve">
-    <value>MemoryAlertCheckBox</value>
-  </data>
-  <data name="&gt;&gt;MemoryAlertCheckBox.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;MemoryAlertCheckBox.Parent" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;MemoryAlertCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;memoryDurationThresholdLabel.Name" xml:space="preserve">
-    <value>memoryDurationThresholdLabel</value>
-  </data>
-  <data name="&gt;&gt;memoryDurationThresholdLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryDurationThresholdLabel.Parent" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;memoryDurationThresholdLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;memoryUsageLabel.Name" xml:space="preserve">
-    <value>memoryUsageLabel</value>
-  </data>
-  <data name="&gt;&gt;memoryUsageLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryUsageLabel.Parent" xml:space="preserve">
-    <value>MemoryGroupBox</value>
-  </data>
-  <data name="&gt;&gt;memoryUsageLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="MemoryGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 641</value>
-  </data>
-  <data name="MemoryGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="Dom0MemoryUsageGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
   </data>
-  <data name="MemoryGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="Dom0MemoryUsageGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 0</value>
   </data>
-  <data name="MemoryGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1112, 195</value>
+  <data name="Dom0MemoryUsageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 189</value>
   </data>
-  <data name="MemoryGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="Dom0MemoryUsageGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
   </data>
-  <data name="MemoryGroupBox.Text" xml:space="preserve">
+  <data name="Dom0MemoryUsageGroupBox.Text" xml:space="preserve">
     <value>                              </value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.Name" xml:space="preserve">
-    <value>MemoryGroupBox</value>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Name" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="MemoryGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="memoryMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1416,119 +975,38 @@
   <data name="&gt;&gt;memoryUsageLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;srMinutesLabel.Name" xml:space="preserve">
-    <value>srMinutesLabel</value>
+  <data name="MemoryGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 1025</value>
   </data>
-  <data name="&gt;&gt;srMinutesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;srMinutesLabel.Parent" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;srMinutesLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudSrMinutes.Name" xml:space="preserve">
-    <value>nudSrMinutes</value>
-  </data>
-  <data name="&gt;&gt;nudSrMinutes.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudSrMinutes.Parent" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudSrMinutes.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;srUnitsLabel.Name" xml:space="preserve">
-    <value>srUnitsLabel</value>
-  </data>
-  <data name="&gt;&gt;srUnitsLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;srUnitsLabel.Parent" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;srUnitsLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudSrUsage.Name" xml:space="preserve">
-    <value>nudSrUsage</value>
-  </data>
-  <data name="&gt;&gt;nudSrUsage.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudSrUsage.Parent" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudSrUsage.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;SrAlertCheckBox.Name" xml:space="preserve">
-    <value>SrAlertCheckBox</value>
-  </data>
-  <data name="&gt;&gt;SrAlertCheckBox.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;SrAlertCheckBox.Parent" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;SrAlertCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;SrDurationThresholdLabel.Name" xml:space="preserve">
-    <value>SrDurationThresholdLabel</value>
-  </data>
-  <data name="&gt;&gt;SrDurationThresholdLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;SrDurationThresholdLabel.Parent" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;SrDurationThresholdLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;SrUsageLabel.Name" xml:space="preserve">
-    <value>SrUsageLabel</value>
-  </data>
-  <data name="&gt;&gt;SrUsageLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;SrUsageLabel.Parent" xml:space="preserve">
-    <value>SrGroupBox</value>
-  </data>
-  <data name="&gt;&gt;SrUsageLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="SrGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 852</value>
-  </data>
-  <data name="SrGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="MemoryGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
   </data>
-  <data name="SrGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="MemoryGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 0</value>
   </data>
-  <data name="SrGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1112, 195</value>
+  <data name="MemoryGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 189</value>
   </data>
-  <data name="SrGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="MemoryGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="SrGroupBox.Text" xml:space="preserve">
+  <data name="MemoryGroupBox.Text" xml:space="preserve">
     <value>                              </value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.Name" xml:space="preserve">
-    <value>SrGroupBox</value>
+  <data name="&gt;&gt;MemoryGroupBox.Name" xml:space="preserve">
+    <value>MemoryGroupBox</value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;MemoryGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;MemoryGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;MemoryGroupBox.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="SrGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="srMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1752,119 +1230,38 @@
   <data name="&gt;&gt;SrUsageLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;DiskMinutesLabel.Name" xml:space="preserve">
-    <value>DiskMinutesLabel</value>
+  <data name="SrGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 1230</value>
   </data>
-  <data name="&gt;&gt;DiskMinutesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DiskMinutesLabel.Parent" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;DiskMinutesLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudDiskDurationThreshold.Name" xml:space="preserve">
-    <value>nudDiskDurationThreshold</value>
-  </data>
-  <data name="&gt;&gt;nudDiskDurationThreshold.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudDiskDurationThreshold.Parent" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudDiskDurationThreshold.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;DiskPercentLabel.Name" xml:space="preserve">
-    <value>DiskPercentLabel</value>
-  </data>
-  <data name="&gt;&gt;DiskPercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DiskPercentLabel.Parent" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;DiskPercentLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudDiskUsagePercent.Name" xml:space="preserve">
-    <value>nudDiskUsagePercent</value>
-  </data>
-  <data name="&gt;&gt;nudDiskUsagePercent.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudDiskUsagePercent.Parent" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudDiskUsagePercent.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;DiskAlertCheckBox.Name" xml:space="preserve">
-    <value>DiskAlertCheckBox</value>
-  </data>
-  <data name="&gt;&gt;DiskAlertCheckBox.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;DiskAlertCheckBox.Parent" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;DiskAlertCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;DiskDurationThresholdLabel.Name" xml:space="preserve">
-    <value>DiskDurationThresholdLabel</value>
-  </data>
-  <data name="&gt;&gt;DiskDurationThresholdLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DiskDurationThresholdLabel.Parent" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;DiskDurationThresholdLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;DiskUsagePercentLabel.Name" xml:space="preserve">
-    <value>DiskUsagePercentLabel</value>
-  </data>
-  <data name="&gt;&gt;DiskUsagePercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DiskUsagePercentLabel.Parent" xml:space="preserve">
-    <value>DiskGroupBox</value>
-  </data>
-  <data name="&gt;&gt;DiskUsagePercentLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="DiskGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 430</value>
-  </data>
-  <data name="DiskGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="SrGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
   </data>
-  <data name="DiskGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="SrGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 0</value>
   </data>
-  <data name="DiskGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1112, 195</value>
+  <data name="SrGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 189</value>
   </data>
-  <data name="DiskGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="SrGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="DiskGroupBox.Text" xml:space="preserve">
+  <data name="SrGroupBox.Text" xml:space="preserve">
     <value>                              </value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.Name" xml:space="preserve">
-    <value>DiskGroupBox</value>
+  <data name="&gt;&gt;SrGroupBox.Name" xml:space="preserve">
+    <value>SrGroupBox</value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;SrGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;SrGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;SrGroupBox.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="DiskGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="DiskMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2088,116 +1485,38 @@
   <data name="&gt;&gt;DiskUsagePercentLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;NetPercentLabel.Name" xml:space="preserve">
-    <value>NetPercentLabel</value>
+  <data name="DiskGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 820</value>
   </data>
-  <data name="&gt;&gt;NetPercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;NetPercentLabel.Parent" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;NetPercentLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudNetUsagePercent.Name" xml:space="preserve">
-    <value>nudNetUsagePercent</value>
-  </data>
-  <data name="&gt;&gt;nudNetUsagePercent.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudNetUsagePercent.Parent" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudNetUsagePercent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;NetMinutesLabel.Name" xml:space="preserve">
-    <value>NetMinutesLabel</value>
-  </data>
-  <data name="&gt;&gt;NetMinutesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;NetMinutesLabel.Parent" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;NetMinutesLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudNetDurationThreshold.Name" xml:space="preserve">
-    <value>nudNetDurationThreshold</value>
-  </data>
-  <data name="&gt;&gt;nudNetDurationThreshold.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudNetDurationThreshold.Parent" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudNetDurationThreshold.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;NetAlertCheckBox.Name" xml:space="preserve">
-    <value>NetAlertCheckBox</value>
-  </data>
-  <data name="&gt;&gt;NetAlertCheckBox.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;NetAlertCheckBox.Parent" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;NetAlertCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;NetDurationThresholdLabel.Name" xml:space="preserve">
-    <value>NetDurationThresholdLabel</value>
-  </data>
-  <data name="&gt;&gt;NetDurationThresholdLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;NetDurationThresholdLabel.Parent" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;NetDurationThresholdLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;NetUsagePercentLabel.Name" xml:space="preserve">
-    <value>NetUsagePercentLabel</value>
-  </data>
-  <data name="&gt;&gt;NetUsagePercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;NetUsagePercentLabel.Parent" xml:space="preserve">
-    <value>NetGroupBox</value>
-  </data>
-  <data name="&gt;&gt;NetUsagePercentLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="NetGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 219</value>
-  </data>
-  <data name="NetGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="DiskGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
   </data>
-  <data name="NetGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="DiskGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 0</value>
   </data>
-  <data name="NetGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1112, 195</value>
+  <data name="DiskGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 189</value>
   </data>
-  <data name="NetGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="DiskGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.Name" xml:space="preserve">
-    <value>NetGroupBox</value>
+  <data name="DiskGroupBox.Text" xml:space="preserve">
+    <value>                              </value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;DiskGroupBox.Name" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DiskGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;DiskGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;DiskGroupBox.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="NetGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="NetPercentLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2421,116 +1740,35 @@
   <data name="&gt;&gt;NetUsagePercentLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;cpuPercentLabel.Name" xml:space="preserve">
-    <value>cpuPercentLabel</value>
+  <data name="NetGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 615</value>
   </data>
-  <data name="&gt;&gt;cpuPercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cpuPercentLabel.Parent" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;cpuPercentLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudCPUUsagePercent.Name" xml:space="preserve">
-    <value>nudCPUUsagePercent</value>
-  </data>
-  <data name="&gt;&gt;nudCPUUsagePercent.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudCPUUsagePercent.Parent" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudCPUUsagePercent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cpuMinutesLabel.Name" xml:space="preserve">
-    <value>cpuMinutesLabel</value>
-  </data>
-  <data name="&gt;&gt;cpuMinutesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cpuMinutesLabel.Parent" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;cpuMinutesLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudCPUDurationThreshold.Name" xml:space="preserve">
-    <value>nudCPUDurationThreshold</value>
-  </data>
-  <data name="&gt;&gt;nudCPUDurationThreshold.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudCPUDurationThreshold.Parent" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;nudCPUDurationThreshold.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;CPUAlertCheckBox.Name" xml:space="preserve">
-    <value>CPUAlertCheckBox</value>
-  </data>
-  <data name="&gt;&gt;CPUAlertCheckBox.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CPUAlertCheckBox.Parent" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;CPUAlertCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;CPUUsagePercentLabel.Name" xml:space="preserve">
-    <value>CPUUsagePercentLabel</value>
-  </data>
-  <data name="&gt;&gt;CPUUsagePercentLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CPUUsagePercentLabel.Parent" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;CPUUsagePercentLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;CPUDurationThresholdLabel.Name" xml:space="preserve">
-    <value>CPUDurationThresholdLabel</value>
-  </data>
-  <data name="&gt;&gt;CPUDurationThresholdLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CPUDurationThresholdLabel.Parent" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;CPUDurationThresholdLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="CpuGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="CpuGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="NetGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
   </data>
-  <data name="CpuGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="NetGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 0</value>
   </data>
-  <data name="CpuGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1112, 195</value>
+  <data name="NetGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 189</value>
   </data>
-  <data name="CpuGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="NetGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;CpuGroupBox.Name" xml:space="preserve">
-    <value>CpuGroupBox</value>
+  <data name="&gt;&gt;NetGroupBox.Name" xml:space="preserve">
+    <value>NetGroupBox</value>
   </data>
-  <data name="&gt;&gt;CpuGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;NetGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;CpuGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;NetGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;CpuGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;NetGroupBox.ZOrder" xml:space="preserve">
     <value>6</value>
+  </data>
+  <data name="CpuGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="cpuPercentLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2754,6 +1992,114 @@
   <data name="&gt;&gt;CPUDurationThresholdLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="CpuGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 410</value>
+  </data>
+  <data name="CpuGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="CpuGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="CpuGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>389, 189</value>
+  </data>
+  <data name="CpuGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Name" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="panel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="nudAlertInterval.Location" type="System.Drawing.Point, System.Drawing">
+    <value>356, 5</value>
+  </data>
+  <data name="nudAlertInterval.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="nudAlertInterval.Size" type="System.Drawing.Size, System.Drawing">
+    <value>188, 38</value>
+  </data>
+  <data name="nudAlertInterval.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.Name" xml:space="preserve">
+    <value>nudAlertInterval</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 313</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>399, 86</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 25, 8, 8</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>405, 1837</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelRubric" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="PhysicalUtilisationGroupBox" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Dom0MemoryUsageGroupBox" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemoryGroupBox" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="SrGroupBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="DiskGroupBox" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NetGroupBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CpuGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="panel1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -2770,7 +2116,7 @@
     <value>8, 8, 8, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>878, 1173</value>
+    <value>405, 958</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PerfmonAlertEditPage</value>

--- a/XenAdmin/SettingsPanels/PerfmonAlertEditPage.resx
+++ b/XenAdmin/SettingsPanels/PerfmonAlertEditPage.resx
@@ -127,13 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="AlertIntervalLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 58</value>
+    <value>15, 145</value>
   </data>
   <data name="AlertIntervalLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 15, 3</value>
+    <value>8, 8, 38, 8</value>
   </data>
   <data name="AlertIntervalLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
+    <value>270, 32</value>
   </data>
   <data name="AlertIntervalLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -163,13 +163,13 @@
     <value>NoControl</value>
   </data>
   <data name="AlertIntervalMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>218, 58</value>
+    <value>545, 145</value>
   </data>
   <data name="AlertIntervalMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="AlertIntervalMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="AlertIntervalMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -198,6 +198,330 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Name" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Name" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;MemoryGroupBox.Name" xml:space="preserve">
+    <value>MemoryGroupBox</value>
+  </data>
+  <data name="&gt;&gt;MemoryGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;MemoryGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;MemoryGroupBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;SrGroupBox.Name" xml:space="preserve">
+    <value>SrGroupBox</value>
+  </data>
+  <data name="&gt;&gt;SrGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;SrGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;SrGroupBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;DiskGroupBox.Name" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DiskGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;DiskGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;DiskGroupBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;NetGroupBox.Name" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;NetGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;NetGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;NetGroupBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Name" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 208</value>
+  </data>
+  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 25, 8, 8</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1128, 1477</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="PhysicalUtilisationGroupBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Dom0MemoryUsageGroupBox" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemoryGroupBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="SrGroupBox" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="DiskGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NetGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CpuGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1127, 96</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>[XenServer] can notify you when your resource usage crosses certain thresholds. These notifications are generated as system alerts and can be forwarded  to an email server the same as any other System Alert.</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1143, 112</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50" /&gt;&lt;Rows Styles="Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="nudAlertInterval.Location" type="System.Drawing.Point, System.Drawing">
+    <value>342, 140</value>
+  </data>
+  <data name="nudAlertInterval.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="nudAlertInterval.Size" type="System.Drawing.Size, System.Drawing">
+    <value>188, 38</value>
+  </data>
+  <data name="nudAlertInterval.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.Name" xml:space="preserve">
+    <value>nudAlertInterval</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;nudAlertInterval.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationMinutesLabel.Name" xml:space="preserve">
+    <value>physicalUtilisationMinutesLabel</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationMinutesLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationMinutesLabel.Parent" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationMinutesLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.Name" xml:space="preserve">
+    <value>nudPhysicalUtilisationDurationThreshold</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.Parent" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisationDurationThreshold.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationPercentLabel.Name" xml:space="preserve">
+    <value>physicalUtilisationPercentLabel</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationPercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationPercentLabel.Parent" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationPercentLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisation.Name" xml:space="preserve">
+    <value>nudPhysicalUtilisation</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisation.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisation.Parent" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudPhysicalUtilisation.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.Name" xml:space="preserve">
+    <value>physicalUtilisationAlertCheckBox</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.Parent" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationAlertCheckBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationDurationLabel.Name" xml:space="preserve">
+    <value>physicalUtilisationDurationLabel</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationDurationLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationDurationLabel.Parent" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationDurationLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationLabel.Name" xml:space="preserve">
+    <value>physicalUtilisationLabel</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationLabel.Parent" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;physicalUtilisationLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="PhysicalUtilisationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 1274</value>
+  </data>
+  <data name="PhysicalUtilisationGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="PhysicalUtilisationGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="PhysicalUtilisationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1112, 195</value>
+  </data>
+  <data name="PhysicalUtilisationGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="PhysicalUtilisationGroupBox.Text" xml:space="preserve">
+    <value>                              </value>
+  </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Name" xml:space="preserve">
+    <value>PhysicalUtilisationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;PhysicalUtilisationGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="physicalUtilisationMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -205,10 +529,13 @@
     <value>NoControl</value>
   </data>
   <data name="physicalUtilisationMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 50</value>
+    <value>930, 125</value>
+  </data>
+  <data name="physicalUtilisationMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="physicalUtilisationMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="physicalUtilisationMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -229,13 +556,13 @@
     <value>0</value>
   </data>
   <data name="nudPhysicalUtilisationDurationThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 48</value>
+    <value>725, 120</value>
   </data>
   <data name="nudPhysicalUtilisationDurationThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+    <value>8, 8, 8, 0</value>
   </data>
   <data name="nudPhysicalUtilisationDurationThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudPhysicalUtilisationDurationThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -259,10 +586,13 @@
     <value>NoControl</value>
   </data>
   <data name="physicalUtilisationPercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 24</value>
+    <value>930, 60</value>
+  </data>
+  <data name="physicalUtilisationPercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="physicalUtilisationPercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
+    <value>40, 32</value>
   </data>
   <data name="physicalUtilisationPercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -283,10 +613,13 @@
     <value>2</value>
   </data>
   <data name="nudPhysicalUtilisation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 22</value>
+    <value>725, 55</value>
+  </data>
+  <data name="nudPhysicalUtilisation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="nudPhysicalUtilisation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudPhysicalUtilisation.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -310,13 +643,16 @@
     <value>NoControl</value>
   </data>
   <data name="physicalUtilisationAlertCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 0</value>
+    <value>15, 0</value>
+  </data>
+  <data name="physicalUtilisationAlertCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="physicalUtilisationAlertCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="physicalUtilisationAlertCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 17</value>
+    <value>632, 36</value>
   </data>
   <data name="physicalUtilisationAlertCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -343,10 +679,13 @@
     <value>NoControl</value>
   </data>
   <data name="physicalUtilisationDurationLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 50</value>
+    <value>30, 125</value>
+  </data>
+  <data name="physicalUtilisationDurationLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="physicalUtilisationDurationLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>215, 32</value>
   </data>
   <data name="physicalUtilisationDurationLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -376,10 +715,13 @@
     <value>NoControl</value>
   </data>
   <data name="physicalUtilisationLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>30, 60</value>
+  </data>
+  <data name="physicalUtilisationLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="physicalUtilisationLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 13</value>
+    <value>496, 32</value>
   </data>
   <data name="physicalUtilisationLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -402,38 +744,128 @@
   <data name="&gt;&gt;physicalUtilisationLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="PhysicalUtilisationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 507</value>
+  <data name="&gt;&gt;nudDom0MemUsage.Name" xml:space="preserve">
+    <value>nudDom0MemUsage</value>
   </data>
-  <data name="PhysicalUtilisationGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+  <data name="&gt;&gt;nudDom0MemUsage.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="PhysicalUtilisationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 78</value>
+  <data name="&gt;&gt;nudDom0MemUsage.Parent" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
   </data>
-  <data name="PhysicalUtilisationGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="PhysicalUtilisationGroupBox.Text" xml:space="preserve">
-    <value>                              </value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Name" xml:space="preserve">
-    <value>PhysicalUtilisationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;PhysicalUtilisationGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;nudDom0MemUsage.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.Name" xml:space="preserve">
+    <value>Dom0MemoryDurationThresholdLabel</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.Parent" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryDurationThresholdLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.Name" xml:space="preserve">
+    <value>nudDom0MemoryDurationThreshold</value>
+  </data>
+  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.Parent" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudDom0MemoryDurationThreshold.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.Name" xml:space="preserve">
+    <value>Dom0MemoryUsagePercentLabel</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.Parent" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsagePercentLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.Name" xml:space="preserve">
+    <value>Dom0MemoryAlertCheckBox</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.Parent" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryAlertCheckBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryMinutesLabel.Name" xml:space="preserve">
+    <value>dom0MemoryMinutesLabel</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryMinutesLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryMinutesLabel.Parent" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryMinutesLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryPercentLabel.Name" xml:space="preserve">
+    <value>dom0MemoryPercentLabel</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryPercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryPercentLabel.Parent" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;dom0MemoryPercentLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="Dom0MemoryUsageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 1063</value>
+  </data>
+  <data name="Dom0MemoryUsageGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="Dom0MemoryUsageGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="Dom0MemoryUsageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1112, 195</value>
+  </data>
+  <data name="Dom0MemoryUsageGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="Dom0MemoryUsageGroupBox.Text" xml:space="preserve">
+    <value>                              </value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Name" xml:space="preserve">
+    <value>Dom0MemoryUsageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="nudDom0MemUsage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 22</value>
+    <value>725, 55</value>
+  </data>
+  <data name="nudDom0MemUsage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="nudDom0MemUsage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudDom0MemUsage.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -457,10 +889,13 @@
     <value>NoControl</value>
   </data>
   <data name="Dom0MemoryDurationThresholdLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 50</value>
+    <value>930, 125</value>
+  </data>
+  <data name="Dom0MemoryDurationThresholdLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="Dom0MemoryDurationThresholdLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="Dom0MemoryDurationThresholdLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -481,13 +916,13 @@
     <value>1</value>
   </data>
   <data name="nudDom0MemoryDurationThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 48</value>
+    <value>725, 120</value>
   </data>
   <data name="nudDom0MemoryDurationThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+    <value>8, 8, 8, 0</value>
   </data>
   <data name="nudDom0MemoryDurationThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudDom0MemoryDurationThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -511,10 +946,13 @@
     <value>NoControl</value>
   </data>
   <data name="Dom0MemoryUsagePercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 24</value>
+    <value>930, 60</value>
+  </data>
+  <data name="Dom0MemoryUsagePercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="Dom0MemoryUsagePercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
+    <value>40, 32</value>
   </data>
   <data name="Dom0MemoryUsagePercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -541,13 +979,16 @@
     <value>NoControl</value>
   </data>
   <data name="Dom0MemoryAlertCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 0</value>
+    <value>15, 0</value>
+  </data>
+  <data name="Dom0MemoryAlertCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="Dom0MemoryAlertCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="Dom0MemoryAlertCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>244, 17</value>
+    <value>644, 36</value>
   </data>
   <data name="Dom0MemoryAlertCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -574,10 +1015,13 @@
     <value>NoControl</value>
   </data>
   <data name="dom0MemoryMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 50</value>
+    <value>30, 125</value>
+  </data>
+  <data name="dom0MemoryMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="dom0MemoryMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>215, 32</value>
   </data>
   <data name="dom0MemoryMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -607,10 +1051,13 @@
     <value>NoControl</value>
   </data>
   <data name="dom0MemoryPercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>30, 60</value>
+  </data>
+  <data name="dom0MemoryPercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="dom0MemoryPercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>225, 13</value>
+    <value>597, 32</value>
   </data>
   <data name="dom0MemoryPercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -633,32 +1080,119 @@
   <data name="&gt;&gt;dom0MemoryPercentLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 423</value>
+  <data name="&gt;&gt;memoryMinutesLabel.Name" xml:space="preserve">
+    <value>memoryMinutesLabel</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+  <data name="&gt;&gt;memoryMinutesLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 78</value>
+  <data name="&gt;&gt;memoryMinutesLabel.Parent" xml:space="preserve">
+    <value>MemoryGroupBox</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+  <data name="&gt;&gt;memoryMinutesLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="Dom0MemoryUsageGroupBox.Text" xml:space="preserve">
+  <data name="&gt;&gt;nudMemoryDurationThreshold.Name" xml:space="preserve">
+    <value>nudMemoryDurationThreshold</value>
+  </data>
+  <data name="&gt;&gt;nudMemoryDurationThreshold.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudMemoryDurationThreshold.Parent" xml:space="preserve">
+    <value>MemoryGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudMemoryDurationThreshold.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;memoryUnitsLabel.Name" xml:space="preserve">
+    <value>memoryUnitsLabel</value>
+  </data>
+  <data name="&gt;&gt;memoryUnitsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryUnitsLabel.Parent" xml:space="preserve">
+    <value>MemoryGroupBox</value>
+  </data>
+  <data name="&gt;&gt;memoryUnitsLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudMemoryUsage.Name" xml:space="preserve">
+    <value>nudMemoryUsage</value>
+  </data>
+  <data name="&gt;&gt;nudMemoryUsage.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudMemoryUsage.Parent" xml:space="preserve">
+    <value>MemoryGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudMemoryUsage.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;MemoryAlertCheckBox.Name" xml:space="preserve">
+    <value>MemoryAlertCheckBox</value>
+  </data>
+  <data name="&gt;&gt;MemoryAlertCheckBox.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;MemoryAlertCheckBox.Parent" xml:space="preserve">
+    <value>MemoryGroupBox</value>
+  </data>
+  <data name="&gt;&gt;MemoryAlertCheckBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;memoryDurationThresholdLabel.Name" xml:space="preserve">
+    <value>memoryDurationThresholdLabel</value>
+  </data>
+  <data name="&gt;&gt;memoryDurationThresholdLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryDurationThresholdLabel.Parent" xml:space="preserve">
+    <value>MemoryGroupBox</value>
+  </data>
+  <data name="&gt;&gt;memoryDurationThresholdLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;memoryUsageLabel.Name" xml:space="preserve">
+    <value>memoryUsageLabel</value>
+  </data>
+  <data name="&gt;&gt;memoryUsageLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryUsageLabel.Parent" xml:space="preserve">
+    <value>MemoryGroupBox</value>
+  </data>
+  <data name="&gt;&gt;memoryUsageLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="MemoryGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 641</value>
+  </data>
+  <data name="MemoryGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="MemoryGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="MemoryGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1112, 195</value>
+  </data>
+  <data name="MemoryGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="MemoryGroupBox.Text" xml:space="preserve">
     <value>                              </value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Name" xml:space="preserve">
-    <value>Dom0MemoryUsageGroupBox</value>
+  <data name="&gt;&gt;MemoryGroupBox.Name" xml:space="preserve">
+    <value>MemoryGroupBox</value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;MemoryGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;MemoryGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;Dom0MemoryUsageGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;MemoryGroupBox.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="memoryMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -667,10 +1201,13 @@
     <value>NoControl</value>
   </data>
   <data name="memoryMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 50</value>
+    <value>930, 125</value>
+  </data>
+  <data name="memoryMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="memoryMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="memoryMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -691,13 +1228,13 @@
     <value>0</value>
   </data>
   <data name="nudMemoryDurationThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 48</value>
+    <value>725, 120</value>
   </data>
   <data name="nudMemoryDurationThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+    <value>8, 8, 8, 0</value>
   </data>
   <data name="nudMemoryDurationThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudMemoryDurationThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -721,10 +1258,13 @@
     <value>NoControl</value>
   </data>
   <data name="memoryUnitsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 24</value>
+    <value>930, 60</value>
+  </data>
+  <data name="memoryUnitsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="memoryUnitsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 13</value>
+    <value>57, 32</value>
   </data>
   <data name="memoryUnitsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -745,10 +1285,13 @@
     <value>2</value>
   </data>
   <data name="nudMemoryUsage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 22</value>
+    <value>725, 55</value>
+  </data>
+  <data name="nudMemoryUsage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="nudMemoryUsage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudMemoryUsage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -772,13 +1315,16 @@
     <value>NoControl</value>
   </data>
   <data name="MemoryAlertCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 0</value>
+    <value>15, 0</value>
+  </data>
+  <data name="MemoryAlertCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="MemoryAlertCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="MemoryAlertCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>172, 17</value>
+    <value>450, 36</value>
   </data>
   <data name="MemoryAlertCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -805,10 +1351,13 @@
     <value>NoControl</value>
   </data>
   <data name="memoryDurationThresholdLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 50</value>
+    <value>30, 125</value>
+  </data>
+  <data name="memoryDurationThresholdLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="memoryDurationThresholdLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>215, 32</value>
   </data>
   <data name="memoryDurationThresholdLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -838,10 +1387,13 @@
     <value>NoControl</value>
   </data>
   <data name="memoryUsageLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>30, 60</value>
+  </data>
+  <data name="memoryUsageLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="memoryUsageLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>151, 13</value>
+    <value>402, 32</value>
   </data>
   <data name="memoryUsageLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -864,32 +1416,119 @@
   <data name="&gt;&gt;memoryUsageLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="MemoryGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 255</value>
+  <data name="&gt;&gt;srMinutesLabel.Name" xml:space="preserve">
+    <value>srMinutesLabel</value>
   </data>
-  <data name="MemoryGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+  <data name="&gt;&gt;srMinutesLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="MemoryGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 78</value>
+  <data name="&gt;&gt;srMinutesLabel.Parent" xml:space="preserve">
+    <value>SrGroupBox</value>
   </data>
-  <data name="MemoryGroupBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;srMinutesLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;nudSrMinutes.Name" xml:space="preserve">
+    <value>nudSrMinutes</value>
+  </data>
+  <data name="&gt;&gt;nudSrMinutes.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudSrMinutes.Parent" xml:space="preserve">
+    <value>SrGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudSrMinutes.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;srUnitsLabel.Name" xml:space="preserve">
+    <value>srUnitsLabel</value>
+  </data>
+  <data name="&gt;&gt;srUnitsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;srUnitsLabel.Parent" xml:space="preserve">
+    <value>SrGroupBox</value>
+  </data>
+  <data name="&gt;&gt;srUnitsLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudSrUsage.Name" xml:space="preserve">
+    <value>nudSrUsage</value>
+  </data>
+  <data name="&gt;&gt;nudSrUsage.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudSrUsage.Parent" xml:space="preserve">
+    <value>SrGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudSrUsage.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="MemoryGroupBox.Text" xml:space="preserve">
+  <data name="&gt;&gt;SrAlertCheckBox.Name" xml:space="preserve">
+    <value>SrAlertCheckBox</value>
+  </data>
+  <data name="&gt;&gt;SrAlertCheckBox.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;SrAlertCheckBox.Parent" xml:space="preserve">
+    <value>SrGroupBox</value>
+  </data>
+  <data name="&gt;&gt;SrAlertCheckBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;SrDurationThresholdLabel.Name" xml:space="preserve">
+    <value>SrDurationThresholdLabel</value>
+  </data>
+  <data name="&gt;&gt;SrDurationThresholdLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;SrDurationThresholdLabel.Parent" xml:space="preserve">
+    <value>SrGroupBox</value>
+  </data>
+  <data name="&gt;&gt;SrDurationThresholdLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;SrUsageLabel.Name" xml:space="preserve">
+    <value>SrUsageLabel</value>
+  </data>
+  <data name="&gt;&gt;SrUsageLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;SrUsageLabel.Parent" xml:space="preserve">
+    <value>SrGroupBox</value>
+  </data>
+  <data name="&gt;&gt;SrUsageLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="SrGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 852</value>
+  </data>
+  <data name="SrGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="SrGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="SrGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1112, 195</value>
+  </data>
+  <data name="SrGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="SrGroupBox.Text" xml:space="preserve">
     <value>                              </value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.Name" xml:space="preserve">
-    <value>MemoryGroupBox</value>
+  <data name="&gt;&gt;SrGroupBox.Name" xml:space="preserve">
+    <value>SrGroupBox</value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;SrGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;SrGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;MemoryGroupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;SrGroupBox.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="srMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -898,10 +1537,13 @@
     <value>NoControl</value>
   </data>
   <data name="srMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 50</value>
+    <value>930, 125</value>
+  </data>
+  <data name="srMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="srMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="srMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -922,13 +1564,13 @@
     <value>0</value>
   </data>
   <data name="nudSrMinutes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 48</value>
+    <value>725, 120</value>
   </data>
   <data name="nudSrMinutes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+    <value>8, 8, 8, 0</value>
   </data>
   <data name="nudSrMinutes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudSrMinutes.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -952,10 +1594,13 @@
     <value>NoControl</value>
   </data>
   <data name="srUnitsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 24</value>
+    <value>930, 60</value>
+  </data>
+  <data name="srUnitsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="srUnitsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
+    <value>75, 32</value>
   </data>
   <data name="srUnitsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -976,10 +1621,13 @@
     <value>2</value>
   </data>
   <data name="nudSrUsage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 22</value>
+    <value>725, 55</value>
+  </data>
+  <data name="nudSrUsage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="nudSrUsage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudSrUsage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1003,13 +1651,16 @@
     <value>NoControl</value>
   </data>
   <data name="SrAlertCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 0</value>
+    <value>15, 0</value>
+  </data>
+  <data name="SrAlertCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="SrAlertCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="SrAlertCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 17</value>
+    <value>503, 36</value>
   </data>
   <data name="SrAlertCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1036,10 +1687,13 @@
     <value>NoControl</value>
   </data>
   <data name="SrDurationThresholdLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 50</value>
+    <value>30, 125</value>
+  </data>
+  <data name="SrDurationThresholdLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="SrDurationThresholdLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>215, 32</value>
   </data>
   <data name="SrDurationThresholdLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1069,10 +1723,13 @@
     <value>NoControl</value>
   </data>
   <data name="SrUsageLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>30, 60</value>
+  </data>
+  <data name="SrUsageLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="SrUsageLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 13</value>
+    <value>554, 32</value>
   </data>
   <data name="SrUsageLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1095,32 +1752,119 @@
   <data name="&gt;&gt;SrUsageLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="SrGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 339</value>
+  <data name="&gt;&gt;DiskMinutesLabel.Name" xml:space="preserve">
+    <value>DiskMinutesLabel</value>
   </data>
-  <data name="SrGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+  <data name="&gt;&gt;DiskMinutesLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="SrGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 78</value>
+  <data name="&gt;&gt;DiskMinutesLabel.Parent" xml:space="preserve">
+    <value>DiskGroupBox</value>
   </data>
-  <data name="SrGroupBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;DiskMinutesLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;nudDiskDurationThreshold.Name" xml:space="preserve">
+    <value>nudDiskDurationThreshold</value>
+  </data>
+  <data name="&gt;&gt;nudDiskDurationThreshold.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudDiskDurationThreshold.Parent" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudDiskDurationThreshold.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;DiskPercentLabel.Name" xml:space="preserve">
+    <value>DiskPercentLabel</value>
+  </data>
+  <data name="&gt;&gt;DiskPercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DiskPercentLabel.Parent" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DiskPercentLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudDiskUsagePercent.Name" xml:space="preserve">
+    <value>nudDiskUsagePercent</value>
+  </data>
+  <data name="&gt;&gt;nudDiskUsagePercent.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudDiskUsagePercent.Parent" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudDiskUsagePercent.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;DiskAlertCheckBox.Name" xml:space="preserve">
+    <value>DiskAlertCheckBox</value>
+  </data>
+  <data name="&gt;&gt;DiskAlertCheckBox.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;DiskAlertCheckBox.Parent" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DiskAlertCheckBox.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="SrGroupBox.Text" xml:space="preserve">
+  <data name="&gt;&gt;DiskDurationThresholdLabel.Name" xml:space="preserve">
+    <value>DiskDurationThresholdLabel</value>
+  </data>
+  <data name="&gt;&gt;DiskDurationThresholdLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DiskDurationThresholdLabel.Parent" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DiskDurationThresholdLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;DiskUsagePercentLabel.Name" xml:space="preserve">
+    <value>DiskUsagePercentLabel</value>
+  </data>
+  <data name="&gt;&gt;DiskUsagePercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DiskUsagePercentLabel.Parent" xml:space="preserve">
+    <value>DiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DiskUsagePercentLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="DiskGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 430</value>
+  </data>
+  <data name="DiskGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="DiskGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="DiskGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1112, 195</value>
+  </data>
+  <data name="DiskGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="DiskGroupBox.Text" xml:space="preserve">
     <value>                              </value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.Name" xml:space="preserve">
-    <value>SrGroupBox</value>
+  <data name="&gt;&gt;DiskGroupBox.Name" xml:space="preserve">
+    <value>DiskGroupBox</value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;DiskGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;DiskGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;SrGroupBox.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;DiskGroupBox.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="DiskMinutesLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1129,10 +1873,13 @@
     <value>NoControl</value>
   </data>
   <data name="DiskMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 50</value>
+    <value>930, 125</value>
+  </data>
+  <data name="DiskMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="DiskMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="DiskMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1153,13 +1900,13 @@
     <value>0</value>
   </data>
   <data name="nudDiskDurationThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 48</value>
+    <value>725, 120</value>
   </data>
   <data name="nudDiskDurationThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+    <value>8, 8, 8, 0</value>
   </data>
   <data name="nudDiskDurationThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudDiskDurationThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1183,10 +1930,13 @@
     <value>NoControl</value>
   </data>
   <data name="DiskPercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 24</value>
+    <value>930, 60</value>
+  </data>
+  <data name="DiskPercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="DiskPercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
+    <value>75, 32</value>
   </data>
   <data name="DiskPercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1207,10 +1957,13 @@
     <value>2</value>
   </data>
   <data name="nudDiskUsagePercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 22</value>
+    <value>725, 55</value>
+  </data>
+  <data name="nudDiskUsagePercent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="nudDiskUsagePercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudDiskUsagePercent.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1234,13 +1987,16 @@
     <value>NoControl</value>
   </data>
   <data name="DiskAlertCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 0</value>
+    <value>15, 0</value>
+  </data>
+  <data name="DiskAlertCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="DiskAlertCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="DiskAlertCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 17</value>
+    <value>400, 36</value>
   </data>
   <data name="DiskAlertCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1267,10 +2023,13 @@
     <value>NoControl</value>
   </data>
   <data name="DiskDurationThresholdLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 48</value>
+    <value>30, 120</value>
+  </data>
+  <data name="DiskDurationThresholdLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="DiskDurationThresholdLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>215, 32</value>
   </data>
   <data name="DiskDurationThresholdLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1300,10 +2059,13 @@
     <value>NoControl</value>
   </data>
   <data name="DiskUsagePercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>30, 60</value>
+  </data>
+  <data name="DiskUsagePercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="DiskUsagePercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 13</value>
+    <value>353, 32</value>
   </data>
   <data name="DiskUsagePercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1326,32 +2088,116 @@
   <data name="&gt;&gt;DiskUsagePercentLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="DiskGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 171</value>
+  <data name="&gt;&gt;NetPercentLabel.Name" xml:space="preserve">
+    <value>NetPercentLabel</value>
   </data>
-  <data name="DiskGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+  <data name="&gt;&gt;NetPercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="DiskGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 78</value>
+  <data name="&gt;&gt;NetPercentLabel.Parent" xml:space="preserve">
+    <value>NetGroupBox</value>
   </data>
-  <data name="DiskGroupBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;NetPercentLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;nudNetUsagePercent.Name" xml:space="preserve">
+    <value>nudNetUsagePercent</value>
+  </data>
+  <data name="&gt;&gt;nudNetUsagePercent.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudNetUsagePercent.Parent" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudNetUsagePercent.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;NetMinutesLabel.Name" xml:space="preserve">
+    <value>NetMinutesLabel</value>
+  </data>
+  <data name="&gt;&gt;NetMinutesLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NetMinutesLabel.Parent" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;NetMinutesLabel.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="DiskGroupBox.Text" xml:space="preserve">
-    <value>                              </value>
+  <data name="&gt;&gt;nudNetDurationThreshold.Name" xml:space="preserve">
+    <value>nudNetDurationThreshold</value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.Name" xml:space="preserve">
-    <value>DiskGroupBox</value>
+  <data name="&gt;&gt;nudNetDurationThreshold.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;nudNetDurationThreshold.Parent" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudNetDurationThreshold.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;NetAlertCheckBox.Name" xml:space="preserve">
+    <value>NetAlertCheckBox</value>
+  </data>
+  <data name="&gt;&gt;NetAlertCheckBox.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;NetAlertCheckBox.Parent" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;NetAlertCheckBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;NetDurationThresholdLabel.Name" xml:space="preserve">
+    <value>NetDurationThresholdLabel</value>
+  </data>
+  <data name="&gt;&gt;NetDurationThresholdLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NetDurationThresholdLabel.Parent" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;NetDurationThresholdLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;NetUsagePercentLabel.Name" xml:space="preserve">
+    <value>NetUsagePercentLabel</value>
+  </data>
+  <data name="&gt;&gt;NetUsagePercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NetUsagePercentLabel.Parent" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;NetUsagePercentLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="NetGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 219</value>
+  </data>
+  <data name="NetGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="NetGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="NetGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1112, 195</value>
+  </data>
+  <data name="NetGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;NetGroupBox.Name" xml:space="preserve">
+    <value>NetGroupBox</value>
+  </data>
+  <data name="&gt;&gt;NetGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;NetGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;DiskGroupBox.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;NetGroupBox.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="NetPercentLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1360,10 +2206,13 @@
     <value>NoControl</value>
   </data>
   <data name="NetPercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 24</value>
+    <value>930, 60</value>
+  </data>
+  <data name="NetPercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="NetPercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
+    <value>75, 32</value>
   </data>
   <data name="NetPercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1384,10 +2233,13 @@
     <value>0</value>
   </data>
   <data name="nudNetUsagePercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 22</value>
+    <value>725, 55</value>
+  </data>
+  <data name="nudNetUsagePercent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="nudNetUsagePercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudNetUsagePercent.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1411,10 +2263,13 @@
     <value>NoControl</value>
   </data>
   <data name="NetMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 50</value>
+    <value>930, 125</value>
+  </data>
+  <data name="NetMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="NetMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="NetMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1435,13 +2290,13 @@
     <value>2</value>
   </data>
   <data name="nudNetDurationThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 48</value>
+    <value>725, 120</value>
   </data>
   <data name="nudNetDurationThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+    <value>8, 8, 8, 0</value>
   </data>
   <data name="nudNetDurationThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudNetDurationThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1465,13 +2320,16 @@
     <value>NoControl</value>
   </data>
   <data name="NetAlertCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 0</value>
+    <value>15, 0</value>
+  </data>
+  <data name="NetAlertCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="NetAlertCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="NetAlertCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 17</value>
+    <value>448, 36</value>
   </data>
   <data name="NetAlertCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1498,10 +2356,13 @@
     <value>NoControl</value>
   </data>
   <data name="NetDurationThresholdLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 50</value>
+    <value>30, 125</value>
+  </data>
+  <data name="NetDurationThresholdLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="NetDurationThresholdLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>215, 32</value>
   </data>
   <data name="NetDurationThresholdLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1531,10 +2392,13 @@
     <value>NoControl</value>
   </data>
   <data name="NetUsagePercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>30, 60</value>
+  </data>
+  <data name="NetUsagePercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="NetUsagePercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 13</value>
+    <value>401, 32</value>
   </data>
   <data name="NetUsagePercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1557,29 +2421,116 @@
   <data name="&gt;&gt;NetUsagePercentLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="NetGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 87</value>
+  <data name="&gt;&gt;cpuPercentLabel.Name" xml:space="preserve">
+    <value>cpuPercentLabel</value>
   </data>
-  <data name="NetGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+  <data name="&gt;&gt;cpuPercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="NetGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 78</value>
+  <data name="&gt;&gt;cpuPercentLabel.Parent" xml:space="preserve">
+    <value>CpuGroupBox</value>
   </data>
-  <data name="NetGroupBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;cpuPercentLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;nudCPUUsagePercent.Name" xml:space="preserve">
+    <value>nudCPUUsagePercent</value>
+  </data>
+  <data name="&gt;&gt;nudCPUUsagePercent.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudCPUUsagePercent.Parent" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudCPUUsagePercent.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.Name" xml:space="preserve">
-    <value>NetGroupBox</value>
+  <data name="&gt;&gt;cpuMinutesLabel.Name" xml:space="preserve">
+    <value>cpuMinutesLabel</value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;cpuMinutesLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cpuMinutesLabel.Parent" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;cpuMinutesLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudCPUDurationThreshold.Name" xml:space="preserve">
+    <value>nudCPUDurationThreshold</value>
+  </data>
+  <data name="&gt;&gt;nudCPUDurationThreshold.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nudCPUDurationThreshold.Parent" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;nudCPUDurationThreshold.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;CPUAlertCheckBox.Name" xml:space="preserve">
+    <value>CPUAlertCheckBox</value>
+  </data>
+  <data name="&gt;&gt;CPUAlertCheckBox.Type" xml:space="preserve">
+    <value>XenAdmin.SettingsPanels.AlertCheckBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CPUAlertCheckBox.Parent" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;CPUAlertCheckBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;CPUUsagePercentLabel.Name" xml:space="preserve">
+    <value>CPUUsagePercentLabel</value>
+  </data>
+  <data name="&gt;&gt;CPUUsagePercentLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CPUUsagePercentLabel.Parent" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;CPUUsagePercentLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;CPUDurationThresholdLabel.Name" xml:space="preserve">
+    <value>CPUDurationThresholdLabel</value>
+  </data>
+  <data name="&gt;&gt;CPUDurationThresholdLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CPUDurationThresholdLabel.Parent" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;CPUDurationThresholdLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="CpuGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="CpuGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
+  <data name="CpuGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 0</value>
+  </data>
+  <data name="CpuGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1112, 195</value>
+  </data>
+  <data name="CpuGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Name" xml:space="preserve">
+    <value>CpuGroupBox</value>
+  </data>
+  <data name="&gt;&gt;CpuGroupBox.Type" xml:space="preserve">
     <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;CpuGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;NetGroupBox.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;CpuGroupBox.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="cpuPercentLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1588,10 +2539,13 @@
     <value>NoControl</value>
   </data>
   <data name="cpuPercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 24</value>
+    <value>930, 60</value>
+  </data>
+  <data name="cpuPercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="cpuPercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
+    <value>40, 32</value>
   </data>
   <data name="cpuPercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1612,10 +2566,13 @@
     <value>0</value>
   </data>
   <data name="nudCPUUsagePercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 22</value>
+    <value>725, 55</value>
+  </data>
+  <data name="nudCPUUsagePercent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="nudCPUUsagePercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudCPUUsagePercent.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1639,10 +2596,13 @@
     <value>NoControl</value>
   </data>
   <data name="cpuMinutesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>372, 50</value>
+    <value>930, 125</value>
+  </data>
+  <data name="cpuMinutesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="cpuMinutesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>115, 32</value>
   </data>
   <data name="cpuMinutesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1663,13 +2623,13 @@
     <value>2</value>
   </data>
   <data name="nudCPUDurationThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 48</value>
+    <value>725, 120</value>
   </data>
   <data name="nudCPUDurationThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
+    <value>8, 8, 8, 0</value>
   </data>
   <data name="nudCPUDurationThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>188, 38</value>
   </data>
   <data name="nudCPUDurationThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1693,16 +2653,16 @@
     <value>NoControl</value>
   </data>
   <data name="CPUAlertCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 0</value>
+    <value>15, 0</value>
   </data>
   <data name="CPUAlertCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 7</value>
+    <value>8, 8, 8, 18</value>
   </data>
   <data name="CPUAlertCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="CPUAlertCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 17</value>
+    <value>408, 36</value>
   </data>
   <data name="CPUAlertCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1729,10 +2689,13 @@
     <value>NoControl</value>
   </data>
   <data name="CPUUsagePercentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>30, 60</value>
+  </data>
+  <data name="CPUUsagePercentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="CPUUsagePercentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 13</value>
+    <value>361, 32</value>
   </data>
   <data name="CPUUsagePercentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1762,10 +2725,13 @@
     <value>NoControl</value>
   </data>
   <data name="CPUDurationThresholdLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 50</value>
+    <value>30, 125</value>
+  </data>
+  <data name="CPUDurationThresholdLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="CPUDurationThresholdLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>215, 32</value>
   </data>
   <data name="CPUDurationThresholdLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1788,119 +2754,11 @@
   <data name="&gt;&gt;CPUDurationThresholdLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="CpuGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="CpuGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
-  </data>
-  <data name="CpuGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>445, 78</value>
-  </data>
-  <data name="CpuGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.Name" xml:space="preserve">
-    <value>CpuGroupBox</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;CpuGroupBox.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 83</value>
-  </data>
-  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 10, 3, 3</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 588</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="PhysicalUtilisationGroupBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Dom0MemoryUsageGroupBox" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemoryGroupBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="SrGroupBox" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="DiskGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NetGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CpuGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>454, 53</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>[XenServer] can notify you when your resource usage crosses certain thresholds. These notifications are generated as system alerts and can be forwarded  to an email server the same as any other System Alert.</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="nudAlertInterval.Location" type="System.Drawing.Point, System.Drawing">
-    <value>137, 56</value>
-  </data>
-  <data name="nudAlertInterval.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
-  </data>
-  <data name="nudAlertInterval.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudAlertInterval.Name" xml:space="preserve">
-    <value>nudAlertInterval</value>
-  </data>
-  <data name="&gt;&gt;nudAlertInterval.Type" xml:space="preserve">
-    <value>XenAdmin.SettingsPanels.AlertNumericUpDown, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;nudAlertInterval.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;nudAlertInterval.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>96, 96</value>
+    <value>240, 240</value>
   </data>
   <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1908,8 +2766,11 @@
   <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 8, 8, 8</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>420, 538</value>
+    <value>878, 1173</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PerfmonAlertEditPage</value>

--- a/XenAdmin/SettingsPanels/PerfmonAlertEditPage.resx
+++ b/XenAdmin/SettingsPanels/PerfmonAlertEditPage.resx
@@ -220,7 +220,7 @@
     <value>0, 0, 0, 38</value>
   </data>
   <data name="labelRubric.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 294</value>
+    <value>303, 422</value>
   </data>
   <data name="labelRubric.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -466,7 +466,7 @@
     <value>6</value>
   </data>
   <data name="PhysicalUtilisationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 1640</value>
+    <value>8, 1768</value>
   </data>
   <data name="PhysicalUtilisationGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -475,10 +475,10 @@
     <value>8, 8, 8, 0</value>
   </data>
   <data name="PhysicalUtilisationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 189</value>
+    <value>303, 189</value>
   </data>
   <data name="PhysicalUtilisationGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="PhysicalUtilisationGroupBox.Text" xml:space="preserve">
     <value>                              </value>
@@ -721,7 +721,7 @@
     <value>6</value>
   </data>
   <data name="Dom0MemoryUsageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 1435</value>
+    <value>8, 1563</value>
   </data>
   <data name="Dom0MemoryUsageGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -730,10 +730,10 @@
     <value>8, 8, 8, 0</value>
   </data>
   <data name="Dom0MemoryUsageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 189</value>
+    <value>303, 189</value>
   </data>
   <data name="Dom0MemoryUsageGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="Dom0MemoryUsageGroupBox.Text" xml:space="preserve">
     <value>                              </value>
@@ -976,7 +976,7 @@
     <value>6</value>
   </data>
   <data name="MemoryGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 1025</value>
+    <value>8, 1153</value>
   </data>
   <data name="MemoryGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -985,10 +985,10 @@
     <value>8, 8, 8, 0</value>
   </data>
   <data name="MemoryGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 189</value>
+    <value>303, 189</value>
   </data>
   <data name="MemoryGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="MemoryGroupBox.Text" xml:space="preserve">
     <value>                              </value>
@@ -1231,7 +1231,7 @@
     <value>6</value>
   </data>
   <data name="SrGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 1230</value>
+    <value>8, 1358</value>
   </data>
   <data name="SrGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -1240,10 +1240,10 @@
     <value>8, 8, 8, 0</value>
   </data>
   <data name="SrGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 189</value>
+    <value>303, 189</value>
   </data>
   <data name="SrGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="SrGroupBox.Text" xml:space="preserve">
     <value>                              </value>
@@ -1486,7 +1486,7 @@
     <value>6</value>
   </data>
   <data name="DiskGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 820</value>
+    <value>8, 948</value>
   </data>
   <data name="DiskGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -1495,10 +1495,10 @@
     <value>8, 8, 8, 0</value>
   </data>
   <data name="DiskGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 189</value>
+    <value>303, 189</value>
   </data>
   <data name="DiskGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="DiskGroupBox.Text" xml:space="preserve">
     <value>                              </value>
@@ -1741,7 +1741,7 @@
     <value>6</value>
   </data>
   <data name="NetGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 615</value>
+    <value>8, 743</value>
   </data>
   <data name="NetGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -1750,10 +1750,10 @@
     <value>8, 8, 8, 0</value>
   </data>
   <data name="NetGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 189</value>
+    <value>303, 189</value>
   </data>
   <data name="NetGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;NetGroupBox.Name" xml:space="preserve">
     <value>NetGroupBox</value>
@@ -1993,7 +1993,7 @@
     <value>6</value>
   </data>
   <data name="CpuGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 410</value>
+    <value>8, 538</value>
   </data>
   <data name="CpuGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>8, 8, 8, 8</value>
@@ -2002,10 +2002,10 @@
     <value>8, 8, 8, 0</value>
   </data>
   <data name="CpuGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>389, 189</value>
+    <value>303, 189</value>
   </data>
   <data name="CpuGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;CpuGroupBox.Name" xml:space="preserve">
     <value>CpuGroupBox</value>
@@ -2032,7 +2032,7 @@
     <value>188, 38</value>
   </data>
   <data name="nudAlertInterval.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;nudAlertInterval.Name" xml:space="preserve">
     <value>nudAlertInterval</value>
@@ -2047,13 +2047,13 @@
     <value>2</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 313</value>
+    <value>3, 441</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>399, 86</value>
+    <value>313, 86</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;panel1.Name" xml:space="preserve">
     <value>panel1</value>
@@ -2080,7 +2080,7 @@
     <value>9</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>405, 1837</value>
+    <value>319, 1965</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -2116,7 +2116,7 @@
     <value>8, 8, 8, 8</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>405, 958</value>
+    <value>319, 958</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PerfmonAlertEditPage</value>


### PR DESCRIPTION
This is resolved by moving the label into a TableLayoutPanel, docked to the top and with auto-grow on.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>