### PR TITLE
CA-140181: Inconsistent name displaying when it contains symbol '&’

### DIFF
--- a/XenAdmin/SettingsPanels/CustomFieldsDisplayPage.cs
+++ b/XenAdmin/SettingsPanels/CustomFieldsDisplayPage.cs
@@ -243,7 +243,7 @@ namespace XenAdmin.SettingsPanels
                 {
                     // Create the display label
                     Label lblKey = new Label();
-                    lblKey.Text = customFieldDefinition.Name;
+                    lblKey.Text = customFieldDefinition.Name.EscapeAmpersands();
                     lblKey.Margin = new Padding(3, 7, 3, 3);
                     lblKey.Font = Program.DefaultFont;
                     lblKey.Width = (int)tableLayoutPanel.ColumnStyles[0].Width;

--- a/XenAdmin/TabPages/PerformancePage.cs
+++ b/XenAdmin/TabPages/PerformancePage.cs
@@ -360,9 +360,10 @@ namespace XenAdmin.TabPages
 
         private void DeleteGraph()
         {
+            var formattableName = GraphList.SelectedGraph.DisplayName.Replace("&", "&&");
             using (ThreeButtonDialog dlog = new ThreeButtonDialog(
                 new ThreeButtonDialog.Details(SystemIcons.Warning,
-                    string.Format(Messages.DELETE_GRAPH_MESSAGE, GraphList.SelectedGraph.DisplayName),
+                    string.Format(Messages.DELETE_GRAPH_MESSAGE, formattableName),
                     Messages.XENCENTER),
                 ThreeButtonDialog.ButtonYes,
                 ThreeButtonDialog.ButtonNo))

--- a/XenAdmin/TabPages/PerformancePage.cs
+++ b/XenAdmin/TabPages/PerformancePage.cs
@@ -360,10 +360,9 @@ namespace XenAdmin.TabPages
 
         private void DeleteGraph()
         {
-            var formattableName = GraphList.SelectedGraph.DisplayName.Replace("&", "&&");
             using (ThreeButtonDialog dlog = new ThreeButtonDialog(
                 new ThreeButtonDialog.Details(SystemIcons.Warning,
-                    string.Format(Messages.DELETE_GRAPH_MESSAGE, formattableName),
+                    string.Format(Messages.DELETE_GRAPH_MESSAGE, GraphList.SelectedGraph.DisplayName.EscapeAmpersands()),
                     Messages.XENCENTER),
                 ThreeButtonDialog.ButtonYes,
                 ThreeButtonDialog.ButtonNo))


### PR DESCRIPTION
The ticket said the character after the & became a hotkey (like labels etc do with UseMnemonic enabled) but I couldn't reproduce that - & symbols were simply removed from the string. The fix is to replace them with &&, so the string.format prints a single & as it should.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>