### PR TITLE
CA-214628: .NET Image limit causes exception

### DIFF
--- a/XenAdmin/Commands/AddHostCommand.cs
+++ b/XenAdmin/Commands/AddHostCommand.cs
@@ -95,7 +95,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_AddApplicationServer_h32bit_16;
+                return Images.StaticImages._000_AddApplicationServer_h32bit_16;
             }
         }
 
@@ -103,7 +103,8 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_AddApplicationServer_h32bit_24;
+                
+                return Images.StaticImages._000_AddApplicationServer_h32bit_24;
             }
         }
 

--- a/XenAdmin/Commands/AddNewHostToPoolCommand.cs
+++ b/XenAdmin/Commands/AddNewHostToPoolCommand.cs
@@ -68,7 +68,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_AddApplicationServer_h32bit_16;
+                return Images.StaticImages._000_AddApplicationServer_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/Controls/AddHostToSelectedPoolToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/AddHostToSelectedPoolToolStripMenuItem.cs
@@ -109,7 +109,7 @@ namespace XenAdmin.Commands
                 }
 
                 AddHostToPoolCommand cmd = new AddHostToPoolCommand(Command.MainWindowCommandInterface, new Host[] { host }, Helpers.GetPool(connection), true);
-                CommandToolStripMenuItem hostMenuItem = new CommandToolStripMenuItem(cmd, hostName.EscapeAmpersands(), Resources._000_TreeConnected_h32bit_16);
+                CommandToolStripMenuItem hostMenuItem = new CommandToolStripMenuItem(cmd, hostName.EscapeAmpersands(), Images.StaticImages._000_TreeConnected_h32bit_16);
 
                 base.DropDownItems.Add(hostMenuItem);
             }

--- a/XenAdmin/Commands/Controls/AddSelectedHostToPoolToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/AddSelectedHostToPoolToolStripMenuItem.cs
@@ -80,7 +80,7 @@ namespace XenAdmin.Commands
                 {
                     String poolName = Helpers.GetName(connection).EscapeAmpersands().Ellipsise(Helpers.DEFAULT_NAME_TRIM_LENGTH);
                     AddHostToPoolCommand cmd = new AddHostToPoolCommand(Command.MainWindowCommandInterface, selection.AsXenObjects<Host>(), Helpers.GetPool(connection), true);
-                    base.DropDownItems.Add(new CommandToolStripMenuItem(cmd, poolName, Resources._000_PoolConnected_h32bit_16));
+                    base.DropDownItems.Add(new CommandToolStripMenuItem(cmd, poolName, Images.StaticImages._000_PoolConnected_h32bit_16));
                 }
             }
 

--- a/XenAdmin/Commands/Controls/EditPropertiesToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/EditPropertiesToolStripMenuItem.cs
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 
+using XenAdmin.Properties;
 
 namespace XenAdmin.Commands
 {
@@ -40,7 +41,7 @@ namespace XenAdmin.Commands
         }
 
         public PropertiesToolStripMenuItem(PropertiesCommand cmd)
-            : base(cmd, Messages.EDIT, Properties.Resources.edit_16)
+            : base(cmd, Messages.EDIT, Images.StaticImages.edit_16)
         { }
     }
 }

--- a/XenAdmin/Commands/Controls/MultipleWarningDialog.cs
+++ b/XenAdmin/Commands/Controls/MultipleWarningDialog.cs
@@ -170,7 +170,7 @@ namespace XenAdmin.Commands.Controls
             {
                 DataGridViewRow row = new DataGridViewRow();
                 DataGridViewImageCell warningImageCell = new DataGridViewImageCell();
-                warningImageCell.Value = Resources._000_Alert2_h32bit_16;
+                warningImageCell.Value = Images.StaticImages._000_Alert2_h32bit_16;
 
                 DataGridViewTextBoxCell warningCell = new DataGridViewTextBoxCell();
                 warningCell.Value = string.Format("{0}\n\r\n\r{1}", ActionTitle, WarningMessage);

--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -93,18 +93,18 @@ namespace XenAdmin.Commands
 
             if (wlb)
             {
-                base.DropDownItems.Add(new VMOperationToolStripMenuSubItem(Messages.WLB_OPT_MENU_OPTIMAL_SERVER, Resources._000_ServerWlb_h32bit_16));
+                base.DropDownItems.Add(new VMOperationToolStripMenuSubItem(Messages.WLB_OPT_MENU_OPTIMAL_SERVER, Images.StaticImages._000_ServerWlb_h32bit_16));
             }
             else
             {
-                base.DropDownItems.Add(new VMOperationToolStripMenuSubItem(Messages.HOME_SERVER_MENU_ITEM, Resources._000_ServerHome_h32bit_16));
+                base.DropDownItems.Add(new VMOperationToolStripMenuSubItem(Messages.HOME_SERVER_MENU_ITEM, Images.StaticImages._000_ServerHome_h32bit_16));
             }
 
             List<Host> hosts = new List<Host>(connection.Cache.Hosts);
             hosts.Sort();
             foreach (Host host in hosts)
             {
-                VMOperationToolStripMenuSubItem item = new VMOperationToolStripMenuSubItem(String.Format(Messages.MAINWINDOW_CONTEXT_UPDATING, host.name_label.EscapeAmpersands()), Resources._000_ServerDisconnected_h32bit_16);
+                VMOperationToolStripMenuSubItem item = new VMOperationToolStripMenuSubItem(String.Format(Messages.MAINWINDOW_CONTEXT_UPDATING, host.name_label.EscapeAmpersands()), Images.StaticImages._000_ServerDisconnected_h32bit_16);
                 item.Tag = host;
                 base.DropDownItems.Add(item);
             }

--- a/XenAdmin/Commands/CrossPoolMigrateCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMigrateCommand.cs
@@ -70,7 +70,7 @@ namespace XenAdmin.Commands
 
         public override Image MenuImage
         {
-            get { return preSelectedHost == null ? Resources._000_MigrateVM_h32bit_16 : Resources._000_TreeConnected_h32bit_16; }
+            get { return preSelectedHost == null ? Images.StaticImages._000_MigrateVM_h32bit_16 : Images.StaticImages._000_TreeConnected_h32bit_16; }
         }
 
         protected override void ExecuteCore(SelectedItemCollection selection)

--- a/XenAdmin/Commands/CrossPoolMigrateToHomeCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMigrateToHomeCommand.cs
@@ -56,7 +56,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_ServerHome_h32bit_16;
+                return Images.StaticImages._000_ServerHome_h32bit_16;
             }
         }
     }

--- a/XenAdmin/Commands/EditTagsCommand.cs
+++ b/XenAdmin/Commands/EditTagsCommand.cs
@@ -157,7 +157,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_Tag_h32bit_16;
+                return Images.StaticImages._000_Tag_h32bit_16;
             }
         }
     }

--- a/XenAdmin/Commands/ForceVMRebootCommand.cs
+++ b/XenAdmin/Commands/ForceVMRebootCommand.cs
@@ -116,7 +116,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_ForceReboot_h32bit_16;
+                return Images.StaticImages._001_ForceReboot_h32bit_16;
             }
         }
 
@@ -124,7 +124,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_ForceReboot_h32bit_24;
+                return Images.StaticImages._001_ForceReboot_h32bit_24;
             }
         }
 

--- a/XenAdmin/Commands/ForceVMShutDownCommand.cs
+++ b/XenAdmin/Commands/ForceVMShutDownCommand.cs
@@ -96,7 +96,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_ForceShutDown_h32bit_16;
+                return Images.StaticImages._001_ForceShutDown_h32bit_16;
             }
         }
 
@@ -104,7 +104,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_ForceShutDown_h32bit_24;
+                return Images.StaticImages._001_ForceShutDown_h32bit_24;
             }
         }
 

--- a/XenAdmin/Commands/InstallNewUpdateCommand.cs
+++ b/XenAdmin/Commands/InstallNewUpdateCommand.cs
@@ -75,7 +75,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_HostUnpatched_h32bit_16;
+                return Images.StaticImages._000_HostUnpatched_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/NewFolderCommand.cs
+++ b/XenAdmin/Commands/NewFolderCommand.cs
@@ -171,7 +171,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_Folder_open_h32bit_16;
+                return Images.StaticImages._000_Folder_open_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/NewPoolCommand.cs
+++ b/XenAdmin/Commands/NewPoolCommand.cs
@@ -90,7 +90,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_PoolNew_h32bit_16;
+                return Images.StaticImages._000_PoolNew_h32bit_16;
             }
         }
     }

--- a/XenAdmin/Commands/NewSRCommand.cs
+++ b/XenAdmin/Commands/NewSRCommand.cs
@@ -114,7 +114,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_NewStorage_h32bit_16;
+                return Images.StaticImages._000_NewStorage_h32bit_16;
             }
         }
 
@@ -122,7 +122,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_NewStorage_h32bit_24;
+                return Images.StaticImages._000_NewStorage_h32bit_24;
             }
         }
     }

--- a/XenAdmin/Commands/NewVMCommand.cs
+++ b/XenAdmin/Commands/NewVMCommand.cs
@@ -123,7 +123,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_CreateVM_h32bit_24;
+                return Images.StaticImages._000_CreateVM_h32bit_24;
             }
         }
 
@@ -131,7 +131,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_CreateVM_h32bit_16;
+                return Images.StaticImages._001_CreateVM_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/NewVMFromSnapshotCommand.cs
+++ b/XenAdmin/Commands/NewVMFromSnapshotCommand.cs
@@ -93,7 +93,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_CreateVM_h32bit_16;
+                return Images.StaticImages._001_CreateVM_h32bit_16;
             }
         }
     }

--- a/XenAdmin/Commands/NewVMFromTemplateCommand.cs
+++ b/XenAdmin/Commands/NewVMFromTemplateCommand.cs
@@ -88,7 +88,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_CreateVM_h32bit_16;
+                return Images.StaticImages._001_CreateVM_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/PauseDockerContainerCommand.cs
+++ b/XenAdmin/Commands/PauseDockerContainerCommand.cs
@@ -50,9 +50,9 @@ namespace XenAdmin.Commands
 
         public override string MenuText { get { return Messages.MAINWINDOW_PAUSE; } }
         
-        public override Image MenuImage { get { return Resources._000_paused_h32bit_16; } }
+        public override Image MenuImage { get { return Images.StaticImages._000_paused_h32bit_16; } }
 
-        public override Image ToolBarImage { get { return Resources._000_Paused_h32bit_24; } }
+        public override Image ToolBarImage { get { return Images.StaticImages._000_Paused_h32bit_24; } }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {

--- a/XenAdmin/Commands/PowerOnHostCommand.cs
+++ b/XenAdmin/Commands/PowerOnHostCommand.cs
@@ -85,7 +85,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_PowerOn_h32bit_16;
+                return Images.StaticImages._001_PowerOn_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/PropertiesCommands.cs
+++ b/XenAdmin/Commands/PropertiesCommands.cs
@@ -102,7 +102,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources.edit_16;
+                return Images.StaticImages.edit_16;
             }
         }
     }

--- a/XenAdmin/Commands/RebootCommand.cs
+++ b/XenAdmin/Commands/RebootCommand.cs
@@ -95,7 +95,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_Reboot_h32bit_24;
+                return Images.StaticImages._001_Reboot_h32bit_24;
             }
         }
     }

--- a/XenAdmin/Commands/RebootHostCommand.cs
+++ b/XenAdmin/Commands/RebootHostCommand.cs
@@ -104,7 +104,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_Reboot_h32bit_16;
+                return Images.StaticImages._001_Reboot_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/RebootVMCommand.cs
+++ b/XenAdmin/Commands/RebootVMCommand.cs
@@ -107,7 +107,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_Reboot_h32bit_16;
+                return Images.StaticImages._001_Reboot_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/RepairSRCommand.cs
+++ b/XenAdmin/Commands/RepairSRCommand.cs
@@ -104,7 +104,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_StorageBroken_h32bit_16;
+                return Images.StaticImages._000_StorageBroken_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/RestartDockerContainerCommand.cs
+++ b/XenAdmin/Commands/RestartDockerContainerCommand.cs
@@ -50,9 +50,9 @@ namespace XenAdmin.Commands
 
         public override string MenuText { get { return Messages.MAINWINDOW_RESTART; } }
 
-        public override Image MenuImage { get { return Resources._001_Reboot_h32bit_16; } }
+        public override Image MenuImage { get { return Images.StaticImages._001_Reboot_h32bit_16; } }
 
-        public override Image ToolBarImage { get { return Resources._001_Reboot_h32bit_24; } }
+        public override Image ToolBarImage { get { return Images.StaticImages._001_Reboot_h32bit_24; } }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {

--- a/XenAdmin/Commands/RestoreHostFromBackupCommand.cs
+++ b/XenAdmin/Commands/RestoreHostFromBackupCommand.cs
@@ -41,7 +41,7 @@ using XenAdmin.Core;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Drawing;
-
+using XenAdmin.Properties;
 
 namespace XenAdmin.Commands
 {
@@ -118,7 +118,7 @@ namespace XenAdmin.Commands
                 SelectHostDialog hostdialog = new SelectHostDialog();
                 hostdialog.TheHost = host;
                 hostdialog.DispString = Messages.BACKUP_SELECT_HOST;
-                hostdialog.SetPicture = Properties.Resources.backup_restore_32;
+                hostdialog.SetPicture = Images.StaticImages.backup_restore_32;
                 hostdialog.HelpString = "Backup"; // dont i18n
                 hostdialog.Text = Messages.BACKUP_SELECT_HOST_TITLE;
                 hostdialog.okbutton.Text = Messages.BACKUP_SELECT_HOST_BUTTON;

--- a/XenAdmin/Commands/ResumeDockerContainerCommand.cs
+++ b/XenAdmin/Commands/ResumeDockerContainerCommand.cs
@@ -50,9 +50,9 @@ namespace XenAdmin.Commands
 
         public override string MenuText { get { return Messages.MAINWINDOW_RESUME; } }
         
-        public override Image MenuImage { get { return Resources._000_Resumed_h32bit_16; } }
+        public override Image MenuImage { get { return Images.StaticImages._000_Resumed_h32bit_16; } }
 
-        public override Image ToolBarImage { get { return Resources._000_Resumed_h32bit_24; } }
+        public override Image ToolBarImage { get { return Images.StaticImages._000_Resumed_h32bit_24; } }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {

--- a/XenAdmin/Commands/ResumeVMCommand.cs
+++ b/XenAdmin/Commands/ResumeVMCommand.cs
@@ -112,7 +112,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_Resumed_h32bit_16;
+                return Images.StaticImages._000_Resumed_h32bit_16;
             }
         }
 
@@ -120,7 +120,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_Resumed_h32bit_24;
+                return Images.StaticImages._000_Resumed_h32bit_24;
             }
         }
 

--- a/XenAdmin/Commands/SetAsDefaultSRCommand.cs
+++ b/XenAdmin/Commands/SetAsDefaultSRCommand.cs
@@ -89,7 +89,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_StorageDefault_h32bit_16;
+                return Images.StaticImages._000_StorageDefault_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/ShutDownCommand.cs
+++ b/XenAdmin/Commands/ShutDownCommand.cs
@@ -90,7 +90,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_ShutDown_h32bit_24;
+                return Images.StaticImages._001_ShutDown_h32bit_24;
             }
         }
 

--- a/XenAdmin/Commands/ShutDownHostCommand.cs
+++ b/XenAdmin/Commands/ShutDownHostCommand.cs
@@ -101,7 +101,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_ShutDown_h32bit_16;
+                return Images.StaticImages._001_ShutDown_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/ShutDownVMCommand.cs
+++ b/XenAdmin/Commands/ShutDownVMCommand.cs
@@ -91,7 +91,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_ShutDown_h32bit_16;
+                return Images.StaticImages._001_ShutDown_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/StartDockerContainerCommand.cs
+++ b/XenAdmin/Commands/StartDockerContainerCommand.cs
@@ -50,9 +50,9 @@ namespace XenAdmin.Commands
 
         public override string MenuText { get { return Messages.MAINWINDOW_START; } }
 
-        public override Image MenuImage { get { return Resources._001_PowerOn_h32bit_16; } }
+        public override Image MenuImage { get { return Images.StaticImages._001_PowerOn_h32bit_16; } }
 
-        public override Image ToolBarImage { get { return Resources._001_PowerOn_h32bit_24; } }
+        public override Image ToolBarImage { get { return Images.StaticImages._001_PowerOn_h32bit_24; } }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {

--- a/XenAdmin/Commands/StartVMCommand.cs
+++ b/XenAdmin/Commands/StartVMCommand.cs
@@ -148,7 +148,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_PowerOn_h32bit_24;
+                return Images.StaticImages._001_PowerOn_h32bit_24;
             }
         }
 
@@ -164,7 +164,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._001_PowerOn_h32bit_16;
+                return Images.StaticImages._001_PowerOn_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/StopDockerContainerCommand.cs
+++ b/XenAdmin/Commands/StopDockerContainerCommand.cs
@@ -50,9 +50,9 @@ namespace XenAdmin.Commands
 
         public override string MenuText { get { return Messages.MAINWINDOW_STOP; } }
 
-        public override Image MenuImage { get { return Resources._001_ShutDown_h32bit_16; } }
+        public override Image MenuImage { get { return Images.StaticImages._001_ShutDown_h32bit_16; } }
 
-        public override Image ToolBarImage { get { return Resources._001_ShutDown_h32bit_24; } }
+        public override Image ToolBarImage { get { return Images.StaticImages._001_ShutDown_h32bit_24; } }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {

--- a/XenAdmin/Commands/SuspendVMCommand.cs
+++ b/XenAdmin/Commands/SuspendVMCommand.cs
@@ -95,7 +95,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_paused_h32bit_16;
+                return Images.StaticImages._000_paused_h32bit_16;
             }
         }
 
@@ -103,7 +103,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_Paused_h32bit_24;
+                return Images.StaticImages._000_Paused_h32bit_24;
             }
         }
 

--- a/XenAdmin/Commands/VMOperationHomeServerCommand.cs
+++ b/XenAdmin/Commands/VMOperationHomeServerCommand.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_ServerHome_h32bit_16;
+                return Images.StaticImages._000_ServerHome_h32bit_16;
             }
         }
     }

--- a/XenAdmin/Commands/VMOperationHostCommand.cs
+++ b/XenAdmin/Commands/VMOperationHostCommand.cs
@@ -100,7 +100,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_TreeConnected_h32bit_16;
+                return Images.StaticImages._000_TreeConnected_h32bit_16;
             }
         }
 

--- a/XenAdmin/Commands/VMOperationWlbHostCommand.cs
+++ b/XenAdmin/Commands/VMOperationWlbHostCommand.cs
@@ -60,13 +60,13 @@ namespace XenAdmin.Commands
             
             //Default or failure case, there is no score/star rating actually, just don't display star
             _secondImage = null;
-            _menuImage = Resources._000_ServerDisconnected_h32bit_16;
+            _menuImage = Images.StaticImages._000_ServerDisconnected_h32bit_16;
             _recommendation = recommendation;
 
             if (CanExecute())
             {
                 _starRating = _recommendation.StarRating;
-                _menuImage = Resources._000_TreeConnected_h32bit_16;
+                _menuImage = Images.StaticImages._000_TreeConnected_h32bit_16;
                 _secondImage = GetWLBStarImage(_starRating);
             }
             else
@@ -138,28 +138,28 @@ namespace XenAdmin.Commands
         /// </summary>
         private static Image GetWLBStarImage(double stars)
         {
-            Image img = Resources._000_host_0_star;
+            Image img = Images.StaticImages._000_host_0_star;
 
             if (stars >= 4.8)
-                img = Resources._000_host_10_star;
+                img = Images.StaticImages._000_host_10_star;
             else if (stars >= 4.3)
-                img = Resources._000_host_9_star;
+                img = Images.StaticImages._000_host_9_star;
             else if (stars >= 3.8)
-                img = Resources._000_host_8_star;
+                img = Images.StaticImages._000_host_8_star;
             else if (stars >= 3.3)
-                img = Resources._000_host_7_star;
+                img = Images.StaticImages._000_host_7_star;
             else if (stars >= 2.8)
-                img = Resources._000_host_6_star;
+                img = Images.StaticImages._000_host_6_star;
             else if (stars >= 2.3)
-                img = Resources._000_host_5_star;
+                img = Images.StaticImages._000_host_5_star;
             else if (stars >= 1.8)
-                img = Resources._000_host_4_star;
+                img = Images.StaticImages._000_host_4_star;
             else if (stars >= 1.3)
-                img = Resources._000_host_3_star;
+                img = Images.StaticImages._000_host_3_star;
             else if (stars >= .8)
-                img = Resources._000_host_2_star;
+                img = Images.StaticImages._000_host_2_star;
             else if (stars > 0)
-                img = Resources._000_host_1_star;
+                img = Images.StaticImages._000_host_1_star;
 
             return img;
         }

--- a/XenAdmin/Commands/VMOperationWlbOptimalServerCommand.cs
+++ b/XenAdmin/Commands/VMOperationWlbOptimalServerCommand.cs
@@ -73,7 +73,7 @@ namespace XenAdmin.Commands
         {
             get
             {
-                return Resources._000_ServerWlb_h32bit_16;
+                return Images.StaticImages._000_ServerWlb_h32bit_16;
             }
         }
         

--- a/XenAdmin/Commands/VappShutDownCommand.cs
+++ b/XenAdmin/Commands/VappShutDownCommand.cs
@@ -53,7 +53,7 @@ namespace XenAdmin.Commands
 
         public override string ContextMenuText { get { return Messages.VAPP_SHUTDOWN_CONTEXT_MENU; } }
 
-        public override Image MenuImage { get { return Resources._001_ShutDown_h32bit_16; } }
+        public override Image MenuImage { get { return Images.StaticImages._001_ShutDown_h32bit_16; } }
 
         protected override bool ConfirmationRequired { get { return true; } }
 

--- a/XenAdmin/Commands/VappStartCommand.cs
+++ b/XenAdmin/Commands/VappStartCommand.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Commands
 
         public override string ContextMenuText { get { return Messages.VAPP_START_CONTEXT_MENU; } }
 
-        public override Image MenuImage { get { return Resources._001_PowerOn_h32bit_16; } }
+        public override Image MenuImage { get { return Images.StaticImages._001_PowerOn_h32bit_16; } }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)
         {

--- a/XenAdmin/Core/ActionBaseExtensions.cs
+++ b/XenAdmin/Core/ActionBaseExtensions.cs
@@ -45,53 +45,37 @@ namespace XenAdmin.Core
 {
     static class ActionBaseExtensions
     {
-        private static Image IMAGE__000_TICK_H32BIT_16 = Properties.Resources._000_Tick_h32bit_16;
-        private static Image IMAGE_CANCELLED_ACTION_16 = Properties.Resources.cancelled_action_16;
-        private static Image IMAGE__000_ERROR_H32BIT_16 = Properties.Resources._000_error_h32bit_16;
-
-        private static Image IMAGE_USAGEBAR_0 = Properties.Resources.usagebar_0;
-        private static Image IMAGE_USAGEBAR_1 = Properties.Resources.usagebar_1;
-        private static Image IMAGE_USAGEBAR_2 = Properties.Resources.usagebar_2;
-        private static Image IMAGE_USAGEBAR_3 = Properties.Resources.usagebar_3;
-        private static Image IMAGE_USAGEBAR_4 = Properties.Resources.usagebar_4;
-        private static Image IMAGE_USAGEBAR_5 = Properties.Resources.usagebar_5;
-        private static Image IMAGE_USAGEBAR_6 = Properties.Resources.usagebar_6;
-        private static Image IMAGE_USAGEBAR_7 = Properties.Resources.usagebar_7;
-        private static Image IMAGE_USAGEBAR_8 = Properties.Resources.usagebar_8;
-        private static Image IMAGE_USAGEBAR_9 = Properties.Resources.usagebar_9;
-        private static Image IMAGE_USAGEBAR_10 = Properties.Resources.usagebar_10;
-
         internal static Image GetImage(this ActionBase action)
         {
             if (action.IsCompleted)
                 return action.Succeeded
-                           ? IMAGE__000_TICK_H32BIT_16
+                           ? Images.StaticImages._000_Tick_h32bit_16
                            : action.Exception is CancelledException
-                                 ? IMAGE_CANCELLED_ACTION_16
-                                 : IMAGE__000_ERROR_H32BIT_16;
+                                 ? Images.StaticImages.cancelled_action_16
+                                 : Images.StaticImages._000_error_h32bit_16;
 
             if (action.PercentComplete < 9)
-                return IMAGE_USAGEBAR_0;
+                return Images.StaticImages.usagebar_0;
             if (action.PercentComplete < 18)
-                return IMAGE_USAGEBAR_1;
+                return Images.StaticImages.usagebar_1;
             if (action.PercentComplete < 27)
-                return IMAGE_USAGEBAR_2;
+                return Images.StaticImages.usagebar_2;
             if (action.PercentComplete < 36)
-                return IMAGE_USAGEBAR_3;
+                return Images.StaticImages.usagebar_3;
             if (action.PercentComplete < 45)
-                return IMAGE_USAGEBAR_4;
+                return Images.StaticImages.usagebar_4;
             if (action.PercentComplete < 54)
-                return IMAGE_USAGEBAR_5;
+                return Images.StaticImages.usagebar_5;
             if (action.PercentComplete < 63)
-                return IMAGE_USAGEBAR_6;
+                return Images.StaticImages.usagebar_6;
             if (action.PercentComplete < 72)
-                return IMAGE_USAGEBAR_7;
+                return Images.StaticImages.usagebar_7;
             if (action.PercentComplete < 81)
-                return IMAGE_USAGEBAR_8;
+                return Images.StaticImages.usagebar_8;
             if (action.PercentComplete < 90)
-                return IMAGE_USAGEBAR_9;
+                return Images.StaticImages.usagebar_9;
 
-            return IMAGE_USAGEBAR_10;
+            return Images.StaticImages.usagebar_10;
         }
 
         internal static string GetDetails(this ActionBase action)

--- a/XenAdmin/Core/ActionBaseExtensions.cs
+++ b/XenAdmin/Core/ActionBaseExtensions.cs
@@ -45,37 +45,53 @@ namespace XenAdmin.Core
 {
     static class ActionBaseExtensions
     {
+        private static Image IMAGE__000_TICK_H32BIT_16 = Properties.Resources._000_Tick_h32bit_16;
+        private static Image IMAGE_CANCELLED_ACTION_16 = Properties.Resources.cancelled_action_16;
+        private static Image IMAGE__000_ERROR_H32BIT_16 = Properties.Resources._000_error_h32bit_16;
+
+        private static Image IMAGE_USAGEBAR_0 = Properties.Resources.usagebar_0;
+        private static Image IMAGE_USAGEBAR_1 = Properties.Resources.usagebar_1;
+        private static Image IMAGE_USAGEBAR_2 = Properties.Resources.usagebar_2;
+        private static Image IMAGE_USAGEBAR_3 = Properties.Resources.usagebar_3;
+        private static Image IMAGE_USAGEBAR_4 = Properties.Resources.usagebar_4;
+        private static Image IMAGE_USAGEBAR_5 = Properties.Resources.usagebar_5;
+        private static Image IMAGE_USAGEBAR_6 = Properties.Resources.usagebar_6;
+        private static Image IMAGE_USAGEBAR_7 = Properties.Resources.usagebar_7;
+        private static Image IMAGE_USAGEBAR_8 = Properties.Resources.usagebar_8;
+        private static Image IMAGE_USAGEBAR_9 = Properties.Resources.usagebar_9;
+        private static Image IMAGE_USAGEBAR_10 = Properties.Resources.usagebar_10;
+
         internal static Image GetImage(this ActionBase action)
         {
             if (action.IsCompleted)
                 return action.Succeeded
-                           ? Properties.Resources._000_Tick_h32bit_16
+                           ? IMAGE__000_TICK_H32BIT_16
                            : action.Exception is CancelledException
-                                 ? Properties.Resources.cancelled_action_16
-                                 : Properties.Resources._000_error_h32bit_16;
+                                 ? IMAGE_CANCELLED_ACTION_16
+                                 : IMAGE__000_ERROR_H32BIT_16;
 
             if (action.PercentComplete < 9)
-                return Properties.Resources.usagebar_0;
+                return IMAGE_USAGEBAR_0;
             if (action.PercentComplete < 18)
-                return Properties.Resources.usagebar_1;
+                return IMAGE_USAGEBAR_1;
             if (action.PercentComplete < 27)
-                return Properties.Resources.usagebar_2;
+                return IMAGE_USAGEBAR_2;
             if (action.PercentComplete < 36)
-                return Properties.Resources.usagebar_3;
+                return IMAGE_USAGEBAR_3;
             if (action.PercentComplete < 45)
-                return Properties.Resources.usagebar_4;
+                return IMAGE_USAGEBAR_4;
             if (action.PercentComplete < 54)
-                return Properties.Resources.usagebar_5;
+                return IMAGE_USAGEBAR_5;
             if (action.PercentComplete < 63)
-                return Properties.Resources.usagebar_6;
+                return IMAGE_USAGEBAR_6;
             if (action.PercentComplete < 72)
-                return Properties.Resources.usagebar_7;
+                return IMAGE_USAGEBAR_7;
             if (action.PercentComplete < 81)
-                return Properties.Resources.usagebar_8;
+                return IMAGE_USAGEBAR_8;
             if (action.PercentComplete < 90)
-                return Properties.Resources.usagebar_9;
+                return IMAGE_USAGEBAR_9;
 
-            return Properties.Resources.usagebar_10;
+            return IMAGE_USAGEBAR_10;
         }
 
         internal static string GetDetails(this ActionBase action)

--- a/XenAdmin/Images.cs
+++ b/XenAdmin/Images.cs
@@ -45,7 +45,7 @@ using System.IO;
 
 namespace XenAdmin
 {
-    class Images
+    static class Images
     {
         public static readonly ImageList ImageList16 = new ImageList();
         /// <summary>
@@ -104,7 +104,7 @@ namespace XenAdmin
             ImageList16.Images.Add("000_Network_h32bit_16.png", Properties.Resources._000_Network_h32bit_16);
             ImageList16.Images.Add("000_defaultSpyglass_h32bit_16.png", Properties.Resources._000_defaultSpyglass_h32bit_16);
             ImageList16.Images.Add("000_Search_h32bit_16.png", Properties.Resources._000_Search_h32bit_16);
-            
+
             #region Server message images
 
             ImageList16.Images.Add("001_PowerOn_h32bit_16.png", Properties.Resources._001_PowerOn_h32bit_16);
@@ -227,7 +227,7 @@ namespace XenAdmin
             return ImageArray16[(int)icon];
         }
 
-     
+
 
         public static Icons GetIconFor(IXenObject o)
         {
@@ -235,9 +235,9 @@ namespace XenAdmin
             if (vm != null)
                 return GetIconFor(vm);
 
-			VM_appliance appl = o as VM_appliance;
-			if (appl != null)
-				return GetIconFor(appl);
+            VM_appliance appl = o as VM_appliance;
+            if (appl != null)
+                return GetIconFor(appl);
 
             SR sr = o as SR;
             if (sr != null)
@@ -309,10 +309,10 @@ namespace XenAdmin
             return folder.Grey ? Icons.FolderGrey : Icons.Folder;
         }
 
-		public static Icons GetIconFor(VM_appliance appl)
-		{
-			return Icons.VmAppliance;
-		}
+        public static Icons GetIconFor(VM_appliance appl)
+        {
+            return Icons.VmAppliance;
+        }
 
         public static Icons GetIconFor(VM vm)
         {
@@ -387,7 +387,7 @@ namespace XenAdmin
         public static Icons GetIconFor(Host host)
         {
 
-            Host_metrics metrics =host.Connection.Resolve<Host_metrics>(host.metrics);
+            Host_metrics metrics = host.Connection.Resolve<Host_metrics>(host.metrics);
             bool host_is_live = metrics != null && metrics.live;
 
             if (host_is_live)
@@ -532,6 +532,336 @@ namespace XenAdmin
                 default:
                     return Icons.DCStopped;
             }
+        }
+
+        public static class StaticImages
+        {
+            // the followings are generated from Resources using:
+            // cat Resources.Designer.cs | grep 'internal static System.Drawing.Bitmap' | sed "s/ {//g" | awk -F"Bitmap " '{print"public static Image " $2 " = Properties.Resources." $2 ";"}'
+            public static Image _000_Abort_h32bit_16 = Properties.Resources._000_Abort_h32bit_16;
+            public static Image _000_AddApplicationServer_h32bit_16 = Properties.Resources._000_AddApplicationServer_h32bit_16;
+            public static Image _000_AddApplicationServer_h32bit_24 = Properties.Resources._000_AddApplicationServer_h32bit_24;
+            public static Image _000_AddIPAddress_h32bit_16 = Properties.Resources._000_AddIPAddress_h32bit_16;
+            public static Image _000_AddSite_h32bit_16 = Properties.Resources._000_AddSite_h32bit_16;
+            public static Image _000_Alert2_h32bit_16 = Properties.Resources._000_Alert2_h32bit_16;
+            public static Image _000_BackupMetadata_h32bit_16 = Properties.Resources._000_BackupMetadata_h32bit_16;
+            public static Image _000_BackupMetadata_h32bit_32 = Properties.Resources._000_BackupMetadata_h32bit_32;
+            public static Image _000_ConfigureIPAddresses_h32bit_16 = Properties.Resources._000_ConfigureIPAddresses_h32bit_16;
+            public static Image _000_CPU_h32bit_16 = Properties.Resources._000_CPU_h32bit_16;
+            public static Image _000_CreateVirtualStorage_h32bit_32 = Properties.Resources._000_CreateVirtualStorage_h32bit_32;
+            public static Image _000_CreateVM_h32bit_24 = Properties.Resources._000_CreateVM_h32bit_24;
+            public static Image _000_CreateVM_h32bit_32 = Properties.Resources._000_CreateVM_h32bit_32;
+            public static Image _000_defaultSpyglass_h32bit_16 = Properties.Resources._000_defaultSpyglass_h32bit_16;
+            public static Image _000_DeleteAllMessages_h32bit_16 = Properties.Resources._000_DeleteAllMessages_h32bit_16;
+            public static Image _000_DeleteMessage_h32bit_16 = Properties.Resources._000_DeleteMessage_h32bit_16;
+            public static Image _000_DeleteVirtualAppliance_h32bit_16 = Properties.Resources._000_DeleteVirtualAppliance_h32bit_16;
+            public static Image _000_DisasterRecovery_h32bit_32 = Properties.Resources._000_DisasterRecovery_h32bit_32;
+            public static Image _000_Email_h32bit_16 = Properties.Resources._000_Email_h32bit_16;
+            public static Image _000_EnablePowerControl_h32bit_16 = Properties.Resources._000_EnablePowerControl_h32bit_16;
+            public static Image _000_error_h32bit_16 = Properties.Resources._000_error_h32bit_16;
+            public static Image _000_error_h32bit_32 = Properties.Resources._000_error_h32bit_32;
+            public static Image _000_ExcludeHost_h32bit_16 = Properties.Resources._000_ExcludeHost_h32bit_16;
+            public static Image _000_ExportMessages_h32bit_16 = Properties.Resources._000_ExportMessages_h32bit_16;
+            public static Image _000_ExportVirtualAppliance_h32bit_16 = Properties.Resources._000_ExportVirtualAppliance_h32bit_16;
+            public static Image _000_ExportVirtualAppliance_h32bit_32 = Properties.Resources._000_ExportVirtualAppliance_h32bit_32;
+            public static Image _000_Failback_h32bit_32 = Properties.Resources._000_Failback_h32bit_32;
+            public static Image _000_Failover_h32bit_32 = Properties.Resources._000_Failover_h32bit_32;
+            public static Image _000_Fields_h32bit_16 = Properties.Resources._000_Fields_h32bit_16;
+            public static Image _000_FilterDates_h32bit_16 = Properties.Resources._000_FilterDates_h32bit_16;
+            public static Image _000_FilterServer_h32bit_16 = Properties.Resources._000_FilterServer_h32bit_16;
+            public static Image _000_FilterSeverity_h32bit_16 = Properties.Resources._000_FilterSeverity_h32bit_16;
+            public static Image _000_Folder_open_h32bit_16 = Properties.Resources._000_Folder_open_h32bit_16;
+            public static Image _000_GetMemoryInfo_h32bit_16 = Properties.Resources._000_GetMemoryInfo_h32bit_16;
+            public static Image _000_GetMemoryInfo_h32bit_32 = Properties.Resources._000_GetMemoryInfo_h32bit_32;
+            public static Image _000_GetServerReport_h32bit_16 = Properties.Resources._000_GetServerReport_h32bit_16;
+            public static Image _000_GetServerReport_h32bit_32 = Properties.Resources._000_GetServerReport_h32bit_32;
+            public static Image _000_HAServer_h32bit_32 = Properties.Resources._000_HAServer_h32bit_32;
+            public static Image _000_HelpIM_h32bit_16 = Properties.Resources._000_HelpIM_h32bit_16;
+            public static Image _000_HelpIM_h32bit_32 = Properties.Resources._000_HelpIM_h32bit_32;
+            public static Image _000_HighlightVM_h32bit_24 = Properties.Resources._000_HighlightVM_h32bit_24;
+            public static Image _000_HighLightVM_h32bit_32 = Properties.Resources._000_HighLightVM_h32bit_32;
+            public static Image _000_host_0_star = Properties.Resources._000_host_0_star;
+            public static Image _000_host_1_star = Properties.Resources._000_host_1_star;
+            public static Image _000_host_10_star = Properties.Resources._000_host_10_star;
+            public static Image _000_host_2_star = Properties.Resources._000_host_2_star;
+            public static Image _000_host_3_star = Properties.Resources._000_host_3_star;
+            public static Image _000_host_4_star = Properties.Resources._000_host_4_star;
+            public static Image _000_host_5_star = Properties.Resources._000_host_5_star;
+            public static Image _000_host_6_star = Properties.Resources._000_host_6_star;
+            public static Image _000_host_7_star = Properties.Resources._000_host_7_star;
+            public static Image _000_host_8_star = Properties.Resources._000_host_8_star;
+            public static Image _000_host_9_star = Properties.Resources._000_host_9_star;
+            public static Image _000_HostUnpatched_h32bit_16 = Properties.Resources._000_HostUnpatched_h32bit_16;
+            public static Image _000_ImportVirtualAppliance_h32bit_16 = Properties.Resources._000_ImportVirtualAppliance_h32bit_16;
+            public static Image _000_ImportVirtualAppliance_h32bit_32 = Properties.Resources._000_ImportVirtualAppliance_h32bit_32;
+            public static Image _000_ImportVM_h32bit_32 = Properties.Resources._000_ImportVM_h32bit_32;
+            public static Image _000_Info3_h32bit_16 = Properties.Resources._000_Info3_h32bit_16;
+            public static Image _000_ManagementInterface_h32bit_16 = Properties.Resources._000_ManagementInterface_h32bit_16;
+            public static Image _000_MigrateStoppedVM_h32bit_16 = Properties.Resources._000_MigrateStoppedVM_h32bit_16;
+            public static Image _000_MigrateSuspendedVM_h32bit_16 = Properties.Resources._000_MigrateSuspendedVM_h32bit_16;
+            public static Image _000_MigrateVM_h32bit_16 = Properties.Resources._000_MigrateVM_h32bit_16;
+            public static Image _000_MigrateVM_h32bit_32 = Properties.Resources._000_MigrateVM_h32bit_32;
+            public static Image _000_Module_h32bit_16 = Properties.Resources._000_Module_h32bit_16;
+            public static Image _000_Network_h32bit_16 = Properties.Resources._000_Network_h32bit_16;
+            public static Image _000_NewNetwork_h32bit_32 = Properties.Resources._000_NewNetwork_h32bit_32;
+            public static Image _000_NewStorage_h32bit_16 = Properties.Resources._000_NewStorage_h32bit_16;
+            public static Image _000_NewStorage_h32bit_24 = Properties.Resources._000_NewStorage_h32bit_24;
+            public static Image _000_NewStorage_h32bit_32 = Properties.Resources._000_NewStorage_h32bit_32;
+            public static Image _000_NewVirtualAppliance_h32bit_16 = Properties.Resources._000_NewVirtualAppliance_h32bit_16;
+            public static Image _000_NewVirtualAppliance_h32bit_32 = Properties.Resources._000_NewVirtualAppliance_h32bit_32;
+            public static Image _000_Optimize_h32bit_16 = Properties.Resources._000_Optimize_h32bit_16;
+            public static Image _000_Patch_h32bit_16 = Properties.Resources._000_Patch_h32bit_16;
+            public static Image _000_Patch_h32bit_32 = Properties.Resources._000_Patch_h32bit_32;
+            public static Image _000_paused_h32bit_16 = Properties.Resources._000_paused_h32bit_16;
+            public static Image _000_Paused_h32bit_24 = Properties.Resources._000_Paused_h32bit_24;
+            public static Image _000_Pool_h32bit_16 = Properties.Resources._000_Pool_h32bit_16;
+            public static Image _000_PoolConnected_h32bit_16 = Properties.Resources._000_PoolConnected_h32bit_16;
+            public static Image _000_PoolNew_h32bit_16 = Properties.Resources._000_PoolNew_h32bit_16;
+            public static Image _000_PoolNew_h32bit_24 = Properties.Resources._000_PoolNew_h32bit_24;
+            public static Image _000_RebootVM_h32bit_16 = Properties.Resources._000_RebootVM_h32bit_16;
+            public static Image _000_RemoveIPAddress_h32bit_16 = Properties.Resources._000_RemoveIPAddress_h32bit_16;
+            public static Image _000_RemoveSite_h32bit_16 = Properties.Resources._000_RemoveSite_h32bit_16;
+            public static Image _000_Resumed_h32bit_16 = Properties.Resources._000_Resumed_h32bit_16;
+            public static Image _000_Resumed_h32bit_24 = Properties.Resources._000_Resumed_h32bit_24;
+            public static Image _000_ScheduledVMsnapshotDiskMemory_h32bit_16 = Properties.Resources._000_ScheduledVMsnapshotDiskMemory_h32bit_16;
+            public static Image _000_ScheduledVMSnapshotDiskMemory_h32bit_32 = Properties.Resources._000_ScheduledVMSnapshotDiskMemory_h32bit_32;
+            public static Image _000_ScheduledVMsnapshotDiskOnly_h32bit_16 = Properties.Resources._000_ScheduledVMsnapshotDiskOnly_h32bit_16;
+            public static Image _000_ScheduledVMsnapshotDiskOnly_h32bit_32 = Properties.Resources._000_ScheduledVMsnapshotDiskOnly_h32bit_32;
+            public static Image _000_Search_h32bit_16 = Properties.Resources._000_Search_h32bit_16;
+            public static Image _000_Server_h32bit_16 = Properties.Resources._000_Server_h32bit_16;
+            public static Image _000_ServerDisconnected_h32bit_16 = Properties.Resources._000_ServerDisconnected_h32bit_16;
+            public static Image _000_ServerErrorFile_h32bit_16 = Properties.Resources._000_ServerErrorFile_h32bit_16;
+            public static Image _000_ServerHome_h32bit_16 = Properties.Resources._000_ServerHome_h32bit_16;
+            public static Image _000_ServerInProgress_h32bit_16 = Properties.Resources._000_ServerInProgress_h32bit_16;
+            public static Image _000_ServerMaintenance_h32bit_16 = Properties.Resources._000_ServerMaintenance_h32bit_16;
+            public static Image _000_ServerMaintenance_h32bit_32 = Properties.Resources._000_ServerMaintenance_h32bit_32;
+            public static Image _000_ServerWlb_h32bit_16 = Properties.Resources._000_ServerWlb_h32bit_16;
+            public static Image _000_Sites_h32bit_16 = Properties.Resources._000_Sites_h32bit_16;
+            public static Image _000_SliderTexture = Properties.Resources._000_SliderTexture;
+            public static Image _000_StartVM_h32bit_16 = Properties.Resources._000_StartVM_h32bit_16;
+            public static Image _000_StoppedVM_h32bit_16 = Properties.Resources._000_StoppedVM_h32bit_16;
+            public static Image _000_Storage_h32bit_16 = Properties.Resources._000_Storage_h32bit_16;
+            public static Image _000_StorageBroken_h32bit_16 = Properties.Resources._000_StorageBroken_h32bit_16;
+            public static Image _000_StorageDefault_h32bit_16 = Properties.Resources._000_StorageDefault_h32bit_16;
+            public static Image _000_StorageDisabled_h32bit_16 = Properties.Resources._000_StorageDisabled_h32bit_16;
+            public static Image _000_SuspendVM_h32bit_16 = Properties.Resources._000_SuspendVM_h32bit_16;
+            public static Image _000_SwitcherBackground = Properties.Resources._000_SwitcherBackground;
+            public static Image _000_Tag_h32bit_16 = Properties.Resources._000_Tag_h32bit_16;
+            public static Image _000_TCP_IPGroup_h32bit_16 = Properties.Resources._000_TCP_IPGroup_h32bit_16;
+            public static Image _000_TemplateDisabled_h32bit_16 = Properties.Resources._000_TemplateDisabled_h32bit_16;
+            public static Image _000_TestFailover_h32bit_32 = Properties.Resources._000_TestFailover_h32bit_32;
+            public static Image _000_Tick_h32bit_16 = Properties.Resources._000_Tick_h32bit_16;
+            public static Image _000_ToolBar_Pref_Icon_dis = Properties.Resources._000_ToolBar_Pref_Icon_dis;
+            public static Image _000_ToolBar_Pref_Icon_ovr = Properties.Resources._000_ToolBar_Pref_Icon_ovr;
+            public static Image _000_ToolBar_Pref_Icon_up = Properties.Resources._000_ToolBar_Pref_Icon_up;
+            public static Image _000_ToolBar_USB_Icon_dis = Properties.Resources._000_ToolBar_USB_Icon_dis;
+            public static Image _000_ToolBar_USB_Icon_ovr = Properties.Resources._000_ToolBar_USB_Icon_ovr;
+            public static Image _000_ToolBar_USB_Icon_up = Properties.Resources._000_ToolBar_USB_Icon_up;
+            public static Image _000_TreeConnected_h32bit_16 = Properties.Resources._000_TreeConnected_h32bit_16;
+            public static Image _000_UpgradePool_h32bit_32 = Properties.Resources._000_UpgradePool_h32bit_32;
+            public static Image _000_User_h32bit_16 = Properties.Resources._000_User_h32bit_16;
+            public static Image _000_UserAndGroup_h32bit_32 = Properties.Resources._000_UserAndGroup_h32bit_32;
+            public static Image _000_UserTemplate_h32bit_16 = Properties.Resources._000_UserTemplate_h32bit_16;
+            public static Image _000_ViewModeList_h32bit_16 = Properties.Resources._000_ViewModeList_h32bit_16;
+            public static Image _000_ViewModeTree_h32bit_16 = Properties.Resources._000_ViewModeTree_h32bit_16;
+            public static Image _000_VirtualAppliance_h32bit_16 = Properties.Resources._000_VirtualAppliance_h32bit_16;
+            public static Image _000_VirtualStorage_h32bit_16 = Properties.Resources._000_VirtualStorage_h32bit_16;
+            public static Image _000_VM_h32bit_16 = Properties.Resources._000_VM_h32bit_16;
+            public static Image _000_VM_h32bit_24 = Properties.Resources._000_VM_h32bit_24;
+            public static Image _000_VMDisabled_h32bit_16 = Properties.Resources._000_VMDisabled_h32bit_16;
+            public static Image _000_VMPausedDisabled_h32bit_16 = Properties.Resources._000_VMPausedDisabled_h32bit_16;
+            public static Image _000_VMSession_h32bit_16 = Properties.Resources._000_VMSession_h32bit_16;
+            public static Image _000_VMSnapshotDiskMemory_h32bit_16 = Properties.Resources._000_VMSnapshotDiskMemory_h32bit_16;
+            public static Image _000_VMSnapshotDiskMemory_h32bit_32 = Properties.Resources._000_VMSnapshotDiskMemory_h32bit_32;
+            public static Image _000_VMSnapShotDiskOnly_h32bit_16 = Properties.Resources._000_VMSnapShotDiskOnly_h32bit_16;
+            public static Image _000_VMSnapShotDiskOnly_h32bit_32 = Properties.Resources._000_VMSnapShotDiskOnly_h32bit_32;
+            public static Image _000_VMStarting_h32bit_16 = Properties.Resources._000_VMStarting_h32bit_16;
+            public static Image _000_VMStartingDisabled_h32bit_16 = Properties.Resources._000_VMStartingDisabled_h32bit_16;
+            public static Image _000_VMStoppedDisabled_h32bit_16 = Properties.Resources._000_VMStoppedDisabled_h32bit_16;
+            public static Image _000_VMTemplate_h32bit_16 = Properties.Resources._000_VMTemplate_h32bit_16;
+            public static Image _000_WarningAlert_h32bit_32 = Properties.Resources._000_WarningAlert_h32bit_32;
+            public static Image _000_weighting_h32bit_16 = Properties.Resources._000_weighting_h32bit_16;
+            public static Image _000_XenCenterAlerts_h32bit_24 = Properties.Resources._000_XenCenterAlerts_h32bit_24;
+            public static Image _001_Back_h32bit_24 = Properties.Resources._001_Back_h32bit_24;
+            public static Image _001_CreateVM_h32bit_16 = Properties.Resources._001_CreateVM_h32bit_16;
+            public static Image _001_ForceReboot_h32bit_16 = Properties.Resources._001_ForceReboot_h32bit_16;
+            public static Image _001_ForceReboot_h32bit_24 = Properties.Resources._001_ForceReboot_h32bit_24;
+            public static Image _001_ForceShutDown_h32bit_16 = Properties.Resources._001_ForceShutDown_h32bit_16;
+            public static Image _001_ForceShutDown_h32bit_24 = Properties.Resources._001_ForceShutDown_h32bit_24;
+            public static Image _001_Forward_h32bit_24 = Properties.Resources._001_Forward_h32bit_24;
+            public static Image _001_LifeCycle_h32bit_24 = Properties.Resources._001_LifeCycle_h32bit_24;
+            public static Image _001_PerformanceGraph_h32bit_16 = Properties.Resources._001_PerformanceGraph_h32bit_16;
+            public static Image _001_Pin_h32bit_16 = Properties.Resources._001_Pin_h32bit_16;
+            public static Image _001_PowerOn_h32bit_16 = Properties.Resources._001_PowerOn_h32bit_16;
+            public static Image _001_PowerOn_h32bit_24 = Properties.Resources._001_PowerOn_h32bit_24;
+            public static Image _001_Reboot_h32bit_16 = Properties.Resources._001_Reboot_h32bit_16;
+            public static Image _001_Reboot_h32bit_24 = Properties.Resources._001_Reboot_h32bit_24;
+            public static Image _001_ShutDown_h32bit_16 = Properties.Resources._001_ShutDown_h32bit_16;
+            public static Image _001_ShutDown_h32bit_24 = Properties.Resources._001_ShutDown_h32bit_24;
+            public static Image _001_Tools_h32bit_16 = Properties.Resources._001_Tools_h32bit_16;
+            public static Image _001_WindowView_h32bit_16 = Properties.Resources._001_WindowView_h32bit_16;
+            public static Image _002_Configure_h32bit_16 = Properties.Resources._002_Configure_h32bit_16;
+            public static Image _015_Download_h32bit_32 = Properties.Resources._015_Download_h32bit_32;
+            public static Image _075_TickRound_h32bit_16 = Properties.Resources._075_TickRound_h32bit_16;
+            public static Image _075_WarningRound_h32bit_16 = Properties.Resources._075_WarningRound_h32bit_16;
+            public static Image _112_LeftArrowLong_Blue_24x24_72 = Properties.Resources._112_LeftArrowLong_Blue_24x24_72;
+            public static Image _112_RightArrowLong_Blue_24x24_72 = Properties.Resources._112_RightArrowLong_Blue_24x24_72;
+            public static Image about_box_graphic_423x79 = Properties.Resources.about_box_graphic_423x79;
+            public static Image ajax_loader = Properties.Resources.ajax_loader;
+            public static Image alert1_16 = Properties.Resources.alert1_16;
+            public static Image alert2_16 = Properties.Resources.alert2_16;
+            public static Image alert3_16 = Properties.Resources.alert3_16;
+            public static Image alert4_16 = Properties.Resources.alert4_16;
+            public static Image alert5_16 = Properties.Resources.alert5_16;
+            public static Image alert6_16 = Properties.Resources.alert6_16;
+            public static Image alerts_32 = Properties.Resources.alerts_32;
+            public static Image ascending_triangle = Properties.Resources.ascending_triangle;
+            public static Image asterisk = Properties.Resources.asterisk;
+            public static Image attach_24 = Properties.Resources.attach_24;
+            public static Image attach_virtualstorage_32 = Properties.Resources.attach_virtualstorage_32;
+            public static Image backup_restore_32 = Properties.Resources.backup_restore_32;
+            public static Image cancelled_action_16 = Properties.Resources.cancelled_action_16;
+            public static Image centos_16x = Properties.Resources.centos_16x;
+            public static Image change_password_16 = Properties.Resources.change_password_16;
+            public static Image change_password_32 = Properties.Resources.change_password_32;
+            public static Image clonevm_16 = Properties.Resources.clonevm_16;
+            public static Image close_16 = Properties.Resources.close_16;
+            public static Image commands_16 = Properties.Resources.commands_16;
+            public static Image console_16 = Properties.Resources.console_16;
+            public static Image contracted_triangle = Properties.Resources.contracted_triangle;
+            public static Image copy_16 = Properties.Resources.copy_16;
+            public static Image coreos_16 = Properties.Resources.coreos_16;
+            public static Image coreos_globe_icon = Properties.Resources.coreos_globe_icon;
+            public static Image cross = Properties.Resources.cross;
+            public static Image DateTime16 = Properties.Resources.DateTime16;
+            public static Image DC_16 = Properties.Resources.DC_16;
+            public static Image debian_16x = Properties.Resources.debian_16x;
+            public static Image descending_triangle = Properties.Resources.descending_triangle;
+            public static Image desktop = Properties.Resources.desktop;
+            public static Image detach_24 = Properties.Resources.detach_24;
+            public static Image edit_16 = Properties.Resources.edit_16;
+            public static Image expanded_triangle = Properties.Resources.expanded_triangle;
+            public static Image export_32 = Properties.Resources.export_32;
+            public static Image folder_grey = Properties.Resources.folder_grey;
+            public static Image folder_separator = Properties.Resources.folder_separator;
+            public static Image grab = Properties.Resources.grab;
+            public static Image grapharea = Properties.Resources.grapharea;
+            public static Image graphline = Properties.Resources.graphline;
+            public static Image gripper = Properties.Resources.gripper;
+            public static Image ha_16 = Properties.Resources.ha_16;
+            public static Image help_16_hover = Properties.Resources.help_16_hover;
+            public static Image help_24 = Properties.Resources.help_24;
+            public static Image help_24_hover = Properties.Resources.help_24_hover;
+            public static Image help_32_hover = Properties.Resources.help_32_hover;
+            public static Image homepage_bullet = Properties.Resources.homepage_bullet;
+            public static Image import_32 = Properties.Resources.import_32;
+            public static Image infra_view_16 = Properties.Resources.infra_view_16;
+            public static Image infra_view_16_textured = Properties.Resources.infra_view_16_textured;
+            public static Image infra_view_24 = Properties.Resources.infra_view_24;
+            public static Image licensekey_32 = Properties.Resources.licensekey_32;
+            public static Image lifecycle_hot = Properties.Resources.lifecycle_hot;
+            public static Image lifecycle_pressed = Properties.Resources.lifecycle_pressed;
+            public static Image log_destination_16 = Properties.Resources.log_destination_16;
+            public static Image Logo = Properties.Resources.Logo;
+            public static Image memory_dynmax_slider = Properties.Resources.memory_dynmax_slider;
+            public static Image memory_dynmax_slider_dark = Properties.Resources.memory_dynmax_slider_dark;
+            public static Image memory_dynmax_slider_light = Properties.Resources.memory_dynmax_slider_light;
+            public static Image memory_dynmax_slider_noedit = Properties.Resources.memory_dynmax_slider_noedit;
+            public static Image memory_dynmax_slider_noedit_small = Properties.Resources.memory_dynmax_slider_noedit_small;
+            public static Image memory_dynmax_slider_small = Properties.Resources.memory_dynmax_slider_small;
+            public static Image memory_dynmin_slider = Properties.Resources.memory_dynmin_slider;
+            public static Image memory_dynmin_slider_dark = Properties.Resources.memory_dynmin_slider_dark;
+            public static Image memory_dynmin_slider_light = Properties.Resources.memory_dynmin_slider_light;
+            public static Image memory_dynmin_slider_noedit = Properties.Resources.memory_dynmin_slider_noedit;
+            public static Image memory_dynmin_slider_noedit_small = Properties.Resources.memory_dynmin_slider_noedit_small;
+            public static Image memory_dynmin_slider_small = Properties.Resources.memory_dynmin_slider_small;
+            public static Image minus = Properties.Resources.minus;
+            public static Image more_16 = Properties.Resources.more_16;
+            public static Image neokylin_16x = Properties.Resources.neokylin_16x;
+            public static Image notif_alerts_16 = Properties.Resources.notif_alerts_16;
+            public static Image notif_events_16 = Properties.Resources.notif_events_16;
+            public static Image notif_events_errors_16 = Properties.Resources.notif_events_errors_16;
+            public static Image notif_none_16 = Properties.Resources.notif_none_16;
+            public static Image notif_none_24 = Properties.Resources.notif_none_24;
+            public static Image notif_updates_16 = Properties.Resources.notif_updates_16;
+            public static Image objects_16 = Properties.Resources.objects_16;
+            public static Image objects_16_textured = Properties.Resources.objects_16_textured;
+            public static Image objects_24 = Properties.Resources.objects_24;
+            public static Image oracle_16x = Properties.Resources.oracle_16x;
+            public static Image org_view_16 = Properties.Resources.org_view_16;
+            public static Image org_view_24 = Properties.Resources.org_view_24;
+            public static Image padlock = Properties.Resources.padlock;
+            public static Image paste_16 = Properties.Resources.paste_16;
+            public static Image PausedDC_16 = Properties.Resources.PausedDC_16;
+            public static Image PDChevronDown = Properties.Resources.PDChevronDown;
+            public static Image PDChevronDownOver = Properties.Resources.PDChevronDownOver;
+            public static Image PDChevronLeft = Properties.Resources.PDChevronLeft;
+            public static Image PDChevronRight = Properties.Resources.PDChevronRight;
+            public static Image PDChevronUp = Properties.Resources.PDChevronUp;
+            public static Image PDChevronUpOver = Properties.Resources.PDChevronUpOver;
+            public static Image pool_up_16 = Properties.Resources.pool_up_16;
+            public static Image redhat_16x = Properties.Resources.redhat_16x;
+            public static Image Refresh16 = Properties.Resources.Refresh16;
+            public static Image RunningDC_16 = Properties.Resources.RunningDC_16;
+            public static Image saved_searches_16 = Properties.Resources.saved_searches_16;
+            public static Image saved_searches_24 = Properties.Resources.saved_searches_24;
+            public static Image scilinux_16x = Properties.Resources.scilinux_16x;
+            public static Image server_up_16 = Properties.Resources.server_up_16;
+            public static Image sl_16 = Properties.Resources.sl_16;
+            public static Image sl_add_storage_system_16 = Properties.Resources.sl_add_storage_system_16;
+            public static Image sl_add_storage_system_32 = Properties.Resources.sl_add_storage_system_32;
+            public static Image sl_add_storage_system_small_16 = Properties.Resources.sl_add_storage_system_small_16;
+            public static Image sl_connected_16 = Properties.Resources.sl_connected_16;
+            public static Image sl_connecting_16 = Properties.Resources.sl_connecting_16;
+            public static Image sl_disconnected_16 = Properties.Resources.sl_disconnected_16;
+            public static Image sl_lun_16 = Properties.Resources.sl_lun_16;
+            public static Image sl_luns_16 = Properties.Resources.sl_luns_16;
+            public static Image sl_pool_16 = Properties.Resources.sl_pool_16;
+            public static Image sl_pools_16 = Properties.Resources.sl_pools_16;
+            public static Image sl_system_16 = Properties.Resources.sl_system_16;
+            public static Image SpinningFrame0 = Properties.Resources.SpinningFrame0;
+            public static Image SpinningFrame1 = Properties.Resources.SpinningFrame1;
+            public static Image SpinningFrame2 = Properties.Resources.SpinningFrame2;
+            public static Image SpinningFrame3 = Properties.Resources.SpinningFrame3;
+            public static Image SpinningFrame4 = Properties.Resources.SpinningFrame4;
+            public static Image SpinningFrame5 = Properties.Resources.SpinningFrame5;
+            public static Image SpinningFrame6 = Properties.Resources.SpinningFrame6;
+            public static Image SpinningFrame7 = Properties.Resources.SpinningFrame7;
+            public static Image StoppedDC_16 = Properties.Resources.StoppedDC_16;
+            public static Image subscribe = Properties.Resources.subscribe;
+            public static Image suse_16x = Properties.Resources.suse_16x;
+            public static Image tools_notinstalled_16x = Properties.Resources.tools_notinstalled_16x;
+            public static Image tools_outofdate_16x = Properties.Resources.tools_outofdate_16x;
+            public static Image tools_uptodate_16x = Properties.Resources.tools_uptodate_16x;
+            public static Image tree_minus = Properties.Resources.tree_minus;
+            public static Image tree_plus = Properties.Resources.tree_plus;
+            public static Image tshadowdown = Properties.Resources.tshadowdown;
+            public static Image tshadowdownleft = Properties.Resources.tshadowdownleft;
+            public static Image tshadowdownright = Properties.Resources.tshadowdownright;
+            public static Image tshadowright = Properties.Resources.tshadowright;
+            public static Image tshadowtopright = Properties.Resources.tshadowtopright;
+            public static Image ubuntu_16x = Properties.Resources.ubuntu_16x;
+            public static Image upsell_16 = Properties.Resources.upsell_16;
+            public static Image usagebar_0 = Properties.Resources.usagebar_0;
+            public static Image usagebar_1 = Properties.Resources.usagebar_1;
+            public static Image usagebar_10 = Properties.Resources.usagebar_10;
+            public static Image usagebar_2 = Properties.Resources.usagebar_2;
+            public static Image usagebar_3 = Properties.Resources.usagebar_3;
+            public static Image usagebar_4 = Properties.Resources.usagebar_4;
+            public static Image usagebar_5 = Properties.Resources.usagebar_5;
+            public static Image usagebar_6 = Properties.Resources.usagebar_6;
+            public static Image usagebar_7 = Properties.Resources.usagebar_7;
+            public static Image usagebar_8 = Properties.Resources.usagebar_8;
+            public static Image usagebar_9 = Properties.Resources.usagebar_9;
+            public static Image virtualstorage_snapshot_16 = Properties.Resources.virtualstorage_snapshot_16;
+            public static Image vmBackground = Properties.Resources.vmBackground;
+            public static Image vmBackgroundCurrent = Properties.Resources.vmBackgroundCurrent;
+            public static Image VMTemplate_h32bit_32 = Properties.Resources.VMTemplate_h32bit_32;
+            public static Image vnc_local_cursor = Properties.Resources.vnc_local_cursor;
+            public static Image windows_h32bit_16 = Properties.Resources.windows_h32bit_16;
+            public static Image wizard_background = Properties.Resources.wizard_background;
+            public static Image WLB = Properties.Resources.WLB;
+            public static Image XS = Properties.Resources.XS;
         }
     }
 }

--- a/XenAdmin/TabPages/AlertSummaryPage.cs
+++ b/XenAdmin/TabPages/AlertSummaryPage.cs
@@ -57,9 +57,6 @@ namespace XenAdmin.TabPages
 
         private static readonly int ALERT_CAP = 1000;
 
-        private static Image IMAGE_CONTRACTED_TRIANGLE = Properties.Resources.contracted_triangle;
-        private static Image IMAGE_EXPANDED_TRIANGLE = Properties.Resources.expanded_triangle;
-
         private readonly CollectionChangeEventHandler m_alertCollectionChangedWithInvoke;
         Dictionary<string, bool> expandedState = new Dictionary<string, bool>();
         private bool inAlertBuild;
@@ -262,13 +259,13 @@ namespace XenAdmin.TabPages
             if (expandedState.ContainsKey(alert.uuid))
             {
                 // show the expanded arrow and the body detail
-                expanderCell.Value = IMAGE_EXPANDED_TRIANGLE;
+                expanderCell.Value = Images.StaticImages.expanded_triangle;
                 detailCell.Value = String.Format("{0}\n\n{1}", alert.Title, alert.Description);
             }
             else
             {
                 // show the expand arrow and just the title
-                expanderCell.Value = IMAGE_CONTRACTED_TRIANGLE;
+                expanderCell.Value = Images.StaticImages.contracted_triangle;
                 detailCell.Value = alert.Title;
             }
             appliesCell.Value = alert.AppliesTo;
@@ -403,13 +400,13 @@ namespace XenAdmin.TabPages
             if (expandedState.ContainsKey(alert.uuid))
             {
                 expandedState.Remove(alert.uuid);
-                row.Cells[ColumnExpand.Index].Value = IMAGE_CONTRACTED_TRIANGLE;
+                row.Cells[ColumnExpand.Index].Value = Images.StaticImages.contracted_triangle;
                 row.Cells[ColumnMessage.Index].Value = alert.Title;
             }
             else
             {
                 expandedState.Add(alert.uuid, true);
-                row.Cells[ColumnExpand.Index].Value = IMAGE_EXPANDED_TRIANGLE;
+                row.Cells[ColumnExpand.Index].Value = Images.StaticImages.expanded_triangle;
                 row.Cells[ColumnMessage.Index].Value = string.Format("{0}\n\n{1}", alert.Title, alert.Description);
             }
         }

--- a/XenAdmin/TabPages/AlertSummaryPage.cs
+++ b/XenAdmin/TabPages/AlertSummaryPage.cs
@@ -57,6 +57,9 @@ namespace XenAdmin.TabPages
 
         private static readonly int ALERT_CAP = 1000;
 
+        private static Image IMAGE_CONTRACTED_TRIANGLE = Properties.Resources.contracted_triangle;
+        private static Image IMAGE_EXPANDED_TRIANGLE = Properties.Resources.expanded_triangle;
+
         private readonly CollectionChangeEventHandler m_alertCollectionChangedWithInvoke;
         Dictionary<string, bool> expandedState = new Dictionary<string, bool>();
         private bool inAlertBuild;
@@ -259,13 +262,13 @@ namespace XenAdmin.TabPages
             if (expandedState.ContainsKey(alert.uuid))
             {
                 // show the expanded arrow and the body detail
-                expanderCell.Value = Properties.Resources.expanded_triangle;
+                expanderCell.Value = IMAGE_EXPANDED_TRIANGLE;
                 detailCell.Value = String.Format("{0}\n\n{1}", alert.Title, alert.Description);
             }
             else
             {
                 // show the expand arrow and just the title
-                expanderCell.Value = Properties.Resources.contracted_triangle;
+                expanderCell.Value = IMAGE_CONTRACTED_TRIANGLE;
                 detailCell.Value = alert.Title;
             }
             appliesCell.Value = alert.AppliesTo;
@@ -400,13 +403,13 @@ namespace XenAdmin.TabPages
             if (expandedState.ContainsKey(alert.uuid))
             {
                 expandedState.Remove(alert.uuid);
-                row.Cells[ColumnExpand.Index].Value = Properties.Resources.contracted_triangle;
+                row.Cells[ColumnExpand.Index].Value = IMAGE_CONTRACTED_TRIANGLE;
                 row.Cells[ColumnMessage.Index].Value = alert.Title;
             }
             else
             {
                 expandedState.Add(alert.uuid, true);
-                row.Cells[ColumnExpand.Index].Value = Properties.Resources.expanded_triangle;
+                row.Cells[ColumnExpand.Index].Value = IMAGE_EXPANDED_TRIANGLE;
                 row.Cells[ColumnMessage.Index].Value = string.Format("{0}\n\n{1}", alert.Title, alert.Description);
             }
         }

--- a/XenAdmin/TabPages/HistoryPage.cs
+++ b/XenAdmin/TabPages/HistoryPage.cs
@@ -54,6 +54,9 @@ namespace XenAdmin.TabPages
 
         internal event Action<IXenObject> GoToXenObjectRequested;
 
+        private static Image IMAGE_CONTRACTED_TRIANGLE = Properties.Resources.contracted_triangle;
+        private static Image IMAGE_EXPANDED_TRIANGLE = Properties.Resources.expanded_triangle;
+
         public HistoryPage()
         {
             InitializeComponent();
@@ -292,12 +295,12 @@ namespace XenAdmin.TabPages
 
             if (row.Expanded)
             {
-                row.Cells[columnExpander.Index].Value = Properties.Resources.contracted_triangle;
+                row.Cells[columnExpander.Index].Value = IMAGE_CONTRACTED_TRIANGLE;
                 row.Cells[columnMessage.Index].Value = row.Action.GetTitle();
             }
             else
             {
-                row.Cells[columnExpander.Index].Value = Properties.Resources.expanded_triangle;
+                row.Cells[columnExpander.Index].Value = IMAGE_EXPANDED_TRIANGLE;
                 row.Cells[columnMessage.Index].Value = row.Action.GetDetails();
             }
             row.Expanded = !row.Expanded;
@@ -540,12 +543,12 @@ namespace XenAdmin.TabPages
 
                 if (Expanded)
                 {
-                    expanderCell.Value = Properties.Resources.expanded_triangle;
+                    expanderCell.Value = IMAGE_EXPANDED_TRIANGLE;
                     messageCell.Value = Action.GetDetails();
                 }
                 else
                 {
-                    expanderCell.Value = Properties.Resources.contracted_triangle;
+                    expanderCell.Value = IMAGE_CONTRACTED_TRIANGLE;
                     messageCell.Value = Action.GetTitle();
                 }
                 locationCell.Value = Action.GetLocation();

--- a/XenAdmin/TabPages/HistoryPage.cs
+++ b/XenAdmin/TabPages/HistoryPage.cs
@@ -54,9 +54,6 @@ namespace XenAdmin.TabPages
 
         internal event Action<IXenObject> GoToXenObjectRequested;
 
-        private static Image IMAGE_CONTRACTED_TRIANGLE = Properties.Resources.contracted_triangle;
-        private static Image IMAGE_EXPANDED_TRIANGLE = Properties.Resources.expanded_triangle;
-
         public HistoryPage()
         {
             InitializeComponent();
@@ -295,12 +292,12 @@ namespace XenAdmin.TabPages
 
             if (row.Expanded)
             {
-                row.Cells[columnExpander.Index].Value = IMAGE_CONTRACTED_TRIANGLE;
+                row.Cells[columnExpander.Index].Value = Images.StaticImages.contracted_triangle;
                 row.Cells[columnMessage.Index].Value = row.Action.GetTitle();
             }
             else
             {
-                row.Cells[columnExpander.Index].Value = IMAGE_EXPANDED_TRIANGLE;
+                row.Cells[columnExpander.Index].Value = Images.StaticImages.expanded_triangle;
                 row.Cells[columnMessage.Index].Value = row.Action.GetDetails();
             }
             row.Expanded = !row.Expanded;
@@ -543,12 +540,12 @@ namespace XenAdmin.TabPages
 
                 if (Expanded)
                 {
-                    expanderCell.Value = IMAGE_EXPANDED_TRIANGLE;
+                    expanderCell.Value = Images.StaticImages.expanded_triangle;
                     messageCell.Value = Action.GetDetails();
                 }
                 else
                 {
-                    expanderCell.Value = IMAGE_CONTRACTED_TRIANGLE;
+                    expanderCell.Value = Images.StaticImages.contracted_triangle;
                     messageCell.Value = Action.GetTitle();
                 }
                 locationCell.Value = Action.GetLocation();


### PR DESCRIPTION
Changed code at a a few places where it made sense to limit how many times XenCenter asks the Resource Manager for a new instance(*1) of the same(*2) image.
*1: RM returns a new object each time
*2: they are the same as we don't change the locale of a thread and also we don't localise these images - by design

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>