### PR TITLE
[CA-203752] New VM from Snapshot doesn't use default host

### DIFF
--- a/XenAdmin/Commands/NewVMCommand.cs
+++ b/XenAdmin/Commands/NewVMCommand.cs
@@ -83,7 +83,19 @@ namespace XenAdmin.Commands
                 }
             }
 
-            Execute(selection[0].Connection, selection[0].HostAncestor, template);
+            var connection = selection[0].Connection;
+            Host host = null;
+
+            if (template != null)
+            {
+                host = template.Home();
+            }
+            else
+            {
+                host = selection[0].HostAncestor;
+            }
+
+            Execute(connection, host, template);
         }
 
         private void Execute(IXenConnection connection, Host DefaultAffinity, VM DefaultTemplate)


### PR DESCRIPTION
The reported bug was that the new VM would crash because when clicking through the wizard the pool master is selected by default, not the slave the VM snapshot is on. We already select a default host when a new VM is created from a selected host using HostAncestor, but this property is null for a template (which isn't in the server/VM tree). The fix is that if the selection is a template (which it is when we use new VM from Snapshot) then we instead use its host (using Home()) as the default host. Now the correct host is selected in the VM wizard and the VM creation succeeds.

Signed-off-by: Callum McIntyre callumiandavid.mcintyre@citrix.com
