### PR TITLE
[CA-211267] Add a lightweight polling mechanism to the appliance tasks, to provide an accurate timer

### DIFF
--- a/XenAdmin/Actions/OVFActions/ApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ApplianceAction.cs
@@ -46,6 +46,8 @@ namespace XenAdmin.Actions.OVFActions
 		protected string m_tvmGateway;
 		protected XenOvfTransportBase m_transportAction;
 
+        private const int SLEEP_TIME = 900;
+
 		/// <summary>
 		/// RBAC dependencies needed to import appliance/export an appliance/import disk image.
 		/// </summary>
@@ -101,17 +103,15 @@ namespace XenAdmin.Actions.OVFActions
 
 	    protected void InitialiseTicker()
 	    {
-	        System.Threading.Tasks.Task.Run(() => TickUntilCompletion(this));
+	        System.Threading.Tasks.Task.Run(() => TickUntilCompletion());
 	    }
 
-	    private void TickUntilCompletion(ApplianceAction action)
+	    private void TickUntilCompletion()
 	    {
-	        int sleepTime = 900;
-
-	        while (!action.IsCompleted)
+	        while (!IsCompleted)
 	        {
-	            action.OnChanged();
-                Thread.Sleep(sleepTime);
+	            OnChanged();
+                Thread.Sleep(SLEEP_TIME);
 	        }
 	    }
 

--- a/XenAdmin/Actions/OVFActions/ApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ApplianceAction.cs
@@ -47,6 +47,7 @@ namespace XenAdmin.Actions.OVFActions
 		protected XenOvfTransportBase m_transportAction;
 
         private const int SLEEP_TIME = 900;
+        private const int MAX_ITERATIONS = 60 * 60 * 24; // seconds in 24 hours
 
 		/// <summary>
 		/// RBAC dependencies needed to import appliance/export an appliance/import disk image.
@@ -114,7 +115,8 @@ namespace XenAdmin.Actions.OVFActions
 
 	    private void TickUntilCompletion()
 	    {
-	        while (!IsCompleted)
+	        int i = 0;
+	        while (!IsCompleted && ++i<MAX_ITERATIONS)
 	        {
 	            OnChanged();
                 Thread.Sleep(SLEEP_TIME);

--- a/XenAdmin/Actions/OVFActions/ApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ApplianceAction.cs
@@ -47,7 +47,7 @@ namespace XenAdmin.Actions.OVFActions
 		protected XenOvfTransportBase m_transportAction;
 
         private const int SLEEP_TIME = 900;
-        private const int MAX_ITERATIONS = 60 * 60 * 24; // seconds in 24 hours
+        private const int MAX_ITERATIONS = 60 * 60 * 24 / SLEEP_TIME * 1000; //iterations in 24h
 
 		/// <summary>
 		/// RBAC dependencies needed to import appliance/export an appliance/import disk image.

--- a/XenAdmin/Actions/OVFActions/ApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ApplianceAction.cs
@@ -82,6 +82,12 @@ namespace XenAdmin.Actions.OVFActions
 				Host = Helpers.GetMaster(connection);
 		}
 
+	    protected override void Run()
+	    {
+	        SafeToExit = false; 
+            InitialiseTicker();
+	    }
+
 		protected void UpdateHandler(XenOvfTranportEventArgs e)
 		{
 			if (!string.IsNullOrEmpty(e.Message))
@@ -101,16 +107,16 @@ namespace XenAdmin.Actions.OVFActions
 				m_transportAction.Cancel = true;
 		}
 
-	    protected void InitialiseTicker()
+	    private void InitialiseTicker()
 	    {
-	        System.Threading.Tasks.Task.Run(() => TickUntilCompletion());
+	        System.Threading.Tasks.Task.Run(() => TickUntilCompletion(this));
 	    }
 
-	    private void TickUntilCompletion()
+	    private static  void TickUntilCompletion(ApplianceAction action)
 	    {
-	        while (!IsCompleted)
+	        while (action != null && !action.IsCompleted)
 	        {
-	            OnChanged();
+	            action.OnChanged();
                 Thread.Sleep(SLEEP_TIME);
 	        }
 	    }

--- a/XenAdmin/Actions/OVFActions/ApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ApplianceAction.cs
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 
+using System.Threading;
 using XenAdmin.Core;
 using XenAdmin.Network;
 using XenAPI;
@@ -97,5 +98,23 @@ namespace XenAdmin.Actions.OVFActions
 			if (m_transportAction != null)
 				m_transportAction.Cancel = true;
 		}
+
+	    protected void InitialiseTicker()
+	    {
+	        System.Threading.Tasks.Task.Run(() => TickUntilCompletion(this));
+	    }
+
+	    private void TickUntilCompletion(ApplianceAction action)
+	    {
+	        int sleepTime = 900;
+
+	        while (!action.IsCompleted)
+	        {
+	            action.OnChanged();
+                Thread.Sleep(sleepTime);
+	        }
+	    }
+
+
 	}
 }

--- a/XenAdmin/Actions/OVFActions/ApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ApplianceAction.cs
@@ -109,14 +109,14 @@ namespace XenAdmin.Actions.OVFActions
 
 	    private void InitialiseTicker()
 	    {
-	        System.Threading.Tasks.Task.Run(() => TickUntilCompletion(this));
+	        System.Threading.Tasks.Task.Run(() => TickUntilCompletion());
 	    }
 
-	    private static  void TickUntilCompletion(ApplianceAction action)
+	    private void TickUntilCompletion()
 	    {
-	        while (action != null && !action.IsCompleted)
+	        while (!IsCompleted)
 	        {
-	            action.OnChanged();
+	            OnChanged();
                 Thread.Sleep(SLEEP_TIME);
 	        }
 	    }

--- a/XenAdmin/Actions/OVFActions/ExportApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ExportApplianceAction.cs
@@ -92,6 +92,9 @@ namespace XenAdmin.Actions.OVFActions
 		{
 		    SafeToExit = false;
 			var session = Connection.Session;
+
+            InitialiseTicker();
+
 			var url = session.Url;
 			Uri uri = new Uri(url);
 

--- a/XenAdmin/Actions/OVFActions/ExportApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ExportApplianceAction.cs
@@ -90,10 +90,9 @@ namespace XenAdmin.Actions.OVFActions
 
 		protected override void Run()
 		{
-		    SafeToExit = false;
+            base.Run();
+		    
 			var session = Connection.Session;
-
-            InitialiseTicker();
 
 			var url = session.Url;
 			Uri uri = new Uri(url);

--- a/XenAdmin/Actions/OVFActions/ImportApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ImportApplianceAction.cs
@@ -77,6 +77,9 @@ namespace XenAdmin.Actions.OVFActions
 		protected override void Run()
 		{
 		    SafeToExit = false;
+            
+            InitialiseTicker();
+
 			if (m_verifySignature)
 			{
 				Description = Messages.VERIFYING_SIGNATURE;

--- a/XenAdmin/Actions/OVFActions/ImportApplianceAction.cs
+++ b/XenAdmin/Actions/OVFActions/ImportApplianceAction.cs
@@ -76,9 +76,7 @@ namespace XenAdmin.Actions.OVFActions
 
 		protected override void Run()
 		{
-		    SafeToExit = false;
-            
-            InitialiseTicker();
+		    base.Run();
 
 			if (m_verifySignature)
 			{

--- a/XenAdmin/Actions/OVFActions/ImportImageAction.cs
+++ b/XenAdmin/Actions/OVFActions/ImportImageAction.cs
@@ -73,6 +73,8 @@ namespace XenAdmin.Actions.OVFActions
 		    SafeToExit = false;
 			Debug.Assert(m_vmMappings.Count == 1, "There is one VM mapping");
 
+            InitialiseTicker();
+
 			string systemid = m_vmMappings.Keys.ElementAt(0);
 			var mapping = m_vmMappings.Values.ElementAt(0);
 

--- a/XenAdmin/Actions/OVFActions/ImportImageAction.cs
+++ b/XenAdmin/Actions/OVFActions/ImportImageAction.cs
@@ -70,10 +70,9 @@ namespace XenAdmin.Actions.OVFActions
 
 		protected override void Run()
 		{
-		    SafeToExit = false;
-			Debug.Assert(m_vmMappings.Count == 1, "There is one VM mapping");
+		    base.Run();
 
-            InitialiseTicker();
+			Debug.Assert(m_vmMappings.Count == 1, "There is one VM mapping");
 
 			string systemid = m_vmMappings.Keys.ElementAt(0);
 			var mapping = m_vmMappings.Values.ElementAt(0);


### PR DESCRIPTION
For other actions we get a ticking timer in the Events view because they use PollToCompletion, which calls their Changed event (via Action.Tick) every 900ms. These actions don't use PollToCompletion, and didn't regularly call their Changed event - so their timer didn't tick regularly. This change adds a lightweight mechanism to call their changed event every 900ms until they complete. This allows the events page timer to tick every second in the same way as it does for other actions.

Signed-off-by: Callum McIntyre callumiandavid.mcintyre@citrix.com