### PR TITLE
[CA-207601] License expiry time in general tab is incorrect

### DIFF
--- a/XenAdmin/TabPages/GeneralTabLicenseStatusStringifier.cs
+++ b/XenAdmin/TabPages/GeneralTabLicenseStatusStringifier.cs
@@ -89,13 +89,13 @@ namespace XenAdmin.TabPages
                     {
                         
                         if (s.TotalMinutes < 2)
-                            return String.Format(Messages.LICENSE_REQUIRES_ACTIVATION_ONE_MIN, s.Minutes);
+                            return Messages.LICENSE_REQUIRES_ACTIVATION_ONE_MIN;
 
                         if (s.TotalHours < 2)
-                            return String.Format(Messages.LICENSE_REQUIRES_ACTIVATION_MINUTES, s.Minutes);
+                            return String.Format(Messages.LICENSE_REQUIRES_ACTIVATION_MINUTES, Math.Floor(s.TotalMinutes));
 
                         if (s.TotalDays < 2)
-                            return String.Format(Messages.LICENSE_REQUIRES_ACTIVATION_HOURS, s.Hours);
+                            return String.Format(Messages.LICENSE_REQUIRES_ACTIVATION_HOURS, Math.Floor(s.TotalHours));
 
                         if (s.TotalDays < 30)
                             return String.Format(Messages.LICENSE_REQUIRES_ACTIVATION_DAYS, s.Days);
@@ -104,13 +104,13 @@ namespace XenAdmin.TabPages
                     }
 
                     if (s.TotalMinutes < 2)
-                        return String.Format(Messages.LICENSE_EXPIRES_ONE_MIN, s.Minutes);
+                        return Messages.LICENSE_EXPIRES_ONE_MIN;
 
                     if (s.TotalHours < 2)
-                        return String.Format(Messages.LICENSE_EXPIRES_MINUTES, s.Minutes);
+                        return String.Format(Messages.LICENSE_EXPIRES_MINUTES, Math.Floor(s.TotalMinutes));
 
                     if (s.TotalDays < 2)
-                        return String.Format(Messages.LICENSE_EXPIRES_HOURS, s.Hours);
+                        return String.Format(Messages.LICENSE_EXPIRES_HOURS, Math.Floor(s.TotalHours));
 
                     if (s.TotalDays < 30)
                         return String.Format(Messages.LICENSE_EXPIRES_DAYS, s.Days);


### PR DESCRIPTION
The problem here was that TimeSpan.Minutes is always below 60, eg. for 67 minutes it is 7 (with TimeSpan.Hours being 1 then). So our TimeSpan was correct, but if it was between 1 and 2 hours then we would write the minutes in the second hour (which is below 60), ignoring the hour. The fix is to use s.TotalMinutes which for 67 minutes is 67. Hours also had a similar issue, except it would be off by 24 hours for spans between 1 and 2 days.

Signed-off-by: Callum McIntyre callumiandavid.mcintyre@citrix.com
