### PR TITLE
[CA-226116] Add Windows update as a hidden feature

### DIFF
--- a/XenAdmin/Core/HiddenFeatures.cs
+++ b/XenAdmin/Core/HiddenFeatures.cs
@@ -74,6 +74,11 @@ namespace XenAdmin.Core
             { return Registry.HiddenFeatures != null && Registry.HiddenFeatures.Contains(LICENSE_OPERATIONS_HIDDEN); }
         }
 
+        internal static bool WindowsUpdateHidden
+        {
+            get { return Registry.HiddenFeatures != null && Registry.HiddenFeatures.Contains(WINDOWS_UPDATE_HIDDEN); }
+        }
+
         private const string CPS_OPTIMIZATION_HIDDEN = "cps_optimization";
         private const string RDP_POLLING_HIDDEN = "rdp_polling";
         private const string LEARN_MORE_HIDDEN = "learn_more";
@@ -85,5 +90,6 @@ namespace XenAdmin.Core
         private const string UPLOAD_OPTION_HIDDEN = "upload_option";
         private const string LICENSE_NAG = "license_nag";
         private const string LICENSE_OPERATIONS_HIDDEN = "license_operations";
+        private const string WINDOWS_UPDATE_HIDDEN = "windows_update";
     }
 }

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1419,7 +1419,8 @@ namespace XenAdmin.TabPages
                     }
 
                     //Row 3 : vendor device - Windows Update
-                    sb.Append(vm.has_vendor_device ? Messages.VIRTUALIZATION_STATE_VM_RECEIVING_UPDATES : Messages.VIRTUALIZATION_STATE_VM_NOT_RECEIVING_UPDATES);
+                    if(!HiddenFeatures.WindowsUpdateHidden)
+                        sb.Append(vm.has_vendor_device ? Messages.VIRTUALIZATION_STATE_VM_RECEIVING_UPDATES : Messages.VIRTUALIZATION_STATE_VM_NOT_RECEIVING_UPDATES);
 
                     // displaying Row1 - Row3
                     s.AddEntry(FriendlyName("VM.VirtualizationState"), sb.ToString());


### PR DESCRIPTION
If windows_update is in the hidden features registry key, then we hide the virtualization state line about Windows update.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>