### PR TITLE
CA-218260: Reverting to Snapshots causes VM to go back to parent host

### DIFF
--- a/XenModel/Actions/VM/VMSnapshotRevertAction.cs
+++ b/XenModel/Actions/VM/VMSnapshotRevertAction.cs
@@ -45,7 +45,6 @@ namespace XenAdmin.Actions
         {
             this.VM = Connection.Resolve<VM>(snapshot.snapshot_of);
             previousHost = Connection.Resolve<Host>(VM.resident_on);
-
             this.m_Snapshot = snapshot;
             Description = String.Format(Messages.VM_REVERTING, m_Snapshot.Name);
 
@@ -107,22 +106,21 @@ namespace XenAdmin.Actions
                         }
 
                     }
-                }
-                else if (vm.power_state == vm_power_state.Suspended)
-                {
-                    if (previousHost != null && vm.CanBootOnHost(previousHost))
+                    else if (vm.power_state == vm_power_state.Suspended)
                     {
-                        RelatedTask = XenAPI.VM.async_resume_on(Session, vm.opaque_ref, previousHost.opaque_ref,
-                            false, false);
-                    }
-                    else
-                    {
-                        RelatedTask = XenAPI.VM.async_resume(Session, vm.opaque_ref, false, false);
-                    }
+                        if (previousHost != null && vm.CanBootOnHost(previousHost))
+                        {
+                            RelatedTask = XenAPI.VM.async_resume_on(Session, vm.opaque_ref, previousHost.opaque_ref,
+                                false, false);
+                        }
+                        else
+                        {
+                            RelatedTask = XenAPI.VM.async_resume(Session, vm.opaque_ref, false, false);
+                        }
 
+                    }
+                    PollToCompletion();
                 }
-
-                PollToCompletion();
             }
         }
     }

--- a/XenModel/Actions/VM/VMSnapshotRevertAction.cs
+++ b/XenModel/Actions/VM/VMSnapshotRevertAction.cs
@@ -94,7 +94,7 @@ namespace XenAdmin.Actions
                 {
                     if (vm.power_state == vm_power_state.Halted)
                     {
-                        if (previousHost != null && vm.CanBootOnHost(previousHost))
+                        if (previousHost != null && VMCanBootOnHost(vm, previousHost))
                         {
                             RelatedTask = XenAPI.VM.async_start_on(Session,
                                 vm.opaque_ref, previousHost.opaque_ref, false, false);
@@ -108,7 +108,7 @@ namespace XenAdmin.Actions
                     }
                     else if (vm.power_state == vm_power_state.Suspended)
                     {
-                        if (previousHost != null && vm.CanBootOnHost(previousHost))
+                        if (previousHost != null && VMCanBootOnHost(vm, previousHost))
                         {
                             RelatedTask = XenAPI.VM.async_resume_on(Session, vm.opaque_ref, previousHost.opaque_ref,
                                 false, false);
@@ -122,6 +122,20 @@ namespace XenAdmin.Actions
                     PollToCompletion();
                 }
             }
+        }
+
+        private bool VMCanBootOnHost(VM vm, Host host)
+        {
+            try
+            {
+                VM.assert_can_boot_here(Session, vm.opaque_ref, host.opaque_ref);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -2073,6 +2073,20 @@ namespace XenAPI
                 return other_config != null && other_config.ContainsKey("hci-warn-before-shutdown");
             }
         }
+
+        public bool CanBootOnHost(Host host)
+        {
+            try
+            {
+                assert_can_boot_here(Connection.Session, this.opaque_ref, host.opaque_ref);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 
     public struct VMStartupOptions

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -2073,20 +2073,6 @@ namespace XenAPI
                 return other_config != null && other_config.ContainsKey("hci-warn-before-shutdown");
             }
         }
-
-        public bool CanBootOnHost(Host host)
-        {
-            try
-            {
-                assert_can_boot_here(Connection.Session, this.opaque_ref, host.opaque_ref);
-            }
-            catch
-            {
-                return false;
-            }
-
-            return true;
-        }
     }
 
     public struct VMStartupOptions


### PR DESCRIPTION
Where we have a host the VM is running on (ie vm.resident_on is not null) at the time it is reverted, attempt to start/resume on that host if possible, instead of the home server of the VM.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>