### PR TITLE
CA-150198: EN: Missing hotkey for “Properties” after right clicking virtual disk

### DIFF
--- a/XenAdmin/TabPages/SrStoragePage.resx
+++ b/XenAdmin/TabPages/SrStoragePage.resx
@@ -191,7 +191,7 @@
     <value>173, 22</value>
   </data>
   <data name="editVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
-    <value>Properties</value>
+    <value>P&amp;roperties</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="TitleLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">


### PR DESCRIPTION


Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>