### PR TITLE
CA-227072: Improvements to the confirmation message on deleting a site

### DIFF
--- a/XenAdmin/Dialogs/PvsCacheConfigurationDialog.cs
+++ b/XenAdmin/Dialogs/PvsCacheConfigurationDialog.cs
@@ -159,9 +159,12 @@ namespace XenAdmin.Dialogs
             }
 
             // show confirmation dialog
+            var message = site != null && !string.IsNullOrEmpty(site.PVS_uuid)
+                ? string.Format(Messages.CONFIRM_DELETE_PVS_SITE_IN_USE, siteName)
+                : string.Format(Messages.CONFIRM_DELETE_PVS_SITE, siteName);
             DialogResult dialogResult;
             using (var dlg = new ThreeButtonDialog(
-                    new ThreeButtonDialog.Details(SystemIcons.Warning, string.Format(Messages.CONFIRM_DELETE_PVS_SITE, siteName), Messages.XENCENTER),
+                    new ThreeButtonDialog.Details(SystemIcons.Warning, message, Messages.XENCENTER),
                     ThreeButtonDialog.ButtonOK,
                     ThreeButtonDialog.ButtonCancel))
             {

--- a/XenAdmin/Dialogs/PvsCacheConfigurationDialog.resx
+++ b/XenAdmin/Dialogs/PvsCacheConfigurationDialog.resx
@@ -139,19 +139,19 @@
     <value>NoControl</value>
   </data>
   <data name="addSiteButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>194, 111</value>
+    <value>172, 111</value>
   </data>
   <data name="addSiteButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>5, 0, 3, 0</value>
   </data>
   <data name="addSiteButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 25</value>
+    <value>199, 25</value>
   </data>
   <data name="addSiteButton.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
   <data name="addSiteButton.Text" xml:space="preserve">
-    <value>A&amp;dd Site for Caching</value>
+    <value>A&amp;dd PVS Cache Configuration</value>
   </data>
   <data name="addSiteButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageBeforeText</value>
@@ -268,13 +268,13 @@
     <value>5, 0, 3, 0</value>
   </data>
   <data name="AddButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 25</value>
+    <value>199, 25</value>
   </data>
   <data name="AddButton.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
   <data name="AddButton.Text" xml:space="preserve">
-    <value>A&amp;dd Site for Caching</value>
+    <value>A&amp;dd PVS Cache Configuration</value>
   </data>
   <data name="AddButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>

--- a/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.resx
+++ b/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.resx
@@ -176,7 +176,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>NoControl</value>
   </data>
   <data name="deleteButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 330</value>
+    <value>231, 330</value>
   </data>
   <data name="deleteButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>
@@ -185,13 +185,13 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>5, 0, 5, 0</value>
   </data>
   <data name="deleteButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 23</value>
+    <value>206, 23</value>
   </data>
   <data name="deleteButton.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="deleteButton.Text" xml:space="preserve">
-    <value>&amp;Remove Cache Configuration</value>
+    <value>&amp;Remove PVS Cache Configuration</value>
   </data>
   <data name="deleteButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageBeforeText</value>
@@ -341,7 +341,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>NoControl</value>
   </data>
   <data name="viewPvsServersButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>127, 330</value>
+    <value>103, 330</value>
   </data>
   <data name="viewPvsServersButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -403,7 +403,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configuring PVS site.
+        ///   Looks up a localized string similar to Configuring PVS cache.
         /// </summary>
         public static string ACTION_CONFUGURE_PVS_SITE_DESCRIPTION {
             get {
@@ -421,7 +421,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configure PVS site &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Configure PVS cache on &apos;{0}&apos;.
         /// </summary>
         public static string ACTION_CONFUGURE_PVS_SITE_TITLE {
             get {
@@ -475,7 +475,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deleting PVS site.
+        ///   Looks up a localized string similar to Deleting PVS cache configuration.
         /// </summary>
         public static string ACTION_DELETE_PVS_SITE_DESCRIPTION {
             get {
@@ -493,7 +493,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deleting PVS site &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Deleting PVS cache configuration on &apos;{0}&apos;.
         /// </summary>
         public static string ACTION_DELETE_PVS_SITE_TITLE {
             get {
@@ -943,7 +943,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enabling PVS read caching for VM &apos;{0}&apos; on site &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Enabling PVS read caching for VM &apos;{0}&apos; on &apos;{1}&apos;.
         /// </summary>
         public static string ACTION_ENABLE_PVS_READ_CACHING_FOR {
             get {
@@ -7305,6 +7305,15 @@ namespace XenAdmin {
         public static string CONFIRM_DELETE_PVS_SITE {
             get {
                 return ResourceManager.GetString("CONFIRM_DELETE_PVS_SITE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This configuration is in use by PVS. Are you sure you want to delete &apos;{0}&apos;?.
+        /// </summary>
+        public static string CONFIRM_DELETE_PVS_SITE_IN_USE {
+            get {
+                return ResourceManager.GetString("CONFIRM_DELETE_PVS_SITE_IN_USE", resourceCulture);
             }
         }
         
@@ -28003,7 +28012,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This PVS site cannot be removed because it contains running proxies..
+        ///   Looks up a localized string similar to This PVS cache configuration cannot be removed because it contains running proxies..
         /// </summary>
         public static string PVS_SITE_CANNOT_BE_REMOVED {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -232,13 +232,13 @@
     <value>Clean up disk space</value>
   </data>
   <data name="ACTION_CONFUGURE_PVS_SITE_DESCRIPTION" xml:space="preserve">
-    <value>Configuring PVS site</value>
+    <value>Configuring PVS cache</value>
   </data>
   <data name="ACTION_CONFUGURE_PVS_SITE_DONE" xml:space="preserve">
     <value>Configured</value>
   </data>
   <data name="ACTION_CONFUGURE_PVS_SITE_TITLE" xml:space="preserve">
-    <value>Configure PVS site '{0}'</value>
+    <value>Configure PVS cache on '{0}'</value>
   </data>
   <data name="ACTION_CREATE_BOND_DESCRIPTION" xml:space="preserve">
     <value>Creating {0} ...</value>
@@ -256,13 +256,13 @@
     <value>Deactivating Multiple Virtual Disks</value>
   </data>
   <data name="ACTION_DELETE_PVS_SITE_DESCRIPTION" xml:space="preserve">
-    <value>Deleting PVS site</value>
+    <value>Deleting PVS cache configuration</value>
   </data>
   <data name="ACTION_DELETE_PVS_SITE_DONE" xml:space="preserve">
     <value>Done</value>
   </data>
   <data name="ACTION_DELETE_PVS_SITE_TITLE" xml:space="preserve">
-    <value>Deleting PVS site '{0}'</value>
+    <value>Deleting PVS cache configuration on '{0}'</value>
   </data>
   <data name="ACTION_DELETING_MULTIPLE_STORAGE_ITEMS_STATUS" xml:space="preserve">
     <value>Deleting storage items...</value>
@@ -415,7 +415,7 @@
     <value>Enable PVS read caching</value>
   </data>
   <data name="ACTION_ENABLE_PVS_READ_CACHING_FOR" xml:space="preserve">
-    <value>Enabling PVS read caching for VM '{0}' on site '{1}'</value>
+    <value>Enabling PVS read caching for VM '{0}' on '{1}'</value>
   </data>
   <data name="ACTION_ENABLE_VM_ENLIGHTENMENT_DESCRIPTION" xml:space="preserve">
     <value>Enabling</value>
@@ -2654,6 +2654,9 @@ Do you want to continue?</value>
   </data>
   <data name="CONFIRM_DELETE_PVS_SITE" xml:space="preserve">
     <value>Are you sure you want to delete '{0}'?</value>
+  </data>
+  <data name="CONFIRM_DELETE_PVS_SITE_IN_USE" xml:space="preserve">
+    <value>Are you sure you want to delete '{0}'? This configuration is in use by PVS.</value>
   </data>
   <data name="CONFIRM_DELETE_TAG" xml:space="preserve">
     <value>Are you sure you want to delete the tag '{0}' from all managed resources?</value>
@@ -9737,7 +9740,7 @@ Press OK to continue the wizard and return to the server and follow the instruct
     <value>Not configured</value>
   </data>
   <data name="PVS_SITE_CANNOT_BE_REMOVED" xml:space="preserve">
-    <value>This PVS site cannot be removed because it contains running proxies.</value>
+    <value>This PVS cache configuration cannot be removed because there are VMs that are streamed from this site.</value>
   </data>
   <data name="PVS_SITE_DIALOG_TITLE" xml:space="preserve">
     <value>PVS Servers on site {0}'</value>


### PR DESCRIPTION
- show a different message when deleting a Cache Configuration (a PVS_site object) that is actively in use by a PVS site
- some more text changes on the "Configure PVS Cache" dialog

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>