### PR TITLE
[CA-225715] Performance Graph reporting for CPU for a VM based on max VCPUs

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/GraphList.cs
+++ b/XenAdmin/Controls/CustomDataGraph/GraphList.cs
@@ -404,7 +404,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
                 DesignedGraph cpudg = new DesignedGraph();
                 cpudg.DisplayName = Messages.GRAPHS_DEFAULT_NAME_CPU;
-                for (int i = 0; i < vm.VCPUs_max; i++)
+                for (int i = 0; i < vm.VCPUs_at_startup; i++)
                 {
                     AddDataSource(string.Format("vm:{0}:cpu{1}", vm.uuid, i), dsuuids, cpudg);
                 }


### PR DESCRIPTION
(not current vcpus)

Instead of using VCPUs_max, use VCPUs_at_startup, which is the value set when we change the VCPUs count on the VM. Note that despite its name we don't need to restart to see this value change.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>