### PR TITLE
CA-216752: Not all wizards progress through to the next page by press…

### DIFF
--- a/XenAdmin/Controls/XenTabPage.cs
+++ b/XenAdmin/Controls/XenTabPage.cs
@@ -191,6 +191,11 @@ namespace XenAdmin.Controls
         /// Check whether this step needs to be disabled. Not always overriden in derived classes
         /// </summary>
         public virtual void CheckPageDisabled() { }
+        
+        /// <summary>
+        /// Select a control on the page. Not always overriden in derived classes
+        /// </summary>
+        public virtual void SelectDefaultControl() { }
 
         protected void OnPageUpdated()
         {

--- a/XenAdmin/SettingsPanels/GpuEditPage.cs
+++ b/XenAdmin/SettingsPanels/GpuEditPage.cs
@@ -233,6 +233,12 @@ namespace XenAdmin.SettingsPanels
             }
         }
 
+        public override void SelectDefaultControl()
+        {
+            if (comboBoxGpus.CanSelect)
+                comboBoxGpus.Select();
+        }
+
         #endregion
 
         private void PopulateComboBox()

--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageDestination.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageDestination.cs
@@ -101,6 +101,12 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
             base.PageLeave(direction, ref cancel);
         }
 
+        public override void SelectDefaultControl()
+        {
+            if (string.IsNullOrEmpty(m_textBoxLocation.Text))
+                m_textBoxLocation.Select();
+        }
+
         public string OutputFile
         {
             get

--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageRetrieveData.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageRetrieveData.cs
@@ -109,6 +109,11 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
                 CancelAction();
         }
 
+        public override void SelectDefaultControl()
+        {
+            flickerFreeListBox1.Select();
+        }
+
         public List<Host> SelectedHosts { private get; set; }
         public IEnumerable<Capability> CapabilityList { private get; set; }
 

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -173,6 +173,11 @@ namespace XenAdmin.Wizards.GenericPages
             restoreGridHomeServerSelection = (direction == PageLoadedDirection.Back);
 		}
 
+        public override void SelectDefaultControl()
+        {
+            m_comboBoxConnection.Select();
+        }
+
         public override bool EnableNext()
         {
             return m_buttonNextEnabled;

--- a/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
+++ b/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
@@ -686,6 +686,11 @@ namespace XenAdmin.Wizards.HAWizard_Pages
             StartNtolUpdate();
         }
 
+        public override void SelectDefaultControl()
+        {
+            dataGridViewVms.Select();
+        }
+
         public override void PageLeave(PageLoadedDirection direction, ref bool cancel)
         {
             StopNtolUpdate();

--- a/XenAdmin/Wizards/ImportWizard/ImageVMConfigPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImageVMConfigPage.cs
@@ -83,6 +83,11 @@ namespace XenAdmin.Wizards.ImportWizard
 			m_upDownAddSpace.Value = m_upDownAddSpace.Minimum;
 		}
 
+        public override void SelectDefaultControl()
+        {
+            m_textBoxVMName.Select();
+        }
+
         public override bool EnableNext()
         {
             return m_buttonNextEnabled;

--- a/XenAdmin/Wizards/ImportWizard/ImportEulaPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportEulaPage.cs
@@ -129,6 +129,11 @@ namespace XenAdmin.Wizards.ImportWizard
 			}
 		}
 
+        public override void SelectDefaultControl()
+        {
+            m_tabControlEULA.Select();
+        }
+
         public override bool EnableNext()
         {
             return m_buttonNextEnabled;

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFSFrontend.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFSFrontend.cs
@@ -84,6 +84,12 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
                 listBoxCifsSRs.SetMustSelectUUID(SrWizardType.UUID);
         }
 
+
+        public override void SelectDefaultControl()
+        {
+            CifsServerPathTextBox.Select();
+        }
+
         #endregion
 
         private void UpdateButtons()

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/CIFS_ISO.cs
@@ -108,6 +108,11 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             this.comboBoxCifsSharename.Items.AddRange(add_srs.ToArray());
         }
 
+        public override void SelectDefaultControl()
+        {
+            comboBoxCifsSharename.Select();
+        }
+
         #endregion
 
         #region Accessors

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/LVMoHBA.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/LVMoHBA.cs
@@ -230,6 +230,11 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             return Helpers.DundeeOrGreater(Connection) ?  Messages.WIZARD_BUTTON_NEXT : Messages.NEWSR_LVMOHBA_NEXT_TEXT;
         }
 
+        public override void SelectDefaultControl()
+        {
+            dataGridView.Select();
+        }
+
         #endregion
 
         #region Event handlers

--- a/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/Frontends/VHDoNFS.cs
@@ -89,6 +89,11 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages.Frontends
             nfsVersionLabel.Visible = nfsVersionSelectorTableLayoutPanel.Visible = Helpers.DundeeOrGreater(Connection);
         }
 
+        public override void SelectDefaultControl()
+        {
+            NfsServerPathTextBox.Select();
+        }
+
         #endregion
 
         private void UpdateButtons()

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -126,6 +126,11 @@ namespace XenAdmin.Wizards.NewVMWizard
             initialising = false;
         }
 
+        public override void SelectDefaultControl()
+        {
+            comboBoxVCPUs.Select();
+        }
+
         private void InitialiseVcpuControls()
         {
             labelVCPUs.Text = isVcpuHotplugSupported

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
@@ -84,7 +84,10 @@ namespace XenAdmin.Wizards.NewVMWizard
             var entries = SummaryRetreiver.Invoke();
             foreach (KeyValuePair<string, string> pair in entries)
                 SummaryGridView.Rows.Add(pair.Key, pair.Value);
-            
+        }
+
+        public override void SelectDefaultControl()
+        {
             AutoStartCheckBox.Select();
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_HomeServer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_HomeServer.cs
@@ -114,6 +114,10 @@ namespace XenAdmin.Wizards.NewVMWizard
                 affinityPicker1.SetAffinity(Connection, Affinity,
                                            CdAffinity ?? Template.GetStorageHost(false));
             }
+        }
+
+        public override void SelectDefaultControl()
+        {
             affinityPicker1.Select();
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_Name.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Name.cs
@@ -82,6 +82,10 @@ namespace XenAdmin.Wizards.NewVMWizard
             Template = SelectedTemplate;
 
             NameTextBox.Text = Helpers.DefaultVMName(Helpers.GetName(Template), Connection);
+        }
+
+        public override void SelectDefaultControl()
+        {
             NameTextBox.Select();
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_Networking.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Networking.cs
@@ -98,6 +98,10 @@ namespace XenAdmin.Wizards.NewVMWizard
                 NetworksGridView.Rows[0].Selected = true;
 
             UpdateEnablement();
+        }
+
+        public override void SelectDefaultControl()
+        {
             NetworksGridView.Select();
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
@@ -93,6 +93,10 @@ namespace XenAdmin.Wizards.NewVMWizard
             LoadDisks();
             UpdateEnablement();
             UpdateCloneCheckboxEnablement(true);
+        }
+
+        public override void SelectDefaultControl()
+        {
             DisksGridView.Select();
         }
 

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -149,6 +149,11 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
         }
 
+        public override void SelectDefaultControl()
+        {
+            dataGridView1.Select();
+        }
+
         protected void RefreshRechecks()
         {
             buttonResolveAll.Enabled = buttonReCheckProblems.Enabled = checkBoxViewPrecheckFailuresOnly.Enabled = false;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -165,6 +165,11 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
         }
 
+        public override void SelectDefaultControl()
+        {
+            dataGridViewHosts.Select();
+        }
+
         public bool IsInAutomaticMode { set; get; }
 
         private void EnabledRow(Host host, UpdateType type, int index)

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -96,6 +96,11 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
         }
 
+        public override void SelectDefaultControl()
+        {
+            flickerFreeListBox1.Select();
+        }
+
         private void DownloadFile()
         {            
             string patchUri = ((XenServerPatchAlert)SelectedUpdateAlert).Patch.PatchUrl;

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.cs
@@ -189,6 +189,11 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             BuildServerList();
         }
 
+        public override void SelectDefaultControl()
+        {
+            dataGridView1.Select();
+        }
+
         private void BuildServerList()
         {
             IList<Host> masters = SelectedMasters;

--- a/XenAdmin/Wizards/XenWizardBase.cs
+++ b/XenAdmin/Wizards/XenWizardBase.cs
@@ -166,6 +166,7 @@ namespace XenAdmin.Wizards
             xenTabControlBody.SelectedTab = wizardProgress.CurrentStepTabPage;
 
             wizardProgress.CurrentStepTabPage.PageLoaded(e.IsForwardsTransition ? PageLoadedDirection.Forward : PageLoadedDirection.Back);
+            wizardProgress.CurrentStepTabPage.SelectDefaultControl();
             UpdateWizard();
 
             if (wizardProgress.IsLastStep)
@@ -325,7 +326,11 @@ namespace XenAdmin.Wizards
         private void XenWizardBase_KeyPress(object sender, KeyPressEventArgs e)
         {
             if (e.KeyChar == (char)Keys.Enter)
+            { 
+                if (buttonNext.CanSelect)
+                    buttonNext.Select();
                 buttonNext.PerformClick();
+            }
         }
 
         [Browsable(false)]


### PR DESCRIPTION
…ing the Enter key

- Added a new method in XenTabPage which the derived classes can implement to select a default control after the page is loaded.
- Added a new wizard test that runs through the wizard by pressing the Enter key and checks if it has landed on the right page.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>