### PR TITLE
CA-213496: Snapshots taken part of VMSS have same symbol as manually taken snapshots

### DIFF
--- a/XenAdmin/Images.cs
+++ b/XenAdmin/Images.cs
@@ -311,7 +311,7 @@ namespace XenAdmin
 
             if (vm.is_a_snapshot)
             {
-                if (vm.is_snapshot_from_vmpp)
+                if (vm.is_snapshot_from_vmpp || vm.is_vmss_snapshot)
                 {
                     if (vm.power_state == vm_power_state.Suspended)
                         return Icons.ScheduledSnapshotDiskMemory;


### PR DESCRIPTION
Snapshots taken part of VMSS have same symbol as manually taken snapshots in saved snapshot searchas manually taken snapshots in saved snapshot search

Signed-off-by: Sharath Babu <Sharath.Babu@citrix.com>