### PR TITLE
CA-227067: General tab: XenCenter does not show Reboot required when Toolstack restart required

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -15792,7 +15792,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Toolstack on server &apos;{0}&apos; needs to be restarted for update &apos;{1}&apos; to take effect.
+        ///   Looks up a localized string similar to The toolstack on server &apos;{0}&apos; needs to be restarted for update &apos;{1}&apos; to take effect.
         /// </summary>
         public static string GENERAL_PANEL_UPDATE_RESTART_TOOLSTACK_WARNING {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5537,7 +5537,7 @@ Would you like to eject these ISOs before continuing?</value>
     <value>The server '{0}' needs to be rebooted for update '{1}' to take effect</value>
   </data>
   <data name="GENERAL_PANEL_UPDATE_RESTART_TOOLSTACK_WARNING" xml:space="preserve">
-    <value>Toolstack on server '{0}' needs to be restarted for update '{1}' to take effect</value>
+    <value>The toolstack on server '{0}' needs to be restarted for update '{1}' to take effect</value>
   </data>
   <data name="GENERAL_SR_CONTEXT_REPAIR" xml:space="preserve">
     <value>Repair</value>


### PR DESCRIPTION
Fixed the displayed text

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>