### PR TITLE
CA-219777: Bad progress dialog message

### DIFF
--- a/XenAdmin/Dialogs/ActionProgressDialog.cs
+++ b/XenAdmin/Dialogs/ActionProgressDialog.cs
@@ -77,6 +77,7 @@ namespace XenAdmin.Dialogs
         {
             InitializeComponent();
             labelStatus.Text = text;
+            labelSubActionStatus.Visible = false;
             progressBar1.Style = ProgressBarStyle.Marquee;
             ShowIcon = false;
             HideTitleBarIcons();


### PR DESCRIPTION
The bad message was in the dialog created in the BugToolWizard after selecting servers. Since this method is the only one using the ActionProgressDialog(String) constructor, I've modified that ctor to hide the subaction label - which makes sense because there is no action in that ctor (to set a subaction) and no other appropriate label.