### PR TITLE
CP-18618: If live patching fails, warn the user

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using log4net;
@@ -43,6 +44,7 @@ using XenAdmin.Dialogs;
 using XenAdmin.Wizards.PatchingWizard.PlanActions;
 using XenAPI;
 using XenAdmin.Actions;
+using XenAdmin.Core;
 
 namespace XenAdmin.Wizards.PatchingWizard
 {
@@ -307,7 +309,6 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
             OnPageUpdated();
             _thisPageHasBeenCompleted = true;
-
         }
 
         private List<PlanAction> CompileActionList(Host host, Pool_patch patch)
@@ -449,11 +450,88 @@ namespace XenAdmin.Wizards.PatchingWizard
             panel1.Visible = true;
         }
 
+        /// <summary>
+        /// Live patching is attempted for a host if the LivePatchCodesByHost contains the LIVEPATCH_COMPLETE value for that host
+        /// </summary>
+        /// <param name="host"></param>
+        /// <returns></returns>
+        private bool LivePatchingAttemptedForHost(Host host)
+        {
+            return LivePatchCodesByHost != null && LivePatchCodesByHost.ContainsKey(host.uuid) &&
+                   LivePatchCodesByHost[host.uuid] == LivePatchCode.PATCH_PRECHECK_LIVEPATCH_COMPLETE;
+
+        }
+
+        /// <summary>
+        /// Live patching has failed for a host if that host requires a reboot for this patch, and we expected to live patch
+        /// </summary>
+        /// <param name="host"></param>
+        /// <returns></returns>
+        private bool LivePatchingFailedForHost(Host host)
+        {
+            if (!host.patches_requiring_reboot.Any())
+            {
+                return false;
+            }
+
+            foreach (var patchRef in host.patches_requiring_reboot)
+            {
+                var poolPatch = host.Connection.Resolve(patchRef);
+                if (poolPatch.uuid.Equals(Patch.uuid))
+                {
+                    // This patch failed
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private void FinishedSuccessfully()
         {
             labelTitle.Text = string.Format(Messages.UPDATE_WAS_SUCCESSFULLY_INSTALLED, GetUpdateName());
             pictureBox1.Image = null;
             labelError.Text = Messages.CLOSE_WIZARD_CLICK_FINISH;
+
+            // Live patching failed is per-host
+            var livePatchingFailedHosts = new List<Host>();
+
+            foreach (var host in SelectedMasters)
+            {
+                if (LivePatchingAttemptedForHost(host) && LivePatchingFailedForHost(host))
+                {
+                    livePatchingFailedHosts.Add(host);
+                }
+            }
+
+            if (livePatchingFailedHosts.Count == 0)
+            {
+                return;
+            }
+
+            LivePatchingFailed(livePatchingFailedHosts);
+        }
+
+        private void LivePatchingFailed(IList<Host> hosts)
+        {
+            string dialogMessage;
+            if (hosts.Count == 1)
+            {
+                dialogMessage = string.Format(Messages.LIVE_PATCHING_FAILED_ONE_HOST, hosts[0]);
+            }
+            else
+            {
+                dialogMessage = string.Format(Messages.LIVE_PATCHING_FAILED_MULTI_HOST,
+                    string.Join(Messages.LIST_SEPARATOR, hosts.Select(s => s.ToString().SurroundWith('\''))));
+            }
+
+            using (var dlg = new ThreeButtonDialog(
+                new ThreeButtonDialog.Details(SystemIcons.Warning,
+                    dialogMessage, Messages.XENCENTER),
+                ThreeButtonDialog.ButtonOK))
+            {
+                dlg.ShowDialog(Program.MainWindow);
+            }
         }
 
         private string GetUpdateName()

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19714,6 +19714,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Live patching failed for servers {0}. To apply the patch, please put the servers into maintenance mode and reboot them..
+        /// </summary>
+        public static string LIVE_PATCHING_FAILED_MULTI_HOST {
+            get {
+                return ResourceManager.GetString("LIVE_PATCHING_FAILED_MULTI_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Live patching failed for server ‘{0}’. To apply the patch, please put the server into maintenance mode and reboot it..
+        /// </summary>
+        public static string LIVE_PATCHING_FAILED_ONE_HOST {
+            get {
+                return ResourceManager.GetString("LIVE_PATCHING_FAILED_ONE_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading &apos;{0}&apos;....
         /// </summary>
         public static string LOADING {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -6880,6 +6880,12 @@ Standard features only</value>
   <data name="LIVE_PATCHING" xml:space="preserve">
     <value>Live Patching</value>
   </data>
+  <data name="LIVE_PATCHING_FAILED_MULTI_HOST" xml:space="preserve">
+    <value>Live patching failed for servers {0}. To apply the patch, please put the servers into maintenance mode and reboot them.</value>
+  </data>
+  <data name="LIVE_PATCHING_FAILED_ONE_HOST" xml:space="preserve">
+    <value>Live patching failed for server ‘{0}’. To apply the patch, please put the server into maintenance mode and reboot it.</value>
+  </data>
   <data name="LOADING" xml:space="preserve">
     <value>Loading '{0}'...</value>
   </data>

--- a/XenModel/StringExtensions.cs
+++ b/XenModel/StringExtensions.cs
@@ -99,5 +99,21 @@ namespace XenAdmin
         {
             return s == null ? null : s.Replace("\"", "\"\"");
         }
+
+        /// <summary>
+        /// Surround a string with a given character
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="c"></param>
+        /// <returns></returns>
+        public static string SurroundWith(this string s, char c)
+        {
+            if (s == null)
+            {
+                return null;
+            }
+
+            return c + s + c;
+        }
     }
 }


### PR DESCRIPTION
If we are expecting to live patch, but at the end
hosts.patches_requring_reboot contains the patch, then warn the user that
live patching has failed for the host - and it needs to be rebooted.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>