### PR TITLE
CA-140338: Truncation on New Search Page with long Custom Field Filters name

### DIFF
--- a/XenAdmin/Controls/XenSearch/QueryElement.cs
+++ b/XenAdmin/Controls/XenSearch/QueryElement.cs
@@ -203,9 +203,20 @@ namespace XenAdmin.Controls.XenSearch
 
             queryTypeComboButton.BeforePopup += new EventHandler(queryTypeComboButton_BeforePopup);
             resourceSelectButton.BeforePopup += new EventHandler(resourceSelectButton_BeforePopup);
-            SelectDefaultQueryType();
 
+            queryTypeComboButton.SelectedItemChanged += OnQueryTypeComboButton_OnSelectedItemChanged;
+
+            SelectDefaultQueryType();
             Setup();
+        }
+
+        private void OnQueryTypeComboButton_OnSelectedItemChanged(object sender, EventArgs e)
+        {
+            var selectedItem = queryTypeComboButton.SelectedItem;
+            if (selectedItem.Tag is CustomFieldQueryTypeBase)
+            {
+                queryTypeComboButton.Text = selectedItem.ToString().Ellipsise(24);
+            }
         }
 
         /// <summary> 
@@ -271,7 +282,7 @@ namespace XenAdmin.Controls.XenSearch
 
                 if (CurrentQueryType != null)
                 {
-                    queryTypeComboButton.Text = CurrentQueryType.ToString();
+                    queryTypeComboButton.Text = CurrentQueryType.ToString().Ellipsise(20);
                     CurrentQueryType.SomeThingChanged += queryType_SomeThingChanged;
                     Setup();
                 }

--- a/XenAdmin/Controls/XenSearch/QueryElement.cs
+++ b/XenAdmin/Controls/XenSearch/QueryElement.cs
@@ -282,7 +282,7 @@ namespace XenAdmin.Controls.XenSearch
 
                 if (CurrentQueryType != null)
                 {
-                    queryTypeComboButton.Text = CurrentQueryType.ToString().Ellipsise(20);
+                    queryTypeComboButton.Text = CurrentQueryType.ToString();
                     CurrentQueryType.SomeThingChanged += queryType_SomeThingChanged;
                     Setup();
                 }


### PR DESCRIPTION
The truncating of the custom field name by space (instead of ellipsising) seems to be a Windows default, but it's not ideal. This change edits the text displayed in the dropdown when an item is selected so that if a custom field is selected it is ellipsised to an appropriate length. It doesn't affect the dropdown itself, which continues to display the full custom field name.

Signed-off-by: Callum McIntyre callumiandavid.mcintyre@citrix.com