### PR TITLE
CA-235381: XenCenter should not allow users to edit the PVS cache sto…

### DIFF
--- a/XenAdmin/Controls/PvsCacheStorageRow.Designer.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.Designer.cs
@@ -28,16 +28,20 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PvsCacheStorageRow));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.labelUnits = new System.Windows.Forms.Label();
             this.numericUpDownCacheSize = new System.Windows.Forms.NumericUpDown();
-            this.comboBoxCacheSr = new EnableableComboBox();
+            this.comboBoxCacheSr = new XenAdmin.Controls.EnableableComboBox();
             this.labelHostName = new System.Windows.Forms.Label();
             this.labelCacheStorage = new System.Windows.Forms.Label();
             this.labelCacheSize = new System.Windows.Forms.Label();
+            this.pictureBoxInfo = new System.Windows.Forms.PictureBox();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownCacheSize)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -49,6 +53,7 @@
             this.tableLayoutPanel1.Controls.Add(this.labelHostName, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.labelCacheStorage, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.labelCacheSize, 3, 0);
+            this.tableLayoutPanel1.Controls.Add(this.pictureBoxInfo, 5, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // labelUnits
@@ -69,9 +74,10 @@
             // 
             // comboBoxCacheSr
             // 
+            resources.ApplyResources(this.comboBoxCacheSr, "comboBoxCacheSr");
+            this.comboBoxCacheSr.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.comboBoxCacheSr.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxCacheSr.FormattingEnabled = true;
-            resources.ApplyResources(this.comboBoxCacheSr, "comboBoxCacheSr");
             this.comboBoxCacheSr.Name = "comboBoxCacheSr";
             this.comboBoxCacheSr.SelectedIndexChanged += new System.EventHandler(this.comboBoxCacheSr_SelectedIndexChanged);
             // 
@@ -91,6 +97,16 @@
             resources.ApplyResources(this.labelCacheSize, "labelCacheSize");
             this.labelCacheSize.Name = "labelCacheSize";
             // 
+            // pictureBoxInfo
+            // 
+            this.pictureBoxInfo.Cursor = System.Windows.Forms.Cursors.Hand;
+            resources.ApplyResources(this.pictureBoxInfo, "pictureBoxInfo");
+            this.pictureBoxInfo.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
+            this.pictureBoxInfo.Name = "pictureBoxInfo";
+            this.pictureBoxInfo.TabStop = false;
+            this.pictureBoxInfo.Click += new System.EventHandler(this.pictureBoxInfo_Click);
+            this.pictureBoxInfo.MouseLeave += new System.EventHandler(this.pictureBoxInfo_MouseLeave);
+            // 
             // PvsCacheStorageRow
             // 
             resources.ApplyResources(this, "$this");
@@ -100,6 +116,7 @@
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownCacheSize)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -114,5 +131,7 @@
         private System.Windows.Forms.Label labelCacheSize;
         private System.Windows.Forms.Label labelUnits;
         private System.Windows.Forms.NumericUpDown numericUpDownCacheSize;
+        private System.Windows.Forms.PictureBox pictureBoxInfo;
+        private System.Windows.Forms.ToolTip toolTip;
     }
 }

--- a/XenAdmin/Controls/PvsCacheStorageRow.Designer.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PvsCacheStorageRow));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.labelUnits = new System.Windows.Forms.Label();
@@ -37,11 +36,8 @@
             this.labelHostName = new System.Windows.Forms.Label();
             this.labelCacheStorage = new System.Windows.Forms.Label();
             this.labelCacheSize = new System.Windows.Forms.Label();
-            this.pictureBoxInfo = new System.Windows.Forms.PictureBox();
-            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownCacheSize)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -53,7 +49,6 @@
             this.tableLayoutPanel1.Controls.Add(this.labelHostName, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.labelCacheStorage, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.labelCacheSize, 3, 0);
-            this.tableLayoutPanel1.Controls.Add(this.pictureBoxInfo, 5, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // labelUnits
@@ -97,16 +92,6 @@
             resources.ApplyResources(this.labelCacheSize, "labelCacheSize");
             this.labelCacheSize.Name = "labelCacheSize";
             // 
-            // pictureBoxInfo
-            // 
-            this.pictureBoxInfo.Cursor = System.Windows.Forms.Cursors.Hand;
-            resources.ApplyResources(this.pictureBoxInfo, "pictureBoxInfo");
-            this.pictureBoxInfo.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
-            this.pictureBoxInfo.Name = "pictureBoxInfo";
-            this.pictureBoxInfo.TabStop = false;
-            this.pictureBoxInfo.Click += new System.EventHandler(this.pictureBoxInfo_Click);
-            this.pictureBoxInfo.MouseLeave += new System.EventHandler(this.pictureBoxInfo_MouseLeave);
-            // 
             // PvsCacheStorageRow
             // 
             resources.ApplyResources(this, "$this");
@@ -116,7 +101,6 @@
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownCacheSize)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -131,7 +115,5 @@
         private System.Windows.Forms.Label labelCacheSize;
         private System.Windows.Forms.Label labelUnits;
         private System.Windows.Forms.NumericUpDown numericUpDownCacheSize;
-        private System.Windows.Forms.PictureBox pictureBoxInfo;
-        private System.Windows.Forms.ToolTip toolTip;
     }
 }

--- a/XenAdmin/Controls/PvsCacheStorageRow.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.cs
@@ -70,6 +70,9 @@ namespace XenAdmin.Controls
             origCacheSizeGb = numericUpDownCacheSize.Value;
 
             PopulateCacheSrCombobox();
+            var isInUse = OrigPvsCacheStorage != null && OrigPvsCacheStorage.IsInUse;
+            comboBoxCacheSr.Enabled = numericUpDownCacheSize.Enabled = !isInUse;
+            pictureBoxInfo.Visible = isInUse;
         }
 
         private void PopulateCacheSrCombobox()
@@ -198,6 +201,16 @@ namespace XenAdmin.Controls
                     SetupCacheSizeSpinner(numericUpDownCacheSize.Value, numericUpDownCacheSize.Minimum, maxSize);
             }
             SomethingChanged(this, e);
+        }
+
+        private void pictureBoxInfo_Click(object sender, EventArgs e)
+        {
+            toolTip.Show(Messages.PVS_CACHE_STORAGE_CANNOT_BE_CHANGED, pictureBoxInfo, 20, 0);
+        }
+
+        private void pictureBoxInfo_MouseLeave(object sender, EventArgs e)
+        {
+            toolTip.Hide(pictureBoxInfo);
         }
     }
 

--- a/XenAdmin/Controls/PvsCacheStorageRow.cs
+++ b/XenAdmin/Controls/PvsCacheStorageRow.cs
@@ -70,9 +70,8 @@ namespace XenAdmin.Controls
             origCacheSizeGb = numericUpDownCacheSize.Value;
 
             PopulateCacheSrCombobox();
-            var isInUse = OrigPvsCacheStorage != null && OrigPvsCacheStorage.IsInUse;
-            comboBoxCacheSr.Enabled = numericUpDownCacheSize.Enabled = !isInUse;
-            pictureBoxInfo.Visible = isInUse;
+            ReadOnly = OrigPvsCacheStorage != null && OrigPvsCacheStorage.IsInUse;
+            comboBoxCacheSr.Enabled = numericUpDownCacheSize.Enabled = !ReadOnly;
         }
 
         private void PopulateCacheSrCombobox()
@@ -183,6 +182,8 @@ namespace XenAdmin.Controls
             }
         }
 
+        public bool ReadOnly { get; private set; }
+
         private void SomethingChanged(object sender, EventArgs e)
         {
             if (Changed != null)
@@ -201,16 +202,6 @@ namespace XenAdmin.Controls
                     SetupCacheSizeSpinner(numericUpDownCacheSize.Value, numericUpDownCacheSize.Minimum, maxSize);
             }
             SomethingChanged(this, e);
-        }
-
-        private void pictureBoxInfo_Click(object sender, EventArgs e)
-        {
-            toolTip.Show(Messages.PVS_CACHE_STORAGE_CANNOT_BE_CHANGED, pictureBoxInfo, 20, 0);
-        }
-
-        private void pictureBoxInfo_MouseLeave(object sender, EventArgs e)
-        {
-            toolTip.Hide(pictureBoxInfo);
         }
     }
 

--- a/XenAdmin/Controls/PvsCacheStorageRow.resx
+++ b/XenAdmin/Controls/PvsCacheStorageRow.resx
@@ -122,7 +122,7 @@
     <value>True</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>6</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelUnits.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
@@ -130,7 +130,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="labelUnits.Location" type="System.Drawing.Point, System.Drawing">
-    <value>402, 22</value>
+    <value>395, 22</value>
   </data>
   <data name="labelUnits.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -160,7 +160,7 @@
     <value>0</value>
   </data>
   <data name="numericUpDownCacheSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>324, 22</value>
+    <value>317, 22</value>
   </data>
   <data name="numericUpDownCacheSize.Size" type="System.Drawing.Size, System.Drawing">
     <value>72, 20</value>
@@ -180,11 +180,14 @@
   <data name="&gt;&gt;numericUpDownCacheSize.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="comboBoxCacheSr.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
   <data name="comboBoxCacheSr.Location" type="System.Drawing.Point, System.Drawing">
     <value>114, 22</value>
   </data>
   <data name="comboBoxCacheSr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 21</value>
+    <value>189, 21</value>
   </data>
   <data name="comboBoxCacheSr.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -193,7 +196,7 @@
     <value>comboBoxCacheSr</value>
   </data>
   <data name="&gt;&gt;comboBoxCacheSr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>XenAdmin.Controls.EnableableComboBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboBoxCacheSr.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -253,7 +256,7 @@
     <value>3, 3, 3, 3</value>
   </data>
   <data name="labelCacheStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 13</value>
+    <value>189, 13</value>
   </data>
   <data name="labelCacheStorage.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -289,7 +292,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelCacheSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>324, 3</value>
+    <value>317, 3</value>
   </data>
   <data name="labelCacheSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -318,6 +321,39 @@
   <data name="&gt;&gt;labelCacheSize.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="pictureBoxInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="pictureBoxInfo.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="pictureBoxInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBoxInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>427, 22</value>
+  </data>
+  <data name="pictureBoxInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>20, 21</value>
+  </data>
+  <data name="pictureBoxInfo.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
+  </data>
+  <data name="pictureBoxInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxInfo.Name" xml:space="preserve">
+    <value>pictureBoxInfo</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxInfo.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
@@ -328,7 +364,7 @@
     <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>431, 46</value>
+    <value>450, 46</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -346,8 +382,11 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelUnits" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownCacheSize" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxCacheSr" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelHostName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheStorage" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheSize" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,111,AutoSize,0,Absolute,8,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelUnits" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownCacheSize" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxCacheSr" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelHostName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheStorage" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheSize" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="pictureBoxInfo" Row="1" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,111,Percent,100,Absolute,8,AutoSize,0,AutoSize,0,Absolute,26" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -357,8 +396,17 @@
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>360, 21</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>431, 47</value>
+    <value>450, 47</value>
+  </data>
+  <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
+    <value>toolTip</value>
+  </data>
+  <data name="&gt;&gt;toolTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PvsCacheStorageRow</value>

--- a/XenAdmin/Controls/PvsCacheStorageRow.resx
+++ b/XenAdmin/Controls/PvsCacheStorageRow.resx
@@ -122,7 +122,7 @@
     <value>True</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>5</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelUnits.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
@@ -130,7 +130,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="labelUnits.Location" type="System.Drawing.Point, System.Drawing">
-    <value>395, 22</value>
+    <value>421, 22</value>
   </data>
   <data name="labelUnits.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -160,7 +160,7 @@
     <value>0</value>
   </data>
   <data name="numericUpDownCacheSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>317, 22</value>
+    <value>343, 22</value>
   </data>
   <data name="numericUpDownCacheSize.Size" type="System.Drawing.Size, System.Drawing">
     <value>72, 20</value>
@@ -187,7 +187,7 @@
     <value>114, 22</value>
   </data>
   <data name="comboBoxCacheSr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 21</value>
+    <value>215, 21</value>
   </data>
   <data name="comboBoxCacheSr.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -256,7 +256,7 @@
     <value>3, 3, 3, 3</value>
   </data>
   <data name="labelCacheStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 13</value>
+    <value>215, 13</value>
   </data>
   <data name="labelCacheStorage.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -292,7 +292,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelCacheSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>317, 3</value>
+    <value>343, 3</value>
   </data>
   <data name="labelCacheSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -320,39 +320,6 @@
   </data>
   <data name="&gt;&gt;labelCacheSize.ZOrder" xml:space="preserve">
     <value>5</value>
-  </data>
-  <data name="pictureBoxInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="pictureBoxInfo.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="pictureBoxInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="pictureBoxInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>427, 22</value>
-  </data>
-  <data name="pictureBoxInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>20, 21</value>
-  </data>
-  <data name="pictureBoxInfo.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
-  </data>
-  <data name="pictureBoxInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxInfo.Name" xml:space="preserve">
-    <value>pictureBoxInfo</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxInfo.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxInfo.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -382,11 +349,8 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelUnits" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownCacheSize" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxCacheSr" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelHostName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheStorage" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheSize" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="pictureBoxInfo" Row="1" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,111,Percent,100,Absolute,8,AutoSize,0,AutoSize,0,Absolute,26" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelUnits" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownCacheSize" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxCacheSr" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelHostName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheStorage" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelCacheSize" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,111,Percent,100,Absolute,8,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -401,12 +365,6 @@
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>450, 47</value>
-  </data>
-  <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
-    <value>toolTip</value>
-  </data>
-  <data name="&gt;&gt;toolTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PvsCacheStorageRow</value>

--- a/XenAdmin/Dialogs/PvsCacheConfigurationDialog.resx
+++ b/XenAdmin/Dialogs/PvsCacheConfigurationDialog.resx
@@ -306,6 +306,9 @@
   <data name="&gt;&gt;splitContainer.Panel1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="splitContainer.Panel1MinSize" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
   <data name="&gt;&gt;splitContainer.Panel2.Name" xml:space="preserve">
     <value>splitContainer.Panel2</value>
   </data>
@@ -317,6 +320,9 @@
   </data>
   <data name="&gt;&gt;splitContainer.Panel2.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="splitContainer.Panel2MinSize" type="System.Int32, mscorlib">
+    <value>400</value>
   </data>
   <data name="splitContainer.Size" type="System.Drawing.Size, System.Drawing">
     <value>763, 474</value>

--- a/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.Designer.cs
+++ b/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.Designer.cs
@@ -30,6 +30,7 @@ namespace XenAdmin.Dialogs
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PvsCacheConfigurationPage));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.cacheStorageInUseInfoLabel = new System.Windows.Forms.Label();
             this.memoryOnlyInfoLabel = new System.Windows.Forms.Label();
             this.deleteButton = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
@@ -40,25 +41,35 @@ namespace XenAdmin.Dialogs
             this.pvsConfigInfoIcon = new System.Windows.Forms.PictureBox();
             this.pvsConfigInfoLabel = new System.Windows.Forms.Label();
             this.memoryOnlyInfoIcon = new System.Windows.Forms.PictureBox();
+            this.cacheStorageInUseInfoIcon = new System.Windows.Forms.PictureBox();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pvsConfigInfoIcon)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.memoryOnlyInfoIcon)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cacheStorageInUseInfoIcon)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.memoryOnlyInfoLabel, 1, 3);
-            this.tableLayoutPanel1.Controls.Add(this.deleteButton, 4, 5);
+            this.tableLayoutPanel1.Controls.Add(this.cacheStorageInUseInfoLabel, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.memoryOnlyInfoLabel, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.deleteButton, 4, 6);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.label7, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.textBox1, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.hostsPanel, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.viewPvsServersButton, 2, 5);
-            this.tableLayoutPanel1.Controls.Add(this.pvsConfigInfoIcon, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.pvsConfigInfoLabel, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.memoryOnlyInfoIcon, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.viewPvsServersButton, 2, 6);
+            this.tableLayoutPanel1.Controls.Add(this.pvsConfigInfoIcon, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.pvsConfigInfoLabel, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.memoryOnlyInfoIcon, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.cacheStorageInUseInfoIcon, 0, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // cacheStorageInUseInfoLabel
+            // 
+            resources.ApplyResources(this.cacheStorageInUseInfoLabel, "cacheStorageInUseInfoLabel");
+            this.tableLayoutPanel1.SetColumnSpan(this.cacheStorageInUseInfoLabel, 3);
+            this.cacheStorageInUseInfoLabel.Name = "cacheStorageInUseInfoLabel";
             // 
             // memoryOnlyInfoLabel
             // 
@@ -128,6 +139,13 @@ namespace XenAdmin.Dialogs
             this.memoryOnlyInfoIcon.Name = "memoryOnlyInfoIcon";
             this.memoryOnlyInfoIcon.TabStop = false;
             // 
+            // cacheStorageInUseInfoIcon
+            // 
+            resources.ApplyResources(this.cacheStorageInUseInfoIcon, "cacheStorageInUseInfoIcon");
+            this.cacheStorageInUseInfoIcon.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            this.cacheStorageInUseInfoIcon.Name = "cacheStorageInUseInfoIcon";
+            this.cacheStorageInUseInfoIcon.TabStop = false;
+            // 
             // PvsCacheConfigurationPage
             // 
             resources.ApplyResources(this, "$this");
@@ -139,6 +157,7 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pvsConfigInfoIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.memoryOnlyInfoIcon)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cacheStorageInUseInfoIcon)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -156,5 +175,7 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.PictureBox pvsConfigInfoIcon;
         private System.Windows.Forms.Label memoryOnlyInfoLabel;
         private System.Windows.Forms.PictureBox memoryOnlyInfoIcon;
+        private System.Windows.Forms.Label cacheStorageInUseInfoLabel;
+        private System.Windows.Forms.PictureBox cacheStorageInUseInfoIcon;
     }
 }

--- a/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.cs
+++ b/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.cs
@@ -88,6 +88,8 @@ namespace XenAdmin.Dialogs
 
             LoadServers();
             viewPvsServersButton.Enabled = PvsSite != null && PvsSite.servers.Count > 0;
+            cacheStorageInUseInfoIcon.Visible = cacheStorageInUseInfoLabel.Visible = rows.Any(row => row.ReadOnly);
+            memoryOnlyInfoIcon.Visible = memoryOnlyInfoLabel.Visible = rows.Any(row => !row.ReadOnly);
         }
 
         public bool ValidToSave

--- a/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.resx
+++ b/XenAdmin/Dialogs/PvsPages/PvsCacheConfigurationPage.resx
@@ -121,14 +121,50 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="memoryOnlyInfoLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="cacheStorageInUseInfoLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="memoryOnlyInfoLabel.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="cacheStorageInUseInfoLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cacheStorageInUseInfoLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cacheStorageInUseInfoLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 219</value>
+  </data>
+  <data name="cacheStorageInUseInfoLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="cacheStorageInUseInfoLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>357, 15</value>
+  </data>
+  <data name="cacheStorageInUseInfoLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="cacheStorageInUseInfoLabel.Text" xml:space="preserve">
+    <value>The cache storage cannot be changed on servers where it is in use.</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoLabel.Name" xml:space="preserve">
+    <value>cacheStorageInUseInfoLabel</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="memoryOnlyInfoLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="memoryOnlyInfoLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
   <data name="memoryOnlyInfoLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -158,7 +194,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;memoryOnlyInfoLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="deleteButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -206,7 +242,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;deleteButton.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -242,7 +278,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -281,7 +317,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>69, 13</value>
@@ -302,7 +338,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="hostsPanel.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -314,7 +350,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>3, 72</value>
   </data>
   <data name="hostsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>434, 163</value>
+    <value>434, 141</value>
   </data>
   <data name="hostsPanel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -329,7 +365,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;hostsPanel.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="viewPvsServersButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -368,7 +404,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;viewPvsServersButton.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="pvsConfigInfoIcon.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left</value>
@@ -401,7 +437,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;pvsConfigInfoIcon.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="pvsConfigInfoLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -437,7 +473,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;pvsConfigInfoLabel.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="memoryOnlyInfoIcon.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left</value>
@@ -470,7 +506,40 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;memoryOnlyInfoIcon.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
+  </data>
+  <data name="cacheStorageInUseInfoIcon.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left</value>
+  </data>
+  <data name="cacheStorageInUseInfoIcon.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cacheStorageInUseInfoIcon.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 219</value>
+  </data>
+  <data name="cacheStorageInUseInfoIcon.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="cacheStorageInUseInfoIcon.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="cacheStorageInUseInfoIcon.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="cacheStorageInUseInfoIcon.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoIcon.Name" xml:space="preserve">
+    <value>cacheStorageInUseInfoIcon</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoIcon.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoIcon.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;cacheStorageInUseInfoIcon.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -482,7 +551,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>0, 10, 0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>440, 356</value>
@@ -503,7 +572,7 @@ If Memory only is chosen, the allowed cache size depends on the server's Control
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="memoryOnlyInfoLabel" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="deleteButton" Row="5" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="label7" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="textBox1" Row="0" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="hostsPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="viewPvsServersButton" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pvsConfigInfoIcon" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="pvsConfigInfoLabel" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="memoryOnlyInfoIcon" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,21,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cacheStorageInUseInfoLabel" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="memoryOnlyInfoLabel" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="deleteButton" Row="6" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="label7" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="textBox1" Row="0" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="hostsPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="viewPvsServersButton" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pvsConfigInfoIcon" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="pvsConfigInfoLabel" Row="5" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="memoryOnlyInfoIcon" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cacheStorageInUseInfoIcon" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,21,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -28192,6 +28192,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This PVS cache storage cannot be changed because it is in use..
+        /// </summary>
+        public static string PVS_CACHE_STORAGE_CANNOT_BE_CHANGED {
+            get {
+                return ResourceManager.GetString("PVS_CACHE_STORAGE_CANNOT_BE_CHANGED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} (Incomplete Cache Storage configuration).
         /// </summary>
         public static string PVS_CACHE_STORAGE_NOT_CONFIGURED {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9799,6 +9799,9 @@ Press OK to continue the wizard and return to the server and follow the instruct
   <data name="PVS_CACHE_NOT_CONFIGURED" xml:space="preserve">
     <value>Not configured</value>
   </data>
+  <data name="PVS_CACHE_STORAGE_CANNOT_BE_CHANGED" xml:space="preserve">
+    <value>This PVS cache storage cannot be changed because it is in use.</value>
+  </data>
   <data name="PVS_CACHE_STORAGE_NOT_CONFIGURED" xml:space="preserve">
     <value>{0} (Incomplete Cache Storage configuration)</value>
   </data>

--- a/XenModel/XenAPI-Extensions/PVS_cache_storage.cs
+++ b/XenModel/XenAPI-Extensions/PVS_cache_storage.cs
@@ -1,0 +1,52 @@
+﻿/* Copyright (c) Citrix Systems Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+namespace XenAPI
+{
+    public partial class PVS_cache_storage
+    {
+        public bool IsInUse
+        {
+            get
+            {
+                foreach (var pvsProxy in Connection.Cache.PVS_proxies)
+                {
+                    var vm = pvsProxy.VM;
+                    if (vm != null && vm.resident_on.opaque_ref == host.opaque_ref &&
+                        pvsProxy.site.opaque_ref == site.opaque_ref && pvsProxy.currently_attached)
+                        return true;
+                }
+                return false;
+            }
+        }
+    }
+}
+

--- a/XenModel/XenAPI-Extensions/PVS_cache_storage.cs
+++ b/XenModel/XenAPI-Extensions/PVS_cache_storage.cs
@@ -29,6 +29,8 @@
  * SUCH DAMAGE.
  */
 
+using System.Linq;
+
 namespace XenAPI
 {
     public partial class PVS_cache_storage
@@ -37,11 +39,11 @@ namespace XenAPI
         {
             get
             {
-                foreach (var pvsProxy in Connection.Cache.PVS_proxies)
+                foreach (var pvsProxy in Connection.Cache.PVS_proxies.Where(p => p.currently_attached))
                 {
                     var vm = pvsProxy.VM;
-                    if (vm != null && vm.resident_on.opaque_ref == host.opaque_ref &&
-                        pvsProxy.site.opaque_ref == site.opaque_ref && pvsProxy.currently_attached)
+                    if (vm != null && vm.resident_on != null && vm.resident_on.opaque_ref == host.opaque_ref &&
+                        pvsProxy.site != null && pvsProxy.site.opaque_ref == site.opaque_ref)
                         return true;
                 }
                 return false;

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -330,6 +330,7 @@
     <Compile Include="WLB\WlbServerState.cs" />
     <Compile Include="XenAPI-Extensions\Blob.cs" />
     <Compile Include="XenAPI-Extensions\Pool_update.cs" />
+    <Compile Include="XenAPI-Extensions\PVS_cache_storage.cs" />
     <Compile Include="XenAPI-Extensions\pvs_proxy_status.cs" />
     <Compile Include="XenAPI-Extensions\PVS_site.cs" />
     <Compile Include="XenAPI-Extensions\PVS_proxy.cs" />


### PR DESCRIPTION
…rage if it is in use

- On the PVS Cache Configuration dialog, disable the cache storage fields with an information tooltip stating that this PVS cache storage cannot be changed because it is in use.
- Also set the minimum width for the splitter panels, to avoid display issues when the splitter is moved and either of the panels becomes unusable.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>