### PR TITLE
CA-220040: Patching wizard shows reboot required where it is not expected

### DIFF
--- a/XenModel/Actions/ParallelAction.cs
+++ b/XenModel/Actions/ParallelAction.cs
@@ -119,6 +119,9 @@ namespace XenAdmin.Actions
 
         protected override void RunSubActions(List<Exception> exceptions)
         {
+            if (actionsCount == 0)
+                return;
+
             foreach (IXenConnection connection in actionsByConnection.Keys)
             {
                 queuesByConnection[connection] = new ProduceConsumerQueue(Math.Min(maxNumberOfParallelActions, actionsByConnection[connection].Count));


### PR DESCRIPTION
**CA-220040: Patching wizard shows reboot required where it is not expected**
- When building the list of servers that require post-install actions, ignore the ones where the patch has already been installed.
- Also fixing the infinite recursion in Build() method (causing StackOverflowException when installing a supplemental pack).

**Fix an error in ParallelAction with no subactions**
- Immediately complete the ParallelAction when there are no subactions to be executed, to avoid on infinite lock while waiting for the actions to be completed.