### PR TITLE
CA-218956: Expose HIMN when showing hidden objects

### DIFF
--- a/XenAdmin/Actions/GUIActions/ExportResourceReportAction.cs
+++ b/XenAdmin/Actions/GUIActions/ExportResourceReportAction.cs
@@ -659,7 +659,8 @@ namespace XenAdmin.Actions
                 if (Cancelling)
                     throw new CancelledException();
 
-                if (network.IsGuestInstallerNetwork)
+                // CA-218956 - Expose HIMN when showing hidden objects
+                if (network.IsGuestInstallerNetwork && !XenAdmin.Properties.Settings.Default.ShowHiddenVMs)
                 {
                     PercentComplete = Convert.ToInt32((++itemIndex) * baseIndex / itemCount);
                     continue;

--- a/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
+++ b/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
@@ -387,7 +387,10 @@ namespace XenAdmin.Commands
 
             public override bool IsValid(SelectedItemCollection selection)
             {
-                return selection.ContainsOneItemOfType<XenAPI.Network>();
+                return selection.ContainsOneItemOfType<XenAPI.Network>() &&
+                    !(selection.FirstAsXenObject as XenAPI.Network).IsGuestInstallerNetwork;
+                // CA-218956 - Expose HIMN when showing hidden objects
+                // HIMN should not be editable
             }
         }
 

--- a/XenAdmin/Controls/NetworkingTab/NetworkList.cs
+++ b/XenAdmin/Controls/NetworkingTab/NetworkList.cs
@@ -292,7 +292,9 @@ namespace XenAdmin.Controls.NetworkingTab
                     foreach (var vif in vifs)
                     {
                         var network = vif.Connection.Resolve(vif.network);
-                        if (network != null && network.IsGuestInstallerNetwork)
+                        if (network != null &&
+                            // CA-218956 - Expose HIMN when showing hidden objects
+                            (network.IsGuestInstallerNetwork && !XenAdmin.Properties.Settings.Default.ShowHiddenVMs))
                             continue;   // Don't show the guest installer network in the network tab (CA-73056)
                         vifRowsToAdd.Add(new VifRow(vif));
                     }
@@ -394,7 +396,10 @@ namespace XenAdmin.Controls.NetworkingTab
                 XenAPI.Network TheNetwork = SelectedNetwork;
 
                 AddNetworkButton.Enabled = !locked;
-                EditNetworkButton.Enabled = !locked && !TheNetwork.Locked && !TheNetwork.IsSlave && !TheNetwork.CreateInProgress;
+                EditNetworkButton.Enabled = !locked && !TheNetwork.Locked && !TheNetwork.IsSlave && !TheNetwork.CreateInProgress 
+                    && !TheNetwork.IsGuestInstallerNetwork;
+                // CA-218956 - Expose HIMN when showing hidden objects
+                // HIMN should not be editable
 
                 if (HasPhysicalNonBondNIC(TheNetwork))
                 {
@@ -403,7 +408,11 @@ namespace XenAdmin.Controls.NetworkingTab
                 }
                 else
                 {
-                    RemoveNetworkButton.Enabled = !locked && !TheNetwork.Locked && !TheNetwork.IsSlave && !TheNetwork.CreateInProgress;
+                    RemoveNetworkButton.Enabled = !locked && !TheNetwork.Locked && !TheNetwork.IsSlave && !TheNetwork.CreateInProgress
+                        && !TheNetwork.IsGuestInstallerNetwork;
+                    // CA-218956 - Expose HIMN when showing hidden objects
+                    // HIMN should not be removable
+
                     RemoveButtonContainer.SetToolTip("");
                 }
             }

--- a/XenAdmin/SettingsPanels/EditNetworkPage.cs
+++ b/XenAdmin/SettingsPanels/EditNetworkPage.cs
@@ -386,6 +386,7 @@ namespace XenAdmin.SettingsPanels
 
             // Populate Automatic checkbox
             autoCheckBox.Checked = network.AutoPlug;
+            autoCheckBox.Enabled = !network.IsGuestInstallerNetwork;
             // in case some odd value has been set on the CLI
             numericUpDownMTU.Maximum = Math.Max(network.MTU, XenAPI.Network.MTU_MAX);
             numericUpDownMTU.Minimum = Math.Min(network.MTU, XenAPI.Network.MTU_MIN);

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -478,7 +478,8 @@ namespace XenAdmin.Wizards.ImportWizard
 			{
 				var netref = new XenRef<XenAPI.Network>(vif.network);
 				var network = con.Resolve(netref);
-				if (network == null || network.IsGuestInstallerNetwork)
+				// CA-218956 - Expose HIMN when showing hidden objects
+				if (network == null || (network.IsGuestInstallerNetwork && !XenAdmin.Properties.Settings.Default.ShowHiddenVMs))
 					continue;
 
 				temp.Add(new Tuple(first ? Messages.FINISH_PAGE_NETWORK : "", network.Name));

--- a/XenAdmin/Wizards/ImportWizard/NetworkPickerPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/NetworkPickerPage.cs
@@ -295,7 +295,8 @@ namespace XenAdmin.Wizards.ImportWizard
 
             // CA-73056: A row for the guest installer network shouldn't show up. But we still need
             // it present but invisible, otherwise the corresponding VIF doesn't get created at all.
-            if (isGuestInstallerNetwork)
+            // CA-218956 - Expose HIMN when showing hidden objects
+            if (isGuestInstallerNetwork && !XenAdmin.Properties.Settings.Default.ShowHiddenVMs)
                 row.Visible = false;
 
 			m_networkGridView.Rows.Add(row);

--- a/XenAdmin/Wizards/NewVMWizard/Page_Networking.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Networking.cs
@@ -139,7 +139,10 @@ namespace XenAdmin.Wizards.NewVMWizard
                 networks.Sort();
                 foreach (XenAPI.Network network in networks)
                 {
-                    if (!network.AutoPlug || !network.Show(Properties.Settings.Default.ShowHiddenVMs) || network.IsSlave)
+                    // CA-218956 - Expose HIMN when showing hidden objects
+                    // HIMN shouldn't be autoplugged
+                    if (network.IsGuestInstallerNetwork ||
+                        !network.AutoPlug || !network.Show(Properties.Settings.Default.ShowHiddenVMs) || network.IsSlave)
                         continue;
 
                     if (NetworksGridView.Rows.Count < MAX_NETWORKS_FOR_DEFAULT_TEMPLATES)

--- a/XenModel/XenAPI-Extensions/Network.cs
+++ b/XenModel/XenAPI-Extensions/Network.cs
@@ -147,8 +147,8 @@ namespace XenAPI
 
         public override bool Show(bool showHiddenVMs)
         {
-            
-                if (IsGuestInstallerNetwork)
+                // CA-218956 - Expose HIMN when showing hidden objects
+                if (IsGuestInstallerNetwork && !showHiddenVMs)
                     return false;
 
                 if (!ShowAllPifs(showHiddenVMs))


### PR DESCRIPTION
Expose both the HIMN network and any VIFs associated with the HIMN
network using XenCenter when the "View->Show Hidden Objects" option
is displayed. However the shown HIMN should not be able to autoplug,
edit or delete.