### PR TITLE
CA-207011: Don't allow XC to create more than one SMB ISO SR on the same share

### DIFF
--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.Designer.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.Designer.cs
@@ -39,6 +39,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             this.labelCifsShareName = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.passwordFailure1 = new XenAdmin.Controls.Common.PasswordFailure();
             this.comboBoxCifsSharename = new System.Windows.Forms.ComboBox();
             this.groupBoxLogin.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -104,11 +105,18 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.passwordFailure1, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.labelCifsShareName, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.label22, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxCifsSharename, 1, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // passwordFailure1
+            // 
+            resources.ApplyResources(this.passwordFailure1, "passwordFailure1");
+            this.passwordFailure1.Name = "passwordFailure1";
+            this.passwordFailure1.TabStop = false;
             // 
             // comboBoxCifsSharename
             // 
@@ -148,5 +156,6 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.ComboBox comboBoxCifsSharename;
+        private Controls.Common.PasswordFailure passwordFailure1;
     }
 }

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.cs
@@ -166,17 +166,17 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
 
         private void textBoxCifsSharename_TextChanged(object sender, EventArgs e)
         {
-            passwordFailure1.PerformCheck(IsSRNameUnique);
+            passwordFailure1.PerformCheck(IsIsoStorageAlreadyAttached);
 
             OnPageUpdated();
         }
 
-        private bool IsSRNameUnique(out string error)
+        private bool IsIsoStorageAlreadyAttached(out string error)
         {
             error = string.Empty;
             if (my_srs.Contains(comboBoxCifsSharename.Text))
             {
-                error = string.Format(Messages.SMB_ISO_ALREADY_ATTACHED, Connection.FriendlyName);
+                error = string.Format(Messages.SMB_ISO_STORAGE_ALREADY_ATTACHED, Connection.FriendlyName);
                 return false;
             }
             return true;

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.cs
@@ -50,6 +50,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
 
         private bool m_disasterRecoveryTask;
         private SR m_srToReattach;
+        private List<String> my_srs = new List<String>();
         #endregion
 
         public CIFS_ISO()
@@ -68,7 +69,8 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
         public override bool EnableNext()
         {
             return SrWizardHelpers.ValidateCifsSharename(comboBoxCifsSharename.Text)
-                && !(checkBoxUseDifferentUsername.Checked && String.IsNullOrEmpty(textBoxCifsUsername.Text));
+                && !(checkBoxUseDifferentUsername.Checked && String.IsNullOrEmpty(textBoxCifsUsername.Text))
+                && !passwordFailure1.Visible;
         }
 
         public override bool EnablePrevious()
@@ -81,7 +83,6 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
 
         public override void PopulatePage()
         {
-            var my_srs = new List<String>();
             var add_srs = new List<String>();
             foreach (IXenConnection c in ConnectionsManager.XenConnectionsCopy)
             {
@@ -165,7 +166,20 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
 
         private void textBoxCifsSharename_TextChanged(object sender, EventArgs e)
         {
+            passwordFailure1.PerformCheck(IsSRNameUnique);
+
             OnPageUpdated();
+        }
+
+        private bool IsSRNameUnique(out string error)
+        {
+            error = string.Empty;
+            if (my_srs.Contains(comboBoxCifsSharename.Text))
+            {
+                error = string.Format(Messages.SMB_ISO_ALREADY_ATTACHED, Connection.FriendlyName);
+                return false;
+            }
+            return true;
         }
 
         private void checkBoxUseDifferentUsername_CheckedChanged(object sender, EventArgs e)

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.resx
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="checkBoxUseDifferentUsername.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="checkBoxUseDifferentUsername.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="checkBoxUseDifferentUsername.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 130</value>
   </data>
@@ -142,7 +142,7 @@
     <value>checkBoxUseDifferentUsername</value>
   </data>
   <data name="&gt;&gt;checkBoxUseDifferentUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;checkBoxUseDifferentUsername.Parent" xml:space="preserve">
     <value>$this</value>
@@ -175,7 +175,7 @@
     <value>labelCifsPassword</value>
   </data>
   <data name="&gt;&gt;labelCifsPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelCifsPassword.Parent" xml:space="preserve">
     <value>groupBoxLogin</value>
@@ -205,7 +205,7 @@
     <value>labelCifsUsername</value>
   </data>
   <data name="&gt;&gt;labelCifsUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelCifsUsername.Parent" xml:space="preserve">
     <value>groupBoxLogin</value>
@@ -229,7 +229,7 @@
     <value>textBoxCifsPassword</value>
   </data>
   <data name="&gt;&gt;textBoxCifsPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;textBoxCifsPassword.Parent" xml:space="preserve">
     <value>groupBoxLogin</value>
@@ -253,7 +253,7 @@
     <value>textBoxCifsUsername</value>
   </data>
   <data name="&gt;&gt;textBoxCifsUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;textBoxCifsUsername.Parent" xml:space="preserve">
     <value>groupBoxLogin</value>
@@ -313,13 +313,13 @@
     <value>label22</value>
   </data>
   <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label22.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="labelCifsShareName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -352,13 +352,13 @@
     <value>labelCifsShareName</value>
   </data>
   <data name="&gt;&gt;labelCifsShareName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelCifsShareName.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelCifsShareName.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -371,6 +371,45 @@
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
+  </data>
+  <data name="passwordFailure1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="passwordFailure1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="passwordFailure1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="passwordFailure1.Error" xml:space="preserve">
+    <value>This SMB ISO storage is already attached</value>
+  </data>
+  <data name="passwordFailure1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>82, 102</value>
+  </data>
+  <data name="passwordFailure1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="passwordFailure1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>418, 20</value>
+  </data>
+  <data name="passwordFailure1.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="passwordFailure1.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;passwordFailure1.Name" xml:space="preserve">
+    <value>passwordFailure1</value>
+  </data>
+  <data name="&gt;&gt;passwordFailure1.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.Common.PasswordFailure, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;passwordFailure1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;passwordFailure1.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="comboBoxCifsSharename.Location" type="System.Drawing.Point, System.Drawing">
     <value>85, 59</value>
@@ -385,13 +424,13 @@
     <value>comboBoxCifsSharename</value>
   </data>
   <data name="&gt;&gt;comboBoxCifsSharename.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;comboBoxCifsSharename.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxCifsSharename.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -403,10 +442,10 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 102</value>
+    <value>500, 122</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -415,7 +454,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -424,7 +463,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="labelCifsShareName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label22" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxCifsSharename" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,100,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="passwordFailure1" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="labelCifsShareName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label22" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxCifsSharename" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,100,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -448,15 +487,15 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AccessibleDescription" xml:space="preserve">

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -30779,9 +30779,9 @@ namespace XenAdmin {
         /// <summary>
         ///   Looks up a localized string similar to This SMB ISO storage is already attached to &apos;{0}&apos;.
         /// </summary>
-        public static string SMB_ISO_ALREADY_ATTACHED {
+        public static string SMB_ISO_STORAGE_ALREADY_ATTACHED {
             get {
-                return ResourceManager.GetString("SMB_ISO_ALREADY_ATTACHED", resourceCulture);
+                return ResourceManager.GetString("SMB_ISO_STORAGE_ALREADY_ATTACHED", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -30777,6 +30777,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This SMB ISO storage is already attached to &apos;{0}&apos;.
+        /// </summary>
+        public static string SMB_ISO_ALREADY_ATTACHED {
+            get {
+                return ResourceManager.GetString("SMB_ISO_ALREADY_ATTACHED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} (snapshot).
         /// </summary>
         public static string SNAPSHOT_BRACKETS {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10698,6 +10698,9 @@ Do you want to connect to the pool master '{1}'?</value>
   <data name="SMALLER_THAN" xml:space="preserve">
     <value>smaller than</value>
   </data>
+  <data name="SMB_ISO_ALREADY_ATTACHED" xml:space="preserve">
+    <value>This SMB ISO storage is already attached to '{0}'</value>
+  </data>
   <data name="SNAPSHOTS" xml:space="preserve">
     <value>Snapshots</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10698,7 +10698,7 @@ Do you want to connect to the pool master '{1}'?</value>
   <data name="SMALLER_THAN" xml:space="preserve">
     <value>smaller than</value>
   </data>
-  <data name="SMB_ISO_ALREADY_ATTACHED" xml:space="preserve">
+  <data name="SMB_ISO_STORAGE_ALREADY_ATTACHED" xml:space="preserve">
     <value>This SMB ISO storage is already attached to '{0}'</value>
   </data>
   <data name="SNAPSHOTS" xml:space="preserve">


### PR DESCRIPTION
This commit implements the same logic that is used for NFS ISOs.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>