### PR TITLE
CA-224666: Things in PVS tab constantly refreshing

### DIFF
--- a/XenAdmin/Controls/PvsCacheStorageRow.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.cs
@@ -167,8 +167,10 @@ namespace XenAdmin.Controls
         {
             get
             {
-                if (OrigPvsCacheStorage == null || CacheSr == null)
-                    return true;
+                if (OrigPvsCacheStorage == null)
+                    return CacheSr != null;
+                if (CacheSr == null)
+                    return OrigPvsCacheStorage != null;
                 return OrigPvsCacheStorage.SR.opaque_ref != CacheSr.opaque_ref || origCacheSizeGb != numericUpDownCacheSize.Value;
             }
         }

--- a/XenAdmin/Dialogs/AttachDiskDialog.cs
+++ b/XenAdmin/Dialogs/AttachDiskDialog.cs
@@ -302,7 +302,11 @@ namespace XenAdmin.Dialogs
 
             Host affinity = TheVM.Connection.Resolve<Host>(TheVM.affinity);
             Host activeHost = TheVM.Connection.Resolve<Host>(TheVM.resident_on);
-            if (TheSR.content_type != SR.Content_Type_ISO && !((affinity != null && !TheSR.CanBeSeenFrom(affinity)) || (activeHost != null && TheVM.power_state == vm_power_state.Running && !TheSR.CanBeSeenFrom(activeHost))  || TheSR.IsBroken(false) || TheSR.PBDs.Count < 1))
+            if (!TheSR.Show(Properties.Settings.Default.ShowHiddenVMs))
+            {
+                Show = false;
+            }
+            else if (TheSR.content_type != SR.Content_Type_ISO && !((affinity != null && !TheSR.CanBeSeenFrom(affinity)) || (activeHost != null && TheVM.power_state == vm_power_state.Running && !TheSR.CanBeSeenFrom(activeHost))  || TheSR.IsBroken(false) || TheSR.PBDs.Count < 1))
             {
                 Description = "";
                 Enabled = true;

--- a/XenAdmin/Wizards/GenericPages/SelectVMStorageWithMultipleVirtualDisksPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectVMStorageWithMultipleVirtualDisksPage.cs
@@ -429,7 +429,7 @@ namespace XenAdmin.Wizards.GenericPages
 					continue;
 
                 var sr = TargetConnection.Resolve(pbd.SR);
-				if (sr == null || sr.IsDetached)
+                if (sr == null || sr.IsDetached || !sr.Show(XenAdminConfigManager.Provider.ShowHiddenVMs))
 					continue;
 
                 if ((sr.content_type.ToLower() == "iso" || sr.type.ToLower() == "iso") && !resource.SRTypeInvalid)

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -513,6 +513,10 @@ namespace XenAPI
             if (content_type == SR.Content_Type_ISO)
                 return false;
 
+            // Memory SRs should not support VDI create in the GUI
+            if (GetSRType(false) == SR.SRTypes.tmpfs)
+                return false;
+
             Host master = Helpers.GetMaster(Connection);
             if (master == null)
                 return false;


### PR DESCRIPTION

- instead of repopulating the whole grid when a proxy or a site changes, we now refresh just the row that needs refreshing, and when the refresh is indeed needed.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>