### PR TITLE
CA-234628: Errors with no title in XenCenter

### DIFF
--- a/XenAdmin/Core/HealthCheck.cs
+++ b/XenAdmin/Core/HealthCheck.cs
@@ -64,7 +64,7 @@ namespace XenAdmin.Core
             }
             else if (actions.Count > 1)
             {
-                var parallelAction = new ParallelAction(null, "", "", "", actions);
+                var parallelAction = new ParallelAction(null, "", "", "", actions, true, true);
                 parallelAction.Completed += actionCompleted;
                 parallelAction.RunAsync();
             }


### PR DESCRIPTION
Set the suppressHistory flag to true for the parallel action that we run periodically to check the Health Check analysis result

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>