### PR TITLE
[CA-149812] EN: Duplicate hotkeys about “Dismiss All” and “Dismiss Selected" tabs.

### DIFF
--- a/XenAdmin/TabPages/AlertSummaryPage.resx
+++ b/XenAdmin/TabPages/AlertSummaryPage.resx
@@ -244,7 +244,7 @@
     <value>89, 23</value>
   </data>
   <data name="toolStripDropDownButtonDateFilter.Text" xml:space="preserve">
-    <value>Filter by D&amp;ate</value>
+    <value>Filter by &amp;Date</value>
   </data>
   <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 26</value>
@@ -280,13 +280,13 @@
     <value>161, 22</value>
   </data>
   <data name="tsmiDismissAll.Text" xml:space="preserve">
-    <value>&amp;Dismiss All</value>
+    <value>Dismiss &amp;All</value>
   </data>
   <data name="tsmiDismissSelected.Size" type="System.Drawing.Size, System.Drawing">
     <value>161, 22</value>
   </data>
   <data name="tsmiDismissSelected.Text" xml:space="preserve">
-    <value>&amp;Dismiss Selected</value>
+    <value>Dismiss Sele&amp;cted</value>
   </data>
   <data name="toolStripSplitButtonDismiss.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/TabPages/HistoryPage.resx
+++ b/XenAdmin/TabPages/HistoryPage.resx
@@ -154,19 +154,19 @@
     <value>89, 23</value>
   </data>
   <data name="toolStripDdbFilterDates.Text" xml:space="preserve">
-    <value>Filter by D&amp;ate</value>
+    <value>Filter by &amp;Date</value>
   </data>
   <data name="tsmiDismissAll.Size" type="System.Drawing.Size, System.Drawing">
     <value>161, 22</value>
   </data>
   <data name="tsmiDismissAll.Text" xml:space="preserve">
-    <value>&amp;Dismiss All</value>
+    <value>Dismiss &amp;All</value>
   </data>
   <data name="tsmiDismissSelected.Size" type="System.Drawing.Size, System.Drawing">
     <value>161, 22</value>
   </data>
   <data name="tsmiDismissSelected.Text" xml:space="preserve">
-    <value>&amp;Dismiss Selected</value>
+    <value>Dismiss S&amp;elected</value>
   </data>
   <data name="toolStripSplitButtonDismiss.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/TabPages/HistoryPage.resx
+++ b/XenAdmin/TabPages/HistoryPage.resx
@@ -166,7 +166,7 @@
     <value>161, 22</value>
   </data>
   <data name="tsmiDismissSelected.Text" xml:space="preserve">
-    <value>Dismiss S&amp;elected</value>
+    <value>Dismiss Sele&amp;cted</value>
   </data>
   <data name="toolStripSplitButtonDismiss.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -79,6 +79,8 @@ namespace XenAdmin.TabPages
             Updates.CheckForUpdatesStarted += CheckForUpdates_CheckForUpdatesStarted;
             Updates.CheckForUpdatesCompleted += CheckForUpdates_CheckForUpdatesCompleted;
             pictureBox1.Image = SystemIcons.Information.ToBitmap();
+            toolStripSplitButtonDismiss.DefaultItem = dismissAllToolStripMenuItem;
+            toolStripSplitButtonDismiss.Text = dismissAllToolStripMenuItem.Text;
             PageWasRefreshed = false;
         }
 

--- a/XenAdmin/TabPages/ManageUpdatesPage.resx
+++ b/XenAdmin/TabPages/ManageUpdatesPage.resx
@@ -265,7 +265,7 @@
     <value>89, 23</value>
   </data>
   <data name="toolStripDropDownButtonDateFilter.Text" xml:space="preserve">
-    <value>Filter by D&amp;ate</value>
+    <value>Filter by &amp;Date</value>
   </data>
   <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 26</value>
@@ -310,7 +310,7 @@
     <value>161, 22</value>
   </data>
   <data name="dismissAllToolStripMenuItem.Text" xml:space="preserve">
-    <value>Dism&amp;iss All</value>
+    <value>Dismiss &amp;All</value>
   </data>
   <data name="dismissSelectedToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>161, 22</value>


### PR DESCRIPTION
Moved to A for Dismiss All, and E for Dismiss Selected. Since this frees D (the toolstrip menu split button uses one of these, so was previously always D), moved Filter by Date from A to D.