### PR TITLE
CA-218241: Cancel connect right click menu item does not seem to be doing anything

### DIFF
--- a/XenAdmin/Commands/DisconnectCommand.cs
+++ b/XenAdmin/Commands/DisconnectCommand.cs
@@ -71,7 +71,7 @@ namespace XenAdmin.Commands
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {
-            return _connection != null && _connection.IsConnected;
+            return _connection != null && (_connection.IsConnected || _connection.InProgress);
         }
 
         /// <summary>


### PR DESCRIPTION
The CancelHostConnectionCommand executes by using a DisconnectCommand, so the fix here is to allow that command to execute on connections in progress as well as those that are connected.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>