### PR TITLE
Revert "CP-18925: Hide batch hotfixing option in XenCenter"

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -149,7 +149,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             if (direction == PageLoadedDirection.Forward)
             {
                 //if any connected host is licensed for automatic updating
-                bool autoUpdatePossible = false; //temporarily disabled ConnectionsManager.XenConnectionsCopy.Any(c => c != null && c.Cache.Hosts.Any(h => !Host.RestrictBatchHotfixApply(h)));
+                bool autoUpdatePossible = ConnectionsManager.XenConnectionsCopy.Any(c => c != null && c.Cache.Hosts.Any(h => !Host.RestrictBatchHotfixApply(h)));
                
                 labelWithAutomatic.Visible = automaticOptionLabel.Visible = AutomaticRadioButton.Visible = autoUpdatePossible;
                 labelWithoutAutomatic.Visible = !autoUpdatePossible;


### PR DESCRIPTION
Reverts xenserver/xenadmin#1169

Unhide Batch hotfixing