### PR TITLE
[CA-225062] For Ely and greater hosts, don't check for IO tools when activating/deactivating (this covers detatch + delete too in UI) a VBD

### DIFF
--- a/XenAdmin/Commands/ActivateVBDCommand.cs
+++ b/XenAdmin/Commands/ActivateVBDCommand.cs
@@ -75,6 +75,17 @@ namespace XenAdmin.Commands
             return selection.AllItemsAre<VBD>() && selection.AtLeastOneXenObjectCan<VBD>(CanExecute);
         }
 
+        // We only need to check for IO Drivers for hosts before Ely
+        private bool AreIODriversNeededAndMissing(VM vm)
+        {
+            if (Helpers.ElyOrGreater(vm.Connection))
+            {
+                return false;
+            }
+
+            return !vm.GetVirtualisationStatus.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED);
+        }
+
         private bool CanExecute(VBD vbd)
         {
             VM vm = vbd.Connection.Resolve<VM>(vbd.VM);
@@ -85,7 +96,7 @@ namespace XenAdmin.Commands
                 return false;
             if (vdi.type == vdi_type.system)
                 return false;
-            if (!vm.GetVirtualisationStatus.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+            if (AreIODriversNeededAndMissing(vm))
                 return false;    
             if (vbd.currently_attached)
                 return false;
@@ -121,7 +132,7 @@ namespace XenAdmin.Commands
             if (vdi.type == vdi_type.system)
                 return Messages.TOOLTIP_DEACTIVATE_SYSVDI;
 
-            if (!vm.GetVirtualisationStatus.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+            if (AreIODriversNeededAndMissing(vm))
                 return string.Format(
                     vm.HasNewVirtualisationStates ? Messages.CANNOT_ACTIVATE_VD_VM_NEEDS_IO_DRIVERS : Messages.CANNOT_ACTIVATE_VD_VM_NEEDS_TOOLS, 
                     Helpers.GetName(vm).Ellipsise(50));


### PR DESCRIPTION
Instead we use the vbd.allowed_operations list, and check for the plug/unplug operation respectively.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>