### PR TITLE
CA-233454: Fix the action test

### DIFF
--- a/XenAdminTests/XenModelTests/ActionTests/VMActionsTest.cs
+++ b/XenAdminTests/XenModelTests/ActionTests/VMActionsTest.cs
@@ -41,7 +41,7 @@ namespace XenAdminTests.XenModelTests.ActionTests
         protected override CreateVMFastAction NewAction()
         {
             VM template = GetAnyUserTemplate(VmIsInstant);
-            return new CreateVMFastAction(template.Connection, template);
+            return new CreateVMFastAction(template.Connection, template, false);
         }
 
         protected override bool VerifyResult(CreateVMFastAction action)


### PR DESCRIPTION
Added an extra parameter to the CreateVmFastAction constructor, which is used to specify whether to set the VM's property IsBeingCreated. In order to set this property, we need to wait for the newly created VM to appear in the cache. But we cannot do this in the action test, because the cache is not being updated. Therefore the action needs skip this step when running from the tests. The IsBeingCreated property is only used in the UI, to refresh the PVS tab after the VM is created, so the accuracy of the action test (CreateVMFastActionTest) is not affected by this change.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>