### PR TITLE
CA-236547: Unexpected error while applying hotfix on multiple Xenservers of different version

### DIFF
--- a/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
@@ -106,7 +106,7 @@ namespace XenAdmin.Diagnostics.Checks
 
                     return FindProblem(result);
                 }
-                else
+                else if (Helpers.ElyOrGreater(Host))
                 {
                     var livepatchStatus = Pool_update.precheck(session, Update.opaque_ref, Host.opaque_ref);
 
@@ -114,9 +114,9 @@ namespace XenAdmin.Diagnostics.Checks
 
                     if (livePatchCodesByHost != null)
                         livePatchCodesByHost[Host.uuid] = livepatchStatus;
-
-                    return null;
                 }
+
+                return null;
             }
             catch (Failure f)
             {

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -188,6 +188,9 @@ namespace XenAdmin.Wizards.PatchingWizard
                     case UpdateType.ISO:
                         if (CanUploadUpdateOnHost(SelectedNewPatchPath, selectedServer))
                         {
+                            _poolUpdate = null;
+                            _patch = null;
+                            
                             action = new UploadSupplementalPackAction(
                             selectedServer.Connection,
                             SelectedServers.Where(s => s.Connection == selectedServer.Connection).ToList(),

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -457,10 +457,6 @@ namespace XenAdmin.Wizards.PatchingWizard
                                 AllIntroducedPoolUpdates.Add(PoolUpdate);
                             }
                         }
-                        else
-                        {
-                            _poolUpdate = null;
-                        }
                     }
 
                     if (action is DownloadAndUnzipXenServerPatchAction)


### PR DESCRIPTION
Fixing the error, so the hotfix installation will fail as and where it is expected

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>