### PR TITLE
CA-236566: test-hotfix-basic-7 throws error 'VDI is in use by some other operation'

### DIFF
--- a/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
+++ b/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
@@ -165,9 +165,23 @@ namespace XenAdmin.Actions
             catch (Exception ex)
             {
                 log.ErrorFormat("{0} {1}", "Failed to import a virtual disk over HTTP.", ex.Message);
+
                 if (vdiRef != null)
-                    RemoveVDI(Session, vdiRef);
-                throw;
+                {
+                    log.DebugFormat("Removing the VDI on a best effort basis.");
+
+                    try
+                    {
+                        RemoveVDI(Session, vdiRef);
+                    }
+                    catch (Exception removeEx)
+                    {
+                        //best effort
+                        log.Error("Failed to remove the VDI.", removeEx);
+                    }
+                }
+                
+                throw ex; //after having tried to remove the VDI, the original exception is thrown for the UI
             }
             finally
             {


### PR DESCRIPTION
Remove the VDI only on a best effort basis if the upload failed in the UploadSupplementalPackAction. This will make XenCenter to display the message from the original exception and not from the removal action if the latter had also failed.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>