### PR TITLE
CA-226103: Hotkey conflict in the “Choose the type of new storage” UI…

### DIFF
--- a/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.cs
@@ -264,7 +264,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
                 {
                     upsellPage1.Visible = false;
                     selectedStoreTypeLabel.Visible = true;
-                    selectedStoreTypeLabel.Text = radioButton.Text;
+                    selectedStoreTypeLabel.Text = frontend.FrontendTypeName;
                     SRBlurb.Visible = true;
                     SRBlurb.Text = frontend.FrontendBlurb;
                     m_allowNext = true;

--- a/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.resx
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.resx
@@ -142,7 +142,7 @@
     <value>11</value>
   </data>
   <data name="radioButtonNfs.Text" xml:space="preserve">
-    <value>&amp;NFS</value>
+    <value>N&amp;FS</value>
   </data>
   <data name="&gt;&gt;radioButtonNfs.Name" xml:space="preserve">
     <value>radioButtonNfs</value>

--- a/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
@@ -113,6 +113,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
         /// CA-16955: New SR wizard could show blurb for each backend type
         /// </summary>
         public abstract string FrontendBlurb { get; }
+        public abstract string FrontendTypeName { get; }
         public abstract SR.SRTypes Type { get; }
         public abstract string ContentType { get; }
         public abstract bool ShowIntroducePrompt { get; }
@@ -209,6 +210,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
 
         public override bool IsEnhancedSR { get { return false; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_CIFS_ISO_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_CIFS_ISO_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.iso; } }
         public override string ContentType { get { return SR.Content_Type_ISO; } }
         public override bool ShowIntroducePrompt { get { return false; } }
@@ -225,6 +227,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
     {
         public override bool IsEnhancedSR { get { return false; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_LVMOISCSI_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_LVMOISCSI_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.lvmoiscsi; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return false; } }
@@ -241,6 +244,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
     {
         public override bool IsEnhancedSR { get { return false; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_LVMOHBA_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_LVMOHBA_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.lvmohba; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return false; } }
@@ -262,6 +266,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
 
         public override bool IsEnhancedSR { get { return false; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_VHDONFS_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_VHDONFS_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.nfs; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return true; } }
@@ -283,6 +288,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
 
         public override bool IsEnhancedSR { get { return false; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_NFS_ISO_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_NFS_ISO_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.iso; } }
         public override string ContentType { get { return SR.Content_Type_ISO; } }
         public override bool ShowIntroducePrompt { get { return false; } }
@@ -304,6 +310,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
 
         public override bool IsEnhancedSR { get { return false; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_CIFS_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_CIFS_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.smb; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return false; } }
@@ -320,6 +327,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
     {
         public override bool IsEnhancedSR { get { return true; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_CSLG_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_CSLG_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.cslg; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return true; } }
@@ -363,6 +371,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
     {
         public override bool IsEnhancedSR { get { return true; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_NETAPP_BLURB; } }
+        public override string FrontendTypeName { get { return SR.getFriendlyTypeName(Type); } }
         public override SR.SRTypes Type { get { return SR.SRTypes.netapp; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return true; } }
@@ -374,6 +383,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
     {
         public override bool IsEnhancedSR { get { return true; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_EQUAL_LOGIC_BLURB; } }
+        public override string FrontendTypeName { get { return SR.getFriendlyTypeName(Type); } }
         public override SR.SRTypes Type { get { return SR.SRTypes.equal; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return true; } }
@@ -385,6 +395,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
     {
         public override bool IsEnhancedSR { get { return false; } }
         public override string FrontendBlurb { get { return Messages.NEWSR_LVMOFCOE_BLURB; } }
+        public override string FrontendTypeName { get { return Messages.NEWSR_LVMOFCOE_TYPE_NAME; } }
         public override SR.SRTypes Type { get { return SR.SRTypes.lvmofcoe; } }
         public override string ContentType { get { return ""; } }
         public override bool ShowIntroducePrompt { get { return false; } }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -7309,7 +7309,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This configuration is in use by PVS. Are you sure you want to delete &apos;{0}&apos;?.
+        ///   Looks up a localized string similar to Are you sure you want to delete &apos;{0}&apos;? This configuration is in use by PVS..
         /// </summary>
         public static string CONFIRM_DELETE_PVS_SITE_IN_USE {
             get {
@@ -23650,6 +23650,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Windows File Sharing (SMB/CIFS).
+        /// </summary>
+        public static string NEWSR_CIFS_ISO_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_CIFS_ISO_TYPE_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SMB/CIFS.
+        /// </summary>
+        public static string NEWSR_CIFS_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_CIFS_TYPE_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select the storage system adapter.
         /// </summary>
         public static string NEWSR_CSLG_ADAPTER_PAGE_TITLE {
@@ -23754,6 +23772,15 @@ namespace XenAdmin {
         public static string NEWSR_CSLG_THIN_PROVISIONING {
             get {
                 return ResourceManager.GetString("NEWSR_CSLG_THIN_PROVISIONING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StorageLink technology.
+        /// </summary>
+        public static string NEWSR_CSLG_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_CSLG_TYPE_NAME", resourceCulture);
             }
         }
         
@@ -23917,6 +23944,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Software FCoE.
+        /// </summary>
+        public static string NEWSR_LVMOFCOE_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_LVMOFCOE_TYPE_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [XenServer] hosts support Fibre Channel (FC), Fibre Channel over Ethernet (FCoE) and shared Serial Attached SCSI (SAS) storage area networks (SANs) using host bus adapters (HBAs).
         ///
         ///All configuration required to expose a LUN to the host must be completed manually, including storage devices, network devices, and the HBA within the [XenServer] host.
@@ -24020,6 +24056,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hardware HBA.
+        /// </summary>
+        public static string NEWSR_LVMOHBA_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_LVMOHBA_TYPE_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to iSCSI or Fibre Channel access to a shared LUN can be configured using LVM.
         ///
         ///Using an LVM for a shared SR provides the same performance benefits as a unshared LVM for local disk storage but also enables VM agility..
@@ -24027,6 +24072,15 @@ namespace XenAdmin {
         public static string NEWSR_LVMOISCSI_BLURB {
             get {
                 return ResourceManager.GetString("NEWSR_LVMOISCSI_BLURB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to iSCSI.
+        /// </summary>
+        public static string NEWSR_LVMOISCSI_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_LVMOISCSI_TYPE_NAME", resourceCulture);
             }
         }
         
@@ -24125,6 +24179,15 @@ namespace XenAdmin {
         public static string NEWSR_NFS_ISO_BLURB {
             get {
                 return ResourceManager.GetString("NEWSR_NFS_ISO_BLURB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NFS ISO.
+        /// </summary>
+        public static string NEWSR_NFS_ISO_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_NFS_ISO_TYPE_NAME", resourceCulture);
             }
         }
         
@@ -24246,6 +24309,15 @@ namespace XenAdmin {
         public static string NEWSR_VHDONFS_BLURB {
             get {
                 return ResourceManager.GetString("NEWSR_VHDONFS_BLURB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NFS.
+        /// </summary>
+        public static string NEWSR_VHDONFS_TYPE_NAME {
+            get {
+                return ResourceManager.GetString("NEWSR_VHDONFS_TYPE_NAME", resourceCulture);
             }
         }
         
@@ -28039,7 +28111,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This PVS cache configuration cannot be removed because it contains running proxies..
+        ///   Looks up a localized string similar to This PVS cache configuration cannot be removed because there are VMs that are streamed from this site..
         /// </summary>
         public static string PVS_SITE_CANNOT_BE_REMOVED {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8093,6 +8093,12 @@ When you configure a SMB storage repository, you simply provide the hostname or 
   <data name="NEWSR_CIFS_ISO_BLURB" xml:space="preserve">
     <value>Select this option if you have a library of VM installation ISO images available as a Windows (SMB/CIFS) share that you wish to attach to your host or pool.</value>
   </data>
+  <data name="NEWSR_CIFS_ISO_TYPE_NAME" xml:space="preserve">
+    <value>Windows File Sharing (SMB/CIFS)</value>
+  </data>
+  <data name="NEWSR_CIFS_TYPE_NAME" xml:space="preserve">
+    <value>SMB/CIFS</value>
+  </data>
   <data name="NEWSR_CIF_DESCRIPTION" xml:space="preserve">
     <value>SMB ISO Library [{0}]</value>
   </data>
@@ -8131,6 +8137,9 @@ When you configure a SMB storage repository, you simply provide the hostname or 
   </data>
   <data name="NEWSR_CSLG_THIN_PROVISIONING" xml:space="preserve">
     <value>Thin</value>
+  </data>
+  <data name="NEWSR_CSLG_TYPE_NAME" xml:space="preserve">
+    <value>StorageLink technology</value>
   </data>
   <data name="NEWSR_EQUAL_LOGIC_BLURB" xml:space="preserve">
     <value>Dell EqualLogic is a scalable form of high performance network attached storage, which supports the addition of capacity without downtime. You can use Dell EqualLogic shared storage to support [XenServer] features such as Live Migration and High Availability.</value>
@@ -8189,6 +8198,9 @@ Once this configuration has been carried out, this wizard will walk you through 
   <data name="NEWSR_LVMOFCOE_DESCRIPTION" xml:space="preserve">
     <value>Software FCoE SR [{0} - {1}]</value>
   </data>
+  <data name="NEWSR_LVMOFCOE_TYPE_NAME" xml:space="preserve">
+    <value>Software FCoE</value>
+  </data>
   <data name="NEWSR_LVMOHBA_BLURB" xml:space="preserve">
     <value>[XenServer] hosts support Fibre Channel (FC), Fibre Channel over Ethernet (FCoE) and shared Serial Attached SCSI (SAS) storage area networks (SANs) using host bus adapters (HBAs).
 
@@ -8226,10 +8238,16 @@ Once all configuration is complete the HBA will expose a SCSI device backed by t
   <data name="NEWSR_LVMOHBA_SUMMARY_TEXT" xml:space="preserve">
     <value>Summary</value>
   </data>
+  <data name="NEWSR_LVMOHBA_TYPE_NAME" xml:space="preserve">
+    <value>Hardware HBA</value>
+  </data>
   <data name="NEWSR_LVMOISCSI_BLURB" xml:space="preserve">
     <value>iSCSI or Fibre Channel access to a shared LUN can be configured using LVM.
 
 Using an LVM for a shared SR provides the same performance benefits as a unshared LVM for local disk storage but also enables VM agility.</value>
+  </data>
+  <data name="NEWSR_LVMOISCSI_TYPE_NAME" xml:space="preserve">
+    <value>iSCSI</value>
   </data>
   <data name="NEWSR_MULTI_POOL_WARNING" xml:space="preserve">
     <value>Warning: you must ensure that the following SR is not in use by any server not connected to [XenCenter]. Failure to do so may result in data loss.
@@ -8268,6 +8286,9 @@ VM cloning uses the snapshot and clone capabilities of the filer to provide high
   </data>
   <data name="NEWSR_NFS_ISO_BLURB" xml:space="preserve">
     <value>Select this option if you have a library of VM installation ISO images available as a NFS share that you wish to attach to your host or pool.</value>
+  </data>
+  <data name="NEWSR_NFS_ISO_TYPE_NAME" xml:space="preserve">
+    <value>NFS ISO</value>
   </data>
   <data name="NEWSR_NOWHERE_TO_CREATE" xml:space="preserve">
     <value>The given filer has no existing SRs and nowhere to create a new SR.</value>
@@ -8311,6 +8332,9 @@ VM cloning uses the snapshot and clone capabilities of the filer to provide high
 As NFS storage repositories are shared, the virtual disks stored in them allow VMs to be started on any server in a resource pool and to be migrated between them using Live Migration.
 
 When you configure an NFS storage repository, you simply provide the hostname or IP address of the NFS server and the path to a directory that will be used to contain the storage repository. The NFS server must be configured to export the specified path to all servers in the pool.</value>
+  </data>
+  <data name="NEWSR_VHDONFS_TYPE_NAME" xml:space="preserve">
+    <value>NFS</value>
   </data>
   <data name="NEWVMAPPLIANCE_FINISHPAGE_TEXT" xml:space="preserve">
     <value>Finish</value>


### PR DESCRIPTION
… while creating new storage

Also changed the page to use different resource strings for the Storage type in the right hand panel (no hotkeys should be shown there)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>