### PR TITLE
CA-220475: [PAR-173] XenCenter fails when updating network MTU with V…

### DIFF
--- a/XenAdmin/SettingsPanels/EditNetworkPage.cs
+++ b/XenAdmin/SettingsPanels/EditNetworkPage.cs
@@ -568,7 +568,7 @@ namespace XenAdmin.SettingsPanels
                 if (network.PIFs.Count == 0)
                     return false;
 
-                PIF pif = network.Connection.Resolve<PIF>(network.PIFs[0]);
+                PIF pif = GetNetworksPIF();
                 PIF selectedPif = NICNameToVirtualPIF((string)HostPNICList.SelectedItem, (long)numUpDownVLAN.Value);
                 return pif != null && Editable(pif) && pif != selectedPif;
             }


### PR DESCRIPTION
…LAN tag already in use error

- use the PIF of the master when trying to find out if an external network has changed

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>