### PR TITLE
CP-17276: Out of Memory exception when XenCenter exceeds the maximum …

### DIFF
--- a/XenAdmin/Controls/MainWindowControls/NavigationView.cs
+++ b/XenAdmin/Controls/MainWindowControls/NavigationView.cs
@@ -105,7 +105,6 @@ namespace XenAdmin.Controls.MainWindowControls
             //otherwise it's too close together on XP and the icons crash into each other
 
             VirtualTreeNode n = new VirtualTreeNode(Messages.XENCENTER);
-            n.NodeFont = Program.DefaultFont;
             treeView.Nodes.Add(n);
             treeView.SelectedNode = treeView.Nodes[0];
 

--- a/XenAdmin/MainWindowTreeBuilder.cs
+++ b/XenAdmin/MainWindowTreeBuilder.cs
@@ -460,19 +460,16 @@ namespace XenAdmin
                 {
                     result.BackColor = SystemColors.Highlight;
                     result.ForeColor = SystemColors.HighlightText;
-                    result.NodeFont = Program.DefaultFont;
                 }
                 else if (grayed)
                 {
                     result.BackColor = _treeViewBackColor;
                     result.ForeColor = SystemColors.GrayText;
-                    result.NodeFont = Program.DefaultFont;
                 }
                 else
                 {
                     result.BackColor = _treeViewBackColor;
                     result.ForeColor = _treeViewForeColor;
-                    result.NodeFont = Program.DefaultFont;
                 }
 
                 return result;


### PR DESCRIPTION
…number of GDI handles

Changed the tree builder so that the tree nodes rely on the TreeView's font. If the nodes have their NodeFont != null, then a tree update causes new fonts to be generated for each node and when fonts are being created faster than they could be cleaned up, we reach the GLI handles limit of 10000 (which causes the Out of Memory exception).

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>