### PR TITLE
[CA-223486] Storage Link Status validation is wrongly included in Precheck During RPU

### DIFF
--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -197,12 +197,15 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 }
             }
 
-            //iSL (StorageLink) check
-            checks.Add(new KeyValuePair<string, List<Check>>(Messages.CHECKING_STORAGELINK_STATUS, new List<Check>()));
-            checkGroup = checks[checks.Count - 1].Value;
-            foreach (Host host in SelectedServers)
+            //iSL (StorageLink) check - CA-223486: only for pre-Creedence
+            if (SelectedServers.Any(h => !Helpers.CreedenceOrGreater(h)))
             {
-                checkGroup.Add(new HostHasUnsupportedStorageLinkSRCheck(host));
+                checks.Add(new KeyValuePair<string, List<Check>>(Messages.CHECKING_STORAGELINK_STATUS, new List<Check>()));
+                checkGroup = checks[checks.Count - 1].Value;
+                foreach (Host host in SelectedServers)
+                {
+                    checkGroup.Add(new HostHasUnsupportedStorageLinkSRCheck(host));
+                }
             }
 
             //Upgrading to Clearwater and above - license changes warning and deprecations

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -204,7 +204,8 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 checkGroup = checks[checks.Count - 1].Value;
                 foreach (Host host in SelectedServers)
                 {
-                    checkGroup.Add(new HostHasUnsupportedStorageLinkSRCheck(host));
+                    if(!Helpers.CreedenceOrGreater(host))
+                        checkGroup.Add(new HostHasUnsupportedStorageLinkSRCheck(host));
                 }
             }
 
@@ -219,7 +220,8 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                     checkGroup = checks[checks.Count - 1].Value;
                     foreach (Host host in SelectedServers)
                     {
-                        checkGroup.Add(new UpgradingFromTampaAndOlderCheck(host));
+                        if(!Helpers.ClearwaterOrGreater(host))
+                            checkGroup.Add(new UpgradingFromTampaAndOlderCheck(host));
                     }
                 }
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -219,13 +219,15 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             var preClearwaterServers = SelectedServers.Where(h => !Helpers.ClearwaterOrGreater(h)).ToList();
             if(preClearwaterServers.Any())
             {
+                var hostsNeedingLicenseCheck = preClearwaterServers.Where(HostNeedsLicenseCheck).ToList();
+                if (hostsNeedingLicenseCheck.Any())
                 {
-                    checks.Add(new KeyValuePair<string, List<Check>>(Messages.CHECKING_LICENSING_STATUS, new List<Check>()));
+                    checks.Add(new KeyValuePair<string, List<Check>>(Messages.CHECKING_LICENSING_STATUS,
+                        new List<Check>()));
                     checkGroup = checks[checks.Count - 1].Value;
-                    foreach (Host host in preClearwaterServers)
+                    foreach (Host host in hostsNeedingLicenseCheck)
                     {
-                        if(HostNeedsLicenseCheck(host))
-                            checkGroup.Add(new UpgradingFromTampaAndOlderCheck(host));
+                        checkGroup.Add(new UpgradingFromTampaAndOlderCheck(host));
                     }
                 }
 


### PR DESCRIPTION
We now only include the StorageLink check if we have any hosts earlier than Creedence in the RPU.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>