### PR TITLE
CA-238993: Fixed: forever growing updates list while new or updated metadata was not shown

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -258,17 +258,13 @@ namespace XenAdmin.Core
             {
                 lock (downloadedUpdatesLock)
                 {
-                    var xcvs = action.XenCenterVersions.Where(v => !XenCenterVersions.Contains(v));
-                    XenCenterVersions.AddRange(xcvs);
+                    XenCenterVersions = action.XenCenterVersions;
 
-                    var versForAutoCheck = action.XenServerVersionsForAutoCheck.Where(v => !XenServerVersionsForAutoCheck.Contains(v));
-                    XenServerVersionsForAutoCheck.AddRange(versForAutoCheck);
+                    XenServerVersionsForAutoCheck = action.XenServerVersionsForAutoCheck;
 
-                    var vers = action.XenServerVersions.Where(v => !XenServerVersions.Contains(v));
-                    XenServerVersions.AddRange(vers);
+                    XenServerVersions = action.XenServerVersions;
 
-                    var patches = action.XenServerPatches.Where(p => !XenServerPatches.Contains(p));
-                    XenServerPatches.AddRange(patches);
+                    XenServerPatches = action.XenServerPatches;
                 }
 
                 var xenCenterAlert = NewXenCenterUpdateAlert(XenCenterVersions, Program.Version);


### PR DESCRIPTION
These lists were continuously growing on each refresh, because the Where
clauses returned all items as the predicate was always evaluated to
true. The reason is: A. Even IEquatable<XenServerPatch> is
implemented on XenServerPatch, it only compares uuids. B. XenServerVersion
(also XenCenterversion) does not implement Equals (always different as the
Action returns new objects).

The two bugs these caused are: A] forever growing list of versions caused
obsolete data to be kept while everything was added to the end of the list
additionally. B] Any previously added Patch would not be updated unless the uuid had been changed (this never changes).

Fix in this commit: On each refresh, taking the new lists as they are
(from the Action) and not trying to keep or modify existing items. GC will do the rest with the old list (and objects)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>