### PR TITLE
CA-218242: Don't assign values outside the range in the memory spinne…

### DIFF
--- a/XenAdmin/Controls/Ballooning/MemorySpinner.cs
+++ b/XenAdmin/Controls/Ballooning/MemorySpinner.cs
@@ -117,14 +117,20 @@ namespace XenAdmin.Controls.Ballooning
 
         private void setSpinnerValueDisplay(double value)
         {
+            decimal newValue;
             if (Units == "GB")
             {
-                Spinner.Value = (decimal)Util.ToGB(value, 1, RoundingBehaviour.Nearest);
+                newValue = (decimal)Util.ToGB(value, 1, RoundingBehaviour.Nearest);
             }
             else
             {
-                Spinner.Value = (long)Util.ToMB(value, RoundingBehaviour.Nearest);
+                newValue = (long)Util.ToMB(value, RoundingBehaviour.Nearest);
             }
+            if (newValue < Spinner.Minimum)
+                newValue = Spinner.Minimum;
+            if (newValue > Spinner.Maximum)
+                newValue = Spinner.Maximum;
+            Spinner.Value = newValue;
         }
 
         public static void CalcMBRanges(double minBytes, double maxBytes, out double minMB, out double maxMB)


### PR DESCRIPTION
…r control

- The value of the spinner control is rounded to the nearest, while the minimum is rounded up and the maximum down (or, in some cases, min and max are not rounded at all).
In most cases this is fine, but if the current value (in bytes) is equal to one of these ranges, by rounding this way we might end up with a value that is outside of the control's ranges (causing ArgumentOutOfRange exception).

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>