### PR TITLE
[CA-227602] Truncation on the Install Mode page in the Install Upgrade wizard

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.Designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.Designer.cs
@@ -75,11 +75,11 @@ namespace XenAdmin.Wizards.PatchingWizard
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.autoHeightLabel1, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.ManualRadioButton, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.button1, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.removeUpdateFileCheckBox, 0, 7);
-            this.tableLayoutPanel1.Controls.Add(this.textBoxLog, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.ManualRadioButton, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.button1, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.removeUpdateFileCheckBox, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.textBoxLog, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.allowRadioButtonContainer, 0, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
@@ -130,13 +130,13 @@
     <value>Fill</value>
   </data>
   <data name="ManualRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 159</value>
+    <value>15, 99</value>
   </data>
   <data name="ManualRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>15, 3, 3, 3</value>
   </data>
   <data name="ManualRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1394, 36</value>
+    <value>688, 41</value>
   </data>
   <data name="ManualRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -163,13 +163,13 @@
     <value>True</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 208</value>
+    <value>3, 153</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 10, 3, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 32</value>
+    <value>155, 17</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -193,13 +193,13 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="textBoxLog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 243</value>
+    <value>3, 173</value>
   </data>
   <data name="textBoxLog.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="textBoxLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1406, 844</value>
+    <value>700, 321</value>
   </data>
   <data name="textBoxLog.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -223,13 +223,13 @@
     <value>True</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 1093</value>
+    <value>3, 500</value>
   </data>
   <data name="button1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 10</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 23</value>
+    <value>137, 27</value>
   </data>
   <data name="button1.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -265,7 +265,7 @@
     <value>3, 3, 3, 15</value>
   </data>
   <data name="autoHeightLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1406, 96</value>
+    <value>700, 51</value>
   </data>
   <data name="autoHeightLabel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -289,10 +289,10 @@
     <value>True</value>
   </data>
   <data name="removeUpdateFileCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 1129</value>
+    <value>3, 540</value>
   </data>
   <data name="removeUpdateFileCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>730, 36</value>
+    <value>365, 21</value>
   </data>
   <data name="removeUpdateFileCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -331,7 +331,7 @@
     <value>15, 3, 3, 3</value>
   </data>
   <data name="AutomaticRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1394, 36</value>
+    <value>688, 21</value>
   </data>
   <data name="AutomaticRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -355,13 +355,13 @@
     <value>Fill</value>
   </data>
   <data name="allowRadioButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 117</value>
+    <value>15, 72</value>
   </data>
   <data name="allowRadioButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>15, 3, 3, 3</value>
   </data>
   <data name="allowRadioButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1394, 36</value>
+    <value>688, 21</value>
   </data>
   <data name="allowRadioButtonContainer.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -391,7 +391,7 @@
     <value>8</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1412, 1168</value>
+    <value>706, 584</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -409,7 +409,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="autoHeightLabel1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ManualRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button1" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="removeUpdateFileCheckBox" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxLog" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="allowRadioButtonContainer" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="autoHeightLabel1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ManualRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button1" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="removeUpdateFileCheckBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxLog" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="allowRadioButtonContainer" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,47,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -418,16 +418,16 @@
     <value />
   </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>240, 240</value>
+    <value>120, 120</value>
   </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1412, 1168</value>
+    <value>706, 584</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PatchingWizard_ModePage</value>

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
@@ -199,7 +199,7 @@
     <value>True</value>
   </data>
   <data name="textBoxLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>700, 321</value>
+    <value>700, 341</value>
   </data>
   <data name="textBoxLog.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -223,7 +223,7 @@
     <value>True</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 500</value>
+    <value>3, 520</value>
   </data>
   <data name="button1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 10</value>
@@ -289,7 +289,7 @@
     <value>True</value>
   </data>
   <data name="removeUpdateFileCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 540</value>
+    <value>3, 560</value>
   </data>
   <data name="removeUpdateFileCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>365, 21</value>
@@ -388,7 +388,7 @@
     <value>1, 1</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>706, 584</value>


### PR DESCRIPTION
I've looked at how this was implemented in Dundee, and there we used an absolute height on the row containing the manual checkbox. I've done the same here, changing row 3 from autosize to absoliute 47px. I've also removed the empty row that was between the two radio buttons. This is a Winforms problem, without workarounds an autosize radio button in an autosize container (say the table row) will report its height as one row of text, no matter whether it needs more. This seems to be the only place we use a long radio label (as opposed to a separate label underneath the radio), so I doubt it's worth doing anything more complex than this. I've tested it with the CN string used in the ticket, and it uses less space than the English translation. The string also hasn't changed from Dundee.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>