### PR TITLE
[CA-229350] PVS allows Memory Only even when no control domain memory available

### DIFF
--- a/XenAdmin/Controls/ComboBoxes/EnableableComboBox.cs
+++ b/XenAdmin/Controls/ComboBoxes/EnableableComboBox.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Controls
     {
         public EnableableComboBox()
         {
-            DrawMode = DrawMode.OwnerDrawVariable;
+            DrawMode = DrawMode.OwnerDrawFixed;
             DropDownStyle = ComboBoxStyle.DropDownList;
         }
 

--- a/XenAdmin/Controls/PvsCacheStorageRow.Designer.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.Designer.cs
@@ -32,7 +32,7 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.labelUnits = new System.Windows.Forms.Label();
             this.numericUpDownCacheSize = new System.Windows.Forms.NumericUpDown();
-            this.comboBoxCacheSr = new System.Windows.Forms.ComboBox();
+            this.comboBoxCacheSr = new EnableableComboBox();
             this.labelHostName = new System.Windows.Forms.Label();
             this.labelCacheStorage = new System.Windows.Forms.Label();
             this.labelCacheSize = new System.Windows.Forms.Label();
@@ -108,7 +108,7 @@
         #endregion
 
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.ComboBox comboBoxCacheSr;
+        private EnableableComboBox comboBoxCacheSr;
         private System.Windows.Forms.Label labelHostName;
         private System.Windows.Forms.Label labelCacheStorage;
         private System.Windows.Forms.Label labelCacheSize;

--- a/XenAdmin/Controls/PvsCacheStorageRow.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.cs
@@ -98,7 +98,7 @@ namespace XenAdmin.Controls
                 };
             }
 
-            var enabled = Host.dom0_memory_extra >= numericUpDownCacheSize.Minimum;
+            var enabled = Host.dom0_memory_extra >= MIN_CACHE_SIZE_GB * Util.BINARY_GIGA;
             var label = enabled ? Messages.PVS_CACHE_MEMORY_ONLY : Messages.PVS_CACHE_MEMORY_ONLY_DISABLED;
             var memorySrItem = new SrComboBoxItem(memorySr, label, enabled);
             comboBoxCacheSr.Items.Add(memorySrItem);

--- a/XenAdmin/Controls/PvsCacheStorageRow.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.cs
@@ -32,7 +32,6 @@
 using System;
 using System.Linq;
 using System.Windows.Forms;
-using XenAdmin.Core;
 using XenAPI;
 
 namespace XenAdmin.Controls
@@ -77,13 +76,16 @@ namespace XenAdmin.Controls
         {
             comboBoxCacheSr.Items.Clear();
 
-			// add the "Not configured" item first
-            var notConfiguredItem = new ToStringWrapper<SR>(null, Messages.PVS_CACHE_NOT_CONFIGURED); 
+            // add the "Not configured" item first
+            var notConfiguredItem = new SrComboBoxItem(null, Messages.PVS_CACHE_NOT_CONFIGURED);
             comboBoxCacheSr.Items.Add(notConfiguredItem);
             comboBoxCacheSr.SelectedItem = notConfiguredItem;
 
             // add Memeory SR; if no memory SR  found, add a placeholder (we will create the memory SR in ConfigurePvsCacheAction)
-            var memorySr = Host.Connection.Cache.SRs.FirstOrDefault(s => s.GetSRType(false) == SR.SRTypes.tmpfs && s.CanBeSeenFrom(Host));
+            var memorySr =
+                Host.Connection.Cache.SRs.FirstOrDefault(
+                    s => s.GetSRType(false) == SR.SRTypes.tmpfs && s.CanBeSeenFrom(Host));
+            
             if (memorySr == null)
             {
                 // create a placeholder for the memory SR
@@ -95,7 +97,10 @@ namespace XenAdmin.Controls
                     opaque_ref = Helper.NullOpaqueRef
                 };
             }
-            var memorySrItem = new ToStringWrapper<SR>(memorySr, Messages.PVS_CACHE_MEMORY_ONLY);
+
+            var enabled = Host.dom0_memory_extra >= numericUpDownCacheSize.Minimum;
+            var label = enabled ? Messages.PVS_CACHE_MEMORY_ONLY : Messages.PVS_CACHE_MEMORY_ONLY_DISABLED;
+            var memorySrItem = new SrComboBoxItem(memorySr, label, enabled);
             comboBoxCacheSr.Items.Add(memorySrItem);
             if (OrigPvsCacheStorage != null && memorySr.opaque_ref == OrigPvsCacheStorage.SR.opaque_ref)
                 comboBoxCacheSr.SelectedItem = memorySrItem;
@@ -105,7 +110,7 @@ namespace XenAdmin.Controls
             availableSRs.Sort();
             foreach (var sr in availableSRs)
             {
-                var newItem = new ToStringWrapper<SR>(sr, sr.Name);
+                var newItem = new SrComboBoxItem(sr, sr.Name);
                 comboBoxCacheSr.Items.Add(newItem);
                 if (OrigPvsCacheStorage != null && sr.opaque_ref == OrigPvsCacheStorage.SR.opaque_ref)
                     comboBoxCacheSr.SelectedItem = newItem;
@@ -147,8 +152,8 @@ namespace XenAdmin.Controls
         {
             get
             {
-                var selectedItem = (ToStringWrapper<SR>)comboBoxCacheSr.SelectedItem;
-                return selectedItem != null ? selectedItem.item : null;
+                var selectedItem = (SrComboBoxItem)comboBoxCacheSr.SelectedItem;
+                return selectedItem != null ? selectedItem.Item : null;
             }
         }
 
@@ -188,10 +193,35 @@ namespace XenAdmin.Controls
             {
                 var maxSize = (decimal)Util.ToGB(selectedSr.GetSRType(false) == SR.SRTypes.tmpfs ? Host.dom0_memory_extra : selectedSr.FreeSpace, 1, RoundingBehaviour.Down); 
                 maxSize = Math.Min(maxSize, MAX_CACHE_SIZE_GB);
+
                 if (maxSize != numericUpDownCacheSize.Maximum)
                     SetupCacheSizeSpinner(numericUpDownCacheSize.Value, numericUpDownCacheSize.Minimum, maxSize);
             }
             SomethingChanged(this, e);
+        }
+    }
+
+    public class SrComboBoxItem : IEnableableComboBoxItem
+    {
+        public SR Item;
+        private readonly string _toString;
+        private readonly bool _enabled;
+
+        public SrComboBoxItem(SR sr, string label, bool enabled=true)
+        {
+            Item = sr;
+            _toString = label;
+            _enabled = enabled;
+        }
+
+        public override string ToString()
+        {
+            return _toString;
+        }
+
+        public bool Enabled
+        {
+            get { return _enabled; }
         }
     }
 }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -28138,6 +28138,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Memory only (Not enough Control Domain memory).
+        /// </summary>
+        public static string PVS_CACHE_MEMORY_ONLY_DISABLED {
+            get {
+                return ResourceManager.GetString("PVS_CACHE_MEMORY_ONLY_DISABLED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MemorySR.
         /// </summary>
         public static string PVS_CACHE_MEMORY_SR_NAME {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13390,4 +13390,7 @@ You will need to navigate to the Console on each of the selected VMs to complete
   <data name="UPDATES_WIZARD_PRECHECK_FAILED_REQUIRED_UPDATE_MISSING" xml:space="preserve">
     <value>Prerequisite update(s) are missing: {0}</value>
   </data>
+  <data name="PVS_CACHE_MEMORY_ONLY_DISABLED" xml:space="preserve">
+    <value>Memory only (Not enough Control Domain memory)</value>
+  </data>
 </root>


### PR DESCRIPTION
We now disable the Memory Only option if the available dom0 memory is less than the minimum the spinner supports (1Gb)