### PR TITLE
Improvements made while investigating CA-218953:

### DIFF
--- a/XenAdmin/Commands/InstallToolsCommand.cs
+++ b/XenAdmin/Commands/InstallToolsCommand.cs
@@ -150,7 +150,7 @@ namespace XenAdmin.Commands
                 DialogResult dr = new InstallToolsWarningDialog(vm.Connection).ShowDialog(Parent);
                 if (dr == DialogResult.Yes)
                 {
-                    InstallPVToolsAction installToolsAction = new InstallPVToolsAction( vm, XSToolsSRNotFound, Properties.Settings.Default.ShowHiddenVMs);
+                    var installToolsAction = new InstallPVToolsAction(vm, Properties.Settings.Default.ShowHiddenVMs);
                     installToolsAction.Completed += InstallToolsActionCompleted;
 
                     installToolsAction.RunAsync();
@@ -158,18 +158,6 @@ namespace XenAdmin.Commands
                 }
             }
             return null;
-        }
-
-        private static void XSToolsSRNotFound()
-        {
-            Program.Invoke(Program.MainWindow, delegate
-                        {
-                            using (var dlg = new ThreeButtonDialog(
-                                new ThreeButtonDialog.Details(SystemIcons.Error, Messages.XS_TOOLS_SR_NOT_FOUND, Messages.XENCENTER)))
-                            {
-                                dlg.ShowDialog(Program.MainWindow);
-                            }
-                        });
         }
 
         /// <summary>
@@ -225,7 +213,7 @@ namespace XenAdmin.Commands
                 {
                     foreach (VM vm in vms)
                     {
-                        InstallPVToolsAction installToolsAction = new InstallPVToolsAction(vm, XSToolsSRNotFound, Properties.Settings.Default.ShowHiddenVMs);
+                        var installToolsAction = new InstallPVToolsAction(vm, Properties.Settings.Default.ShowHiddenVMs);
 
                         if (vms.IndexOf(vm) == 0)
                         {

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -1932,10 +1932,7 @@ namespace XenAdmin.Network
         public List<VDI> ResolveAllShownXenModelObjects(List<XenRef<VDI>> xenRefs, bool showHiddenObjects)
         {
             List<VDI> result = ResolveAll(xenRefs);
-            result.RemoveAll(delegate(VDI vdi)
-                                 {
-                                     return !vdi.Show(showHiddenObjects);
-                                 });
+            result.RemoveAll(vdi => !vdi.Show(showHiddenObjects));
             return result;
         }
 

--- a/XenModel/XenAPI-Extensions/VDI.cs
+++ b/XenModel/XenAPI-Extensions/VDI.cs
@@ -302,20 +302,15 @@ namespace XenAPI
         }
 
         /// <summary>
-        /// Whether this is a Tools ISO. Finds the old method (by name) as well as
-        /// the new method (field on the VDI).
+        /// Whether this is a Tools ISO.
+        /// The new method is to check the is_tools_iso flag, the old one to check the name_label.
         /// </summary>
         public bool IsToolsIso
         {
             get
             {
-                const string ISONameOld = "xswindrivers.iso";
-                const string ISONameNew = "xs-tools.iso";
-
-                return
-                    is_tools_iso ||
-                    ISONameOld.Equals(name_label) ||
-                    ISONameNew.Equals(name_label);
+                string[] toolIsoNames = {"xswindrivers.iso", "xs-tools.iso", "guest-tools.iso"};
+                return is_tools_iso || toolIsoNames.Contains(name_label);
             }
         }
         


### PR DESCRIPTION
- when the cd drive or the tools iso cannot be found, the action should fail.
- if the tools SR is broken, do not show the error on a pop-up because the UX is
bad when installation is attempted on multiple VMS.
- added one more entry to the list of possible tools iso names.
- small performance improvement.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>