### PR TITLE
CP-19218: Add restart warnings to the Precheck Page when installing h…

### DIFF
--- a/XenAdmin/Diagnostics/Checks/HostNeedsRebootCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/HostNeedsRebootCheck.cs
@@ -75,7 +75,7 @@ namespace XenAdmin.Diagnostics.Checks
             if ((updateGuidance != null && updateGuidance.Contains(update_after_apply_guidance.restartHost))
                 || (patchGuidance != null && patchGuidance.Contains(after_apply_guidance.restartHost)))
             {
-                 return new HostNeedsRebootWarning(this, Host);
+                 return new HostNeedsReboot(this, Host);
             }
 
             successfulCheckDescription = string.Format(Messages.UPDATES_WIZARD_NO_REBOOT_NEEDED, Host);

--- a/XenAdmin/Diagnostics/Checks/HostNeedsRebootCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/HostNeedsRebootCheck.cs
@@ -1,0 +1,95 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using XenAPI;
+using XenAdmin.Diagnostics.Problems;
+using XenAdmin.Diagnostics.Problems.HostProblem;
+using XenAdmin.Wizards.PatchingWizard;
+
+namespace XenAdmin.Diagnostics.Checks
+{
+    public class HostNeedsRebootCheck : Check
+    {
+        private readonly Dictionary<string, LivePatchCode> livePatchCodesByHost;
+        private readonly List<after_apply_guidance> patchGuidance;
+        private readonly List<update_after_apply_guidance> updateGuidance;
+
+        private string successfulCheckDescription;
+
+        public HostNeedsRebootCheck(Host host, List<update_after_apply_guidance> guidance, Dictionary<string, LivePatchCode> livePatchCodesByHost)
+            : base(host)
+        {
+            this.livePatchCodesByHost = livePatchCodesByHost;
+            updateGuidance = guidance;
+        }
+
+        public HostNeedsRebootCheck(Host host, List<after_apply_guidance> guidance, Dictionary<string, LivePatchCode> livePatchCodesByHost)
+            : base(host)
+        {
+            this.livePatchCodesByHost = livePatchCodesByHost;
+            patchGuidance = guidance;
+        }
+
+        protected override Problem RunCheck()
+        {
+            if (!Host.IsLive)
+                return new HostNotLiveWarning(this, Host);
+
+            // when livepatching is available, no restart is expected
+            if (livePatchCodesByHost != null && livePatchCodesByHost.ContainsKey(Host.uuid) &&
+                livePatchCodesByHost[Host.uuid] == LivePatchCode.PATCH_PRECHECK_LIVEPATCH_COMPLETE)
+            {
+                successfulCheckDescription = string.Format(Messages.UPDATES_WIZARD_NO_REBOOT_NEEDED_LIVE_PATCH, Host);
+                return null;
+            }
+            
+            if ((updateGuidance != null && updateGuidance.Contains(update_after_apply_guidance.restartHost))
+                || (patchGuidance != null && patchGuidance.Contains(after_apply_guidance.restartHost)))
+            {
+                 return new HostNeedsRebootWarning(this, Host);
+            }
+
+            successfulCheckDescription = string.Format(Messages.UPDATES_WIZARD_NO_REBOOT_NEEDED, Host);
+            return null;
+        }
+        
+        public override string Description
+        {
+            get { return Messages.HOST_NEEDS_REBOOT_CHECK_DESCRIPTION; }
+        }
+
+        public override string SuccessfulCheckDescription
+        {
+            get { return successfulCheckDescription; }
+        }
+    }
+}

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostNeedsReboot.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostNeedsReboot.cs
@@ -30,40 +30,29 @@
  */
 
 using System;
-using System.Drawing;
-using System.Windows.Forms;
-using XenAdmin.Actions;
 using XenAdmin.Diagnostics.Checks;
-using XenAdmin.Properties;
+using XenAPI;
 
-
-namespace XenAdmin.Diagnostics.Problems
+namespace XenAdmin.Diagnostics.Problems.HostProblem
 {
-    public class NoProblem : Problem
+    public class HostNeedsReboot : Information
     {
-        public NoProblem(Check check)
+        private readonly Host host;
+
+        public HostNeedsReboot(Check check, Host host)
             : base(check)
         {
-            
+            this.host = host;
         }
 
         public override string Title
         {
-            get { return string.Empty; }
+            get { return Description; }
         }
 
         public override string Description
         {
-            get { return Messages.PROBLEM_NOPROBLEM_DESCRIPTION; }
+            get { return String.Format(Messages.UPDATES_WIZARD_REBOOT_NEEDED, host.name_label); }
         }
-
-    
-
-        public override string HelpMessage
-        {
-            get { return string.Empty; }
-        }
-
-
     }
 }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostNeedsRebootWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostNeedsRebootWarning.cs
@@ -29,45 +29,30 @@
  * SUCH DAMAGE.
  */
 
-using System.Collections.Generic;
+using System;
+using XenAdmin.Diagnostics.Checks;
 using XenAPI;
-using XenAdmin.Diagnostics.Problems;
 
-namespace XenAdmin.Diagnostics.Checks
+namespace XenAdmin.Diagnostics.Problems.HostProblem
 {
-    public abstract class Check
+    public class HostNeedsRebootWarning : Warning
     {
-        protected Check(Host host)
+        private readonly Host host;
+
+        public HostNeedsRebootWarning(Check check, Host host)
+            : base(check)
         {
-            _host = host;
+            this.host = host;
         }
 
-        protected abstract Problem RunCheck();
-
-        // By default, most Checks return zero or one Problems: but a
-        // Check can override this to return multiple Problems
-        public virtual List<Problem> RunAllChecks()
+        public override string Title
         {
-            var list = new List<Problem>(1);
-            var problem = RunCheck();
-            if (problem != null)
-                list.Add(problem);
-            return list;
+            get { return Description; }
         }
 
-        public abstract string Description{ get;}
-
-        public virtual string SuccessfulCheckDescription 
+        public override string Description
         {
-            get { return string.Empty; }
+            get { return String.Format(Messages.UPDATES_WIZARD_REBOOT_NEEDED, host.name_label); }
         }
-
-        private readonly Host _host = null;
-        public Host Host
-        {
-            get{ return _host;}
-        }
-
     }
-
 }

--- a/XenAdmin/Diagnostics/Problems/Information.cs
+++ b/XenAdmin/Diagnostics/Problems/Information.cs
@@ -29,30 +29,20 @@
  * SUCH DAMAGE.
  */
 
-using System;
+using System.Drawing;
 using XenAdmin.Diagnostics.Checks;
-using XenAPI;
 
-namespace XenAdmin.Diagnostics.Problems.HostProblem
+namespace XenAdmin.Diagnostics.Problems
 {
-    public class HostNeedsRebootWarning : Warning
+    public abstract class Information : Warning
     {
-        private readonly Host host;
-
-        public HostNeedsRebootWarning(Check check, Host host)
+        protected Information(Check check)
             : base(check)
-        {
-            this.host = host;
-        }
+        { }
 
-        public override string Title
+        public sealed override Image Image
         {
-            get { return Description; }
-        }
-
-        public override string Description
-        {
-            get { return String.Format(Messages.UPDATES_WIZARD_REBOOT_NEEDED, host.name_label); }
+            get { return Images.GetImage16For(Icons.Info); }
         }
     }
 }

--- a/XenAdmin/Diagnostics/Problems/Problem.cs
+++ b/XenAdmin/Diagnostics/Problems/Problem.cs
@@ -30,7 +30,6 @@
  */
 
 using System;
-using System.Windows.Forms;
 using System.Drawing;
 using XenAdmin.Actions;
 using XenAdmin.Diagnostics.Checks;
@@ -121,6 +120,11 @@ namespace XenAdmin.Diagnostics.Problems
         public override int GetHashCode()
         {
             return _check.GetHashCode();
+        }
+
+        public virtual Image Image 
+        {
+            get { return Images.GetImage16For(Icons.Error); }
         }
 
         #region IDisposable Members

--- a/XenAdmin/Diagnostics/Problems/Warning.cs
+++ b/XenAdmin/Diagnostics/Problems/Warning.cs
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 
+using System.Drawing;
 using XenAdmin.Diagnostics.Checks;
 
 namespace XenAdmin.Diagnostics.Problems
@@ -43,6 +44,11 @@ namespace XenAdmin.Diagnostics.Problems
         public override string HelpMessage
         {
             get { return null; }
+        }
+
+        public override Image Image
+        {
+            get { return Images.GetImage16For(Icons.Warning); }
         }
     }
 }

--- a/XenAdmin/Images.cs
+++ b/XenAdmin/Images.cs
@@ -167,6 +167,12 @@ namespace XenAdmin
             ImageList16.Images.Add("StoppedDC_16.png", Properties.Resources.StoppedDC_16);
             ImageList16.Images.Add("PausedDC_16.png", Properties.Resources.PausedDC_16);
 
+            #region Status Icons
+            ImageList16.Images.Add("000_Tick_h32bit_16", Properties.Resources._000_Tick_h32bit_16); //Ok
+            ImageList16.Images.Add("000_Info3_h32bit_16.png", Properties.Resources._000_Info3_h32bit_16); //Info
+            ImageList16.Images.Add("000_Alert2_h32bit_16.png", Properties.Resources._000_Alert2_h32bit_16); //Warning
+            ImageList16.Images.Add("000_Abort_h32bit_16.png", Properties.Resources._000_Abort_h32bit_16); //Error
+            #endregion
 
             System.Diagnostics.Trace.Assert(ImageList16.Images.Count == Enum.GetValues(typeof(Icons)).Length,
                 "Programmer error - you must add an entry to the image list when you add a new icon to the enum");

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.cs
@@ -619,8 +619,8 @@ namespace XenAdmin.Wizards.DRWizards
             private void UpdateRowFields()
             {
                 _iconCell.Value = Problem == null
-                    ? Resources._000_Tick_h32bit_16
-                    : Problem is Warning ? Resources._000_Alert2_h32bit_16 : Resources._000_Abort_h32bit_16;
+                    ? Images.GetImage16For(Icons.Ok)
+                    : Problem.Image;
 
                 if (Problem != null)
                     _descriptionCell.Value = String.Format(Messages.DR_WIZARD_PRECHECKPAGE_PROBLEM, _check.Description, Problem.Description);

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -216,9 +216,10 @@
     <Compile Include="Diagnostics\Checks\HostNeedsRebootCheck.cs" />
     <Compile Include="Diagnostics\Checks\SafeToUpgradeCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostHasUnsupportedStorageLinkSRCheck.cs" />
-    <Compile Include="Diagnostics\Problems\HostProblem\HostNeedsRebootWarning.cs" />
+    <Compile Include="Diagnostics\Problems\HostProblem\HostNeedsReboot.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostNotSafeToUpgradeWarning.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostOutOfSpaceProblem.cs" />
+    <Compile Include="Diagnostics\Problems\Information.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\CPUIncompatibilityProblem.cs" />
     <Compile Include="Diagnostics\Problems\ProblemWithInformationUrl.cs" />
     <Compile Include="Diagnostics\Problems\SRProblem\UnsupportedStorageLinkSrIsPresentProblem.cs" />
@@ -3762,7 +3763,6 @@
     <Compile Include="Plugins\Placeholders.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostProblem.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\WrongServerVersion.cs" />
-    <Compile Include="Diagnostics\Problems\NoProblem.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\PoolProblem.cs" />
     <Compile Include="Diagnostics\Problems\SRProblem\SRProblem.cs" />
     <Compile Include="Diagnostics\Problems\VMProblem\VMProblem.cs" />

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -213,8 +213,10 @@
     <Compile Include="Diagnostics\Checks\AssertCanEvacuateCheck.cs" />
     <Compile Include="Diagnostics\Checks\AssertCanEvacuateUpgradeCheck.cs" />
     <Compile Include="Diagnostics\Checks\DiskSpaceForBatchUpdatesCheck.cs" />
+    <Compile Include="Diagnostics\Checks\HostNeedsRebootCheck.cs" />
     <Compile Include="Diagnostics\Checks\SafeToUpgradeCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostHasUnsupportedStorageLinkSRCheck.cs" />
+    <Compile Include="Diagnostics\Problems\HostProblem\HostNeedsRebootWarning.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostNotSafeToUpgradeWarning.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostOutOfSpaceProblem.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\CPUIncompatibilityProblem.cs" />

--- a/XenModel/Icons.cs
+++ b/XenModel/Icons.cs
@@ -154,8 +154,15 @@ namespace XenAdmin
 
         DCRunning,
         DCStopped,
-        DCPaused
+        DCPaused,
 
+        #endregion
+
+        #region Status Icons
+        Ok,
+        Info,
+        Warning,
+        Error
         #endregion
     }
 }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -6724,7 +6724,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Checking live patching status.
+        ///   Looks up a localized string similar to Checking reboots required.
         /// </summary>
         public static string CHECKING_SERVER_NEEDS_REBOOT {
             get {
@@ -27402,15 +27402,6 @@ namespace XenAdmin {
         public static string PROBLEM_MAC_ADDRESS_IS_DUPLICATE_TITLE {
             get {
                 return ResourceManager.GetString("PROBLEM_MAC_ADDRESS_IS_DUPLICATE_TITLE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No problems were encountered.
-        /// </summary>
-        public static string PROBLEM_NOPROBLEM_DESCRIPTION {
-            get {
-                return ResourceManager.GetString("PROBLEM_NOPROBLEM_DESCRIPTION", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -6724,6 +6724,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking live patching status.
+        /// </summary>
+        public static string CHECKING_SERVER_NEEDS_REBOOT {
+            get {
+                return ResourceManager.GetString("CHECKING_SERVER_NEEDS_REBOOT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Checking server side status.
         /// </summary>
         public static string CHECKING_SERVER_SIDE_STATUS {
@@ -17187,6 +17196,15 @@ namespace XenAdmin {
         public static string HOST_MENU_UNKNOWN_ERROR {
             get {
                 return ResourceManager.GetString("HOST_MENU_UNKNOWN_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Live patching status.
+        /// </summary>
+        public static string HOST_NEEDS_REBOOT_CHECK_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("HOST_NEEDS_REBOOT_CHECK_DESCRIPTION", resourceCulture);
             }
         }
         
@@ -33097,6 +33115,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}: This server does not need to be rebooted..
+        /// </summary>
+        public static string UPDATES_WIZARD_NO_REBOOT_NEEDED {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_NO_REBOOT_NEEDED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: This server does not need to be rebooted as live patching is used..
+        /// </summary>
+        public static string UPDATES_WIZARD_NO_REBOOT_NEEDED_LIVE_PATCH {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_NO_REBOOT_NEEDED_LIVE_PATCH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The VM {0} does not have [XenServer product] Tools installed..
         /// </summary>
         public static string UPDATES_WIZARD_NO_TOOLS {
@@ -33219,6 +33255,15 @@ namespace XenAdmin {
         public static string UPDATES_WIZARD_REBOOT {
             get {
                 return ResourceManager.GetString("UPDATES_WIZARD_REBOOT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: This server needs to be rebooted after the update is applied..
+        /// </summary>
+        public static string UPDATES_WIZARD_REBOOT_NEEDED {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_REBOOT_NEEDED", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2446,7 +2446,7 @@ Do you want to assign it to the policy '{2}' instead?</value>
     <value>Checking partition layout</value>
   </data>
   <data name="CHECKING_SERVER_NEEDS_REBOOT" xml:space="preserve">
-    <value>Checking live patching status</value>
+    <value>Checking reboots required</value>
   </data>
   <data name="CHECKING_SERVER_SIDE_STATUS" xml:space="preserve">
     <value>Checking server side status</value>
@@ -9543,9 +9543,6 @@ The VM protection policy for this VM does not have automatic archiving configure
   </data>
   <data name="PROBLEM_MAC_ADDRESS_IS_DUPLICATE_TITLE" xml:space="preserve">
     <value>Duplicate MAC address</value>
-  </data>
-  <data name="PROBLEM_NOPROBLEM_DESCRIPTION" xml:space="preserve">
-    <value>No problems were encountered</value>
   </data>
   <data name="PROBLEM_POOLPROBLEM_TITLE" xml:space="preserve">
     <value>Pool '{0}'</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2445,6 +2445,9 @@ Do you want to assign it to the policy '{2}' instead?</value>
   <data name="CHECKING_SAFE_TO_UPGRADE" xml:space="preserve">
     <value>Checking partition layout</value>
   </data>
+  <data name="CHECKING_SERVER_NEEDS_REBOOT" xml:space="preserve">
+    <value>Checking live patching status</value>
+  </data>
   <data name="CHECKING_SERVER_SIDE_STATUS" xml:space="preserve">
     <value>Checking server side status</value>
   </data>
@@ -6053,6 +6056,9 @@ Click Configure HA to alter the settings displayed below.</value>
   </data>
   <data name="HOST_MENU_UNKNOWN_ERROR" xml:space="preserve">
     <value>Unknown error</value>
+  </data>
+  <data name="HOST_NEEDS_REBOOT_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>Live patching status</value>
   </data>
   <data name="HOST_NETWORK_TAB_ADD_BUTTON_LABEL" xml:space="preserve">
     <value>&amp;Add Network...</value>
@@ -11455,6 +11461,12 @@ Check your settings and try again.</value>
   <data name="UPDATES_WIZARD_NO_MEMORY" xml:space="preserve">
     <value>{0}: There is not enough memory available on other servers to migrate all the VMs off this server.</value>
   </data>
+  <data name="UPDATES_WIZARD_NO_REBOOT_NEEDED" xml:space="preserve">
+    <value>{0}: This server does not need to be rebooted.</value>
+  </data>
+  <data name="UPDATES_WIZARD_NO_REBOOT_NEEDED_LIVE_PATCH" xml:space="preserve">
+    <value>{0}: This server does not need to be rebooted as live patching is used.</value>
+  </data>
   <data name="UPDATES_WIZARD_NO_TOOLS" xml:space="preserve">
     <value>The VM {0} does not have [XenServer product] Tools installed.</value>
   </data>
@@ -11493,6 +11505,9 @@ Check your settings and try again.</value>
   </data>
   <data name="UPDATES_WIZARD_REBOOTING" xml:space="preserve">
     <value>Rebooting {0} ... </value>
+  </data>
+  <data name="UPDATES_WIZARD_REBOOT_NEEDED" xml:space="preserve">
+    <value>{0}: This server needs to be rebooted after the update is applied.</value>
   </data>
   <data name="UPDATES_WIZARD_REMOVING_UPDATE" xml:space="preserve">
     <value>Deleting update installation file {0} from {1}... </value>


### PR DESCRIPTION
…otfixes

- added a new precheck, called "Live patching status" which checks is a reboot is needed for each host. If reboot is needed, the check will display a warning, otherwise it will show a green tickbox, saying that the server does not need to be rebooted, and if live patching is used, this information will be included as well.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>