### PR TITLE
CA-148427: XC logs get populated with wrong message even when the use…

### DIFF
--- a/XenAdmin/Dialogs/OptionsPages/SaveAndRestoreOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/SaveAndRestoreOptionsPage.cs
@@ -100,9 +100,12 @@ namespace XenAdmin.Dialogs.OptionsPages
                 Properties.Settings.Default.RequirePass = true;
 
                 // set password
-                Program.MasterPassword = TemporaryMasterPassword;
-                new ActionBase(Messages.CHANGED_MASTER_PASSWORD,
-                    Messages.CHANGED_MASTER_PASSWORD_LONG, false, true);
+                if (Program.MasterPassword != TemporaryMasterPassword) 
+                {
+                    Program.MasterPassword = TemporaryMasterPassword;
+                    new ActionBase(Messages.CHANGED_MASTER_PASSWORD,
+                        Messages.CHANGED_MASTER_PASSWORD_LONG, false, true);
+                }
             }
             if (SaveAllAfter)
                 Settings.SaveServerList();


### PR DESCRIPTION
…r does not change the master password when "save and restore" option

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>