### PR TITLE
CA-232294: Can't connect if an Add Server dialog has been cancelled before

### DIFF
--- a/XenAdmin/Dialogs/AddServerDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AddServerDialog.Designer.cs
@@ -186,6 +186,7 @@ namespace XenAdmin.Dialogs
             this.CancelButton = this.CancelButton2;
             this.Controls.Add(this.tableLayoutPanelType);
             this.Name = "AddServerDialog";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.AddServerDialog_FormClosing);
             this.Load += new System.EventHandler(this.AddServerDialog_Load);
             this.Shown += new System.EventHandler(this.AddServerDialog_Shown);
             this.groupBox1.ResumeLayout(false);

--- a/XenAdmin/Dialogs/AddServerDialog.cs
+++ b/XenAdmin/Dialogs/AddServerDialog.cs
@@ -337,6 +337,12 @@ namespace XenAdmin.Dialogs
         {
             pictureBoxError.Visible = labelError.Visible = (labelError.Text != "");
         }
+
+        private void AddServerDialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (connection != null)
+                XenConnectionUI.connectionDialogs.Remove(connection);
+        }
     }
 
     public class CachePopulatedEventArgs : EventArgs


### PR DESCRIPTION
This commit is to fix the following: "when right clicking a disconnected pool the context menu gives you the option to connect, this opens a window to enter credentials. if you close this window (either by cancel or the X), next time when you right click and click connect, nothing happens. you have to restart XenCenter to connect to the pool"

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>