### PR TITLE
CA-234494: System template cross-pool copy fails with Internal error:assert_can_migrate: inter_pool_metadata_transfer returned nonempty list

### DIFF
--- a/XenAdmin/Commands/CrossPoolCopyVMCommand.cs
+++ b/XenAdmin/Commands/CrossPoolCopyVMCommand.cs
@@ -100,7 +100,7 @@ namespace XenAdmin.Commands
 
         public new static bool CanExecute(VM vm, Host preSelectedHost)
         {
-            if (vm == null || !vm.is_a_template || vm.Locked)
+            if (vm == null || !vm.is_a_template || vm.DefaultTemplate || vm.Locked)
                 return false;
 
             return CrossPoolMigrateCommand.CanExecute(vm, preSelectedHost);


### PR DESCRIPTION
Added a check for the vm's default_template as a workaround for an issue where the allowed_operations of a default template _initially_ indicated that cross pool migration was allowed.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>