### PR TITLE
[CA-114492] Stop GroupBy buttons remaining overlapped…

### DIFF
--- a/XenAdmin/Controls/XenSearch/GroupingControl.cs
+++ b/XenAdmin/Controls/XenSearch/GroupingControl.cs
@@ -403,6 +403,7 @@ namespace XenAdmin.Controls.XenSearch
         {
             draggedButton = null;
             dragging = false;
+            Setup();
         }
 
         void button_MouseDown(object sender, MouseEventArgs e)

--- a/XenAdmin/Controls/XenSearch/GroupingControl.cs
+++ b/XenAdmin/Controls/XenSearch/GroupingControl.cs
@@ -401,9 +401,13 @@ namespace XenAdmin.Controls.XenSearch
 
         void button_MouseUp(object sender, MouseEventArgs e)
         {
+            bool wasDragging = dragging;
+
             draggedButton = null;
             dragging = false;
-            Setup();
+
+            if(wasDragging)
+                Setup();
         }
 
         void button_MouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION
 ...after a drag operation by ensuring they snap back to a correct setup on mouseup

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>