### PR TITLE
CP-18012: Use extended precheck information in Update Wizard

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -173,6 +173,8 @@ namespace XenAdmin.Wizards.PatchingWizard
             else if (prevPageType == typeof(PatchingWizard_PrecheckPage))
             {
                 PatchingWizard_PatchingPage.ProblemsResolvedPreCheck = PatchingWizard_PrecheckPage.ProblemsResolvedPreCheck;
+                PatchingWizard_PatchingPage.LivePatchCodesByHost = PatchingWizard_PrecheckPage.LivePatchCodesByHost;
+                PatchingWizard_ModePage.LivePatchCodesByHost = PatchingWizard_PrecheckPage.LivePatchCodesByHost;
             }
         }
 
@@ -322,5 +324,13 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             base.FinishWizard();
         }
+    }
+
+    public enum LivePatchCode
+    {
+        UNKNOWN,
+        PATCH_PRECHECK_LIVEPATCH_COMPLETE,      // An applicable live patch exists for every required component
+        PATCH_PRECHECK_LIVEPATCH_INCOMPLETE,    // An applicable live patch exists but it is not sufficient
+        PATCH_PRECHECK_LIVEPATCH_MISSING,       // There is no applicable live patch
     }
 }

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.cs
@@ -77,6 +77,12 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             return Messages.UPDATES_WIZARD_APPLY_UPDATE;
         }
+
+        public Dictionary<string, LivePatchCode> LivePatchCodesByHost
+        {
+            get;
+            set;
+        }
         
         public override void PageLoaded(PageLoadedDirection direction)
         {
@@ -88,7 +94,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             {
                 case UpdateType.NewRetail:
                 case UpdateType.Existing:
-                    textBoxLog.Text = PatchingWizardModeGuidanceBuilder.ModeRetailPatch(SelectedServers, Patch);
+                    textBoxLog.Text = PatchingWizardModeGuidanceBuilder.ModeRetailPatch(SelectedServers, Patch, LivePatchCodesByHost);
                     AutomaticRadioButton.Enabled = true;
                     AutomaticRadioButton.Checked = true;
                     break;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
@@ -50,6 +50,12 @@ namespace XenAdmin.Wizards.PatchingWizard
     {
         protected static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
+        public Dictionary<string, LivePatchCode> LivePatchCodesByHost
+        {
+            get;
+            set;
+        }
+
         private AsyncAction actionManualMode = null;
         private bool _thisPageHasBeenCompleted = false;
         private BackgroundWorker actionsWorker = null;
@@ -318,7 +324,8 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             actions.Add(new ApplyPatchPlanAction(host, patch));
 
-            if (patch.after_apply_guidance.Contains(after_apply_guidance.restartHost))
+            if (patch.after_apply_guidance.Contains(after_apply_guidance.restartHost) 
+                && !(LivePatchCodesByHost !=null && LivePatchCodesByHost.ContainsKey(host.uuid) && LivePatchCodesByHost[host.uuid] == LivePatchCode.PATCH_PRECHECK_LIVEPATCH_COMPLETE))
             {
                 actions.Add(new EvacuateHostPlanAction(host));
                 actions.Add(new RebootHostPlanAction(host));

--- a/XenAdminTests/WizardTests/PatchingWizard/PatchingWizardModeGuidanceBuilderTests.cs
+++ b/XenAdminTests/WizardTests/PatchingWizard/PatchingWizardModeGuidanceBuilderTests.cs
@@ -73,7 +73,7 @@ namespace XenAdminTests.WizardTests
             host.Setup(h => h.IsMaster()).Returns(true);
             host.Setup(h => h.Name).Returns("MyHost");
             patch.Setup(p => p.after_apply_guidance).Returns(new List<after_apply_guidance> { guidance });
-            msg = PatchingWizardModeGuidanceBuilder.ModeRetailPatch(new List<Host> { host.Object }, patch.Object);
+            msg = PatchingWizardModeGuidanceBuilder.ModeRetailPatch(new List<Host> { host.Object }, patch.Object, new Dictionary<string,LivePatchCode>());
             return patch;
         }
     }


### PR DESCRIPTION
This commit implements the check for LiveUpdate capability of a patch. If
the patch is completely live-updatable, XenCenter will not restart the
host (but will do further checks once it has finished installing the
update - separate ticket)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>