### PR TITLE
CA-100083 (part of): Set minimum width of the main window's tab contr…

### DIFF
--- a/XenAdmin/ConsoleView/VNCTabView.Designer.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.Designer.cs
@@ -47,98 +47,28 @@ namespace XenAdmin.ConsoleView
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(VNCTabView));
-            this.buttonPanel = new System.Windows.Forms.Panel();
-            this.gradientPanel1 = new XenAdmin.Controls.GradientPanel.GradientPanel();
-            this.HostLabel = new System.Windows.Forms.Label();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.buttonSSH = new System.Windows.Forms.Button();
-            this.toggleConsoleButton = new System.Windows.Forms.Button();
-            this.multipleDvdIsoList1 = new XenAdmin.Controls.MultipleDvdIsoList();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.sendCAD = new System.Windows.Forms.Button();
             this.contentPanel = new System.Windows.Forms.Panel();
-            this.bottomPanel = new System.Windows.Forms.Panel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.groupBox1 = new XenAdmin.Controls.DecentGroupBox();
             this.scaleCheckBox = new System.Windows.Forms.CheckBox();
             this.fullscreenButton = new System.Windows.Forms.Button();
             this.dockButton = new System.Windows.Forms.Button();
             this.tip = new System.Windows.Forms.ToolTip(this.components);
             this.LifeCycleMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.panel2 = new System.Windows.Forms.Panel();
             this.powerStateLabel = new System.Windows.Forms.Label();
             this.dedicatedGpuWarning = new System.Windows.Forms.Label();
-            this.buttonPanel.SuspendLayout();
+            this.gradientPanel1 = new XenAdmin.Controls.GradientPanel.GradientPanel();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.HostLabel = new System.Windows.Forms.Label();
+            this.buttonSSH = new System.Windows.Forms.Button();
+            this.toggleConsoleButton = new System.Windows.Forms.Button();
+            this.multipleDvdIsoList1 = new XenAdmin.Controls.MultipleDvdIsoList();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.tableLayoutPanel1.SuspendLayout();
             this.gradientPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.bottomPanel.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.panel2.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // buttonPanel
-            // 
-            this.buttonPanel.Controls.Add(this.gradientPanel1);
-            resources.ApplyResources(this.buttonPanel, "buttonPanel");
-            this.buttonPanel.Name = "buttonPanel";
-            // 
-            // gradientPanel1
-            // 
-            resources.ApplyResources(this.gradientPanel1, "gradientPanel1");
-            this.gradientPanel1.Controls.Add(this.tableLayoutPanel2);
-            this.gradientPanel1.Name = "gradientPanel1";
-            this.gradientPanel1.Scheme = XenAdmin.Controls.GradientPanel.GradientPanel.Schemes.Tab;
-            // 
-            // HostLabel
-            // 
-            this.HostLabel.AutoEllipsis = true;
-            resources.ApplyResources(this.HostLabel, "HostLabel");
-            this.HostLabel.ForeColor = System.Drawing.Color.White;
-            this.HostLabel.Name = "HostLabel";
-            // 
-            // tableLayoutPanel2
-            // 
-            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-            this.tableLayoutPanel2.Controls.Add(this.HostLabel, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.buttonSSH, 3, 0);
-            this.tableLayoutPanel2.Controls.Add(this.toggleConsoleButton, 5, 0);
-            this.tableLayoutPanel2.Controls.Add(this.multipleDvdIsoList1, 2, 0);
-            this.tableLayoutPanel2.Controls.Add(this.pictureBox1, 1, 0);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            // 
-            // buttonSSH
-            // 
-            resources.ApplyResources(this.buttonSSH, "buttonSSH");
-            this.buttonSSH.Name = "buttonSSH";
-            this.buttonSSH.UseVisualStyleBackColor = true;
-            this.buttonSSH.Click += new System.EventHandler(this.buttonSSH_Click);
-            // 
-            // toggleConsoleButton
-            // 
-            resources.ApplyResources(this.toggleConsoleButton, "toggleConsoleButton");
-            this.toggleConsoleButton.Name = "toggleConsoleButton";
-            this.tip.SetToolTip(this.toggleConsoleButton, resources.GetString("toggleConsoleButton.ToolTip"));
-            this.toggleConsoleButton.UseVisualStyleBackColor = true;
-            this.toggleConsoleButton.Click += new System.EventHandler(this.toggleConsoleButton_Click);
-            // 
-            // multipleDvdIsoList1
-            // 
-            resources.ApplyResources(this.multipleDvdIsoList1, "multipleDvdIsoList1");
-            this.multipleDvdIsoList1.Name = "multipleDvdIsoList1";
-            this.multipleDvdIsoList1.VM = null;
-            // 
-            // pictureBox1
-            // 
-            resources.ApplyResources(this.pictureBox1, "pictureBox1");
-            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._001_LifeCycle_h32bit_24;
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.TabStop = false;
-            this.pictureBox1.Click += new System.EventHandler(this.LifeCycleButton_MouseClick);
-            this.pictureBox1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pictureBox1_MouseDown);
-            this.pictureBox1.MouseEnter += new System.EventHandler(this.pictureBox1_MouseEnter);
-            this.pictureBox1.MouseLeave += new System.EventHandler(this.pictureBox1_MouseLeave);
-            this.pictureBox1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.pictureBox1_MouseUp);
             // 
             // sendCAD
             // 
@@ -152,27 +82,14 @@ namespace XenAdmin.ConsoleView
             resources.ApplyResources(this.contentPanel, "contentPanel");
             this.contentPanel.Name = "contentPanel";
             // 
-            // bottomPanel
-            // 
-            this.bottomPanel.Controls.Add(this.tableLayoutPanel1);
-            resources.ApplyResources(this.bottomPanel, "bottomPanel");
-            this.bottomPanel.Name = "bottomPanel";
-            // 
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.sendCAD, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 4, 0);
             this.tableLayoutPanel1.Controls.Add(this.scaleCheckBox, 2, 0);
-            this.tableLayoutPanel1.Controls.Add(this.fullscreenButton, 5, 0);
+            this.tableLayoutPanel1.Controls.Add(this.fullscreenButton, 4, 0);
             this.tableLayoutPanel1.Controls.Add(this.dockButton, 3, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // groupBox1
-            // 
-            resources.ApplyResources(this.groupBox1, "groupBox1");
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.TabStop = false;
             // 
             // scaleCheckBox
             // 
@@ -202,17 +119,11 @@ namespace XenAdmin.ConsoleView
             // 
             // LifeCycleMenuStrip
             // 
+            this.LifeCycleMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.LifeCycleMenuStrip.Name = "LifeCycleMenuStrip";
             resources.ApplyResources(this.LifeCycleMenuStrip, "LifeCycleMenuStrip");
             this.LifeCycleMenuStrip.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.LifeCycleMenuStrip_Closing);
             this.LifeCycleMenuStrip.Opened += new System.EventHandler(this.LifeCycleMenuStrip_Opened);
-            // 
-            // panel2
-            // 
-            resources.ApplyResources(this.panel2, "panel2");
-            this.panel2.BackColor = System.Drawing.Color.Transparent;
-            this.panel2.Controls.Add(this.buttonPanel);
-            this.panel2.Name = "panel2";
             // 
             // powerStateLabel
             // 
@@ -231,6 +142,67 @@ namespace XenAdmin.ConsoleView
             this.dedicatedGpuWarning.ForeColor = System.Drawing.SystemColors.ControlText;
             this.dedicatedGpuWarning.Name = "dedicatedGpuWarning";
             // 
+            // gradientPanel1
+            // 
+            this.gradientPanel1.Controls.Add(this.tableLayoutPanel2);
+            resources.ApplyResources(this.gradientPanel1, "gradientPanel1");
+            this.gradientPanel1.Name = "gradientPanel1";
+            this.gradientPanel1.Scheme = XenAdmin.Controls.GradientPanel.GradientPanel.Schemes.Tab;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this.HostLabel, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.buttonSSH, 3, 0);
+            this.tableLayoutPanel2.Controls.Add(this.toggleConsoleButton, 5, 0);
+            this.tableLayoutPanel2.Controls.Add(this.multipleDvdIsoList1, 2, 0);
+            this.tableLayoutPanel2.Controls.Add(this.pictureBox1, 1, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            // 
+            // HostLabel
+            // 
+            this.HostLabel.AutoEllipsis = true;
+            resources.ApplyResources(this.HostLabel, "HostLabel");
+            this.HostLabel.ForeColor = System.Drawing.Color.White;
+            this.HostLabel.Name = "HostLabel";
+            // 
+            // buttonSSH
+            // 
+            resources.ApplyResources(this.buttonSSH, "buttonSSH");
+            this.buttonSSH.Name = "buttonSSH";
+            this.buttonSSH.UseVisualStyleBackColor = true;
+            this.buttonSSH.Click += new System.EventHandler(this.buttonSSH_Click);
+            // 
+            // toggleConsoleButton
+            // 
+            resources.ApplyResources(this.toggleConsoleButton, "toggleConsoleButton");
+            this.toggleConsoleButton.Name = "toggleConsoleButton";
+            this.tip.SetToolTip(this.toggleConsoleButton, resources.GetString("toggleConsoleButton.ToolTip"));
+            this.toggleConsoleButton.UseVisualStyleBackColor = true;
+            this.toggleConsoleButton.Click += new System.EventHandler(this.toggleConsoleButton_Click);
+            // 
+            // multipleDvdIsoList1
+            // 
+            resources.ApplyResources(this.multipleDvdIsoList1, "multipleDvdIsoList1");
+            this.multipleDvdIsoList1.LabelNewCdForeColor = System.Drawing.SystemColors.HotTrack;
+            this.multipleDvdIsoList1.LabelSingleDvdForeColor = System.Drawing.SystemColors.ControlText;
+            this.multipleDvdIsoList1.LinkLabelLinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(255)))));
+            this.multipleDvdIsoList1.Name = "multipleDvdIsoList1";
+            this.multipleDvdIsoList1.VM = null;
+            // 
+            // pictureBox1
+            // 
+            resources.ApplyResources(this.pictureBox1, "pictureBox1");
+            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._001_LifeCycle_h32bit_24;
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.TabStop = false;
+            this.pictureBox1.Click += new System.EventHandler(this.LifeCycleButton_MouseClick);
+            this.pictureBox1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pictureBox1_MouseDown);
+            this.pictureBox1.MouseEnter += new System.EventHandler(this.pictureBox1_MouseEnter);
+            this.pictureBox1.MouseLeave += new System.EventHandler(this.pictureBox1_MouseLeave);
+            this.pictureBox1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.pictureBox1_MouseUp);
+            // 
             // VNCTabView
             // 
             resources.ApplyResources(this, "$this");
@@ -238,18 +210,15 @@ namespace XenAdmin.ConsoleView
             this.Controls.Add(this.contentPanel);
             this.Controls.Add(this.dedicatedGpuWarning);
             this.Controls.Add(this.powerStateLabel);
-            this.Controls.Add(this.bottomPanel);
-            this.Controls.Add(this.panel2);
+            this.Controls.Add(this.gradientPanel1);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "VNCTabView";
-            this.buttonPanel.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.gradientPanel1.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.bottomPanel.ResumeLayout(false);
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            this.panel2.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -257,20 +226,16 @@ namespace XenAdmin.ConsoleView
 
         #endregion
 
-        private System.Windows.Forms.Panel buttonPanel;
         private System.Windows.Forms.Button dockButton;
         private System.Windows.Forms.Button sendCAD;
         private System.Windows.Forms.Panel contentPanel;
-        private System.Windows.Forms.Panel bottomPanel;
         private System.Windows.Forms.CheckBox scaleCheckBox;
         private System.Windows.Forms.Button fullscreenButton;
-        private XenAdmin.Controls.DecentGroupBox groupBox1;
         private System.Windows.Forms.ToolTip tip;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.ContextMenuStrip LifeCycleMenuStrip;
         private System.Windows.Forms.PictureBox pictureBox1;
-        private System.Windows.Forms.Panel panel2;
         private XenAdmin.Controls.GradientPanel.GradientPanel gradientPanel1;
         private System.Windows.Forms.Label HostLabel;
         private System.Windows.Forms.Button toggleConsoleButton;

--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -898,7 +898,7 @@ namespace XenAdmin.ConsoleView
                     int twoTimeBorderPadding = VNCGraphicsClient.BORDER_PADDING * 2;
 
                     return new Size(vncScreen.DesktopSize.Width + twoTimeBorderPadding,
-                                    vncScreen.DesktopSize.Height + buttonPanel.Height + bottomPanel.Height + twoTimeBorderPadding);
+                                    vncScreen.DesktopSize.Height + gradientPanel1.Height + tableLayoutPanel1.Height + twoTimeBorderPadding);
                 }
                 else
                 {
@@ -1399,7 +1399,7 @@ namespace XenAdmin.ConsoleView
 
         public void showHeaderBar(bool showHeaderBar, bool showLifecycleIcon)
         {
-            panel2.Visible = showHeaderBar;
+            gradientPanel1.Visible = showHeaderBar;
             pictureBox1.Visible = showLifecycleIcon;
         }
 

--- a/XenAdmin/ConsoleView/VNCTabView.resx
+++ b/XenAdmin/ConsoleView/VNCTabView.resx
@@ -127,13 +127,16 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="sendCAD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>2, 2</value>
+  </data>
+  <data name="sendCAD.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="sendCAD.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>154, 38</value>
+    <value>123, 30</value>
   </data>
   <data name="sendCAD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>261, 38</value>
+    <value>209, 30</value>
   </data>
   <data name="sendCAD.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -157,16 +160,13 @@
     <value>Fill</value>
   </data>
   <data name="contentPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 130</value>
-  </data>
-  <data name="contentPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+    <value>0, 105</value>
   </data>
   <data name="contentPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>879, 500</value>
+    <value>703, 400</value>
   </data>
   <data name="contentPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;contentPanel.Name" xml:space="preserve">
     <value>contentPanel</value>
@@ -178,7 +178,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;contentPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -199,10 +199,13 @@
     <value>NoControl</value>
   </data>
   <data name="scaleCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 10</value>
+    <value>433, 8</value>
+  </data>
+  <data name="scaleCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="scaleCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 23</value>
+    <value>52, 17</value>
   </data>
   <data name="scaleCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -229,13 +232,16 @@
     <value>NoControl</value>
   </data>
   <data name="fullscreenButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>722, 3</value>
+    <value>578, 2</value>
+  </data>
+  <data name="fullscreenButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="fullscreenButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>142, 38</value>
+    <value>114, 30</value>
   </data>
   <data name="fullscreenButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 38</value>
+    <value>123, 30</value>
   </data>
   <data name="fullscreenButton.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -268,13 +274,16 @@
     <value>NoControl</value>
   </data>
   <data name="dockButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>610, 3</value>
+    <value>489, 2</value>
+  </data>
+  <data name="dockButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="dockButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>106, 38</value>
+    <value>85, 30</value>
   </data>
   <data name="dockButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 38</value>
+    <value>85, 30</value>
   </data>
   <data name="dockButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -304,19 +313,22 @@
     <value>Bottom</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 630</value>
+    <value>0, 505</value>
+  </data>
+  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="tableLayoutPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>400, 0</value>
+    <value>320, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>879, 44</value>
+    <value>703, 34</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -331,7 +343,7 @@
     <value>5</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sendCAD" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="scaleCheckBox" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="fullscreenButton" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="dockButton" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sendCAD" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="scaleCheckBox" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="fullscreenButton" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="dockButton" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,16" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="tip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -340,7 +352,7 @@
     <value>81, 17</value>
   </metadata>
   <data name="LifeCycleMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 4</value>
+    <value>61, 4</value>
   </data>
   <data name="&gt;&gt;LifeCycleMenuStrip.Name" xml:space="preserve">
     <value>LifeCycleMenuStrip</value>
@@ -358,16 +370,13 @@
     <value>NoControl</value>
   </data>
   <data name="powerStateLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 46</value>
-  </data>
-  <data name="powerStateLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>0, 37</value>
   </data>
   <data name="powerStateLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>879, 42</value>
+    <value>703, 34</value>
   </data>
   <data name="powerStateLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="powerStateLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleCenter</value>
@@ -394,16 +403,13 @@
     <value>NoControl</value>
   </data>
   <data name="dedicatedGpuWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 88</value>
-  </data>
-  <data name="dedicatedGpuWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>0, 71</value>
   </data>
   <data name="dedicatedGpuWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>879, 42</value>
+    <value>703, 34</value>
   </data>
   <data name="dedicatedGpuWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="dedicatedGpuWarning.Text" xml:space="preserve">
     <value>This VM has a pass-through GPU assigned. You must connect to it using Remote Desktop.</value>
@@ -439,16 +445,13 @@
     <value>NoControl</value>
   </data>
   <data name="HostLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 0</value>
-  </data>
-  <data name="HostLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>3, 0</value>
   </data>
   <data name="HostLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>10, 0, 0, 0</value>
+    <value>8, 0, 0, 0</value>
   </data>
   <data name="HostLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>10, 46</value>
+    <value>8, 37</value>
   </data>
   <data name="HostLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -481,13 +484,13 @@
     <value>NoControl</value>
   </data>
   <data name="buttonSSH.Location" type="System.Drawing.Point, System.Drawing">
-    <value>506, 8</value>
+    <value>399, 6</value>
   </data>
   <data name="buttonSSH.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 8, 8, 8</value>
+    <value>3, 6, 6, 6</value>
   </data>
   <data name="buttonSSH.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 29</value>
+    <value>114, 23</value>
   </data>
   <data name="buttonSSH.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -517,13 +520,13 @@
     <value>NoControl</value>
   </data>
   <data name="toggleConsoleButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>652, 8</value>
+    <value>522, 6</value>
   </data>
   <data name="toggleConsoleButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 8, 8, 8</value>
+    <value>3, 6, 6, 6</value>
   </data>
   <data name="toggleConsoleButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>219, 30</value>
+    <value>175, 24</value>
   </data>
   <data name="toggleConsoleButton.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -550,13 +553,13 @@
     <value>Fill</value>
   </data>
   <data name="multipleDvdIsoList1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>59, 4</value>
+    <value>47, 3</value>
   </data>
   <data name="multipleDvdIsoList1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 15, 4</value>
+    <value>3, 3, 12, 3</value>
   </data>
   <data name="multipleDvdIsoList1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>428, 38</value>
+    <value>337, 31</value>
   </data>
   <data name="multipleDvdIsoList1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -583,13 +586,13 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 1</value>
+    <value>15, 1</value>
   </data>
   <data name="pictureBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
   </data>
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 44</value>
+    <value>28, 35</value>
   </data>
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>CenterImage</value>
@@ -622,13 +625,13 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="tableLayoutPanel2.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>506, 0</value>
+    <value>405, 0</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>879, 46</value>
+    <value>703, 37</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -654,11 +657,8 @@
   <data name="gradientPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="gradientPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
   <data name="gradientPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>879, 46</value>
+    <value>703, 37</value>
   </data>
   <data name="gradientPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -679,16 +679,13 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>120, 120</value>
+    <value>96, 96</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 8.25pt</value>
   </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>879, 674</value>
+    <value>703, 539</value>
   </data>
   <data name="&gt;&gt;tip.Name" xml:space="preserve">
     <value>tip</value>

--- a/XenAdmin/ConsoleView/VNCTabView.resx
+++ b/XenAdmin/ConsoleView/VNCTabView.resx
@@ -117,11 +117,312 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="gradientPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="sendCAD.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="sendCAD.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="sendCAD.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="sendCAD.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>154, 38</value>
+  </data>
+  <data name="sendCAD.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 38</value>
+  </data>
+  <data name="sendCAD.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="sendCAD.Text" xml:space="preserve">
+    <value>Send Ctrl+&amp;Alt+Del (Ctrl+Alt+Insert)</value>
+  </data>
+  <data name="&gt;&gt;sendCAD.Name" xml:space="preserve">
+    <value>sendCAD</value>
+  </data>
+  <data name="&gt;&gt;sendCAD.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sendCAD.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;sendCAD.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="contentPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="contentPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 130</value>
+  </data>
+  <data name="contentPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="contentPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>879, 500</value>
+  </data>
+  <data name="contentPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;contentPanel.Name" xml:space="preserve">
+    <value>contentPanel</value>
+  </data>
+  <data name="&gt;&gt;contentPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;contentPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;contentPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="scaleCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="scaleCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="scaleCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="scaleCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 10</value>
+  </data>
+  <data name="scaleCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 23</value>
+  </data>
+  <data name="scaleCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="scaleCheckBox.Text" xml:space="preserve">
+    <value>Scal&amp;e</value>
+  </data>
+  <data name="&gt;&gt;scaleCheckBox.Name" xml:space="preserve">
+    <value>scaleCheckBox</value>
+  </data>
+  <data name="&gt;&gt;scaleCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;scaleCheckBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;scaleCheckBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="fullscreenButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="fullscreenButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="fullscreenButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>722, 3</value>
+  </data>
+  <data name="fullscreenButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>142, 38</value>
+  </data>
+  <data name="fullscreenButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 38</value>
+  </data>
+  <data name="fullscreenButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="fullscreenButton.Text" xml:space="preserve">
+    <value>Fulls&amp;creen (Ctrl+Alt)</value>
+  </data>
+  <data name="&gt;&gt;fullscreenButton.Name" xml:space="preserve">
+    <value>fullscreenButton</value>
+  </data>
+  <data name="&gt;&gt;fullscreenButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fullscreenButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;fullscreenButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="dockButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="dockButton.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="dockButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="dockButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="dockButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>610, 3</value>
+  </data>
+  <data name="dockButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>106, 38</value>
+  </data>
+  <data name="dockButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 38</value>
+  </data>
+  <data name="dockButton.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="dockButton.Text" xml:space="preserve">
+    <value>&amp;Undock</value>
+  </data>
+  <data name="dockButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="dockButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
+    <value>ImageBeforeText</value>
+  </data>
+  <data name="&gt;&gt;dockButton.Name" xml:space="preserve">
+    <value>dockButton</value>
+  </data>
+  <data name="&gt;&gt;dockButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dockButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;dockButton.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 630</value>
+  </data>
+  <data name="tableLayoutPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>400, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>879, 44</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sendCAD" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="scaleCheckBox" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="fullscreenButton" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="dockButton" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="tip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="LifeCycleMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>81, 17</value>
+  </metadata>
+  <data name="LifeCycleMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 4</value>
+  </data>
+  <data name="&gt;&gt;LifeCycleMenuStrip.Name" xml:space="preserve">
+    <value>LifeCycleMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;LifeCycleMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="powerStateLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="powerStateLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 8.25pt, style=Bold</value>
+  </data>
+  <data name="powerStateLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="powerStateLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 46</value>
+  </data>
+  <data name="powerStateLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="powerStateLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>879, 42</value>
+  </data>
+  <data name="powerStateLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="powerStateLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;powerStateLabel.Name" xml:space="preserve">
+    <value>powerStateLabel</value>
+  </data>
+  <data name="&gt;&gt;powerStateLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;powerStateLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;powerStateLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="dedicatedGpuWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="dedicatedGpuWarning.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 8.25pt, style=Bold</value>
+  </data>
+  <data name="dedicatedGpuWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="dedicatedGpuWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 88</value>
+  </data>
+  <data name="dedicatedGpuWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="dedicatedGpuWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>879, 42</value>
+  </data>
+  <data name="dedicatedGpuWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="dedicatedGpuWarning.Text" xml:space="preserve">
+    <value>This VM has a pass-through GPU assigned. You must connect to it using Remote Desktop.</value>
+  </data>
+  <data name="dedicatedGpuWarning.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;dedicatedGpuWarning.Name" xml:space="preserve">
+    <value>dedicatedGpuWarning</value>
+  </data>
+  <data name="&gt;&gt;dedicatedGpuWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dedicatedGpuWarning.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;dedicatedGpuWarning.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
@@ -131,7 +432,6 @@
   <data name="HostLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="HostLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 11.25pt</value>
   </data>
@@ -139,13 +439,16 @@
     <value>NoControl</value>
   </data>
   <data name="HostLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
+    <value>4, 0</value>
+  </data>
+  <data name="HostLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="HostLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 0, 0, 0</value>
+    <value>10, 0, 0, 0</value>
   </data>
   <data name="HostLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>8, 37</value>
+    <value>10, 46</value>
   </data>
   <data name="HostLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -178,23 +481,20 @@
     <value>NoControl</value>
   </data>
   <data name="buttonSSH.Location" type="System.Drawing.Point, System.Drawing">
-    <value>399, 6</value>
+    <value>506, 8</value>
   </data>
   <data name="buttonSSH.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 6, 6, 6</value>
+    <value>4, 8, 8, 8</value>
   </data>
   <data name="buttonSSH.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 23</value>
+    <value>134, 29</value>
   </data>
   <data name="buttonSSH.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>2</value>
   </data>
   <data name="buttonSSH.Text" xml:space="preserve">
     <value>Open SSH Console</value>
   </data>
-  <metadata name="tip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="&gt;&gt;buttonSSH.Name" xml:space="preserve">
     <value>buttonSSH</value>
   </data>
@@ -217,16 +517,16 @@
     <value>NoControl</value>
   </data>
   <data name="toggleConsoleButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>522, 6</value>
+    <value>652, 8</value>
   </data>
   <data name="toggleConsoleButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 6, 6, 6</value>
+    <value>4, 8, 8, 8</value>
   </data>
   <data name="toggleConsoleButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>175, 24</value>
+    <value>219, 30</value>
   </data>
   <data name="toggleConsoleButton.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>3</value>
   </data>
   <data name="toggleConsoleButton.Text" xml:space="preserve">
     <value>Looking for guest console...</value>
@@ -250,16 +550,16 @@
     <value>Fill</value>
   </data>
   <data name="multipleDvdIsoList1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>47, 3</value>
+    <value>59, 4</value>
   </data>
   <data name="multipleDvdIsoList1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 12, 3</value>
+    <value>4, 4, 15, 4</value>
   </data>
   <data name="multipleDvdIsoList1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>337, 31</value>
+    <value>428, 38</value>
   </data>
   <data name="multipleDvdIsoList1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;multipleDvdIsoList1.Name" xml:space="preserve">
     <value>multipleDvdIsoList1</value>
@@ -283,13 +583,13 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 1</value>
+    <value>19, 1</value>
   </data>
   <data name="pictureBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
   </data>
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 35</value>
+    <value>35, 44</value>
   </data>
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>CenterImage</value>
@@ -322,16 +622,16 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="tableLayoutPanel2.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>405, 0</value>
+    <value>506, 0</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 37</value>
+    <value>879, 46</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -346,16 +646,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="HostLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonSSH" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="toggleConsoleButton" Row="0" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="multipleDvdIsoList1" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100,Absolute,37" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="HostLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonSSH" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="toggleConsoleButton" Row="0" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="multipleDvdIsoList1" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100,Absolute,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="gradientPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
   </data>
   <data name="gradientPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="gradientPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="gradientPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 37</value>
+    <value>879, 46</value>
   </data>
   <data name="gradientPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>45</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;gradientPanel1.Name" xml:space="preserve">
     <value>gradientPanel1</value>
@@ -364,424 +670,25 @@
     <value>XenAdmin.Controls.GradientPanel.GradientPanel, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;gradientPanel1.Parent" xml:space="preserve">
-    <value>buttonPanel</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;gradientPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="buttonPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="buttonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="buttonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 37</value>
-  </data>
-  <data name="buttonPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.Name" xml:space="preserve">
-    <value>buttonPanel</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="sendCAD.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
-  <data name="sendCAD.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="sendCAD.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="sendCAD.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="sendCAD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="sendCAD.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>123, 30</value>
-  </data>
-  <data name="sendCAD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 30</value>
-  </data>
-  <data name="sendCAD.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="sendCAD.Text" xml:space="preserve">
-    <value>Send Ctrl+&amp;Alt+Del (Ctrl+Alt+Insert)</value>
-  </data>
-  <data name="&gt;&gt;sendCAD.Name" xml:space="preserve">
-    <value>sendCAD</value>
-  </data>
-  <data name="&gt;&gt;sendCAD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;sendCAD.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;sendCAD.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="contentPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="contentPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 105</value>
-  </data>
-  <data name="contentPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 398</value>
-  </data>
-  <data name="contentPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;contentPanel.Name" xml:space="preserve">
-    <value>contentPanel</value>
-  </data>
-  <data name="&gt;&gt;contentPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;contentPanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;contentPanel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>574, 9</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>2, 17</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="scaleCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Right</value>
-  </data>
-  <data name="scaleCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="scaleCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="scaleCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>425, 9</value>
-  </data>
-  <data name="scaleCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 17</value>
-  </data>
-  <data name="scaleCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="scaleCheckBox.Text" xml:space="preserve">
-    <value>Scal&amp;e</value>
-  </data>
-  <data name="&gt;&gt;scaleCheckBox.Name" xml:space="preserve">
-    <value>scaleCheckBox</value>
-  </data>
-  <data name="&gt;&gt;scaleCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;scaleCheckBox.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;scaleCheckBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="fullscreenButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="fullscreenButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="fullscreenButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="fullscreenButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>582, 3</value>
-  </data>
-  <data name="fullscreenButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>114, 30</value>
-  </data>
-  <data name="fullscreenButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 30</value>
-  </data>
-  <data name="fullscreenButton.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
-  </data>
-  <data name="fullscreenButton.Text" xml:space="preserve">
-    <value>Fulls&amp;creen (Ctrl+Alt)</value>
-  </data>
-  <data name="&gt;&gt;fullscreenButton.Name" xml:space="preserve">
-    <value>fullscreenButton</value>
-  </data>
-  <data name="&gt;&gt;fullscreenButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fullscreenButton.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;fullscreenButton.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="dockButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="dockButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="dockButton.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="dockButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="dockButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="dockButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>483, 3</value>
-  </data>
-  <data name="dockButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>85, 30</value>
-  </data>
-  <data name="dockButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 30</value>
-  </data>
-  <data name="dockButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="dockButton.Text" xml:space="preserve">
-    <value>&amp;Undock</value>
-  </data>
-  <data name="dockButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="dockButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
-    <value>ImageBeforeText</value>
-  </data>
-  <data name="&gt;&gt;dockButton.Name" xml:space="preserve">
-    <value>dockButton</value>
-  </data>
-  <data name="&gt;&gt;dockButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dockButton.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;dockButton.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="tableLayoutPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>320, 0</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 36</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>bottomPanel</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sendCAD" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="groupBox1" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="scaleCheckBox" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="fullscreenButton" Row="0" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="dockButton" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="bottomPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="bottomPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 503</value>
-  </data>
-  <data name="bottomPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 36</value>
-  </data>
-  <data name="bottomPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;bottomPanel.Name" xml:space="preserve">
-    <value>bottomPanel</value>
-  </data>
-  <data name="&gt;&gt;bottomPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bottomPanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;bottomPanel.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <metadata name="LifeCycleMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>81, 17</value>
-  </metadata>
-  <data name="LifeCycleMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 4</value>
-  </data>
-  <data name="&gt;&gt;LifeCycleMenuStrip.Name" xml:space="preserve">
-    <value>LifeCycleMenuStrip</value>
-  </data>
-  <data name="&gt;&gt;LifeCycleMenuStrip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="panel2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panel2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 37</value>
-  </data>
-  <data name="panel2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="powerStateLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="powerStateLabel.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 8.25pt, style=Bold</value>
-  </data>
-  <data name="powerStateLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="powerStateLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 37</value>
-  </data>
-  <data name="powerStateLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 34</value>
-  </data>
-  <data name="powerStateLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="powerStateLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
-  </data>
-  <data name="&gt;&gt;powerStateLabel.Name" xml:space="preserve">
-    <value>powerStateLabel</value>
-  </data>
-  <data name="&gt;&gt;powerStateLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;powerStateLabel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;powerStateLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="dedicatedGpuWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="dedicatedGpuWarning.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 8.25pt, style=Bold</value>
-  </data>
-  <data name="dedicatedGpuWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="dedicatedGpuWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 71</value>
-  </data>
-  <data name="dedicatedGpuWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 34</value>
-  </data>
-  <data name="dedicatedGpuWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="dedicatedGpuWarning.Text" xml:space="preserve">
-    <value>This VM has a pass-through GPU assigned. You must connect to it using Remote Desktop.</value>
-  </data>
-  <data name="dedicatedGpuWarning.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
-  </data>
-  <data name="&gt;&gt;dedicatedGpuWarning.Name" xml:space="preserve">
-    <value>dedicatedGpuWarning</value>
-  </data>
-  <data name="&gt;&gt;dedicatedGpuWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dedicatedGpuWarning.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;dedicatedGpuWarning.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>96, 96</value>
+    <value>120, 120</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 8.25pt</value>
   </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 539</value>
+    <value>879, 674</value>
   </data>
   <data name="&gt;&gt;tip.Name" xml:space="preserve">
     <value>tip</value>

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -3272,7 +3272,7 @@ namespace XenAdmin
         private void SetSplitterDistance()
         {
             //CA-71697: chosen min size so the tab contents are visible
-            int chosenPanel2MinSize = MinimumSize.Width / 2;
+            int chosenPanel2MinSize = MinimumSize.Width * 3 / 5;
             int min = splitContainer1.Panel1MinSize;
             int max = splitContainer1.Width - chosenPanel2MinSize;
 


### PR DESCRIPTION
…ol to 40% to

avoid buttons on the console tab overlapping. Removed some panels from the console
tab to reduce control nesting.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>