### PR TITLE
CA-180127: Unable to unset VM home server if all shared SRs are full

### DIFF
--- a/XenAdmin/SettingsPanels/HomeServerEditPage.cs
+++ b/XenAdmin/SettingsPanels/HomeServerEditPage.cs
@@ -84,10 +84,7 @@ namespace XenAdmin.SettingsPanels
                 return;
 
             Host currentAffinity = vm.Connection.Resolve(vm.affinity);
-            picker.SetAffinity(vm.Connection, currentAffinity,
-                              vm.HasNoDisksAndNoLocalCD
-                                  ? null
-                                  : vm.GetStorageHost(false));
+            picker.SetAffinity(vm.Connection, currentAffinity, null);
         }
 
         public bool ValidToSave


### PR DESCRIPTION
By passing null as the srHost parameter to the affinity picker, the "no home server" radio button remains enabled, even when no shared SRs are available, allowing users to unset the home server of a VM

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>