### PR TITLE
[CA-228054] Performance graph datasources aren't sorted naturally

### DIFF
--- a/XenAdmin/Dialogs/GraphDetailsDialog.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.cs
@@ -37,6 +37,7 @@ using System.Linq;
 using System.Windows.Forms;
 using XenAdmin.Actions;
 using XenAdmin.Controls.CustomDataGraph;
+using XenAdmin.Core;
 
 
 namespace XenAdmin.Dialogs
@@ -266,7 +267,7 @@ namespace XenAdmin.Dialogs
                 }
                 else
                 {
-                    result = string.Compare(row1.Cells[columnIndex].Value.ToString(),
+                    result = StringUtility.NaturalCompare(row1.Cells[columnIndex].Value.ToString(),
                                             row2.Cells[columnIndex].Value.ToString());
                 }
 


### PR DESCRIPTION
Replace the string comparison used when sorting columns of the datasources list table with a natural compare, which sorts these cases correctly.