### PR TITLE
CA-225015: XenCenter Allows VM migration to MemorySR

### DIFF
--- a/XenAdmin/Dialogs/AttachDiskDialog.cs
+++ b/XenAdmin/Dialogs/AttachDiskDialog.cs
@@ -302,7 +302,11 @@ namespace XenAdmin.Dialogs
 
             Host affinity = TheVM.Connection.Resolve<Host>(TheVM.affinity);
             Host activeHost = TheVM.Connection.Resolve<Host>(TheVM.resident_on);
-            if (TheSR.content_type != SR.Content_Type_ISO && !((affinity != null && !TheSR.CanBeSeenFrom(affinity)) || (activeHost != null && TheVM.power_state == vm_power_state.Running && !TheSR.CanBeSeenFrom(activeHost))  || TheSR.IsBroken(false) || TheSR.PBDs.Count < 1))
+            if (!TheSR.Show(Properties.Settings.Default.ShowHiddenVMs))
+            {
+                Show = false;
+            }
+            else if (TheSR.content_type != SR.Content_Type_ISO && !((affinity != null && !TheSR.CanBeSeenFrom(affinity)) || (activeHost != null && TheVM.power_state == vm_power_state.Running && !TheSR.CanBeSeenFrom(activeHost))  || TheSR.IsBroken(false) || TheSR.PBDs.Count < 1))
             {
                 Description = "";
                 Enabled = true;

--- a/XenAdmin/Wizards/GenericPages/SelectVMStorageWithMultipleVirtualDisksPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectVMStorageWithMultipleVirtualDisksPage.cs
@@ -429,7 +429,7 @@ namespace XenAdmin.Wizards.GenericPages
 					continue;
 
                 var sr = TargetConnection.Resolve(pbd.SR);
-				if (sr == null || sr.IsDetached)
+                if (sr == null || sr.IsDetached || !sr.Show(XenAdminConfigManager.Provider.ShowHiddenVMs))
 					continue;
 
                 if ((sr.content_type.ToLower() == "iso" || sr.type.ToLower() == "iso") && !resource.SRTypeInvalid)

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -513,6 +513,10 @@ namespace XenAPI
             if (content_type == SR.Content_Type_ISO)
                 return false;
 
+            // Memory SRs should not support VDI create in the GUI
+            if (GetSRType(false) == SR.SRTypes.tmpfs)
+                return false;
+
             Host master = Helpers.GetMaster(Connection);
             if (master == null)
                 return false;


### PR DESCRIPTION
- We shouldn't include the hidden SRs in the list of available SRs in the Migration wizard
- Updated the SR.SupportsVdiCreate function to return false for the Memory SR; this fixes other places where the Memory SR might be visible (e.g. all places where SrPicker is used)
- Also fixed the same issue in the  Attach disk dialog

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>