### PR TITLE
[CA-228051] XenCenter allows user to create unusable PVS Proxy cache config

### DIFF
--- a/XenAdmin/Controls/ComboBoxes/EnableableComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/EnableableComboBox.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Controls
     {
         public EnableableComboBox()
         {
-            DrawMode = DrawMode.OwnerDrawFixed;
+            DrawMode = DrawMode.OwnerDrawVariable;
             DropDownStyle = ComboBoxStyle.DropDownList;
         }
 

--- a/XenAdmin/Controls/ComboBoxes/EnableableComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/EnableableComboBox.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Controls
     {
         public EnableableComboBox()
         {
-            DrawMode = DrawMode.OwnerDrawVariable;
+            DrawMode = DrawMode.OwnerDrawFixed;
             DropDownStyle = ComboBoxStyle.DropDownList;
         }
 

--- a/XenAdmin/Dialogs/EnablePvsReadCachingDialog.Designer.cs
+++ b/XenAdmin/Dialogs/EnablePvsReadCachingDialog.Designer.cs
@@ -32,7 +32,7 @@ namespace XenAdmin.Dialogs
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EnablePvsReadCachingDialog));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.pvsSiteList = new EnableableComboBox();
+            this.pvsSiteList = new LongStringComboBox();
             this.rubricLabel = new System.Windows.Forms.Label();
             this.pvsSiteLabel = new System.Windows.Forms.Label();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
@@ -120,7 +120,7 @@ namespace XenAdmin.Dialogs
         private XenAdmin.Controls.ToolTipContainer readonlyCheckboxToolTipContainer;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label rubricLabel;
-        private EnableableComboBox pvsSiteList;
+        private LongStringComboBox pvsSiteList;
         private System.Windows.Forms.Label pvsSiteLabel;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.Button cancel;

--- a/XenAdmin/Dialogs/EnablePvsReadCachingDialog.Designer.cs
+++ b/XenAdmin/Dialogs/EnablePvsReadCachingDialog.Designer.cs
@@ -1,3 +1,5 @@
+using XenAdmin.Controls;
+
 namespace XenAdmin.Dialogs
 {
     partial class EnablePvsReadCachingDialog
@@ -30,7 +32,7 @@ namespace XenAdmin.Dialogs
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EnablePvsReadCachingDialog));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.pvsSiteList = new System.Windows.Forms.ComboBox();
+            this.pvsSiteList = new EnableableComboBox();
             this.rubricLabel = new System.Windows.Forms.Label();
             this.pvsSiteLabel = new System.Windows.Forms.Label();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
@@ -118,7 +120,7 @@ namespace XenAdmin.Dialogs
         private XenAdmin.Controls.ToolTipContainer readonlyCheckboxToolTipContainer;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label rubricLabel;
-        private System.Windows.Forms.ComboBox pvsSiteList;
+        private EnableableComboBox pvsSiteList;
         private System.Windows.Forms.Label pvsSiteLabel;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.Button cancel;

--- a/XenAdmin/Dialogs/EnablePvsReadCachingDialog.cs
+++ b/XenAdmin/Dialogs/EnablePvsReadCachingDialog.cs
@@ -35,8 +35,6 @@ using System.Diagnostics;
 using System.Linq;
 using XenAPI;
 using XenAdmin.Actions;
-using XenAdmin.Wizards.GenericPages;
-
 
 namespace XenAdmin.Dialogs
 {
@@ -67,7 +65,7 @@ namespace XenAdmin.Dialogs
             // We assume all VMs share a pool
             var vm = _vms[0];
 
-            foreach (var site in vm.Connection.Cache.PVS_sites.Reverse())
+            foreach (var site in vm.Connection.Cache.PVS_sites)
             {
                  var siteToAdd = new PvsSiteComboBoxItem(site);
                  pvsSiteList.Items.Add(siteToAdd);
@@ -143,7 +141,7 @@ namespace XenAdmin.Dialogs
         }
     }
 
-    internal class PvsSiteComboBoxItem : IEnableableXenObjectComboBoxItem
+    internal class PvsSiteComboBoxItem
     {
         private readonly PVS_site _site;
 
@@ -153,16 +151,9 @@ namespace XenAdmin.Dialogs
             _site = site;
         }
 
-        public bool Enabled
-        {
-            get { return !string.IsNullOrEmpty(_site.PVS_uuid); }
-        }
-
         public override string ToString()
         {
-            return Enabled
-                ? _site.Name
-                : string.Format("{0} ({1})", _site.Name, Messages.PVS_CACHE_NOT_CONFIGURED);
+            return _site.NameWithWarning;
         }
 
         public IXenObject Item

--- a/XenAdmin/TabPages/PvsPage.cs
+++ b/XenAdmin/TabPages/PvsPage.cs
@@ -208,7 +208,7 @@ namespace XenAdmin.TabPages
             PVS_site pvsSite = pvsProxy == null ? null : Connection.Resolve(pvsProxy.site);
             row.Cells[0].Value = vm.Name;
             row.Cells[1].Value = pvsProxy == null ? Messages.NO : Messages.YES;
-            row.Cells[2].Value = pvsProxy == null || pvsSite == null ? Messages.NO_VALUE : pvsSite.Name;
+            row.Cells[2].Value = pvsProxy == null || pvsSite == null ? Messages.NO_VALUE : pvsSite.NameWithWarning;
             row.Cells[3].Value = pvsProxy == null ? Messages.NO_VALUE : pvs_proxy_status_extensions.ToFriendlyString(pvsProxy.status);
         }
 
@@ -327,7 +327,7 @@ namespace XenAdmin.TabPages
 
         private void PvsSitePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != "name_label")
+            if (e.PropertyName != "name_label" && e.PropertyName != "cache_storage")
                 return;
 
             Program.Invoke(this, () =>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -28111,7 +28111,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incomplete PVS configuration.
+        ///   Looks up a localized string similar to {0} (Incomplete PVS configuration).
         /// </summary>
         public static string PVS_CACHE_INCOMPLETE_CONFIGURATION {
             get {
@@ -28156,7 +28156,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incomplete Cache Storage configuration.
+        ///   Looks up a localized string similar to {0} (Incomplete Cache Storage configuration).
         /// </summary>
         public static string PVS_CACHE_STORAGE_NOT_CONFIGURED {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -28111,6 +28111,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Incomplete PVS configuration.
+        /// </summary>
+        public static string PVS_CACHE_INCOMPLETE_CONFIGURATION {
+            get {
+                return ResourceManager.GetString("PVS_CACHE_INCOMPLETE_CONFIGURATION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Memory and disk.
         /// </summary>
         public static string PVS_CACHE_MEMORY_AND_DISK {
@@ -28138,7 +28147,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incomplete PVS configuration.
+        ///   Looks up a localized string similar to Not configured.
         /// </summary>
         public static string PVS_CACHE_NOT_CONFIGURED {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -28138,11 +28138,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Not configured.
+        ///   Looks up a localized string similar to Incomplete PVS configuration.
         /// </summary>
         public static string PVS_CACHE_NOT_CONFIGURED {
             get {
                 return ResourceManager.GetString("PVS_CACHE_NOT_CONFIGURED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Incomplete Cache Storage configuration.
+        /// </summary>
+        public static string PVS_CACHE_STORAGE_NOT_CONFIGURED {
+            get {
+                return ResourceManager.GetString("PVS_CACHE_STORAGE_NOT_CONFIGURED", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9763,6 +9763,9 @@ Press OK to continue the wizard and return to the server and follow the instruct
   <data name="PVS_CACHE_CONFIG_DIALOG_TITLE" xml:space="preserve">
     <value>PVS Cache Configuration - '{0}'</value>
   </data>
+  <data name="PVS_CACHE_INCOMPLETE_CONFIGURATION" xml:space="preserve">
+    <value>Incomplete PVS configuration</value>
+  </data>
   <data name="PVS_CACHE_MEMORY_AND_DISK" xml:space="preserve">
     <value>Memory and disk</value>
   </data>
@@ -9773,7 +9776,7 @@ Press OK to continue the wizard and return to the server and follow the instruct
     <value>MemorySR</value>
   </data>
   <data name="PVS_CACHE_NOT_CONFIGURED" xml:space="preserve">
-    <value>Incomplete PVS configuration</value>
+    <value>Not configured</value>
   </data>
   <data name="PVS_CACHE_STORAGE_NOT_CONFIGURED" xml:space="preserve">
     <value>Incomplete Cache Storage configuration</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9773,7 +9773,10 @@ Press OK to continue the wizard and return to the server and follow the instruct
     <value>MemorySR</value>
   </data>
   <data name="PVS_CACHE_NOT_CONFIGURED" xml:space="preserve">
-    <value>Not configured</value>
+    <value>Incomplete PVS configuration</value>
+  </data>
+  <data name="PVS_CACHE_STORAGE_NOT_CONFIGURED" xml:space="preserve">
+    <value>Incomplete Cache Storage configuration</value>
   </data>
   <data name="PVS_SITE_CANNOT_BE_REMOVED" xml:space="preserve">
     <value>This PVS cache configuration cannot be removed because there are VMs that are streamed from this site.</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9764,7 +9764,7 @@ Press OK to continue the wizard and return to the server and follow the instruct
     <value>PVS Cache Configuration - '{0}'</value>
   </data>
   <data name="PVS_CACHE_INCOMPLETE_CONFIGURATION" xml:space="preserve">
-    <value>Incomplete PVS configuration</value>
+    <value>{0} (Incomplete PVS configuration)</value>
   </data>
   <data name="PVS_CACHE_MEMORY_AND_DISK" xml:space="preserve">
     <value>Memory and disk</value>
@@ -9779,7 +9779,7 @@ Press OK to continue the wizard and return to the server and follow the instruct
     <value>Not configured</value>
   </data>
   <data name="PVS_CACHE_STORAGE_NOT_CONFIGURED" xml:space="preserve">
-    <value>Incomplete Cache Storage configuration</value>
+    <value>{0} (Incomplete Cache Storage configuration)</value>
   </data>
   <data name="PVS_SITE_CANNOT_BE_REMOVED" xml:space="preserve">
     <value>This PVS cache configuration cannot be removed because there are VMs that are streamed from this site.</value>

--- a/XenModel/XenAPI-Extensions/PVS_site.cs
+++ b/XenModel/XenAPI-Extensions/PVS_site.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Linq;
+using XenAdmin;
 
 namespace XenAPI
 {
@@ -52,6 +53,39 @@ namespace XenAPI
 
             return Connection.Cache.PVS_cache_storages.FirstOrDefault(pvsCacheStorage => 
                 pvsCacheStorage.site.opaque_ref == opaque_ref && pvsCacheStorage.host.opaque_ref == host.opaque_ref);
+        }
+
+        public string NameWithWarning
+        {
+            get
+            {
+                if (!IsCacheConfigured())
+                {
+                    return string.Format(Messages.NEWVM_DEFAULTNAME, Name, Messages.PVS_CACHE_NOT_CONFIGURED);
+                }
+
+                if (!IsStorageConfigured())
+                {
+                    return string.Format(Messages.NEWVM_DEFAULTNAME, Name, Messages.PVS_CACHE_STORAGE_NOT_CONFIGURED);
+                }
+
+                return Name;
+            }
+        }
+
+        private bool IsCacheConfigured()
+        {
+            return !string.IsNullOrEmpty(PVS_uuid);
+        }
+
+        private bool IsStorageConfigured()
+        {
+            var connectionHosts = Connection.Cache.Hosts;
+
+            var siteStorages = Connection.ResolveAll(cache_storage);
+            var storageHosts = Connection.ResolveAll(siteStorages.Select(storage => storage.host));
+
+            return connectionHosts.All(host => storageHosts.Contains(host));
         }
 
         #region IEquatable<PVS_site> Members

--- a/XenModel/XenAPI-Extensions/PVS_site.cs
+++ b/XenModel/XenAPI-Extensions/PVS_site.cs
@@ -61,7 +61,7 @@ namespace XenAPI
             {
                 if (!IsCacheConfigured())
                 {
-                    return string.Format(Messages.NEWVM_DEFAULTNAME, Name, Messages.PVS_CACHE_NOT_CONFIGURED);
+                    return string.Format(Messages.NEWVM_DEFAULTNAME, Name, Messages.PVS_CACHE_INCOMPLETE_CONFIGURATION);
                 }
 
                 if (!IsStorageConfigured())

--- a/XenModel/XenAPI-Extensions/PVS_site.cs
+++ b/XenModel/XenAPI-Extensions/PVS_site.cs
@@ -61,12 +61,12 @@ namespace XenAPI
             {
                 if (!IsCacheConfigured())
                 {
-                    return string.Format(Messages.NEWVM_DEFAULTNAME, Name, Messages.PVS_CACHE_INCOMPLETE_CONFIGURATION);
+                    return string.Format(Messages.PVS_CACHE_INCOMPLETE_CONFIGURATION, Name);
                 }
 
                 if (!IsStorageConfigured())
                 {
-                    return string.Format(Messages.NEWVM_DEFAULTNAME, Name, Messages.PVS_CACHE_STORAGE_NOT_CONFIGURED);
+                    return string.Format(Messages.PVS_CACHE_STORAGE_NOT_CONFIGURED, Name);
                 }
 
                 return Name;


### PR DESCRIPTION
We now disable sites that aren't configured in the enable read caching dialog, using an EnableableComboBox. I've also changed the DrawMode of that ComboBox component, OwnerDrawFixed more appropriately sizes the dropdown container when the number of items is small.