### PR TITLE
CA-241431: Using standard .net WebClient to download updates.xml

### DIFF
--- a/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
+++ b/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
@@ -87,6 +87,9 @@ namespace XenAdmin.Actions
                 {
                     try
                     {
+                        var proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(Connection);
+                        client.Proxy = proxy;
+
                         //register download events
                         client.DownloadProgressChanged += client_DownloadProgressChanged;
                         client.DownloadFileCompleted += client_DownloadFileCompleted;

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -37,6 +37,7 @@ using System.IO;
 using System.Xml;
 using XenAdmin.Core;
 using System.Diagnostics;
+using System.Net;
 
 
 namespace XenAdmin.Actions
@@ -291,18 +292,21 @@ namespace XenAdmin.Actions
         {
             var xdoc = new XmlDocument();
             var uri = new Uri(location);
-            
+            var proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(Connection);
+
             if (uri.IsFile)
             {
                 xdoc.Load(location);
             }
             else
             {
-                using (Stream xmlstream = HTTPHelper.GET(new Uri(location), Connection, false, true))
-                {
-                    xdoc = Helpers.LoadXmlDocument(xmlstream);
-                }
+                var webClient = new WebClient();
+                webClient.Proxy = proxy;
+
+                var stream = new MemoryStream(webClient.DownloadData(uri));
+                xdoc.Load(stream);
             }
+
             return xdoc;
         }
     }

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -300,11 +300,15 @@ namespace XenAdmin.Actions
             }
             else
             {
-                var webClient = new WebClient();
-                webClient.Proxy = proxy;
+                using (var webClient = new WebClient())
+                {
+                    webClient.Proxy = proxy;
 
-                var stream = new MemoryStream(webClient.DownloadData(uri));
-                xdoc.Load(stream);
+                    using (var stream = new MemoryStream(webClient.DownloadData(uri)))
+                    {
+                        xdoc.Load(stream);
+                    }
+                }
             }
 
             return xdoc;


### PR DESCRIPTION
Switched to use WebClient when downloading updates.xml
Fixed a bug where proxy settings were ignored when downloading updates