### PR TITLE
Tidy up the pdb files in an archive (todo: remove them once the main …

### DIFF
--- a/mk/build.sh
+++ b/mk/build.sh
@@ -135,7 +135,6 @@ production_jenkins_build()
 # Use this option if you're running on a Jenkins that is not the production Jenkins server
 private_jenkins_build()
 {
-    source ${XENADMIN_DIR}/devtools/spellcheck/spellcheck.sh
     source ${XENADMIN_DIR}/mk/xenadmin-build.sh
     # Skip the tests if the SKIP_TESTS variable is defined (e.g. in the Jenkins UI, add "export SKIP_TESTS=1" above the call for build script)
 	if [ -n "${SKIP_TESTS+x}" ]; then

--- a/mk/xenadmin-build.sh
+++ b/mk/xenadmin-build.sh
@@ -311,6 +311,9 @@ do
   dotnet_cp_to_dir "${OUTPUT_DIR}" "${pdb}"
 done
 
+#now package the pdbs
+cd ${OUTPUT_DIR} && tar cjf XenCenter.Symbols.tar.bz2 *.pdb
+
 #create manifest
 echo "@branch=${XS_BRANCH}" >> ${OUTPUT_DIR}/manifest
 echo "xenadmin xenadmin.git ${get_REVISION:0:12}" >> ${OUTPUT_DIR}/manifest


### PR DESCRIPTION
…build system

has started consuming the tar). Leave spell check only in the production build.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>