### PR TITLE
CA-217821: Renaming home server to target server in VM migration wizard

### DIFF
--- a/XenAdmin/Wizards/GenericPages/HomeServerItem.cs
+++ b/XenAdmin/Wizards/GenericPages/HomeServerItem.cs
@@ -87,7 +87,7 @@ namespace XenAdmin.Wizards.GenericPages
 
         public override string ToString()
         {
-            return Messages.DONT_ASSIGN_HOME_SERVER;
+            return Messages.DONT_SELECT_TARGET_SERVER;
         }
     }
 }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -11447,11 +11447,11 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Don&apos;t assign a home server.
+        ///   Looks up a localized string similar to Don&apos;t select a target server.
         /// </summary>
-        public static string DONT_ASSIGN_HOME_SERVER {
+        public static string DONT_SELECT_TARGET_SERVER {
             get {
-                return ResourceManager.GetString("DONT_ASSIGN_HOME_SERVER", resourceCulture);
+                return ResourceManager.GetString("DONT_SELECT_TARGET_SERVER", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -4077,8 +4077,8 @@ This will also delete its subfolders.</value>
   <data name="DONE" xml:space="preserve">
     <value>done.</value>
   </data>
-  <data name="DONT_ASSIGN_HOME_SERVER" xml:space="preserve">
-    <value>Don't assign a home server</value>
+  <data name="DONT_SELECT_TARGET_SERVER" xml:space="preserve">
+    <value>Don't select a target server</value>
   </data>
   <data name="DOWLOAD_LATEST_XS_TITLE" xml:space="preserve">
     <value>{0} is now available</value>


### PR DESCRIPTION
We already renamed the column to target server, this changes the message in the case where the user doesn't choose a server on this page to also use target server.

Previous issue: #1119 

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>