### PR TITLE
CA-237963: On a partially upgraded pool (from Dundee to Ely) the host…

### DIFF
--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -1137,7 +1137,7 @@ namespace XenAPI
                 if (Connection == null)
                     return null;
 
-                if (Helpers.DundeePlusOrGreater(Connection))
+                if (!Helper.IsNullOrEmptyOpaqueRef(control_domain))
                     return Connection.Resolve(control_domain);
 
                 var vms = Connection.ResolveAll(resident_VMs);
@@ -1166,7 +1166,7 @@ namespace XenAPI
 
                 var vms = Connection.ResolveAll(resident_VMs);
 
-                if (Helpers.DundeePlusOrGreater(Connection))
+                if (!Helper.IsNullOrEmptyOpaqueRef(control_domain))
                     return vms.Where(v => v.is_control_domain && v.opaque_ref != control_domain);
 
                 return vms.Where(v => v.is_control_domain && v.domid != 0);

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -1490,7 +1490,7 @@ namespace XenAPI
                 if (host == null)
                     return false;
 
-                if (Helpers.DundeePlusOrGreater(Connection))
+                if (!Helper.IsNullOrEmptyOpaqueRef(host.control_domain))
                     return host.control_domain == opaque_ref;
 
                 var vms = Connection.ResolveAll(host.resident_VMs);


### PR DESCRIPTION
…s lose their consoles

When getting the control domain VM, we should use the control_domain only if it is not null. there is no need to check the version (which was, however, looking at the API version of the master)