### PR TITLE
CA-241844: [VMSS] Deleting a snapshot schedule raises XenCenter error

### DIFF
--- a/XenAdmin/Alerts/Types/MessageAlert.cs
+++ b/XenAdmin/Alerts/Types/MessageAlert.cs
@@ -252,7 +252,7 @@ namespace XenAdmin.Alerts
                     case Message.MessageType.VMSS_SNAPSHOT_SUCCEEDED:
                     case Message.MessageType.VMSS_SNAPSHOT_LOCK_FAILED:
                         VMSS vmss = Helpers.XenObjectFromMessage(Message) as VMSS;
-                        var policyAlertVMSS = new PolicyAlert(Message.priority, Message.name, Message.timestamp, Message.body, vmss.Name);
+                        var policyAlertVMSS = new PolicyAlert(Message.priority, Message.name, Message.timestamp, Message.body, (vmss == null) ? "" : vmss.Name);
                         return policyAlertVMSS.Text;
                 }
 


### PR DESCRIPTION
After deleting the schedule vmss will be null for that message, hence
we need to handle this case.

Signed-Of-By: Sharath Babu <sharath.babu@citrix.com>