### PR TITLE
[CA-228723]  Cancelling update installation leaves the update in xapi db

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -395,7 +395,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                     {
                         Pool_update.pool_clean(session, poolUpdate.opaque_ref);
                         if(!poolUpdate.AppliedOnHosts.Any())
-                            Pool_update.async_destroy(session, poolUpdate.opaque_ref);
+                            Pool_update.destroy(session, poolUpdate.opaque_ref);
                     }
                     catch (Failure f)
                     {

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -380,16 +380,28 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             if (PatchingWizard_UploadPage.AllIntroducedPoolUpdates != null && PatchingWizard_UploadPage.AllIntroducedPoolUpdates.Count > 0)
             {
-                return PatchingWizard_UploadPage.AllIntroducedPoolUpdates.Select(pu => GetCleanUpPoolUpdateAction(pu)).ToList();
+                return PatchingWizard_UploadPage.AllIntroducedPoolUpdates.Select(GetCleanUpPoolUpdateAction).ToList();
             }
 
             return new List<AsyncAction>();
         }
 
-        private AsyncAction GetCleanUpPoolUpdateAction(Pool_update poolUpdate)
+        private static AsyncAction GetCleanUpPoolUpdateAction(Pool_update poolUpdate)
         {
             return
-                new DelegatedAsyncAction(poolUpdate.Connection, Messages.REMOVE_PATCH, "", "", session => Pool_update.pool_clean(session, poolUpdate.opaque_ref));
+                new DelegatedAsyncAction(poolUpdate.Connection, Messages.REMOVE_PATCH, "", "", session =>
+                {
+                    try
+                    {
+                        Pool_update.pool_clean(session, poolUpdate.opaque_ref);
+                        if(!poolUpdate.AppliedOnHosts.Any())
+                            Pool_update.async_destroy(session, poolUpdate.opaque_ref);
+                    }
+                    catch (Failure f)
+                    {
+                        log.Error("Clean up failed", f);
+                    }
+                });
         }
     }
 }


### PR DESCRIPTION
Modify the cleanup pool update action to also call update destroy (removing the update from xapi db) when the update has not been applied to any hosts (ie we cancelled the wizard before completion).