### PR TITLE
CA-213563: VM policy cannot be changed to snapshot with quiesce after installing vss tools

### DIFF
--- a/XenAdmin/Dialogs/PropertiesDialog.cs
+++ b/XenAdmin/Dialogs/PropertiesDialog.cs
@@ -465,6 +465,14 @@ namespace XenAdmin.Dialogs
 
         private void verticalTabs_SelectedIndexChanged(object sender, EventArgs e)
         {
+            
+            var snapshotTypePageSpecific = verticalTabs.SelectedItem as NewPolicySnapshotTypePageSpecific<VMSS>;
+            if (snapshotTypePageSpecific != null)
+            {
+                newPolicyVMSSTypePage1.ToggleQuiesceCheckBox(newVMSSVMsPage1.SelectedVMs);
+                return;
+            }
+
             var selectedPage = verticalTabs.SelectedItem as NewPolicyArchivePage;
             if (selectedPage != null)
             {

--- a/XenAdmin/Wizards/NewPolicyWizard/NewPolicySnapshotTypePageSpecific.cs
+++ b/XenAdmin/Wizards/NewPolicyWizard/NewPolicySnapshotTypePageSpecific.cs
@@ -164,6 +164,39 @@ namespace XenAdmin.Wizards.NewPolicyWizard
             }
         }
 
+        public void ToggleQuiesceCheckBox(List <VM> SelectedVMs)
+        {
+
+            switch (BackupType)
+            {
+                case policy_backup_type.snapshot:
+                    quiesceCheckBox.Enabled = true;
+                    quiesceCheckBox.Checked = false;
+                    break;
+
+                case policy_backup_type.snapshot_with_quiesce:
+                    quiesceCheckBox.Enabled = true;
+                    quiesceCheckBox.Checked = true;
+                    break;
+
+                case policy_backup_type.checkpoint:
+                    quiesceCheckBox.Enabled = true;
+                    quiesceCheckBox.Checked = false;
+                    break;
+            }
+
+            foreach (VM vm in SelectedVMs)
+            {
+                if (!vm.allowed_operations.Contains(vm_operations.snapshot_with_quiesce) || Helpers.FeatureForbidden(vm, Host.RestrictVss))
+                {
+                    quiesceCheckBox.Enabled = false;
+                    quiesceCheckBox.Checked = false;
+                    break;
+                }
+            }
+
+        }
+
         private void RefreshTab(IVMPolicy policy)
         {
             /* when a policy does not have any VMs, irrespective of


### PR DESCRIPTION
Enabling snapshot policy type to be changed to quiesce from other snapshot policy types if the selected VMs are quiesce snapshot capable.

Signed-off-by: Sharath Babu <sharath.babu@citrix.com>