### PR TITLE
CA-229185: XenCenter: Dundee and Creedence hosts should be disabled for Ely updates in 'Select Servers'

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -264,7 +264,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                         row.Enabled = false;
                         row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_SUPP_PACKS;
                     }
-                    if (Helpers.ElyOrGreater(host) && selectedHosts != null)
+                    if (selectedHosts != null)
                     {
                         disableNotApplicableHosts(row, selectedHosts, host);
                     }


### PR DESCRIPTION

For ISO updates, when disabling hosts, use the filename matching logic for pre-Ely hosts as well.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>