### PR TITLE
CA-227274: Fix CN and JP version process lable size

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.ja.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.ja.resx
@@ -173,7 +173,7 @@
     <value>1, 1, 1, 1</value>
   </data>
   <data name="labelProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>694, 15</value>
+    <value>694, 18</value>
   </data>
   <data name="labelProgress.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.zh-CN.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.zh-CN.resx
@@ -173,7 +173,7 @@
     <value>1, 1, 1, 1</value>
   </data>
   <data name="labelProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>694, 15</value>
+    <value>694, 18</value>
   </data>
   <data name="labelProgress.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>


### PR DESCRIPTION
This change is to change CN and JP process_lable height same as EN version
Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>