### PR TITLE
[CA-233454] PVS tab doesn't show a new VM when it's created

### DIFF
--- a/XenAdmin/TabPages/PvsPage.cs
+++ b/XenAdmin/TabPages/PvsPage.cs
@@ -99,7 +99,12 @@ namespace XenAdmin.TabPages
             if (XenAdminConfigManager.Provider.ObjectIsHidden(vm.opaque_ref))
                 return false;
 
-            return vm.is_a_real_vm && vm.Show(Properties.Settings.Default.ShowHiddenVMs);
+            return vm.is_a_real_vm && vm.Show(Properties.Settings.Default.ShowHiddenVMs) && !vm.IsBeingCreated;
+        }
+
+        private static bool VmIsJustAdded(VM vm)
+        {
+            return vm.is_a_template && vm.name_label.StartsWith(Helpers.GuiTempObjectPrefix);
         }
 
         private void LoadVMs()
@@ -131,8 +136,7 @@ namespace XenAdmin.TabPages
                 foreach (var vm in Connection.Cache.VMs)
                 {
                     // Add all real VMs and templates that begin with __gui__ (because this may be a new VM)
-                    var addVm = vm.is_a_real_vm ||
-                                (vm.is_a_template && vm.name_label.StartsWith(Helpers.GuiTempObjectPrefix));
+                    var addVm = vm.is_a_real_vm || VmIsJustAdded(vm) || vm.IsBeingCreated;
 
                     if (!addVm)
                         continue;

--- a/XenAdmin/TabPages/PvsPage.cs
+++ b/XenAdmin/TabPages/PvsPage.cs
@@ -96,7 +96,7 @@ namespace XenAdmin.TabPages
 
         private static bool VmShouldBeVisible(VM vm)
         {
-            return vm.Show(Properties.Settings.Default.ShowHiddenVMs);
+            return vm.is_a_real_vm && vm.Show(Properties.Settings.Default.ShowHiddenVMs);
         }
 
         private void LoadVMs()

--- a/XenModel/Actions/VM/CreateVMAction.cs
+++ b/XenModel/Actions/VM/CreateVMAction.cs
@@ -690,7 +690,7 @@ namespace XenAdmin.Actions.VMActions
         {
             get
             {
-                return string.Format("{0}{1}", Helpers.GuiTempObjectPrefix, NameLabel);
+                return Helpers.MakeHiddenName(NameLabel);
             }
         }
 

--- a/XenModel/Actions/VM/CreateVMAction.cs
+++ b/XenModel/Actions/VM/CreateVMAction.cs
@@ -210,6 +210,7 @@ namespace XenAdmin.Actions.VMActions
             AddDisks();
             AddNetworks();
             XenAdminConfigManager.Provider.ShowObject(VM.opaque_ref);
+            VM.IsBeingCreated = false;
             PointOfNoReturn = true;
 
             CloudCreateConfigDrive();
@@ -292,6 +293,7 @@ namespace XenAdmin.Actions.VMActions
 
         private void SetXenCenterProperties()
         {
+            VM.IsBeingCreated = true;
             XenAdminConfigManager.Provider.HideObject(VM.opaque_ref);
             AppliesTo.Add(VM.opaque_ref);
         }

--- a/XenModel/Actions/VM/CreateVMFastAction.cs
+++ b/XenModel/Actions/VM/CreateVMFastAction.cs
@@ -59,13 +59,16 @@ namespace XenAdmin.Actions.VMActions
             PollToCompletion(0, 80);
 
             string new_vm_ref = Result;
+            VM = Connection.WaitForCache(new XenRef<VM>(new_vm_ref));
 
+            VM.IsBeingCreated = true;
             XenAdminConfigManager.Provider.HideObject(new_vm_ref);
 
             RelatedTask = XenAPI.VM.async_provision(Session, new_vm_ref);
             PollToCompletion(80, 90);
 
             XenAdminConfigManager.Provider.ShowObject(new_vm_ref);
+            VM.IsBeingCreated = false;
 
          
             Result = new_vm_ref;

--- a/XenModel/Actions/VM/CreateVMFastAction.cs
+++ b/XenModel/Actions/VM/CreateVMFastAction.cs
@@ -42,20 +42,25 @@ namespace XenAdmin.Actions.VMActions
     /// </summary>
     public class CreateVMFastAction : AsyncAction
     {
+        private readonly String _nameLabel;
+
         public CreateVMFastAction(IXenConnection connection, VM template)
             : base(connection, Messages.INSTANT_VM_CREATE_TITLE, string.Format(Messages.INSTANT_VM_CREATE_DESCRIPTION, Helpers.DefaultVMName(Helpers.GetName(template), connection), Helpers.GetName(template)))
         {
             Template = template;
+            _nameLabel = Helpers.DefaultVMName(Helpers.GetName(Template), Connection);
+
             ApiMethodsToRoleCheck.AddRange(Role.CommonTaskApiList);
             ApiMethodsToRoleCheck.AddRange(Role.CommonSessionApiList);
             ApiMethodsToRoleCheck.Add("vm.clone");
             ApiMethodsToRoleCheck.Add("vm.provision");
             ApiMethodsToRoleCheck.Add("vm.start");
+            ApiMethodsToRoleCheck.Add("vm.set_name_label");
         }
 
         protected override void Run()
         {
-            RelatedTask = XenAPI.VM.async_clone(Session, Template.opaque_ref, Helpers.DefaultVMName(Helpers.GetName(Template), Connection));
+            RelatedTask = XenAPI.VM.async_clone(Session, Template.opaque_ref, Helpers.MakeHiddenName(_nameLabel));
             PollToCompletion(0, 80);
 
             string new_vm_ref = Result;
@@ -67,10 +72,11 @@ namespace XenAdmin.Actions.VMActions
             RelatedTask = XenAPI.VM.async_provision(Session, new_vm_ref);
             PollToCompletion(80, 90);
 
+            VM.set_name_label(Session, new_vm_ref, _nameLabel);
+            VM.name_label = _nameLabel; //the set_name_label method takes some time, we want to show the VM right away
             XenAdminConfigManager.Provider.ShowObject(new_vm_ref);
             VM.IsBeingCreated = false;
 
-         
             Result = new_vm_ref;
         }
     }

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -998,6 +998,11 @@ namespace XenAdmin.Core
             return val;
         }
 
+        public static string MakeHiddenName(string name)
+        {
+            return string.Format("{0}{1}", GuiTempObjectPrefix, name);
+        }
+
         public static string GetFriendlyLicenseName(Host host)
         {
 			if (string.IsNullOrEmpty(host.edition))

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -1509,6 +1509,17 @@ namespace XenAPI
             get { return !not_a_real_vm; }
         }
 
+        private bool _isBeingCreated;
+        public bool IsBeingCreated
+        {
+            get { return _isBeingCreated; }
+            set
+            {
+                _isBeingCreated = value;
+                NotifyPropertyChanged("IsBeingCreated");
+            }
+        }
+
         public XmlNode ProvisionXml
         {
             get


### PR DESCRIPTION
Refined the rules for not adding a VM to the table, if it is a template (thus not_a_real_vm), and it has the __gui__ prefix (thus hidden), we still add it, but hide it.
When its name is changed (to remove the __gui__ prefix), we update its name and re-calculate whether it should be visible (in the case of a new VM this will be true once the __gui__ prefix is gone). Also resort the table if a node changes from hidden to visible, because it appears as an addition to the table.

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>