### PR TITLE
CA-107341:  Truncation issue occurred on rolling pool upgrade window.

### DIFF
--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeReadyToUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeReadyToUpgradePage.cs
@@ -64,14 +64,14 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 {
                     e.Graphics.DrawString(string.Format(host.IsMaster()
                                                             ? Messages.UPGRADE_POOL_MASTER_X
-                                                            : Messages.UPGRADE_SERVER_X, host.Name), Program.DefaultFont, brush, e.Bounds);
+                                                            : Messages.UPGRADE_SERVER_X, host.Name.Ellipsise(64)), Program.DefaultFont, brush, e.Bounds);
                     return;
                 }
 
                 Pool pool = item as Pool;
                 if (pool != null)
                 {
-                    e.Graphics.DrawString(string.Format(Messages.POOL_X_READYUPGRADE, pool.Name), Program.DefaultFontBold, brush, e.Bounds);
+                    e.Graphics.DrawString(string.Format(Messages.POOL_X_READYUPGRADE, pool.Name.Ellipsise(64)), Program.DefaultFontBold, brush, e.Bounds);
                     return;
                 }
 


### PR DESCRIPTION
Ellipsised pool and host names on the Ready to Upgrade page to 64 characters, which resolves the layout problem from extremely long names.