### PR TITLE
CA-112317: Sorting on SR storage tab is incorrect

### DIFF
--- a/XenAdmin/TabPages/SrStoragePage.cs
+++ b/XenAdmin/TabPages/SrStoragePage.cs
@@ -51,6 +51,8 @@ namespace XenAdmin.TabPages
         private SR sr;
         private readonly DataGridViewColumn sizeColumn;
         private readonly DataGridViewColumn storageLinkVolumeColumn;
+        private readonly DataGridViewColumn nameColumn;
+        private readonly DataGridViewColumn descriptionColumn;
         private bool rebuildRequired;
 
         private readonly VDIsDataGridViewBuilder dataGridViewBuilder;
@@ -61,6 +63,9 @@ namespace XenAdmin.TabPages
 
             storageLinkVolumeColumn = ColumnVolume;
             sizeColumn = ColumnSize;
+            nameColumn = ColumnName;
+            descriptionColumn = ColumnDesc;
+
             for (int i = 0; i < 5; i++)
             {
                 dataGridViewVDIs.Columns[i].SortMode = DataGridViewColumnSortMode.Automatic;
@@ -275,6 +280,44 @@ namespace XenAdmin.TabPages
         #region datagridviewevents
         void DataGridViewObject_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
         {
+            if (e.Column.Index == nameColumn.Index)
+            {
+                var vdi1 = ((VDIRow) dataGridViewVDIs.Rows[e.RowIndex1]).VDI;
+                var vdi2 = ((VDIRow) dataGridViewVDIs.Rows[e.RowIndex2]).VDI;
+
+                var nameCompare = StringUtility.NaturalCompare(vdi1.Name, vdi2.Name);
+                if (nameCompare != 0)
+                {
+                    e.SortResult = nameCompare;
+                }
+                else
+                {
+                    var uuidCompare = String.Compare(vdi1.uuid, vdi2.uuid, StringComparison.Ordinal);
+                    e.SortResult = uuidCompare;
+                }
+                e.Handled = true;
+                return;
+            }
+
+            if (e.Column.Index == descriptionColumn.Index)
+            {
+                var vdi1 = ((VDIRow)dataGridViewVDIs.Rows[e.RowIndex1]).VDI;
+                var vdi2 = ((VDIRow)dataGridViewVDIs.Rows[e.RowIndex2]).VDI;
+
+                var descCompare = StringUtility.NaturalCompare(vdi1.Description, vdi2.Description);
+                if (descCompare != 0)
+                {
+                    e.SortResult = descCompare;
+                }
+                else
+                {
+                    var uuidCompare = String.Compare(vdi1.uuid, vdi2.uuid, StringComparison.Ordinal);
+                    e.SortResult = uuidCompare;
+                }
+                e.Handled = true;
+                return;
+            }
+
             if (e.Column.Index == sizeColumn.Index)
             {
                 VDI vdi1 = ((VDIRow)dataGridViewVDIs.Rows[e.RowIndex1]).VDI;


### PR DESCRIPTION
Change the sorting on the Name and Description columns to use StringUtility.NaturalCompare, which correctly sorts strings with numbers at the end (eg name, name0, name1, name2, name10 will now sort correctly while alphabetic sorting is incorrect). Also added a tie break on uuid to make sorting behave predictably with duplicates in these columns.