### PR TITLE
CP-19111: Added ability to choose Basic or Digest authentication for proxy server

### DIFF
--- a/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.Designer.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.Designer.cs
@@ -52,12 +52,17 @@ namespace XenAdmin.Dialogs.OptionsPages
             this.ProxyAddressTextBox = new System.Windows.Forms.TextBox();
             this.ProxyPortTextBox = new System.Windows.Forms.TextBox();
             this.ProxyPortLabel = new System.Windows.Forms.Label();
+            this.AuthenticationMethodLabel = new System.Windows.Forms.Label();
+            this.AuthenticationMethodPanel = new System.Windows.Forms.Panel();
+            this.DigestRadioButton = new System.Windows.Forms.RadioButton();
+            this.BasicRadioButton = new System.Windows.Forms.RadioButton();
             this.ConnectionTableLayoutPanel.SuspendLayout();
             this.TimeoutGroupBox.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ConnectionTimeoutNud)).BeginInit();
             this.ProxyGroupBox.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
+            this.AuthenticationMethodPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // ConnectionTableLayoutPanel
@@ -135,18 +140,20 @@ namespace XenAdmin.Dialogs.OptionsPages
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.BypassForServersCheckbox, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.ProxyPasswordTextBox, 6, 6);
+            this.tableLayoutPanel1.Controls.Add(this.ProxyPasswordTextBox, 7, 6);
             this.tableLayoutPanel1.Controls.Add(this.ProxyUsernameLabel, 2, 6);
-            this.tableLayoutPanel1.Controls.Add(this.ProxyUsernameTextBox, 4, 6);
-            this.tableLayoutPanel1.Controls.Add(this.ProxyPasswordLabel, 5, 6);
+            this.tableLayoutPanel1.Controls.Add(this.ProxyUsernameTextBox, 3, 6);
+            this.tableLayoutPanel1.Controls.Add(this.ProxyPasswordLabel, 6, 6);
             this.tableLayoutPanel1.Controls.Add(this.AuthenticationCheckBox, 1, 5);
             this.tableLayoutPanel1.Controls.Add(this.ProxyAddressLabel, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.UseProxyRadioButton, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.DirectConnectionRadioButton, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.UseIERadioButton, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.ProxyAddressTextBox, 3, 3);
-            this.tableLayoutPanel1.Controls.Add(this.ProxyPortTextBox, 5, 3);
-            this.tableLayoutPanel1.Controls.Add(this.ProxyPortLabel, 4, 3);
+            this.tableLayoutPanel1.Controls.Add(this.ProxyPortTextBox, 7, 3);
+            this.tableLayoutPanel1.Controls.Add(this.ProxyPortLabel, 6, 3);
+            this.tableLayoutPanel1.Controls.Add(this.AuthenticationMethodLabel, 2, 8);
+            this.tableLayoutPanel1.Controls.Add(this.AuthenticationMethodPanel, 5, 8);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // BypassForServersCheckbox
@@ -172,6 +179,7 @@ namespace XenAdmin.Dialogs.OptionsPages
             // 
             // ProxyUsernameTextBox
             // 
+            this.tableLayoutPanel1.SetColumnSpan(this.ProxyUsernameTextBox, 2);
             resources.ApplyResources(this.ProxyUsernameTextBox, "ProxyUsernameTextBox");
             this.ProxyUsernameTextBox.Name = "ProxyUsernameTextBox";
             this.ProxyUsernameTextBox.TextChanged += new System.EventHandler(this.ProxyUsernameTextBox_TextChanged);
@@ -222,7 +230,7 @@ namespace XenAdmin.Dialogs.OptionsPages
             // 
             // ProxyAddressTextBox
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.ProxyAddressTextBox, 2);
+            this.tableLayoutPanel1.SetColumnSpan(this.ProxyAddressTextBox, 3);
             resources.ApplyResources(this.ProxyAddressTextBox, "ProxyAddressTextBox");
             this.ProxyAddressTextBox.Name = "ProxyAddressTextBox";
             this.ProxyAddressTextBox.TextChanged += new System.EventHandler(this.ProxyAddressTextBox_TextChanged);
@@ -237,6 +245,34 @@ namespace XenAdmin.Dialogs.OptionsPages
             // 
             resources.ApplyResources(this.ProxyPortLabel, "ProxyPortLabel");
             this.ProxyPortLabel.Name = "ProxyPortLabel";
+            // 
+            // AuthenticationMethodLabel
+            // 
+            resources.ApplyResources(this.AuthenticationMethodLabel, "AuthenticationMethodLabel");
+            this.tableLayoutPanel1.SetColumnSpan(this.AuthenticationMethodLabel, 3);
+            this.AuthenticationMethodLabel.Name = "AuthenticationMethodLabel";
+            // 
+            // AuthenticationMethodPanel
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.AuthenticationMethodPanel, 2);
+            this.AuthenticationMethodPanel.Controls.Add(this.DigestRadioButton);
+            this.AuthenticationMethodPanel.Controls.Add(this.BasicRadioButton);
+            resources.ApplyResources(this.AuthenticationMethodPanel, "AuthenticationMethodPanel");
+            this.AuthenticationMethodPanel.Name = "AuthenticationMethodPanel";
+            // 
+            // DigestRadioButton
+            // 
+            resources.ApplyResources(this.DigestRadioButton, "DigestRadioButton");
+            this.DigestRadioButton.Name = "DigestRadioButton";
+            this.DigestRadioButton.UseVisualStyleBackColor = true;
+            this.DigestRadioButton.CheckedChanged += new System.EventHandler(this.DigestRadioButton_CheckedChanged);
+            // 
+            // BasicRadioButton
+            // 
+            resources.ApplyResources(this.BasicRadioButton, "BasicRadioButton");
+            this.BasicRadioButton.Name = "BasicRadioButton";
+            this.BasicRadioButton.UseVisualStyleBackColor = true;
+            this.BasicRadioButton.CheckedChanged += new System.EventHandler(this.BasicRadioButton_CheckedChanged);
             // 
             // ConnectionOptionsPage
             // 
@@ -255,6 +291,8 @@ namespace XenAdmin.Dialogs.OptionsPages
             this.ProxyGroupBox.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.AuthenticationMethodPanel.ResumeLayout(false);
+            this.AuthenticationMethodPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -285,5 +323,9 @@ namespace XenAdmin.Dialogs.OptionsPages
         private System.Windows.Forms.Label ProxyUsernameLabel;
         private System.Windows.Forms.TextBox ProxyUsernameTextBox;
         private System.Windows.Forms.Label ProxyPasswordLabel;
+        private System.Windows.Forms.RadioButton BasicRadioButton;
+        private System.Windows.Forms.Label AuthenticationMethodLabel;
+        private System.Windows.Forms.RadioButton DigestRadioButton;
+        private System.Windows.Forms.Panel AuthenticationMethodPanel;
     }
 }

--- a/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.Designer.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.Designer.cs
@@ -162,14 +162,14 @@ namespace XenAdmin.Dialogs.OptionsPages
             this.tableLayoutPanel1.SetColumnSpan(this.BypassForServersCheckbox, 6);
             this.BypassForServersCheckbox.Name = "BypassForServersCheckbox";
             this.BypassForServersCheckbox.UseVisualStyleBackColor = true;
-            this.BypassForServersCheckbox.CheckedChanged += new System.EventHandler(this.BypassForServersCheckbox_CheckedChanged);
+            this.BypassForServersCheckbox.CheckedChanged += new System.EventHandler(this.GeneralProxySettingsChanged);
             // 
             // ProxyPasswordTextBox
             // 
             resources.ApplyResources(this.ProxyPasswordTextBox, "ProxyPasswordTextBox");
             this.ProxyPasswordTextBox.Name = "ProxyPasswordTextBox";
             this.ProxyPasswordTextBox.UseSystemPasswordChar = true;
-            this.ProxyPasswordTextBox.TextChanged += new System.EventHandler(this.ProxyPasswordTextBox_TextChanged);
+            this.ProxyPasswordTextBox.TextChanged += new System.EventHandler(this.ProxyAuthenticationSettingsChanged);
             // 
             // ProxyUsernameLabel
             // 
@@ -182,7 +182,7 @@ namespace XenAdmin.Dialogs.OptionsPages
             this.tableLayoutPanel1.SetColumnSpan(this.ProxyUsernameTextBox, 2);
             resources.ApplyResources(this.ProxyUsernameTextBox, "ProxyUsernameTextBox");
             this.ProxyUsernameTextBox.Name = "ProxyUsernameTextBox";
-            this.ProxyUsernameTextBox.TextChanged += new System.EventHandler(this.ProxyUsernameTextBox_TextChanged);
+            this.ProxyUsernameTextBox.TextChanged += new System.EventHandler(this.ProxyAuthenticationSettingsChanged);
             // 
             // ProxyPasswordLabel
             // 
@@ -233,13 +233,13 @@ namespace XenAdmin.Dialogs.OptionsPages
             this.tableLayoutPanel1.SetColumnSpan(this.ProxyAddressTextBox, 3);
             resources.ApplyResources(this.ProxyAddressTextBox, "ProxyAddressTextBox");
             this.ProxyAddressTextBox.Name = "ProxyAddressTextBox";
-            this.ProxyAddressTextBox.TextChanged += new System.EventHandler(this.ProxyAddressTextBox_TextChanged);
+            this.ProxyAddressTextBox.TextChanged += new System.EventHandler(this.GeneralProxySettingsChanged);
             // 
             // ProxyPortTextBox
             // 
             resources.ApplyResources(this.ProxyPortTextBox, "ProxyPortTextBox");
             this.ProxyPortTextBox.Name = "ProxyPortTextBox";
-            this.ProxyPortTextBox.TextChanged += new System.EventHandler(this.ProxyPortTextBox_TextChanged);
+            this.ProxyPortTextBox.TextChanged += new System.EventHandler(this.GeneralProxySettingsChanged);
             // 
             // ProxyPortLabel
             // 
@@ -265,14 +265,14 @@ namespace XenAdmin.Dialogs.OptionsPages
             resources.ApplyResources(this.DigestRadioButton, "DigestRadioButton");
             this.DigestRadioButton.Name = "DigestRadioButton";
             this.DigestRadioButton.UseVisualStyleBackColor = true;
-            this.DigestRadioButton.CheckedChanged += new System.EventHandler(this.DigestRadioButton_CheckedChanged);
+            this.DigestRadioButton.CheckedChanged += new System.EventHandler(this.ProxyAuthenticationSettingsChanged);
             // 
             // BasicRadioButton
             // 
             resources.ApplyResources(this.BasicRadioButton, "BasicRadioButton");
             this.BasicRadioButton.Name = "BasicRadioButton";
             this.BasicRadioButton.UseVisualStyleBackColor = true;
-            this.BasicRadioButton.CheckedChanged += new System.EventHandler(this.BasicRadioButton_CheckedChanged);
+            this.BasicRadioButton.CheckedChanged += new System.EventHandler(this.ProxyAuthenticationSettingsChanged);
             // 
             // ConnectionOptionsPage
             // 

--- a/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.cs
@@ -151,73 +151,19 @@ namespace XenAdmin.Dialogs.OptionsPages
             enableOK();
         }
 
-        private void ProxyAddressTextBox_TextChanged(object sender, EventArgs e)
+        private void GeneralProxySettingsChanged(object sender, EventArgs e)
         {
             if (eventsDisabled)
                 return;
-
             SelectUseThisProxyServer();
-
             enableOK();
         }
 
-        private void ProxyPortTextBox_TextChanged(object sender, EventArgs e)
+        private void ProxyAuthenticationSettingsChanged(object sender, EventArgs e)
         {
             if (eventsDisabled)
                 return;
-
-            SelectUseThisProxyServer();
-
-            enableOK();
-        }
-
-        private void ProxyUsernameTextBox_TextChanged(object sender, EventArgs e)
-        {
-            if (eventsDisabled)
-                return;
-
             SelectProvideCredentials();
-
-            enableOK();
-        }
-
-        private void ProxyPasswordTextBox_TextChanged(object sender, EventArgs e)
-        {
-            if (eventsDisabled)
-                return;
-
-            SelectProvideCredentials();
-
-            enableOK();
-        }
-
-        private void BypassForServersCheckbox_CheckedChanged(object sender, EventArgs e)
-        {
-            if (eventsDisabled)
-                return;
-
-            SelectUseThisProxyServer();
-
-            enableOK();
-        }
-
-        private void BasicRadioButton_CheckedChanged(object sender, EventArgs e)
-        {
-            if (eventsDisabled)
-                return;
-
-            SelectProvideCredentials();
-
-            enableOK();
-        }
-
-        private void DigestRadioButton_CheckedChanged(object sender, EventArgs e)
-        {
-            if (eventsDisabled)
-                return;
-
-            SelectProvideCredentials();
-
             enableOK();
         }
 

--- a/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.resx
+++ b/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.resx
@@ -319,7 +319,7 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="TimeoutGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 241</value>
+    <value>3, 267</value>
   </data>
   <data name="TimeoutGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 0</value>
@@ -403,13 +403,13 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="ProxyPasswordTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 139</value>
+    <value>365, 139</value>
   </data>
   <data name="ProxyPasswordTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 3, 0</value>
   </data>
   <data name="ProxyPasswordTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>140, 20</value>
+    <value>137, 20</value>
   </data>
   <data name="ProxyPasswordTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -475,13 +475,13 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="ProxyUsernameTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 139</value>
+    <value>105, 139</value>
   </data>
   <data name="ProxyUsernameTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 3, 0</value>
   </data>
   <data name="ProxyUsernameTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 20</value>
+    <value>192, 20</value>
   </data>
   <data name="ProxyUsernameTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -511,7 +511,7 @@
     <value>NoControl</value>
   </data>
   <data name="ProxyPasswordLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>298, 136</value>
+    <value>308, 136</value>
   </data>
   <data name="ProxyPasswordLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
@@ -598,7 +598,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="ProxyAddressLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 23</value>
+    <value>55, 23</value>
   </data>
   <data name="ProxyAddressLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -727,7 +727,7 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="ProxyAddressTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>70, 72</value>
+    <value>75, 72</value>
   </data>
   <data name="ProxyAddressTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 3, 0</value>
@@ -757,7 +757,7 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="ProxyPortTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 72</value>
+    <value>365, 72</value>
   </data>
   <data name="ProxyPortTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 3, 0</value>
@@ -766,7 +766,7 @@
     <value>5</value>
   </data>
   <data name="ProxyPortTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>140, 20</value>
+    <value>137, 20</value>
   </data>
   <data name="ProxyPortTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -796,7 +796,7 @@
     <value>NoControl</value>
   </data>
   <data name="ProxyPortLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>324, 74</value>
+    <value>334, 74</value>
   </data>
   <data name="ProxyPortLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
@@ -825,14 +825,143 @@
   <data name="&gt;&gt;ProxyPortLabel.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
+  <data name="AuthenticationMethodLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="AuthenticationMethodLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="AuthenticationMethodLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="AuthenticationMethodLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 159</value>
+  </data>
+  <data name="AuthenticationMethodLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="AuthenticationMethodLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 0</value>
+  </data>
+  <data name="AuthenticationMethodLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 18</value>
+  </data>
+  <data name="AuthenticationMethodLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="AuthenticationMethodLabel.Text" xml:space="preserve">
+    <value>Authentication method:</value>
+  </data>
+  <data name="AuthenticationMethodLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodLabel.Name" xml:space="preserve">
+    <value>AuthenticationMethodLabel</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodLabel.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="DigestRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="DigestRadioButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="DigestRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="DigestRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>60, 0</value>
+  </data>
+  <data name="DigestRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 17</value>
+  </data>
+  <data name="DigestRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="DigestRadioButton.Text" xml:space="preserve">
+    <value>Di&amp;gest</value>
+  </data>
+  <data name="&gt;&gt;DigestRadioButton.Name" xml:space="preserve">
+    <value>DigestRadioButton</value>
+  </data>
+  <data name="&gt;&gt;DigestRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DigestRadioButton.Parent" xml:space="preserve">
+    <value>AuthenticationMethodPanel</value>
+  </data>
+  <data name="&gt;&gt;DigestRadioButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="BasicRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="BasicRadioButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="BasicRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BasicRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="BasicRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>49, 17</value>
+  </data>
+  <data name="BasicRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="BasicRadioButton.Text" xml:space="preserve">
+    <value>Ba&amp;sic</value>
+  </data>
+  <data name="&gt;&gt;BasicRadioButton.Name" xml:space="preserve">
+    <value>BasicRadioButton</value>
+  </data>
+  <data name="&gt;&gt;BasicRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BasicRadioButton.Parent" xml:space="preserve">
+    <value>AuthenticationMethodPanel</value>
+  </data>
+  <data name="&gt;&gt;BasicRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="AuthenticationMethodPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>183, 162</value>
+  </data>
+  <data name="AuthenticationMethodPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 20</value>
+  </data>
+  <data name="AuthenticationMethodPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodPanel.Name" xml:space="preserve">
+    <value>AuthenticationMethodPanel</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodPanel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;AuthenticationMethodPanel.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 19</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>498, 159</value>
+    <value>505, 185</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -850,7 +979,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="BypassForServersCheckbox" Row="4" RowSpan="1" Column="1" ColumnSpan="6" /&gt;&lt;Control Name="ProxyPasswordTextBox" Row="6" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="ProxyUsernameLabel" Row="6" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="ProxyUsernameTextBox" Row="6" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="ProxyPasswordLabel" Row="6" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="AuthenticationCheckBox" Row="5" RowSpan="1" Column="1" ColumnSpan="6" /&gt;&lt;Control Name="ProxyAddressLabel" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="UseProxyRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="DirectConnectionRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="UseIERadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="ProxyAddressTextBox" Row="3" RowSpan="1" Column="3" ColumnSpan="2" /&gt;&lt;Control Name="ProxyPortTextBox" Row="3" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="ProxyPortLabel" Row="3" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="BypassForServersCheckbox" Row="4" RowSpan="1" Column="1" ColumnSpan="6" /&gt;&lt;Control Name="ProxyPasswordTextBox" Row="6" RowSpan="1" Column="7" ColumnSpan="1" /&gt;&lt;Control Name="ProxyUsernameLabel" Row="6" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="ProxyUsernameTextBox" Row="6" RowSpan="1" Column="3" ColumnSpan="2" /&gt;&lt;Control Name="ProxyPasswordLabel" Row="6" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="AuthenticationCheckBox" Row="5" RowSpan="1" Column="1" ColumnSpan="6" /&gt;&lt;Control Name="ProxyAddressLabel" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="UseProxyRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="DirectConnectionRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="UseIERadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="ProxyAddressTextBox" Row="3" RowSpan="1" Column="3" ColumnSpan="3" /&gt;&lt;Control Name="ProxyPortTextBox" Row="3" RowSpan="1" Column="7" ColumnSpan="1" /&gt;&lt;Control Name="ProxyPortLabel" Row="3" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="AuthenticationMethodLabel" Row="8" RowSpan="1" Column="2" ColumnSpan="3" /&gt;&lt;Control Name="AuthenticationMethodPanel" Row="8" RowSpan="1" Column="5" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,Absolute,20,Absolute,35,Absolute,30,Absolute,75,Absolute,120,Absolute,65,Absolute,140" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="ProxyGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -865,7 +994,7 @@
     <value>3, 3, 3, 0</value>
   </data>
   <data name="ProxyGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>584, 194</value>
+    <value>584, 220</value>
   </data>
   <data name="ProxyGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -503,15 +503,17 @@ namespace XenAdmin
             try
             {
                 Settings.RestoreSession();
-                new TransferProxySettingsAction((HTTPHelper.ProxyStyle)Properties.Settings.Default.ProxySetting,
-                                Properties.Settings.Default.ProxyAddress,
-                                Properties.Settings.Default.ProxyPort,
-                                Properties.Settings.Default.ConnectionTimeout,
-                                true,
-                                Properties.Settings.Default.BypassProxyForServers,
-                                Properties.Settings.Default.ProvideProxyAuthentication,
-                                Properties.Settings.Default.ProxyUsername,
-                                Properties.Settings.Default.ProxyPassword).RunAsync();
+                new TransferProxySettingsAction(
+                    (HTTPHelper.ProxyStyle)Properties.Settings.Default.ProxySetting,
+                    Properties.Settings.Default.ProxyAddress,
+                    Properties.Settings.Default.ProxyPort,
+                    Properties.Settings.Default.ConnectionTimeout,
+                    true,
+                    Properties.Settings.Default.BypassProxyForServers,
+                    Properties.Settings.Default.ProvideProxyAuthentication,
+                    Properties.Settings.Default.ProxyUsername,
+                    Properties.Settings.Default.ProxyPassword,
+                    (HTTPHelper.ProxyAuthenticationMethod)Properties.Settings.Default.ProxyAuthenticationMethod).RunAsync();
             }
             catch (ConfigurationErrorsException ex)
             {

--- a/XenAdmin/Program.cs
+++ b/XenAdmin/Program.cs
@@ -56,7 +56,14 @@ namespace XenAdmin
     {
         public const int DEFAULT_WLB_PORT = 8012;
 
-
+        /// <summary>
+        /// Module for authenticating with proxy server using the Basic authentication scheme.
+        /// </summary>
+        private static IAuthenticationModule BasicAuthenticationModule = null;
+        /// <summary>
+        /// Module for authenticating with proxy server using the Digest authentication scheme.
+        /// </summary>
+        private static IAuthenticationModule DigestAuthenticationModule = null;
 
         /// <summary>
         /// A UUID for the current instance of XenCenter.  Used to identify our own task instances.
@@ -303,6 +310,7 @@ namespace XenAdmin
             ServicePointManager.ServerCertificateValidationCallback = SSL.ValidateServerCertificate;
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
             XenAPI.Session.UserAgent = string.Format("XenCenter/{0}", ClientVersion());
+            RememberProxyAuthenticationModules();
             ReconfigureConnectionSettings();
 
             log.Info("Application started");
@@ -990,7 +998,57 @@ namespace XenAdmin
                 Properties.Settings.Default.ProvideProxyAuthentication = false;
                 Properties.Settings.Default.Save();
             }
+            else
+            {
+                ReconfigureProxyAuthenticationSettings();
+            }
             XenAPI.Session.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null);
+        }
+
+        /// <summary>
+        /// Stores the Basic and Digest authentication modules, used for proxy server authentication, 
+        /// for later use; this is needed because we cannot create new instances of them and it 
+        /// saves us needing to create our own custom authentication modules.
+        /// </summary>
+        private static void RememberProxyAuthenticationModules()
+        {
+            var authModules = AuthenticationManager.RegisteredModules;
+            while (authModules.MoveNext())
+            {
+                var module = (IAuthenticationModule)authModules.Current;
+                if (module.AuthenticationType == "Basic")
+                    BasicAuthenticationModule = module;
+                else if (module.AuthenticationType == "Digest")
+                    DigestAuthenticationModule = module;
+            }
+        }
+
+        /// <summary>
+        /// Configures .NET's AuthenticationManager to only use the authentication module that is 
+        /// specified in the ProxyAuthenticationMethod setting. Also sets XenAPI's HTTP class to 
+        /// use the same authentication method.
+        /// </summary>
+        private static void ReconfigureProxyAuthenticationSettings()
+        {
+            var authModules = AuthenticationManager.RegisteredModules;
+            var modulesToUnregister = new List<IAuthenticationModule>();
+
+            while (authModules.MoveNext())
+            {
+                var module = (IAuthenticationModule)authModules.Current;
+                modulesToUnregister.Add(module);
+            }
+
+            foreach (var module in modulesToUnregister)
+                AuthenticationManager.Unregister(module);
+
+            var authSetting = (HTTPHelper.ProxyAuthenticationMethod)Properties.Settings.Default.ProxyAuthenticationMethod;
+            if (authSetting == HTTPHelper.ProxyAuthenticationMethod.Basic)
+                AuthenticationManager.Register(BasicAuthenticationModule);
+            else
+                AuthenticationManager.Register(DigestAuthenticationModule);
+
+            XenAPI.HTTP.ProxyAuthenticationMethod = authSetting;
         }
 
         private const string SplashWindowClass = "XenCenterSplash0001";

--- a/XenAdmin/Properties/Settings.Designer.cs
+++ b/XenAdmin/Properties/Settings.Designer.cs
@@ -743,5 +743,17 @@ namespace XenAdmin.Properties {
                 this["BypassProxyForServers"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int ProxyAuthenticationMethod {
+            get {
+                return ((int)(this["ProxyAuthenticationMethod"]));
+            }
+            set {
+                this["ProxyAuthenticationMethod"] = value;
+            }
+        }
     }
 }

--- a/XenAdmin/Properties/Settings.settings
+++ b/XenAdmin/Properties/Settings.settings
@@ -173,5 +173,8 @@
     <Setting Name="BypassProxyForServers" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ProxyAuthenticationMethod" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -168,6 +168,9 @@
             <setting name="BypassProxyForServers" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="ProxyAuthenticationMethod" serializeAs="String">
+                <value>1</value>
+            </setting>
         </XenAdmin.Properties.Settings>
     </userSettings>
 

--- a/XenModel/Actions/HealthCheck/TransferProxySettingsAction.cs
+++ b/XenModel/Actions/HealthCheck/TransferProxySettingsAction.cs
@@ -48,9 +48,10 @@ namespace XenAdmin.Actions
         private bool provideProxyCredentials;
         private string proxyUsername;
         private string proxyPassword;
+        private HTTPHelper.ProxyAuthenticationMethod proxyAuthenticationMethod;
 
         public TransferProxySettingsAction(HTTPHelper.ProxyStyle style, string address, int port, int timeout,
-            bool suppressHistory, bool bypassForServer, bool provideCredentials, string username, string password)
+            bool suppressHistory, bool bypassForServer, bool provideCredentials, string username, string password, HTTPHelper.ProxyAuthenticationMethod proxyAuthMethod)
             : base(null, Messages.ACTION_TRANSFER_HEALTHCHECK_SETTINGS, Messages.ACTION_TRANSFER_HEALTHCHECK_SETTINGS, suppressHistory)
         {
             proxyStyle = style;
@@ -61,6 +62,7 @@ namespace XenAdmin.Actions
             provideProxyCredentials = provideCredentials;
             proxyUsername = username;
             proxyPassword = password;
+            proxyAuthenticationMethod = proxyAuthMethod;
         }
 
         private const string HEALTHCHECKSERVICENAME = "XenServerHealthCheck";
@@ -81,7 +83,8 @@ namespace XenAdmin.Actions
                             bypassProxyForServers.ToString(),
                             provideProxyCredentials.ToString(),
                             proxyUsername.ToString(),
-                            proxyPassword.ToString()});
+                            proxyPassword.ToString(),
+                            ((Int32)proxyAuthenticationMethod).ToString()});
                     return proxySettings;
                     
                 case HTTPHelper.ProxyStyle.SystemProxy:

--- a/XenModel/Network/HTTPHelper.cs
+++ b/XenModel/Network/HTTPHelper.cs
@@ -52,6 +52,13 @@ namespace XenAPI
             SpecifiedProxy = 2
         }
 
+        public enum ProxyAuthenticationMethod
+        {
+            // Note that these numbers make it into user settings files, so need to be preserved.
+            Basic = 0,
+            Digest = 1
+        }
+
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 

--- a/XenServerHealthCheck/Properties/Settings.Designer.cs
+++ b/XenServerHealthCheck/Properties/Settings.Designer.cs
@@ -163,5 +163,17 @@ namespace XenServerHealthCheck.Properties {
                 this["ProxyPassword"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int ProxyAuthenticationMethod {
+            get {
+                return ((int)(this["ProxyAuthenticationMethod"]));
+            }
+            set {
+                this["ProxyAuthenticationMethod"] = value;
+            }
+        }
     }
 }

--- a/XenServerHealthCheck/Properties/Settings.settings
+++ b/XenServerHealthCheck/Properties/Settings.settings
@@ -36,5 +36,8 @@
     <Setting Name="ProxyPassword" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ProxyAuthenticationMethod" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/XenServerHealthCheck/ServerListHelper.cs
+++ b/XenServerHealthCheck/ServerListHelper.cs
@@ -232,6 +232,7 @@ namespace XenServerHealthCheck
                         Properties.Settings.Default.ProvideProxyAuthentication = bool.Parse(proxySettings[6]);
                         Properties.Settings.Default.ProxyUsername = proxySettings[7];
                         Properties.Settings.Default.ProxyPassword = proxySettings[8];
+                        Properties.Settings.Default.ProxyAuthenticationMethod = Int32.Parse(proxySettings[9]);
                         break;
 
                     case HTTPHelper.ProxyStyle.SystemProxy:

--- a/XenServerHealthCheck/XenServerHealthCheckService.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckService.cs
@@ -76,6 +76,8 @@ namespace XenServerHealthCheck
         public static void ReconfigureConnectionSettings()
         {
             XenAPI.Session.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null);
+            XenAPI.HTTP.ProxyAuthenticationMethod = 
+                (HTTPHelper.ProxyAuthenticationMethod)Properties.Settings.Default.ProxyAuthenticationMethod;
         }
 
         protected override void OnStart(string[] args)

--- a/XenServerHealthCheck/app.config
+++ b/XenServerHealthCheck/app.config
@@ -81,6 +81,9 @@
       <setting name="ProxyPassword" serializeAs="String">
         <value />
       </setting>
+      <setting name="ProxyAuthenticationMethod" serializeAs="String">
+        <value>1</value>
+      </setting>
     </XenServerHealthCheck.Properties.Settings>
   </userSettings>
 </configuration>


### PR DESCRIPTION
2 new radio buttons in Connection Options page, for Basic and Digest; Digest is the default as it's the most secure.
New proxy authentication method setting, which is used to configure XenAPI's HTTP class and the .NET AuthenticationManager (which handles which authentication schemes can be used by the .NET web classes).
The new setting is also transferred and used by the Health Check service.

The bug noted in CA-214653 also occurs here, but the work-around on PR#1201 for that bug will also work for this.

Signed-off-by: Frezzle <frederico.mazzone@citrix.com>