### PR TITLE
CA-236705: [XSO-662]: Applying Updates as Non-root Pool_admin user causes exception and crash of XenCenter

### DIFF
--- a/XenModel/Actions/Pool_Patch/PoolPatchCleanAction.cs
+++ b/XenModel/Actions/Pool_Patch/PoolPatchCleanAction.cs
@@ -18,7 +18,7 @@ namespace XenAdmin.Actions
                 throw new ArgumentNullException("pool_patch");
 
             #region RBAC Dependencies
-            ApiMethodsToRoleCheck.Add("pool_patch_pool_clean");
+            ApiMethodsToRoleCheck.Add("pool_patch.pool_clean");
             #endregion
             
         }


### PR DESCRIPTION
Fixed a typo that caused XenCenter to show a Trace error dialog (and to fail to do the clean-up) after applying an update in manual mode. (only if RBAC is involved)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>