### PR TITLE
CA-236844: XenCenter throws "Assertion failed" error when toggling be…

### DIFF
--- a/XenAdmin/ConsoleView/VNCGraphicsClient.cs
+++ b/XenAdmin/ConsoleView/VNCGraphicsClient.cs
@@ -248,8 +248,9 @@ namespace XenAdmin.ConsoleView
         private void OnError(object sender, Exception e)
         {
             Program.AssertOffEventThread();
-            System.Diagnostics.Trace.Assert(sender == this.vncStream);
-
+            if (sender != vncStream)
+                return;
+            
             this.connected = false;
             if (ErrorOccurred != null)
                 ErrorOccurred(this, e);
@@ -262,6 +263,8 @@ namespace XenAdmin.ConsoleView
         {
             connected = false;
             terminated = true;
+            vncStream.ErrorOccurred -= OnError;
+            vncStream.ConnectionSuccess -= vncStream_ConnectionSuccess;
             VNCStream s = vncStream;
             vncStream = null;
             if (s != null)

--- a/XenAdmin/ConsoleView/VNCGraphicsClient.cs
+++ b/XenAdmin/ConsoleView/VNCGraphicsClient.cs
@@ -248,6 +248,8 @@ namespace XenAdmin.ConsoleView
         private void OnError(object sender, Exception e)
         {
             Program.AssertOffEventThread();
+            System.Diagnostics.Debug.Assert(sender == vncStream); // Please see to CA-236844 if this assertion fails
+
             if (sender != vncStream)
                 return;
             
@@ -263,8 +265,11 @@ namespace XenAdmin.ConsoleView
         {
             connected = false;
             terminated = true;
-            vncStream.ErrorOccurred -= OnError;
-            vncStream.ConnectionSuccess -= vncStream_ConnectionSuccess;
+            if (vncStream != null)
+            {
+                vncStream.ErrorOccurred -= OnError;
+                vncStream.ConnectionSuccess -= vncStream_ConnectionSuccess;
+            } 
             VNCStream s = vncStream;
             vncStream = null;
             if (s != null)


### PR DESCRIPTION
…tween the RDP and VNC consoles

Couldn't reproduce it, but it looks like the assertion is hit because the console view still holds a subscription to an event from an old vnc stream (maybe not garbage collected yet).
Added code to deregister event handlers when the vcnStream is disconnected and also replaced the the assertion with an if statement, ignoring the case that might have caused the assertion failure.