### PR TITLE
Avoid KeyNotFoundException when moving VMs with unresolved VDIs

### DIFF
--- a/XenModel/Actions/VM/VMMoveAction.cs
+++ b/XenModel/Actions/VM/VMMoveAction.cs
@@ -109,10 +109,15 @@ namespace XenAdmin.Actions.VMActions
                     if (!oldVBD.IsOwner)
                         continue;
 
-                    SR sr = StorageMapping != null ? StorageMapping[oldVBD.VDI.opaque_ref] : null;
-
                     var curVdi = Connection.Resolve(oldVBD.VDI);
-                    if (curVdi == null || sr == null || curVdi.SR.opaque_ref == sr.opaque_ref)
+                    if (curVdi == null)
+                        continue;
+
+                    if (StorageMapping == null || !StorageMapping.ContainsKey(oldVBD.VDI.opaque_ref))
+                        continue;
+
+                    SR sr = StorageMapping[oldVBD.VDI.opaque_ref];
+                    if (sr == null || curVdi.SR.opaque_ref == sr.opaque_ref)
                         continue;
 
                     RelatedTask = XenAPI.VDI.async_copy(Session, oldVBD.VDI.opaque_ref, sr.opaque_ref);


### PR DESCRIPTION
A VM can find itself with a VBD with an unresolved VDI (e.g. ejected CD). The VDI will not have been included in the storage mapping and the user will be presented with a KeyNotFoundException message even if the move of the other VDIs has succeeded. To fix this ignore unresolved VDIs first, then check 
if the storage mapping contains the resolved ones and then try getting the target SR from the mapping.