### PR TITLE
CA-182453: XenCenter does not show an active XenMotion in another ses…

### DIFF
--- a/XenAdmin/Actions/GUIActions/MeddlingAction.cs
+++ b/XenAdmin/Actions/GUIActions/MeddlingAction.cs
@@ -47,7 +47,7 @@ namespace XenAdmin.Actions.GUIActions
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         public MeddlingAction(Task task)
-            : base(task.MeddlingActionTitle ?? task.Title, task.Description, false, false)
+            : base(task.Title, task.Description, false, false)
         {
             RelatedTask = new XenRef<Task>(task.opaque_ref);
 

--- a/XenAdminTests/XenModelTests/PureAsyncActionTests.cs
+++ b/XenAdminTests/XenModelTests/PureAsyncActionTests.cs
@@ -141,7 +141,6 @@ namespace XenAdminTests.XenModelTests
                     ,new Role() { name_label = "vm.destroy" }
                     ,new Role() { name_label = "vm.clean_shutdown" }
                     , new Role() { name_label = "task.add_to_other_config/key:xencenteruuid" }
-                    , new Role() { name_label = "task.add_to_other_config/key:xencentermeddlingactiontitle" }
                     ,new Role(){name_label ="task.add_to_other_config/key:applies_to" }});
             mockConnection.Setup(x => x.HostnameWithPort).Returns("");
             var sessionMock = new Mock<Session>(mockProxy.Object, mockConnection.Object);

--- a/XenModel/Actions/CancellingAction.cs
+++ b/XenModel/Actions/CancellingAction.cs
@@ -99,7 +99,6 @@ namespace XenAdmin.Actions
         
         private delegate void SetXenCenterUUIDDelegate(Session session, string _task, string uuid);
         private delegate void SetAppliesToDelegate(Session session, string _task, List<string> applies_to);
-        private delegate void SetMeddlingActionTitleDelegate(Session session, string task, string title);
 
         /// <summary>
         /// The XenAPI.Task object (if any) that corresponds to this action.
@@ -115,7 +114,6 @@ namespace XenAdmin.Actions
                 {
                     DoWithSessionRetry(ref _session, (SetXenCenterUUIDDelegate)Task.SetXenCenterUUID, _relatedTask.opaque_ref, XenAdminConfigManager.Provider.XenCenterUUID);
                     DoWithSessionRetry(ref _session, (SetAppliesToDelegate)Task.SetAppliesTo, _relatedTask.opaque_ref, AppliesTo);
-                    DoWithSessionRetry(ref _session, (SetMeddlingActionTitleDelegate)Task.SetMeddlingActionTitle, _relatedTask.opaque_ref, Title);
                     RecomputeCanCancel();
                 }
             }

--- a/XenModel/XenAPI-Extensions/Task.cs
+++ b/XenModel/XenAPI-Extensions/Task.cs
@@ -63,6 +63,7 @@ namespace XenAPI
             Names["VM.hard_reboot"] = Messages.ACTION_VM_REBOOTING;
             Names["VM.hard_shutdown"] = Messages.ACTION_VM_SHUTTING_DOWN;
             Names["VM.migrate_send"] = Messages.ACTION_VM_MIGRATING;
+            Names["VM.pool_migrate"] = Messages.ACTION_VM_MIGRATING;
             Names["VM.resume"] = Messages.ACTION_VM_RESUMING;
             Names["VM.resume_on"] = Messages.ACTION_VM_RESUMING;
             Names["VM.start"] = Messages.ACTION_VM_STARTING;
@@ -82,6 +83,7 @@ namespace XenAPI
             Titles["VM.hard_reboot"] = Messages.ACTION_VM_REBOOTING_TITLE;
             Titles["VM.hard_shutdown"] = Messages.ACTION_VM_SHUTTING_DOWN_TITLE;
             Titles["VM.migrate_send"] = Messages.ACTION_VM_MIGRATING_RESIDENT;
+            Titles["VM.pool_migrate"] = Messages.ACTION_VM_MIGRATING_RESIDENT;
             Titles["VM.resume"] = Messages.ACTION_VM_RESUMING_ON_TITLE;
             Titles["VM.resume_on"] = Messages.ACTION_VM_RESUMING_ON_TITLE;
             Titles["VM.start"] = Messages.ACTION_VM_STARTING_ON_TITLE;
@@ -233,47 +235,6 @@ namespace XenAPI
             }
         }
 
-        private const string XenCenterMeddlingActionTitleKey = "XenCenterMeddlingActionTitle";
-        
-        /// <summary>
-        /// Gets the meddling action title which is stored on the task
-        /// </summary>
-        public string MeddlingActionTitle
-        {
-            get
-            {
-                return Get(other_config, XenCenterMeddlingActionTitleKey);
-            }
-        }
-
-        /// <summary>
-        /// Set a title that can be looked up if this task is re-opened as a
-        /// meddling action. This is stored on the server
-        /// </summary>
-        /// <param name="session"></param>
-        /// <param name="task">task opaque ref</param>
-        /// <param name="title">title to set</param>
-        public static void SetMeddlingActionTitle(Session session, string task, string title)
-        {
-            if (!Helpers.TampaOrGreater(session.Connection))
-                return;
-
-            try
-            {
-                remove_from_other_config(session, task, XenCenterMeddlingActionTitleKey); 
-                add_to_other_config(session, task, XenCenterMeddlingActionTitleKey, title);
-            }
-            catch (Failure f)
-            {
-                if (f.ErrorDescription[0] == Failure.RBAC_PERMISSION_DENIED)
-                {
-                    return;
-                }
-                throw;
-            }
-        }
-
-
         public string XenCenterUUID
         {
             get
@@ -327,8 +288,6 @@ namespace XenAPI
         {
             get
             {
-                if (!String.IsNullOrEmpty(MeddlingActionTitle))
-                    return false;
                 return  Name == null;
             }
         }


### PR DESCRIPTION
…sion

Added "VM.pool_migrate" to the list of tasks suitable for meddling actions.
Removed the usage of MeddlingActionTitle other_config key, because it wasn't working as intended for two reasons:
- If XenCenter starts an action that does multiple async api calls, so multiple tasks, the action's title is assigned to all tasks as MeddlingActionTitles, so the second XenCenter instance would create multiple meddling actions with the same title.
- When a second XenCenter instance tries to see if a task is suitable for a meddling action, the MeddlingActionTitle is not yet present in the task's other_config, so the task is ignored in most of the cases.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>