### PR TITLE
[CA-220457] Add friendly names for new graphs, and filter duplicates

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/DataSet.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataSet.cs
@@ -297,6 +297,19 @@ namespace XenAdmin.Controls.CustomDataGraph
                     dataSet.CustomYRange = new DataRange(1, 0, 1, Unit.None, RangeScaleMode.Auto);
                 dataSet.Type = DataType.Pvs;
             }
+            else if (settype.StartsWith("read_latency") || settype.StartsWith("write_latency"))
+            {
+                // Units are microseconds
+                dataSet.MultiplyingFactor = 1000;
+                dataSet.CustomYRange = new DataRange(1, 0, 1, Unit.NanoSeconds, RangeScaleMode.Auto);
+                dataSet.Type = DataType.Latency;
+            }
+            else if (settype.StartsWith("read") || settype.StartsWith("write"))
+            {
+                // Units are Bytes/second
+                dataSet.CustomYRange = new DataRange(1, 0, 1, Unit.BytesPerSecond, RangeScaleMode.Auto);
+                dataSet.Type = DataType.Storage;
+            }
             else
             {
                 dataSet.CustomYRange = new DataRange(1, 0, 1, Unit.None, RangeScaleMode.Auto);

--- a/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
+++ b/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using XenAPI;
@@ -190,6 +191,16 @@ namespace XenAdmin.Controls.CustomDataGraph
 
                 string itemUuid = Palette.GetUuid(dataSource.name_label, xenObject);
                 dataSourceItems.Add(new DataSourceItem(dataSource, friendlyName, Palette.GetColour(itemUuid), itemUuid, xenObject));
+            }
+
+            // Filter old datasources only if we have their replacement ones
+            Regex io_throughput_rw_regex = new Regex("^io_throughput_(read|write)_([a-f0-9]{8})$"); // old datasources
+            Regex sr_rw_regex = new Regex("^(read|write)_([a-f0-9]{8})$"); // replacement datasources
+
+            if (dataSourceItems.Any(dsi => sr_rw_regex.IsMatch(dsi.DataSource.name_label)))
+            {
+                // Remove any old style data sources
+                dataSourceItems.RemoveAll(dsi => io_throughput_rw_regex.IsMatch(dsi.DataSource.name_label));
             }
 
             return dataSourceItems;

--- a/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
+++ b/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
@@ -172,6 +172,9 @@ namespace XenAdmin.Controls.CustomDataGraph
 
     public static class DataSourceItemList
     {
+        private static Regex io_throughput_rw_regex = new Regex("^io_throughput_(read|write)_([a-f0-9]{8})$"); // old SR read/write datasources
+        private static Regex sr_rw_regex = new Regex("^(read|write)_([a-f0-9]{8})$"); // replacement SR read/write datasources
+
         public static List<DataSourceItem> BuildList(IXenObject xenObject, List<Data_source> dataSources)
         {
             List<DataSourceItem> dataSourceItems = new List<DataSourceItem>();
@@ -194,9 +197,6 @@ namespace XenAdmin.Controls.CustomDataGraph
             }
 
             // Filter old datasources only if we have their replacement ones
-            Regex io_throughput_rw_regex = new Regex("^io_throughput_(read|write)_([a-f0-9]{8})$"); // old datasources
-            Regex sr_rw_regex = new Regex("^(read|write)_([a-f0-9]{8})$"); // replacement datasources
-
             if (dataSourceItems.Any(dsi => sr_rw_regex.IsMatch(dsi.DataSource.name_label)))
             {
                 // Remove any old style data sources

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -2311,6 +2311,42 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; Read Throughput.
+        /// </summary>
+        public static string Label_performance_sr_rw_read {
+            get {
+                return ResourceManager.GetString("Label-performance.sr_rw_read", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; Read Latency.
+        /// </summary>
+        public static string Label_performance_sr_rw_read_latency {
+            get {
+                return ResourceManager.GetString("Label-performance.sr_rw_read_latency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; Write Throughput.
+        /// </summary>
+        public static string Label_performance_sr_rw_write {
+            get {
+                return ResourceManager.GetString("Label-performance.sr_rw_write", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; Write Latency.
+        /// </summary>
+        public static string Label_performance_sr_rw_write_latency {
+            get {
+                return ResourceManager.GetString("Label-performance.sr_rw_write_latency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HA Statefile Latency.
         /// </summary>
         public static string Label_performance_statefile_latency {

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1904,4 +1904,16 @@
   <data name="Label-VM.pvs_read_caching_status" xml:space="preserve">
     <value>PVS Read Caching Status</value>
   </data>
+  <data name="Label-performance.sr_rw_read" xml:space="preserve">
+    <value>'{0}' Read Throughput</value>
+  </data>
+  <data name="Label-performance.sr_rw_read_latency" xml:space="preserve">
+    <value>'{0}' Read Latency</value>
+  </data>
+  <data name="Label-performance.sr_rw_write" xml:space="preserve">
+    <value>'{0}' Write Throughput</value>
+  </data>
+  <data name="Label-performance.sr_rw_write_latency" xml:space="preserve">
+    <value>'{0}' Write Latency</value>
+  </data>
 </root>

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1145,6 +1145,7 @@ namespace XenAdmin.Core
     	static Regex SrRegex = new Regex("^sr_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}_cache_(size|hits|misses)");
         static Regex SrIORegex = new Regex("^(io_throughput|iops)_(read|write|total)_([a-f0-9]{8})$");
         static Regex SrOtherRegex = new Regex("^(latency|avgqu_sz|inflight|iowait)_([a-f0-9]{8})$");
+        static Regex SrReadWriteRegex = new Regex("^((read|write)(_latency)?)_([a-f0-9]{8})$");
         static Regex GpuRegex = new Regex(@"^gpu_((memory_(free|used))|power_usage|temperature|(utilisation_(compute|memory_io)))_(([a-fA-F0-9]{4}\/)?[a-fA-F0-9]{2}\/[0-1][a-fA-F0-9].[0-7])$");
 
         public static string GetFriendlyDataSourceName(string name, IXenObject iXenObject)
@@ -1286,6 +1287,16 @@ namespace XenAdmin.Core
                            ? null
                            : FormatFriendly(string.Format("Label-performance.sr_{0}", m.Groups[1].Value),
                                sr.Name.Ellipsise(30));
+            }
+
+            m = SrReadWriteRegex.Match(name);
+            if (m.Success)
+            {
+                SR sr = FindSr(iXenObject, m.Groups[4].Value);
+                return sr == null
+                    ? null
+                    : FormatFriendly(string.Format("Label-performance.sr_rw_{0}", m.Groups[1].Value),
+                        sr.Name.Ellipsise(30));
             }
 
             m = GpuRegex.Match(name);


### PR DESCRIPTION
We have some new RRDs - read, write, read_latency and write_latency. This adds support for them by adding a friendly name and using it to display them. It also adds some filtering (see GraphHelpers.cs) because for backward compatibility io_throughput_read and io_throughput_write (which differ from read and write only in scale) are still available, but shouldn't be displayed in XC. If the new read or write are available, we filter these old datasources out.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>