### PR TITLE
CA-241883: [VMSS] Pool Operator/Pool Admin - VMSS Policy creation raises an assertion error in XC

### DIFF
--- a/XenModel/Actions/VMPP/CreateVMPP.cs
+++ b/XenModel/Actions/VMPP/CreateVMPP.cs
@@ -59,7 +59,7 @@ namespace XenAdmin.Actions
             {
                 ApiMethodsToRoleCheck.Add("VMSS.async_create");
                 ApiMethodsToRoleCheck.Add("VM.set_snapshot_schedule");
-                ApiMethodsToRoleCheck.Add("VMSS.protect_now");
+                ApiMethodsToRoleCheck.Add("VMSS.snapshot_now");
             }
         }
 


### PR DESCRIPTION
A wrong api was being tested against the RBAC roles. Removed
vmss.protect_now and added vmss.snapshot_now.

Signed-Of-By: Sharath Babu <sharath.babu@citrix.com>