### PR TITLE
CA-223082: Replace PATCH_PRECHECK_LIVEPATCH_MISSING

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -369,8 +369,8 @@ namespace XenAdmin.Wizards.PatchingWizard
     public enum LivePatchCode
     {
         UNKNOWN,
-        PATCH_PRECHECK_LIVEPATCH_COMPLETE,      // An applicable live patch exists for every required component
-        PATCH_PRECHECK_LIVEPATCH_INCOMPLETE,    // An applicable live patch exists but it is not sufficient
-        PATCH_PRECHECK_LIVEPATCH_MISSING,       // There is no applicable live patch
+        PATCH_PRECHECK_LIVEPATCH_COMPLETE,       // An applicable live patch exists for every required component
+        PATCH_PRECHECK_LIVEPATCH_INCOMPLETE,     // An applicable live patch exists but it is not sufficient
+        PATCH_PRECHECK_LIVEPATCH_NOT_APPLICABLE, // There is no applicable live patch
     }
 }


### PR DESCRIPTION
Replace PATCH_PRECHECK_LIVEPATCH_MISSING to PATCH_PRECHECK_LIVEPATCH_NOT_APPLICABLE due to changes in XAPI
Note: if XAPI change gets active before this change we will see UNKNOWN instead of PATCH_PRECHECK_LIVEPATCH_NOT_APPLICABLE in XenCenter what will make no difference