### PR TITLE
CA-229009: VDI is not deleted for the updates

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RemoveUpdateFilesFromMaster.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RemoveUpdateFilesFromMaster.cs
@@ -82,13 +82,14 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 }
                 else
                 {
-                    Pool_update poolUpdate = null;
-                    
                     if (mapping != null || mapping.Pool_update != null && mapping.Pool_update.opaque_ref != null)
                     {
-                        poolUpdate = mapping.Pool_update;
+                        var poolUpdate = mapping.Pool_update;
 
                         Pool_update.pool_clean(session, poolUpdate.opaque_ref);
+                        
+                        if (!poolUpdate.AppliedOnHosts.Any())
+                            Pool_update.destroy(session, poolUpdate.opaque_ref);
 
                         patchMappings.Remove(mapping);
                     }

--- a/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
+++ b/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
@@ -201,6 +201,22 @@ namespace XenAdmin.Actions
                         string uuidFound = ex.ErrorDescription[1];
 
                         poolUpdate = Connection.Cache.Pool_updates.FirstOrDefault(pu => string.Equals(pu.uuid, uuidFound, System.StringComparison.InvariantCultureIgnoreCase));
+
+                        //clean-up the VDI we've just created
+                        try
+                        {
+                            RemoveVDI(Session, vdiRef);
+
+                            //remove the vdi that have just been cleaned up
+                            var remaining = VdiRefsToCleanUp.Where(kvp => kvp.Value != null && kvp.Value.opaque_ref != vdiRef.opaque_ref).ToList();
+                            VdiRefsToCleanUp.Clear();
+                            remaining.ForEach(rem => VdiRefsToCleanUp.Add(rem.Key, rem.Value));
+                        }
+                        catch
+                        { 
+                            //best effort cleanup
+                        }
+
                     }
                     else
                     {


### PR DESCRIPTION
If batch updating fails in a pool, this code will do the clean up by running the appropriate (next in the queue) RemoveUpdateFilesFromMaster action. In addition to Pool_update.clean(), Pool_update.destroy() will be called when needed.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>