### PR TITLE
CA-220599: Supplemental Pack installed via XenCenter does not get listed in updates box

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
@@ -179,7 +179,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 List<Host> poolHosts = new List<Host>(pool.Connection.Cache.Hosts);
                 Host master = SelectedServers.Find(host => host.IsMaster() && poolHosts.Contains(host));
-                if (master != null && poolPatch != null && poolPatch.AppliedOn(master) == DateTime.MaxValue)
+                if (master != null && (poolPatch == null || poolPatch.AppliedOn(master) == DateTime.MaxValue))
                     planActions.AddRange(CompileActionList(master, poolPatch));
                 foreach (Host server in SelectedServers)
                 {


### PR DESCRIPTION
Fixed regression caused by 5555709337d60c9c786d7058fb2f8100982c4b5e.
Supplemental packs can now be installed again in automatic mode.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>