### PR TITLE
CA-214653: Work-around for XC reconnecting to proxy server with new wrong credentials

### DIFF
--- a/XenModel/Network/Heartbeat.cs
+++ b/XenModel/Network/Heartbeat.cs
@@ -148,6 +148,23 @@ namespace XenAdmin.Network
                 HandleConnectionLoss();
                 return;
             }
+            catch (WebException exn)
+            {
+                log.Error(exn);
+                if (((HttpWebResponse)exn.Response).StatusCode == HttpStatusCode.ProxyAuthenticationRequired) // work-around for CA-214653
+                {
+                    log.DebugFormat("Heartbeat for {0} has failed due to {1} credentials; closing the main connection",
+                        session == null ? "null" : session.Url,
+                        session.proxy.Proxy.Credentials == null ? "missing" : "incorrect");
+                    connection.Interrupt();
+                    DropSession();
+                }
+                else
+                {
+                    HandleConnectionLoss();
+                }
+                return;
+            }
             catch (Exception exn)
             {
                 log.Error(exn);


### PR DESCRIPTION
Normally, a heartbeat is done every 15 seconds by getting the server time, and starts as soon as connection to host is established, but if an error occurs XC retries once more in another 15 seconds before actually closing the connection to the host.

Now, if a 407 Proxy Authentication Required error occurs on the initial heartbeat then XC does not retry again in 15 seconds; it will close the connection immediately. The disconnection was instant to up to 2 seconds, depending on time taken to get server time (testing with FreeProxy was ~instant and CCProxy was ~2 seconds). This is only a work-around, as the exact reason for this behaviour is still unknown.

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>