### PR TITLE
CA-234638: XenCenter does not retry downloading: Workaround for temporary download problems

### DIFF
--- a/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
+++ b/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
@@ -124,6 +124,7 @@ namespace XenAdmin.Actions
                             
                             // wait for some randomly increased amount of time after each retry
                             nextSleepMs += random.Next(5000);
+                            Thread.Sleep(nextSleepMs);
                         }
                     }
                     finally


### PR DESCRIPTION
This change implements a lightweight retry logic for downloading updates to protect against temporary network issues.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>