### PR TITLE
CP-17920: Show the PVS tab only when the supplemental pack is installed & Hide Memory SR

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1427,8 +1427,8 @@ namespace XenAdmin
 
             ShowTab(ad_upsell ? TabPageADUpsell : TabPageAD, !multi && !SearchMode && (isPoolSelected || isHostSelected && isHostLive));
 
-            bool hasPvsSites = selectionConnection != null && selectionConnection.Cache.PVS_sites.Length > 0;
-            ShowTab(TabPagePvs, !multi && !SearchMode && isPoolOrLiveStandaloneHost && !Helpers.FeatureForbidden(SelectionManager.Selection.FirstAsXenObject, Host.RestrictPvsCache));
+            ShowTab(TabPagePvs, !multi && !SearchMode && isPoolOrLiveStandaloneHost && !Helpers.FeatureForbidden(SelectionManager.Selection.FirstAsXenObject, Host.RestrictPvsCache)
+                && Helpers.PvsCacheCapability(selectionConnection));
 
             foreach (TabPageFeature f in pluginManager.GetAllFeatures<TabPageFeature>(f => !f.IsConsoleReplacement && !multi && f.ShowTab))
                 ShowTab(f.TabPage, true);

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -2076,6 +2076,12 @@ namespace XenAdmin.Core
            return CreamOrGreater(connection) && master != null && master.SuppPacks.Any(suppPack => suppPack.Name.ToLower().StartsWith("xscontainer")); 
        }
 
+       public static bool PvsCacheCapability(IXenConnection connection)
+       {
+           var master = GetMaster(connection);
+           return master != null && master.SuppPacks.Any(suppPack => suppPack.Name.ToLower().StartsWith("xspvscache"));
+       }
+
        /// <summary>
        /// This method returns the disk space required (bytes) on the provided SR for the provided VDI.
        /// This method also considers thin provisioning. For thin provisioned SRs the provided sm_config in the VDI will be considered first, or it will use the values from the SR's sm_config in case the VDI does not have these set. For fully provisioned SRs the sm_config in the VDI will be ignored.

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -54,7 +54,8 @@ namespace XenAPI
             iscsi,
             ebs, rawhba,
             smb, lvmofcoe,
-            nutanix, nutanixiso
+            nutanix, nutanixiso, 
+            tmpfs
         }
 
         public const string Content_Type_ISO = "iso";
@@ -416,8 +417,14 @@ namespace XenAPI
             if (name_label.StartsWith(Helpers.GuiTempObjectPrefix))
                 return false;
 
+            SRTypes srType = GetSRType(false);
+
             // CA-15012 - dont show cd drives of type local on miami (if dont get destroyed properly on upgrade)
-            if (GetSRType(false) == SRTypes.local)
+            if (srType == SRTypes.local)
+                return false;
+
+            // Hide Memory SR
+            if (srType == SRTypes.tmpfs)
                 return false;
 
             if (showHiddenVMs)


### PR DESCRIPTION
- Show the PVS tab only when the supplemental pack is installed 
- Hide memory SR in XenCenter 