### PR TITLE
Did some work on the SrStoragePage:

### DIFF
--- a/XenAdmin/TabPages/SrStoragePage.Designer.cs
+++ b/XenAdmin/TabPages/SrStoragePage.Designer.cs
@@ -21,6 +21,8 @@ namespace XenAdmin.TabPages
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SrStoragePage));
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.rescanToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.addToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.moveVirtualDiskToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteVirtualDiskToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -34,17 +36,16 @@ namespace XenAdmin.TabPages
             this.label1 = new System.Windows.Forms.Label();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolTipContainerRescan = new XenAdmin.Controls.ToolTipContainer();
-            this.buttonRefresh = new System.Windows.Forms.Button();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.buttonRescan = new System.Windows.Forms.Button();
             this.toolTipContainerMove = new XenAdmin.Controls.ToolTipContainer();
             this.buttonMove = new System.Windows.Forms.Button();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.dataGridViewVDIs = new System.Windows.Forms.DataGridView();
+            this.dataGridViewVDIs = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
             this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnVolume = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnDesc = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnVM = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.pageContainerPanel.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
             this.RemoveButtonContainer.SuspendLayout();
@@ -52,19 +53,21 @@ namespace XenAdmin.TabPages
             this.flowLayoutPanel1.SuspendLayout();
             this.toolTipContainerRescan.SuspendLayout();
             this.toolTipContainerMove.SuspendLayout();
-            this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewVDIs)).BeginInit();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // pageContainerPanel
             // 
-            this.pageContainerPanel.Controls.Add(this.panel1);
-            this.pageContainerPanel.Controls.Add(this.label1);
+            this.pageContainerPanel.Controls.Add(this.tableLayoutPanel1);
             resources.ApplyResources(this.pageContainerPanel, "pageContainerPanel");
             // 
             // contextMenuStrip1
             // 
+            this.contextMenuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.rescanToolStripMenuItem,
+            this.addToolStripMenuItem,
             this.moveVirtualDiskToolStripMenuItem,
             this.deleteVirtualDiskToolStripMenuItem,
             this.toolStripSeparator1,
@@ -72,6 +75,18 @@ namespace XenAdmin.TabPages
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             resources.ApplyResources(this.contextMenuStrip1, "contextMenuStrip1");
             this.contextMenuStrip1.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
+            // 
+            // rescanToolStripMenuItem
+            // 
+            this.rescanToolStripMenuItem.Name = "rescanToolStripMenuItem";
+            resources.ApplyResources(this.rescanToolStripMenuItem, "rescanToolStripMenuItem");
+            this.rescanToolStripMenuItem.Click += new System.EventHandler(this.rescanToolStripMenuItem_Click);
+            // 
+            // addToolStripMenuItem
+            // 
+            this.addToolStripMenuItem.Name = "addToolStripMenuItem";
+            resources.ApplyResources(this.addToolStripMenuItem, "addToolStripMenuItem");
+            this.addToolStripMenuItem.Click += new System.EventHandler(this.addToolStripMenuItem_Click);
             // 
             // moveVirtualDiskToolStripMenuItem
             // 
@@ -83,7 +98,7 @@ namespace XenAdmin.TabPages
             // 
             this.deleteVirtualDiskToolStripMenuItem.Name = "deleteVirtualDiskToolStripMenuItem";
             resources.ApplyResources(this.deleteVirtualDiskToolStripMenuItem, "deleteVirtualDiskToolStripMenuItem");
-            this.deleteVirtualDiskToolStripMenuItem.Click += new System.EventHandler(this.removeVirtualDisk_Click);
+            this.deleteVirtualDiskToolStripMenuItem.Click += new System.EventHandler(this.deleteVirtualDiskToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
@@ -93,8 +108,8 @@ namespace XenAdmin.TabPages
             // editVirtualDiskToolStripMenuItem
             // 
             this.editVirtualDiskToolStripMenuItem.Image = global::XenAdmin.Properties.Resources.edit_16;
-            this.editVirtualDiskToolStripMenuItem.Name = "editVirtualDiskToolStripMenuItem";
             resources.ApplyResources(this.editVirtualDiskToolStripMenuItem, "editVirtualDiskToolStripMenuItem");
+            this.editVirtualDiskToolStripMenuItem.Name = "editVirtualDiskToolStripMenuItem";
             this.editVirtualDiskToolStripMenuItem.Click += new System.EventHandler(this.editVirtualDiskToolStripMenuItem_Click);
             // 
             // TitleLabel
@@ -105,8 +120,8 @@ namespace XenAdmin.TabPages
             // 
             // RemoveButtonContainer
             // 
-            resources.ApplyResources(this.RemoveButtonContainer, "RemoveButtonContainer");
             this.RemoveButtonContainer.Controls.Add(this.RemoveButton);
+            resources.ApplyResources(this.RemoveButtonContainer, "RemoveButtonContainer");
             this.RemoveButtonContainer.Name = "RemoveButtonContainer";
             // 
             // RemoveButton
@@ -145,7 +160,6 @@ namespace XenAdmin.TabPages
             // 
             this.flowLayoutPanel1.Controls.Add(this.toolTipContainerRescan);
             this.flowLayoutPanel1.Controls.Add(this.addVirtualDiskButton);
-            this.flowLayoutPanel1.Controls.Add(this.groupBox1);
             this.flowLayoutPanel1.Controls.Add(this.EditButtonContainer);
             this.flowLayoutPanel1.Controls.Add(this.toolTipContainerMove);
             this.flowLayoutPanel1.Controls.Add(this.RemoveButtonContainer);
@@ -154,22 +168,16 @@ namespace XenAdmin.TabPages
             // 
             // toolTipContainerRescan
             // 
-            this.toolTipContainerRescan.Controls.Add(this.buttonRefresh);
+            this.toolTipContainerRescan.Controls.Add(this.buttonRescan);
             resources.ApplyResources(this.toolTipContainerRescan, "toolTipContainerRescan");
             this.toolTipContainerRescan.Name = "toolTipContainerRescan";
             // 
-            // buttonRefresh
+            // buttonRescan
             // 
-            resources.ApplyResources(this.buttonRefresh, "buttonRefresh");
-            this.buttonRefresh.Name = "buttonRefresh";
-            this.buttonRefresh.UseVisualStyleBackColor = true;
-            this.buttonRefresh.Click += new System.EventHandler(this.buttonRefresh_Click);
-            // 
-            // groupBox1
-            // 
-            resources.ApplyResources(this.groupBox1, "groupBox1");
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.TabStop = false;
+            resources.ApplyResources(this.buttonRescan, "buttonRescan");
+            this.buttonRescan.Name = "buttonRescan";
+            this.buttonRescan.UseVisualStyleBackColor = true;
+            this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
             // 
             // toolTipContainerMove
             // 
@@ -184,18 +192,8 @@ namespace XenAdmin.TabPages
             this.buttonMove.UseVisualStyleBackColor = true;
             this.buttonMove.Click += new System.EventHandler(this.buttonMove_Click);
             // 
-            // panel1
-            // 
-            resources.ApplyResources(this.panel1, "panel1");
-            this.panel1.Controls.Add(this.dataGridViewVDIs);
-            this.panel1.Controls.Add(this.flowLayoutPanel1);
-            this.panel1.Name = "panel1";
-            // 
             // dataGridViewVDIs
             // 
-            this.dataGridViewVDIs.AllowUserToAddRows = false;
-            this.dataGridViewVDIs.AllowUserToDeleteRows = false;
-            this.dataGridViewVDIs.AllowUserToResizeRows = false;
             this.dataGridViewVDIs.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             this.dataGridViewVDIs.BackgroundColor = System.Drawing.SystemColors.Window;
             this.dataGridViewVDIs.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
@@ -207,11 +205,13 @@ namespace XenAdmin.TabPages
             this.ColumnSize,
             this.ColumnVM});
             resources.ApplyResources(this.dataGridViewVDIs, "dataGridViewVDIs");
+            this.dataGridViewVDIs.MultiSelect = true;
             this.dataGridViewVDIs.Name = "dataGridViewVDIs";
             this.dataGridViewVDIs.ReadOnly = true;
-            this.dataGridViewVDIs.RowHeadersVisible = false;
-            this.dataGridViewVDIs.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridViewVDIs.CellMouseUp += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridViewVDIs_CellMouseUp);
+            this.dataGridViewVDIs.SortCompare += DataGridViewObject_SortCompare;
+            this.dataGridViewVDIs.SelectionChanged += dataGridViewVDIs_SelectedIndexChanged;
+            this.dataGridViewVDIs.MouseUp += dataGridViewVDIs_MouseUp;
+            this.dataGridViewVDIs.KeyUp += dataGridViewVDIs_KeyUp;
             // 
             // ColumnName
             // 
@@ -248,6 +248,14 @@ namespace XenAdmin.TabPages
             this.ColumnVM.Name = "ColumnVM";
             this.ColumnVM.ReadOnly = true;
             // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.dataGridViewVDIs, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
             // SrStoragePage
             // 
             resources.ApplyResources(this, "$this");
@@ -257,15 +265,15 @@ namespace XenAdmin.TabPages
             this.Name = "SrStoragePage";
             this.Controls.SetChildIndex(this.pageContainerPanel, 0);
             this.pageContainerPanel.ResumeLayout(false);
-            this.pageContainerPanel.PerformLayout();
             this.contextMenuStrip1.ResumeLayout(false);
             this.RemoveButtonContainer.ResumeLayout(false);
             this.EditButtonContainer.ResumeLayout(false);
             this.flowLayoutPanel1.ResumeLayout(false);
             this.toolTipContainerRescan.ResumeLayout(false);
             this.toolTipContainerMove.ResumeLayout(false);
-            this.panel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewVDIs)).EndInit();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -284,20 +292,21 @@ namespace XenAdmin.TabPages
         private System.Windows.Forms.Button RemoveButton;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Button buttonRefresh;
+        private System.Windows.Forms.Button buttonRescan;
         private XenAdmin.Controls.ToolTipContainer toolTipContainerRescan;
-        private System.Windows.Forms.GroupBox groupBox1;
         private XenAdmin.Controls.ToolTipContainer toolTipContainerMove;
         private System.Windows.Forms.Button buttonMove;
         private System.Windows.Forms.ToolStripMenuItem moveVirtualDiskToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-        private System.Windows.Forms.DataGridView dataGridViewVDIs;
+        private XenAdmin.Controls.DataGridViewEx.DataGridViewEx dataGridViewVDIs;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnName;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnVolume;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDesc;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnSize;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnVM;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.ToolStripMenuItem rescanToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem addToolStripMenuItem;
 
     }
 }

--- a/XenAdmin/TabPages/SrStoragePage.cs
+++ b/XenAdmin/TabPages/SrStoragePage.cs
@@ -49,10 +49,6 @@ namespace XenAdmin.TabPages
     internal partial class SrStoragePage : BaseTabPage
     {
         private SR sr;
-        private readonly DataGridViewColumn sizeColumn;
-        private readonly DataGridViewColumn storageLinkVolumeColumn;
-        private readonly DataGridViewColumn nameColumn;
-        private readonly DataGridViewColumn descriptionColumn;
         private bool rebuildRequired;
 
         private readonly VDIsDataGridViewBuilder dataGridViewBuilder;
@@ -61,27 +57,14 @@ namespace XenAdmin.TabPages
         {
             InitializeComponent();
 
-            storageLinkVolumeColumn = ColumnVolume;
-            sizeColumn = ColumnSize;
-            nameColumn = ColumnName;
-            descriptionColumn = ColumnDesc;
-
             for (int i = 0; i < 5; i++)
             {
                 dataGridViewVDIs.Columns[i].SortMode = DataGridViewColumnSortMode.Automatic;
             }
 
-            dataGridViewVDIs.SortCompare += DataGridViewObject_SortCompare;
-            dataGridViewVDIs.SelectionChanged += dataGridViewVDIs_SelectedIndexChanged;
-            dataGridViewVDIs.MouseUp += dataGridViewVDIs_MouseUp;
-            dataGridViewVDIs.KeyUp += dataGridViewVDIs_KeyUp;
-
-            ConnectionsManager.History.CollectionChanged += new CollectionChangeEventHandler(History_CollectionChanged);
-
+            ConnectionsManager.History.CollectionChanged += History_CollectionChanged;
             base.Text = Messages.VIRTUAL_DISKS;
-
             Properties.Settings.Default.PropertyChanged += Default_PropertyChanged;
-            
             dataGridViewBuilder = new VDIsDataGridViewBuilder(this);
         }
 
@@ -161,12 +144,12 @@ namespace XenAdmin.TabPages
             dataGridViewVDIs.SuspendLayout();
             try
             {
-                storageLinkVolumeColumn.Visible = data.ShowStorageLink;
+                ColumnVolume.Visible = data.ShowStorageLink;
 
                 // Update existing rows
                 foreach (var vdiRow in data.VdiRowsToUpdate)
                 {
-                    vdiRow.RefreshRowDetails(data.ShowStorageLink);
+                    vdiRow.RefreshRowDetails();
                 }
 
                 // Remove rows for deleted VDIs
@@ -178,8 +161,7 @@ namespace XenAdmin.TabPages
                 // Add rows for new VDIs
                 foreach (var vdi in data.VdisToAdd)
                 {
-                    VDIRow newRow = new VDIRow(vdi, data.ShowStorageLink);
-                    dataGridViewVDIs.Rows.Add(newRow);   
+                    dataGridViewVDIs.Rows.Add(new VDIRow(vdi));   
                 }
             }
             finally
@@ -277,10 +259,10 @@ namespace XenAdmin.TabPages
         }
         #endregion
 
-        #region datagridviewevents
-        void DataGridViewObject_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
+        #region datagridvie wevents
+        private void  DataGridViewObject_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
         {
-            if (e.Column.Index == nameColumn.Index)
+            if (e.Column.Index == ColumnName.Index)
             {
                 var vdi1 = ((VDIRow) dataGridViewVDIs.Rows[e.RowIndex1]).VDI;
                 var vdi2 = ((VDIRow) dataGridViewVDIs.Rows[e.RowIndex2]).VDI;
@@ -290,7 +272,7 @@ namespace XenAdmin.TabPages
                 return;
             }
 
-            if (e.Column.Index == descriptionColumn.Index)
+            if (e.Column.Index == ColumnDesc.Index)
             {
                 var vdi1 = ((VDIRow)dataGridViewVDIs.Rows[e.RowIndex1]).VDI;
                 var vdi2 = ((VDIRow)dataGridViewVDIs.Rows[e.RowIndex2]).VDI;
@@ -309,7 +291,7 @@ namespace XenAdmin.TabPages
                 return;
             }
 
-            if (e.Column.Index == sizeColumn.Index)
+            if (e.Column.Index == ColumnSize.Index)
             {
                 VDI vdi1 = ((VDIRow)dataGridViewVDIs.Rows[e.RowIndex1]).VDI;
                 VDI vdi2 = ((VDIRow)dataGridViewVDIs.Rows[e.RowIndex2]).VDI;
@@ -332,55 +314,71 @@ namespace XenAdmin.TabPages
             if (e.KeyCode != Keys.Apps)
                 return;
 
-            if (dataGridViewVDIs.SelectedRows.Count <= 0)
-                return;
-
-            DataGridViewRow row = dataGridViewVDIs.SelectedRows[0];
-
-            contextMenuStrip1.Show(dataGridViewVDIs, 5, row.Height * (row.Index + 2));
+            if (dataGridViewVDIs.SelectedRows.Count == 0)
+            {
+                // 3 is the defaul control margin
+                contextMenuStrip1.Show(dataGridViewVDIs, 3, dataGridViewVDIs.ColumnHeadersHeight + 3);
+            }
+            else
+            {
+                DataGridViewRow row = dataGridViewVDIs.SelectedRows[0];
+                contextMenuStrip1.Show(dataGridViewVDIs, 3, row.Height * (row.Index + 2));
+            }
         }
 
         private void dataGridViewVDIs_MouseUp(object sender, MouseEventArgs e)
         {
-            // Load context menus on right mouse click
-            DataGridView.HitTestInfo hitTestInfo;
-            if (e.Button == MouseButtons.Right)
+            DataGridView.HitTestInfo hitTestInfo = dataGridViewVDIs.HitTest(e.X, e.Y);
+
+            if (hitTestInfo.Type == DataGridViewHitTestType.None)
             {
-                hitTestInfo = dataGridViewVDIs.HitTest(e.X, e.Y);
-                if (hitTestInfo.Type == DataGridViewHitTestType.Cell)
-                {
-                    if (dataGridViewVDIs.Rows.Count >= 0)
-                    {
-                        if (!dataGridViewVDIs.Rows[hitTestInfo.RowIndex].Selected)
-                        {
-                            // Select the row that the user right clicked on (similiar to outlook) if it's not already in the selection
-                            // (avoids clearing a multiselect if you right click inside it)
-                            dataGridViewVDIs.CurrentCell = dataGridViewVDIs[hitTestInfo.ColumnIndex, hitTestInfo.RowIndex];
-                        }
-                        // Show the menus.  We will always have at least one (Add).
-                        contextMenuStrip1.Show(dataGridViewVDIs, new Point(e.X, e.Y));
-                    }
-                }
+                dataGridViewVDIs.ClearSelection();
+            }
+            else if (hitTestInfo.Type == DataGridViewHitTestType.Cell && e.Button == MouseButtons.Right
+                     && 0 <= hitTestInfo.RowIndex && hitTestInfo.RowIndex < dataGridViewVDIs.Rows.Count
+                     && !dataGridViewVDIs.Rows[hitTestInfo.RowIndex].Selected)
+            {
+                // Select the row that the user right clicked on (similiar to outlook) if it's not already in the selection
+                // (avoids clearing a multiselect if you right click inside it)
+                // Check if the CurrentCell is the cell the user right clicked on (but the row is not Selected) [CA-64954]
+                // This happens when the grid is initially shown: the current cell is the first cell in the first column, but the row is not selected
+
+                if (dataGridViewVDIs.CurrentCell == dataGridViewVDIs[hitTestInfo.ColumnIndex, hitTestInfo.RowIndex])
+                    dataGridViewVDIs.Rows[hitTestInfo.RowIndex].Selected = true;
+                else
+                    dataGridViewVDIs.CurrentCell = dataGridViewVDIs[hitTestInfo.ColumnIndex, hitTestInfo.RowIndex];
+            }
+
+            if ((hitTestInfo.Type == DataGridViewHitTestType.None || hitTestInfo.Type == DataGridViewHitTestType.Cell)
+                && e.Button == MouseButtons.Right)
+            {
+                contextMenuStrip1.Show(dataGridViewVDIs, new Point(e.X, e.Y));
             }
         }
+
         #endregion
 
         #region Button and context menu population
         private void contextMenuStrip_Opening(object sender, CancelEventArgs e)
         {
-            SelectedItemCollection vdis = SelectedVDIs;
-            if (vdis.Count == 0)
+            bool rescan = buttonRescan.Enabled;
+            bool add = addVirtualDiskButton.Enabled;
+            bool move = buttonMove.Enabled;
+            bool delete = RemoveButton.Enabled;
+            bool edit = EditButton.Enabled;
+            
+            if (!(rescan || add || move || delete || edit))
+            {
+                e.Cancel = true;
                 return;
+            }
 
-            contextMenuStrip1.Items.Clear();
-
-            DeleteVirtualDiskCommand deleteCmd = new DeleteVirtualDiskCommand(Program.MainWindow, vdis);
-            contextMenuStrip1.Items.Add(new CommandToolStripMenuItem(deleteCmd, true));
-
-            contextMenuStrip1.Items.Add(new CommandToolStripMenuItem(MoveMigrateCommand(vdis), true));
-
-            contextMenuStrip1.Items.Add(editVirtualDiskToolStripMenuItem);
-            editVirtualDiskToolStripMenuItem.Enabled = vdis.Count == 1 && !vdis.AsXenObjects<VDI>()[0].is_a_snapshot;
+            rescanToolStripMenuItem.Visible = rescan;
+            addToolStripMenuItem.Visible = add;
+            moveVirtualDiskToolStripMenuItem.Visible = move;
+            deleteVirtualDiskToolStripMenuItem.Visible = delete;
+            editVirtualDiskToolStripMenuItem.Visible = edit;
+            toolStripSeparator1.Visible = (rescan || add || move || delete) && edit;
         }
 
         private Command MoveMigrateCommand(IEnumerable<SelectedItem> selection)
@@ -395,14 +393,13 @@ namespace XenAdmin.TabPages
 
         private void RefreshButtons()
         {
-            bool srLocked = sr == null || sr.Locked;
             SelectedItemCollection vdis = SelectedVDIs;
 
             // Delete button
-            DeleteVirtualDiskCommand deleteCmd = new DeleteVirtualDiskCommand(Program.MainWindow, vdis);
-            // User has visibility that this disk is related to all it's VM. Allow deletion with multiple VBDs (non default behaviour),
-            // but don't allow them to delete if a running vm is using the disk (default behaviour).
-            deleteCmd.AllowMultipleVBDDelete = true;
+            // The user can see that this disk is attached to more than one VMs. Allow deletion of multiple VBDs (non default behaviour),
+            // but don't allow them to be deleted if a running vm is using the disk (default behaviour).
+
+            DeleteVirtualDiskCommand deleteCmd = new DeleteVirtualDiskCommand(Program.MainWindow, vdis) {AllowMultipleVBDDelete = true};
             if (deleteCmd.CanExecute())
             {
                 RemoveButton.Enabled = true;
@@ -428,29 +425,29 @@ namespace XenAdmin.TabPages
             }
 
             // Rescan button
-            if (srLocked)
+            if (sr == null || sr.Locked)
             {
-                buttonRefresh.Enabled = false;
+                buttonRescan.Enabled = false;
             }
             else if (HelpersGUI.BeingScanned(sr))
             {
-                buttonRefresh.Enabled = false;
+                buttonRescan.Enabled = false;
                 toolTipContainerRescan.SetToolTip(Messages.SCAN_IN_PROGRESS_TOOLTIP);
             }
             else
             {
-                buttonRefresh.Enabled = true;
+                buttonRescan.Enabled = true;
                 toolTipContainerRescan.RemoveAll();
             }
 
             // Add VDI button
-            addVirtualDiskButton.Enabled = !srLocked;
+            addVirtualDiskButton.Enabled = sr != null && !sr.Locked;
 
             // Properties button
             if (vdis.Count == 1)
             {
                 VDI vdi = vdis.AsXenObjects<VDI>()[0];
-                EditButton.Enabled = !srLocked && !vdi.is_a_snapshot && !vdi.Locked;
+                EditButton.Enabled = sr != null && !sr.Locked && !vdi.is_a_snapshot && !vdi.Locked;
             }
             else
                 EditButton.Enabled = false;
@@ -458,17 +455,37 @@ namespace XenAdmin.TabPages
 
         #endregion
 
-        #region buttonHandlers
-        private void removeVirtualDisk_Click(object sender, EventArgs e)
+        #region Actions on Vdis
+
+        private void Rescan()
+        {
+            SrRefreshAction a = new SrRefreshAction(sr);
+            a.RunAsync();
+        }
+
+        private void AddVdi()
+        {
+            if (sr != null)
+                Program.MainWindow.ShowPerConnectionWizard(sr.Connection, new NewDiskDialog(sr.Connection, sr));
+        }
+
+        private void MoveSelectedVdis()
         {
             SelectedItemCollection vdis = SelectedVDIs;
-            DeleteVirtualDiskCommand cmd = new DeleteVirtualDiskCommand(Program.MainWindow, vdis);
-            cmd.AllowMultipleVBDDelete = true;
+            Command cmd = MoveMigrateCommand(vdis);
             if (cmd.CanExecute())
                 cmd.Execute();
         }
 
-        private void editVirtualDiskToolStripMenuItem_Click(object sender, EventArgs e)
+        private void RemoveSelectedVdis()
+        {
+            SelectedItemCollection vdis = SelectedVDIs;
+            DeleteVirtualDiskCommand cmd = new DeleteVirtualDiskCommand(Program.MainWindow, vdis) {AllowMultipleVBDDelete = true};
+            if (cmd.CanExecute())
+                cmd.Execute();
+        }
+
+        private void EditSelectedVdis()
         {
             SelectedItemCollection vdis = SelectedVDIs;
             if (vdis.Count != 1)
@@ -481,68 +498,70 @@ namespace XenAdmin.TabPages
             new PropertiesDialog(vdi).ShowDialog(this);
         }
 
+        #endregion
+
+        #region Button and ToolStripMenuItem handlers
+
         private void addVirtualDiskButton_Click(object sender, EventArgs e)
         {
-            if (sr != null)
-                Program.MainWindow.ShowPerConnectionWizard(sr.Connection, new Dialogs.NewDiskDialog(sr.Connection, sr));
+            AddVdi();
         }
 
         private void RemoveButton_Click(object sender, EventArgs e)
         {
-            removeVirtualDisk_Click(sender, e);
+            RemoveSelectedVdis();
         }
 
         private void EditButton_Click(object sender, EventArgs e)
         {
-            editVirtualDiskToolStripMenuItem_Click(sender, e);
+            EditSelectedVdis();
         }
 
-        private void buttonRefresh_Click(object sender, EventArgs e)
+        private void buttonRescan_Click(object sender, EventArgs e)
         {
-            SrRefreshAction a = new SrRefreshAction(sr);
-            a.RunAsync();
-        }
-
-        private void moveVirtualDiskToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            SelectedItemCollection vdis = SelectedVDIs;
-            Command cmd = MoveMigrateCommand(vdis);
-            if (cmd.CanExecute())
-                cmd.Execute();
+            Rescan();
         }
 
         private void buttonMove_Click(object sender, EventArgs e)
         {
-            moveVirtualDiskToolStripMenuItem_Click(sender, e);
+            MoveSelectedVdis();
         }
+
+
+        private void rescanToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Rescan();
+        }
+
+        private void addToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AddVdi();
+        }
+
+        private void editVirtualDiskToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            EditSelectedVdis();
+        }
+
+        private void moveVirtualDiskToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+           MoveSelectedVdis();
+        }
+
+        private void deleteVirtualDiskToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            RemoveSelectedVdis();
+        }
+
         #endregion
 
-        private void dataGridViewVDIs_CellMouseUp(object sender, DataGridViewCellMouseEventArgs e)
-        {
-            // Select the row that the user right clicked on if it's not already in the selection
-            if (e.Button == MouseButtons.Right && e.RowIndex >= 0)
-            {
-                if (!dataGridViewVDIs.Rows[e.RowIndex].Selected)
-                {
-                    // Check if the CurrentCell is the cell the user right clicked on (but the row is not Selected) [CA-64954]
-                    // This happens when the grid is initially shown: the current cell is the first cell in the first column, but the row is not selected
-                    if (dataGridViewVDIs.CurrentCell == dataGridViewVDIs[e.ColumnIndex, e.RowIndex])
-                        dataGridViewVDIs.Rows[e.RowIndex].Selected = true;
-                    else
-                        dataGridViewVDIs.CurrentCell = dataGridViewVDIs[e.ColumnIndex, e.RowIndex];
-                }
-            }
-        }
 
         public class VDIRow : DataGridViewRow
         {
             public VDI VDI { get; private set; }
 
-            private bool showStorageLink = false;
-
-            public VDIRow(VDI vdi, bool showStorageLink)
+            public VDIRow(VDI vdi)
             {
-                this.showStorageLink = showStorageLink;
                 VDI = vdi;
                 for (int i = 0; i < 5; i++)
                 {
@@ -571,9 +590,8 @@ namespace XenAdmin.TabPages
                 }
             }
 
-            public void RefreshRowDetails(bool showSL)
+            public void RefreshRowDetails()
             {
-                showStorageLink = showSL;
                 for (int i = 0; i < 5; i++)
                 {
                     Cells[i].Value = GetCellText(i);

--- a/XenAdmin/TabPages/SrStoragePage.resx
+++ b/XenAdmin/TabPages/SrStoragePage.resx
@@ -547,13 +547,13 @@
     <value>205, 26</value>
   </data>
   <data name="moveVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Move virtual disk...</value>
+    <value>Mov&amp;e virtual disk...</value>
   </data>
   <data name="deleteVirtualDiskToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>205, 26</value>
   </data>
   <data name="deleteVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
-    <value>Delete virtual disk</value>
+    <value>&amp;Delete virtual disk</value>
   </data>
   <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
     <value>202, 6</value>
@@ -568,7 +568,7 @@
     <value>P&amp;roperties</value>
   </data>
   <data name="contextMenuStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>206, 168</value>
+    <value>206, 140</value>
   </data>
   <data name="&gt;&gt;contextMenuStrip1.Name" xml:space="preserve">
     <value>contextMenuStrip1</value>

--- a/XenAdmin/TabPages/SrStoragePage.resx
+++ b/XenAdmin/TabPages/SrStoragePage.resx
@@ -117,269 +117,71 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
-    <value>pageContainerPanel</value>
-  </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>pageContainerPanel</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 78</value>
-  </data>
-  <data name="pageContainerPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>920, 372</value>
-  </data>
-  <data name="&gt;&gt;pageContainerPanel.Name" xml:space="preserve">
-    <value>pageContainerPanel</value>
-  </data>
-  <data name="&gt;&gt;pageContainerPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pageContainerPanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;pageContainerPanel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <data name="contextMenuStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 76</value>
-  </data>
-  <data name="&gt;&gt;contextMenuStrip1.Name" xml:space="preserve">
-    <value>contextMenuStrip1</value>
-  </data>
-  <data name="&gt;&gt;contextMenuStrip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="moveVirtualDiskToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="moveVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Move virtual disk...</value>
-  </data>
-  <data name="deleteVirtualDiskToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="deleteVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
-    <value>Delete virtual disk</value>
-  </data>
-  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 6</value>
-  </data>
-  <data name="editVirtualDiskToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="editVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
-    <value>P&amp;roperties</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="TitleLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="buttonRescan.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="TitleLabel.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 11.25pt</value>
-  </data>
-  <data name="TitleLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="TitleLabel.Location" type="System.Drawing.Point, System.Drawing">
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="buttonRescan.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="TitleLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 0, 0, 0</value>
+  <data name="buttonRescan.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
-  <data name="TitleLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>920, 36</value>
+  <data name="buttonRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 29</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="TitleLabel.TabIndex" type="System.Int32, mscorlib">
+  <data name="buttonRescan.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="TitleLabel.Text" xml:space="preserve">
-    <value>Virtual Disks</value>
+  <data name="buttonRescan.Text" xml:space="preserve">
+    <value>Res&amp;can</value>
   </data>
-  <data name="TitleLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
+  <data name="&gt;&gt;buttonRescan.Name" xml:space="preserve">
+    <value>buttonRescan</value>
   </data>
-  <data name="&gt;&gt;TitleLabel.Name" xml:space="preserve">
-    <value>TitleLabel</value>
-  </data>
-  <data name="&gt;&gt;TitleLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="RemoveButtonContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Name" xml:space="preserve">
-    <value>RemoveButton</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Type" xml:space="preserve">
+  <data name="&gt;&gt;buttonRescan.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;RemoveButton.Parent" xml:space="preserve">
-    <value>RemoveButtonContainer</value>
+  <data name="&gt;&gt;buttonRescan.Parent" xml:space="preserve">
+    <value>toolTipContainerRescan</value>
   </data>
-  <data name="&gt;&gt;RemoveButton.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;buttonRescan.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="RemoveButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>440, 5</value>
+  <data name="toolTipContainerRescan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
-  <data name="RemoveButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+  <data name="toolTipContainerRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 29</value>
   </data>
-  <data name="RemoveButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
+  <data name="toolTipContainerRescan.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="RemoveButtonContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="&gt;&gt;toolTipContainerRescan.Name" xml:space="preserve">
+    <value>toolTipContainerRescan</value>
   </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Name" xml:space="preserve">
-    <value>RemoveButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Type" xml:space="preserve">
+  <data name="&gt;&gt;toolTipContainerRescan.Type" xml:space="preserve">
     <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Parent" xml:space="preserve">
+  <data name="&gt;&gt;toolTipContainerRescan.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;RemoveButtonContainer.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="RemoveButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="RemoveButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="RemoveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="RemoveButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="RemoveButton.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;toolTipContainerRescan.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="RemoveButton.Text" xml:space="preserve">
-    <value>&amp;Delete</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Name" xml:space="preserve">
-    <value>RemoveButton</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Parent" xml:space="preserve">
-    <value>RemoveButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="EditButtonContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;EditButton.Name" xml:space="preserve">
-    <value>EditButton</value>
-  </data>
-  <data name="&gt;&gt;EditButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;EditButton.Parent" xml:space="preserve">
-    <value>EditButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;EditButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="EditButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>224, 5</value>
-  </data>
-  <data name="EditButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="EditButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="EditButtonContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;EditButtonContainer.Name" xml:space="preserve">
-    <value>EditButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;EditButtonContainer.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;EditButtonContainer.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;EditButtonContainer.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="EditButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="EditButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="EditButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="EditButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="EditButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="EditButton.Text" xml:space="preserve">
-    <value>P&amp;roperties</value>
-  </data>
-  <data name="&gt;&gt;EditButton.Name" xml:space="preserve">
-    <value>EditButton</value>
-  </data>
-  <data name="&gt;&gt;EditButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;EditButton.Parent" xml:space="preserve">
-    <value>EditButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;EditButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="addVirtualDiskButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
   </data>
   <data name="addVirtualDiskButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="addVirtualDiskButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 5</value>
-  </data>
-  <data name="addVirtualDiskButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
+    <value>111, 3</value>
   </data>
   <data name="addVirtualDiskButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
+    <value>102, 29</value>
   </data>
   <data name="addVirtualDiskButton.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -399,70 +201,49 @@
   <data name="&gt;&gt;addVirtualDiskButton.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="EditButtonContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
-  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 12pt</value>
+  <data name="EditButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 7</value>
+  <data name="EditButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 21</value>
+  <data name="EditButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
   </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="EditButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Disks</value>
+  <data name="EditButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 29</value>
   </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>pageContainerPanel</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.Name" xml:space="preserve">
-    <value>toolTipContainerRescan</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.ZOrder" xml:space="preserve">
+  <data name="EditButton.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;addVirtualDiskButton.Name" xml:space="preserve">
-    <value>addVirtualDiskButton</value>
+  <data name="EditButton.Text" xml:space="preserve">
+    <value>P&amp;roperties</value>
   </data>
-  <data name="&gt;&gt;addVirtualDiskButton.Type" xml:space="preserve">
+  <data name="&gt;&gt;EditButton.Name" xml:space="preserve">
+    <value>EditButton</value>
+  </data>
+  <data name="&gt;&gt;EditButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;addVirtualDiskButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
+  <data name="&gt;&gt;EditButton.Parent" xml:space="preserve">
+    <value>EditButtonContainer</value>
   </data>
-  <data name="&gt;&gt;addVirtualDiskButton.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;EditButton.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="EditButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>219, 3</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="EditButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 29</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+  <data name="EditButtonContainer.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="&gt;&gt;EditButtonContainer.Name" xml:space="preserve">
@@ -475,187 +256,7 @@
     <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;EditButtonContainer.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Name" xml:space="preserve">
-    <value>toolTipContainerMove</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Name" xml:space="preserve">
-    <value>RemoveButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 293</value>
-  </data>
-  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>898, 35</value>
-  </data>
-  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.Name" xml:space="preserve">
-    <value>buttonRefresh</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.Parent" xml:space="preserve">
-    <value>toolTipContainerRescan</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="toolTipContainerRescan.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 5</value>
-  </data>
-  <data name="toolTipContainerRescan.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 0</value>
-  </data>
-  <data name="toolTipContainerRescan.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="toolTipContainerRescan.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.Name" xml:space="preserve">
-    <value>toolTipContainerRescan</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerRescan.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="buttonRefresh.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="buttonRefresh.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="buttonRefresh.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="buttonRefresh.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="buttonRefresh.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="buttonRefresh.Text" xml:space="preserve">
-    <value>Res&amp;can</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.Name" xml:space="preserve">
-    <value>buttonRefresh</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.Parent" xml:space="preserve">
-    <value>toolTipContainerRescan</value>
-  </data>
-  <data name="&gt;&gt;buttonRefresh.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>216, 5</value>
-  </data>
-  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>2, 20</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.Name" xml:space="preserve">
-    <value>buttonMove</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.Parent" xml:space="preserve">
-    <value>toolTipContainerMove</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="toolTipContainerMove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>332, 5</value>
-  </data>
-  <data name="toolTipContainerMove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="toolTipContainerMove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="toolTipContainerMove.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Name" xml:space="preserve">
-    <value>toolTipContainerMove</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="buttonMove.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -663,8 +264,11 @@
   <data name="buttonMove.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="buttonMove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
   <data name="buttonMove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
+    <value>102, 29</value>
   </data>
   <data name="buttonMove.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -684,70 +288,100 @@
   <data name="&gt;&gt;buttonMove.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+  <data name="toolTipContainerMove.Location" type="System.Drawing.Point, System.Drawing">
+    <value>327, 3</value>
   </data>
-  <metadata name="ColumnName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ColumnVolume.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ColumnDesc.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ColumnSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ColumnVM.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="dataGridViewVDIs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="toolTipContainerMove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 29</value>
+  </data>
+  <data name="toolTipContainerMove.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.Name" xml:space="preserve">
+    <value>toolTipContainerMove</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="RemoveButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="dataGridViewVDIs.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="RemoveButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="RemoveButton.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="dataGridViewVDIs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>898, 293</value>
+  <data name="RemoveButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 29</value>
   </data>
-  <data name="dataGridViewVDIs.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewVDIs.Name" xml:space="preserve">
-    <value>dataGridViewVDIs</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewVDIs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewVDIs.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewVDIs.ZOrder" xml:space="preserve">
+  <data name="RemoveButton.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 31</value>
+  <data name="RemoveButton.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
   </data>
-  <data name="panel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>900, 400</value>
+  <data name="&gt;&gt;RemoveButton.Name" xml:space="preserve">
+    <value>RemoveButton</value>
   </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>898, 328</value>
+  <data name="&gt;&gt;RemoveButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+  <data name="&gt;&gt;RemoveButton.Parent" xml:space="preserve">
+    <value>RemoveButtonContainer</value>
   </data>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
+  <data name="&gt;&gt;RemoveButton.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="RemoveButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>435, 3</value>
   </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
-    <value>pageContainerPanel</value>
+  <data name="RemoveButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 29</value>
   </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+  <data name="RemoveButtonContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.Name" xml:space="preserve">
+    <value>RemoveButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 337</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1120, 97</value>
+  </data>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="ColumnName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -775,7 +409,7 @@
     <value>Size</value>
   </data>
   <data name="ColumnSize.Width" type="System.Int32, mscorlib">
-    <value>52</value>
+    <value>61</value>
   </data>
   <metadata name="ColumnVM.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -783,11 +417,203 @@
   <data name="ColumnVM.HeaderText" xml:space="preserve">
     <value>Virtual Machine</value>
   </data>
+  <data name="dataGridViewVDIs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="dataGridViewVDIs.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 31</value>
+  </data>
+  <data name="dataGridViewVDIs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 12</value>
+  </data>
+  <data name="dataGridViewVDIs.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>1125, 0</value>
+  </data>
+  <data name="dataGridViewVDIs.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1120, 291</value>
+  </data>
+  <data name="dataGridViewVDIs.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewVDIs.Name" xml:space="preserve">
+    <value>dataGridViewVDIs</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewVDIs.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewVDIs.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewVDIs.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 12pt</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 28</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Disks</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1126, 437</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>pageContainerPanel</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="flowLayoutPanel1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="dataGridViewVDIs" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,75,Percent,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 101</value>
+  </data>
+  <data name="pageContainerPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1150, 461</value>
+  </data>
+  <data name="pageContainerPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pageContainerPanel.Name" xml:space="preserve">
+    <value>pageContainerPanel</value>
+  </data>
+  <data name="&gt;&gt;pageContainerPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pageContainerPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;pageContainerPanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="rescanToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 26</value>
+  </data>
+  <data name="rescanToolStripMenuItem.Text" xml:space="preserve">
+    <value>Res&amp;can</value>
+  </data>
+  <data name="addToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 26</value>
+  </data>
+  <data name="addToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Add...</value>
+  </data>
+  <data name="moveVirtualDiskToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 26</value>
+  </data>
+  <data name="moveVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Move virtual disk...</value>
+  </data>
+  <data name="deleteVirtualDiskToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 26</value>
+  </data>
+  <data name="deleteVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
+    <value>Delete virtual disk</value>
+  </data>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>202, 6</value>
+  </data>
+  <data name="editVirtualDiskToolStripMenuItem.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="editVirtualDiskToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 26</value>
+  </data>
+  <data name="editVirtualDiskToolStripMenuItem.Text" xml:space="preserve">
+    <value>P&amp;roperties</value>
+  </data>
+  <data name="contextMenuStrip1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>206, 168</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip1.Name" xml:space="preserve">
+    <value>contextMenuStrip1</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="TitleLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="TitleLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 11.25pt</value>
+  </data>
+  <data name="TitleLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="TitleLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="TitleLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 0, 0, 0</value>
+  </data>
+  <data name="TitleLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>920, 36</value>
+  </data>
+  <data name="TitleLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="TitleLabel.Text" xml:space="preserve">
+    <value>Virtual Disks</value>
+  </data>
+  <data name="TitleLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;TitleLabel.Name" xml:space="preserve">
+    <value>TitleLabel</value>
+  </data>
+  <data name="&gt;&gt;TitleLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>96, 96</value>
+    <value>120, 120</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 8.25pt</value>
@@ -796,7 +622,19 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>920, 450</value>
+    <value>1150, 562</value>
+  </data>
+  <data name="&gt;&gt;rescanToolStripMenuItem.Name" xml:space="preserve">
+    <value>rescanToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;rescanToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;addToolStripMenuItem.Name" xml:space="preserve">
+    <value>addToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;addToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;moveVirtualDiskToolStripMenuItem.Name" xml:space="preserve">
     <value>moveVirtualDiskToolStripMenuItem</value>


### PR DESCRIPTION
- show/hide the context menu items instead of creating and adding new ones each time the context menu opens
- right click menu with rescan/add was not available for empty list or when empty space was clicked
- the condition for the edit button was slightly different from the edit toolstripmenuitem
- improved button layout (part of CA-100083)
- tidied up button event handlers and renamed one or two class members
- removed unused parameter in constructor and method of VDIRow

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>