### PR TITLE
[CA-227845] Fixing problems caused by tooltip container on hotfix wizard mode page

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.Designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.Designer.cs
@@ -30,18 +30,18 @@ namespace XenAdmin.Wizards.PatchingWizard
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PatchingWizard_ModePage));
             this.ManualRadioButton = new System.Windows.Forms.RadioButton();
             this.label2 = new System.Windows.Forms.Label();
             this.textBoxLog = new System.Windows.Forms.TextBox();
             this.button1 = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.AutomaticRadioButton = new System.Windows.Forms.RadioButton();
             this.autoHeightLabel1 = new XenAdmin.Controls.Common.AutoHeightLabel();
             this.removeUpdateFileCheckBox = new System.Windows.Forms.CheckBox();
-            this.allowRadioButtonContainer = new XenAdmin.Controls.ToolTipContainer();
-            this.AutomaticRadioButton = new System.Windows.Forms.RadioButton();
+            this.automaticRadioButtonTooltip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1.SuspendLayout();
-            this.allowRadioButtonContainer.SuspendLayout();
             this.SuspendLayout();
             // 
             // ManualRadioButton
@@ -74,14 +74,22 @@ namespace XenAdmin.Wizards.PatchingWizard
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.AutomaticRadioButton, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.autoHeightLabel1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.ManualRadioButton, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.button1, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.removeUpdateFileCheckBox, 0, 6);
             this.tableLayoutPanel1.Controls.Add(this.textBoxLog, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.allowRadioButtonContainer, 0, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // AutomaticRadioButton
+            // 
+            resources.ApplyResources(this.AutomaticRadioButton, "AutomaticRadioButton");
+            this.AutomaticRadioButton.Name = "AutomaticRadioButton";
+            this.AutomaticRadioButton.TabStop = true;
+            this.AutomaticRadioButton.UseVisualStyleBackColor = true;
+            this.AutomaticRadioButton.CheckedChanged += new System.EventHandler(this.AutomaticRadioButton_CheckedChanged);
             // 
             // autoHeightLabel1
             // 
@@ -96,20 +104,6 @@ namespace XenAdmin.Wizards.PatchingWizard
             this.removeUpdateFileCheckBox.Name = "removeUpdateFileCheckBox";
             this.removeUpdateFileCheckBox.UseVisualStyleBackColor = true;
             // 
-            // allowRadioButtonContainer
-            // 
-            resources.ApplyResources(this.allowRadioButtonContainer, "allowRadioButtonContainer");
-            this.allowRadioButtonContainer.Controls.Add(this.AutomaticRadioButton);
-            this.allowRadioButtonContainer.Name = "allowRadioButtonContainer";
-            // 
-            // AutomaticRadioButton
-            // 
-            resources.ApplyResources(this.AutomaticRadioButton, "AutomaticRadioButton");
-            this.AutomaticRadioButton.Name = "AutomaticRadioButton";
-            this.AutomaticRadioButton.TabStop = true;
-            this.AutomaticRadioButton.UseVisualStyleBackColor = true;
-            this.AutomaticRadioButton.CheckedChanged += new System.EventHandler(this.AutomaticRadioButton_CheckedChanged);
-            // 
             // PatchingWizard_ModePage
             // 
             resources.ApplyResources(this, "$this");
@@ -118,8 +112,6 @@ namespace XenAdmin.Wizards.PatchingWizard
             this.Name = "PatchingWizard_ModePage";
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
-            this.allowRadioButtonContainer.ResumeLayout(false);
-            this.allowRadioButtonContainer.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -133,7 +125,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private XenAdmin.Controls.Common.AutoHeightLabel autoHeightLabel1;
         private System.Windows.Forms.CheckBox removeUpdateFileCheckBox;
-        private Controls.ToolTipContainer allowRadioButtonContainer;
         private RadioButton AutomaticRadioButton;
+        private ToolTip automaticRadioButtonTooltip;
     }
 }

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
@@ -139,7 +139,7 @@
     <value>688, 41</value>
   </data>
   <data name="ManualRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="ManualRadioButton.Text" xml:space="preserve">
     <value>I will carry out the post-update tasks &amp;myself. If you are intending to apply further updates immediately after this one, choose this option and carry out the post-update tasks once at the end.</value>
@@ -157,7 +157,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;ManualRadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -187,7 +187,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="textBoxLog.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -202,7 +202,7 @@
     <value>700, 341</value>
   </data>
   <data name="textBoxLog.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;textBoxLog.Name" xml:space="preserve">
     <value>textBoxLog</value>
@@ -214,7 +214,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;textBoxLog.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="button1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -232,7 +232,7 @@
     <value>137, 27</value>
   </data>
   <data name="button1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="button1.Text" xml:space="preserve">
     <value>&amp;Save tasks to file...</value>
@@ -247,10 +247,46 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
+  </data>
+  <data name="AutomaticRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="AutomaticRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="AutomaticRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="AutomaticRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 72</value>
+  </data>
+  <data name="AutomaticRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>15, 3, 3, 3</value>
+  </data>
+  <data name="AutomaticRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>688, 21</value>
+  </data>
+  <data name="AutomaticRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="AutomaticRadioButton.Text" xml:space="preserve">
+    <value>&amp;Allow [XenCenter] to carry out the post-update tasks as soon as the update has been applied.</value>
+  </data>
+  <data name="&gt;&gt;AutomaticRadioButton.Name" xml:space="preserve">
+    <value>AutomaticRadioButton</value>
+  </data>
+  <data name="&gt;&gt;AutomaticRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AutomaticRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;AutomaticRadioButton.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="autoHeightLabel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -283,7 +319,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;autoHeightLabel1.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="removeUpdateFileCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -295,7 +331,7 @@
     <value>365, 21</value>
   </data>
   <data name="removeUpdateFileCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>5</value>
   </data>
   <data name="removeUpdateFileCheckBox.Text" xml:space="preserve">
     <value>Allow [XenCenter] to &amp;delete the update installation file</value>
@@ -310,73 +346,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;removeUpdateFileCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="allowRadioButtonContainer.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="AutomaticRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="AutomaticRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="AutomaticRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="AutomaticRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="AutomaticRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>15, 3, 3, 3</value>
-  </data>
-  <data name="AutomaticRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>688, 21</value>
-  </data>
-  <data name="AutomaticRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="AutomaticRadioButton.Text" xml:space="preserve">
-    <value>&amp;Allow [XenCenter] to carry out the post-update tasks as soon as the update has been applied.</value>
-  </data>
-  <data name="&gt;&gt;AutomaticRadioButton.Name" xml:space="preserve">
-    <value>AutomaticRadioButton</value>
-  </data>
-  <data name="&gt;&gt;AutomaticRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AutomaticRadioButton.Parent" xml:space="preserve">
-    <value>allowRadioButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;AutomaticRadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="allowRadioButtonContainer.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="allowRadioButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 72</value>
-  </data>
-  <data name="allowRadioButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>15, 3, 3, 3</value>
-  </data>
-  <data name="allowRadioButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>688, 21</value>
-  </data>
-  <data name="allowRadioButtonContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;allowRadioButtonContainer.Name" xml:space="preserve">
-    <value>allowRadioButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;allowRadioButtonContainer.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;allowRadioButtonContainer.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;allowRadioButtonContainer.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -409,8 +379,11 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="autoHeightLabel1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ManualRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button1" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="removeUpdateFileCheckBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxLog" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="allowRadioButtonContainer" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,47,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AutomaticRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="autoHeightLabel1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ManualRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button1" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="removeUpdateFileCheckBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxLog" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,47,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
+  <metadata name="automaticRadioButtonTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -428,6 +401,12 @@
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>706, 584</value>
+  </data>
+  <data name="&gt;&gt;automaticRadioButtonTooltip.Name" xml:space="preserve">
+    <value>automaticRadioButtonTooltip</value>
+  </data>
+  <data name="&gt;&gt;automaticRadioButtonTooltip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PatchingWizard_ModePage</value>


### PR DESCRIPTION
Due to the tooltip container introduced for the automatic radio button, winforms didn't treat these radio buttons properly - we needed code to make them mutually exclusive, tab didn't behave properly and keyboard arrow navigation between them didn't work. Therefore I have removed the tooltip container (so our radio buttons behave properly without any extra work) and we instead use a winforms tooltip shown when the mouse is over the automatic radio button. Note that since the control is disabled when we want a tooltip, neither hover events nor attaching a winforms tooltip in the usual way will work. Therefore I use a mousemove event on the table, which displays the tooltip if and only if we are over the disabled control. 

Also adjusted the tab indexes to make sure tab works correctly across the whole page.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>