### PR TITLE
CA-227067: General tab: XenCenter does not show Reboot required when Toolstack restart is required

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -15785,9 +15785,18 @@ namespace XenAdmin {
         /// <summary>
         ///   Looks up a localized string similar to The server &apos;{0}&apos; needs to be rebooted for update &apos;{1}&apos; to take effect.
         /// </summary>
-        public static string GENERAL_PANEL_UPDATE_WARNING {
+        public static string GENERAL_PANEL_UPDATE_REBOOT_WARNING {
             get {
-                return ResourceManager.GetString("GENERAL_PANEL_UPDATE_WARNING", resourceCulture);
+                return ResourceManager.GetString("GENERAL_PANEL_UPDATE_REBOOT_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toolstack on server &apos;{0}&apos; needs to be restarted for update &apos;{1}&apos; to take effect.
+        /// </summary>
+        public static string GENERAL_PANEL_UPDATE_RESTART_TOOLSTACK_WARNING {
+            get {
+                return ResourceManager.GetString("GENERAL_PANEL_UPDATE_RESTART_TOOLSTACK_WARNING", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5533,8 +5533,11 @@ Would you like to eject these ISOs before continuing?</value>
   <data name="GENERAL_PANEL_UPDATE_KEY" xml:space="preserve">
     <value>{0} on {1}</value>
   </data>
-  <data name="GENERAL_PANEL_UPDATE_WARNING" xml:space="preserve">
+  <data name="GENERAL_PANEL_UPDATE_REBOOT_WARNING" xml:space="preserve">
     <value>The server '{0}' needs to be rebooted for update '{1}' to take effect</value>
+  </data>
+  <data name="GENERAL_PANEL_UPDATE_RESTART_TOOLSTACK_WARNING" xml:space="preserve">
+    <value>Toolstack on server '{0}' needs to be restarted for update '{1}' to take effect</value>
   </data>
   <data name="GENERAL_SR_CONTEXT_REPAIR" xml:space="preserve">
     <value>Repair</value>


### PR DESCRIPTION
On the General tab XenCenter shows a list of updates that requires the host to be restarted. This is shown for applied updates for which the required guidance hasn't been done (eg. restartHost or restartAgent after-apply-guidances)

This commit fixes a regression that caused restartToolstack warnings to be not shown in the list of warnings.

The displayed messages are also improved, XenCenter will show Toolstack restart or host restart appropriately and not just restart only as it used to.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>