### PR TITLE
CA-231500: XenCenter allows you to open multiple windows from change …

### DIFF
--- a/XenAdmin/TabPages/AdPage.cs
+++ b/XenAdmin/TabPages/AdPage.cs
@@ -1057,8 +1057,8 @@ namespace XenAdmin.TabPages
                 selectedSubjects.Add(selectedRow.subject);
             }
 
-            RoleSelectionDialog dialog = new RoleSelectionDialog(selectedSubjects.ToArray(), pool);
-            dialog.Show(this);
+            using (var dialog = new RoleSelectionDialog(selectedSubjects.ToArray(), pool))
+                dialog.ShowDialog(this);
         }
 
         private void ButtonLogout_Click(object sender, EventArgs e)


### PR DESCRIPTION
…role button

Show the "Change role" dialog as modal. This way we avoid other issues, like removing the user while the "Change role" dialog is open.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>