### PR TITLE
CA-112317: Sorting on SR storage tab is incorrect

### DIFF
--- a/XenAdmin/TabPages/SrStoragePage.cs
+++ b/XenAdmin/TabPages/SrStoragePage.cs
@@ -285,16 +285,7 @@ namespace XenAdmin.TabPages
                 var vdi1 = ((VDIRow) dataGridViewVDIs.Rows[e.RowIndex1]).VDI;
                 var vdi2 = ((VDIRow) dataGridViewVDIs.Rows[e.RowIndex2]).VDI;
 
-                var nameCompare = StringUtility.NaturalCompare(vdi1.Name, vdi2.Name);
-                if (nameCompare != 0)
-                {
-                    e.SortResult = nameCompare;
-                }
-                else
-                {
-                    var uuidCompare = String.Compare(vdi1.uuid, vdi2.uuid, StringComparison.Ordinal);
-                    e.SortResult = uuidCompare;
-                }
+                e.SortResult = vdi1.CompareTo(vdi2);
                 e.Handled = true;
                 return;
             }
@@ -311,8 +302,8 @@ namespace XenAdmin.TabPages
                 }
                 else
                 {
-                    var uuidCompare = String.Compare(vdi1.uuid, vdi2.uuid, StringComparison.Ordinal);
-                    e.SortResult = uuidCompare;
+                    var refCompare = string.Compare(vdi1.opaque_ref, vdi2.opaque_ref, StringComparison.Ordinal);
+                    e.SortResult = refCompare;
                 }
                 e.Handled = true;
                 return;


### PR DESCRIPTION
Making the requested changes: Name is now sorted by the generic CompareTo method (which uses name with opaque ref as tiebreaker), and Description also uses opaque ref as tiebreaker for consistency.

Changes requested to closed #1140 