### PR TITLE
Get the git branch from the environment variable and do not fall back…

### DIFF
--- a/mk/build.sh
+++ b/mk/build.sh
@@ -68,27 +68,9 @@ fi
 
 set -e
 
-ROOT_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
-
 XENADMIN_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
 source ${XENADMIN_DIR}/mk/declarations.sh
-
-# if this is an official build 
-if [ $get_BUILD_NUMBER -ne 0 ]
-then
-	cd ${ROOT_DIR}
-	#DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-	# now we are sure we are running from the branch root
-	#cd ${DIR}/../..
-
-	if [ -d "xenadmin-ref.hg" ]
-	then
-	  hg --cwd xenadmin-ref.hg pull -u
-	else
-	  hg clone ssh://xenhg@hg.uk.xensource.com/carbon/${XS_BRANCH}/xenadmin-ref.hg/
-	fi
-fi
 
 if test -z "${XC_BRANDING}"; then XC_BRANDING=citrix; fi
 
@@ -105,7 +87,7 @@ if [ "$?" -eq 0 ]; then
   fi
 fi
 
-# overwrite archive-push.sh and push-latest-successful-build.sh files, if they exists in Branding folder
+# overwrite archive-push.sh and push-latest-successful-build.sh files, if they exist in Branding folder
 if [ -f ${XENADMIN_DIR}/Branding/branding-archive-push.sh ]; then
   echo "Overwriting mk/archive-push.sh with Branding/branding-archive-push.sh."
   cp ${XENADMIN_DIR}/Branding/branding-archive-push.sh ${XENADMIN_DIR}/mk/archive-push.sh

--- a/mk/declarations.sh
+++ b/mk/declarations.sh
@@ -36,14 +36,11 @@
 #
 #PRODUCT_MICRO_VERSION_OVERRIDE=<My override value here>
 
-#this is the XenServer branch we're building; change this when making a new branch
-
 if [ -n "${DEBUG+xxx}" ]; 
 then 
   set -x
 fi
 
-# that's the code to get the branch name of the repository
 SOURCE="${BASH_SOURCE[0]}"
 XENADMIN_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 DIR="$( dirname "$SOURCE" )"
@@ -89,12 +86,7 @@ then
    	    get_REVISION="${GIT_COMMIT}"
     fi
 
-	XS_BRANCH=`cd $DIR;git config --get remote.origin.url|sed -e 's@.*carbon/\(.*\)/xenadmin.git.*@\1@'`
-	if [[ $XS_BRANCH == *"/"* ]]
-        then
-            XS_BRANCH="trunk"
-            echo "WARN:	Failed to detect XS_BRANCH we will fallback to ${XS_BRANCH}"
-        fi
+    XS_BRANCH=${GIT_LOCAL_BRANCH}
 else
 	if [ -z "${MERCURIAL_REVISION+xxx}" ]
 	then 
@@ -107,10 +99,12 @@ fi
 
 if [ -z "${XS_BRANCH+xxx}" ]
 then
-    echo "ERROR:	Failed to detect the branch, stopping here because this would break things much later."
+    echo "ERROR: Failed to detect the branch; exiting."
     exit 1
-else
-    echo "INFO:	Running on branch: $XS_BRANCH"
+elif [ "${XS_BRANCH}" = "master" ]
+then
+    echo "INFO: found master branch; renaming to trunk."
+    XS_BRANCH="trunk"
 fi
 
 #rename Jenkins environment variables to distinguish them from ours; remember to use them as get only
@@ -193,3 +187,17 @@ WGET () { wget ${WGET_OPT} "${@}"; }
 #check there are xenserver builds on this branch before proceeding
 WGET --spider ${GLOBALS} || WGET --spider ${TRUNK_GLOBALS} || { echo 'FATAL: Unable to locate globals, xenadmin cannot be built if there is no succesfull build of xenserver published for the same branch.' ; exit 1; }
 
+ROOT_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+
+# if this is an official build 
+if [ $get_BUILD_NUMBER -ne 0 ]
+then
+	cd ${ROOT_DIR}
+
+	if [ -d "xenadmin-ref.hg" ]
+	then
+	  hg --cwd xenadmin-ref.hg pull -u
+	else
+	  hg clone ssh://xenhg@hg.uk.xensource.com/carbon/${XS_BRANCH}/xenadmin-ref.hg/
+	fi
+fi


### PR DESCRIPTION
… to trunk

if it can't be found.Use GIT_LOCAL_BRANCH instead of GIT_BRANCH to retrieve the
branch name without the remote.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>