### PR TITLE
CP-20918: Remove proxy authentication registry key

### DIFF
--- a/XenAdmin/Core/Registry.cs
+++ b/XenAdmin/Core/Registry.cs
@@ -80,14 +80,6 @@ namespace XenAdmin.Core
             }
         }
 
-        internal static bool ProxyAuthenticationEnabled
-        {
-            get
-            {
-                return ReadBool(PROXY_AUTHENTICATION_ENABLED, false);
-            }
-        }
-
         public static SSLCertificateTypes AlwaysShowSSLCertificates
         {
             get
@@ -415,7 +407,6 @@ namespace XenAdmin.Core
         private const string HEALTH_CHECK_PRODUCT_KEY = "HealthCheckProductKey";
         private const string HIDDEN_FEATURES = "HiddenFeatures";
         private const string ADDITIONAL_FEATURES = "AdditionalFeatures";
-        private const string PROXY_AUTHENTICATION_ENABLED = "ProxyAuthenticationEnabled";
         private const string CUSTOM_UPDATES_XML_LOCATION = "CheckForUpdatesXmlLocationOverride";
     }
 

--- a/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ConnectionOptionsPage.cs
@@ -84,40 +84,26 @@ namespace XenAdmin.Dialogs.OptionsPages
             ProxyPortTextBox.Text = Properties.Settings.Default.ProxyPort.ToString();
             BypassForServersCheckbox.Checked = Properties.Settings.Default.BypassProxyForServers;
 
-            if (Registry.ProxyAuthenticationEnabled)
-            {
-                AuthenticationCheckBox.Checked = Properties.Settings.Default.ProvideProxyAuthentication;
+            AuthenticationCheckBox.Checked = Properties.Settings.Default.ProvideProxyAuthentication;
                 
-                switch ((HTTP.ProxyAuthenticationMethod)Properties.Settings.Default.ProxyAuthenticationMethod)
-                {
-                    case HTTP.ProxyAuthenticationMethod.Basic:
-                        BasicRadioButton.Checked = true;
-                        break;
-                    case HTTP.ProxyAuthenticationMethod.Digest:
-                        DigestRadioButton.Checked = true;
-                        break;
-                    default:
-                        DigestRadioButton.Checked = true;
-                        break;
-                }
-
-                // checks for empty default username/password which starts out unencrypted
-                string protectedUsername = Properties.Settings.Default.ProxyUsername;
-                ProxyUsernameTextBox.Text = string.IsNullOrEmpty(protectedUsername) ? "" : EncryptionUtils.Unprotect(Properties.Settings.Default.ProxyUsername);
-                string protectedPassword = Properties.Settings.Default.ProxyPassword;
-                ProxyPasswordTextBox.Text = string.IsNullOrEmpty(protectedPassword) ? "" : EncryptionUtils.Unprotect(Properties.Settings.Default.ProxyPassword);
-            }
-            else
+            switch ((HTTP.ProxyAuthenticationMethod)Properties.Settings.Default.ProxyAuthenticationMethod)
             {
-                // hide controls
-                AuthenticationCheckBox.Visible = false;
-                ProxyUsernameLabel.Visible = false;
-                ProxyUsernameTextBox.Visible = false;
-                ProxyPasswordLabel.Visible = false;
-                ProxyPasswordTextBox.Visible = false;
-                AuthenticationMethodPanel.Visible = false;
-                AuthenticationMethodLabel.Visible = false;
+                case HTTP.ProxyAuthenticationMethod.Basic:
+                    BasicRadioButton.Checked = true;
+                    break;
+                case HTTP.ProxyAuthenticationMethod.Digest:
+                    DigestRadioButton.Checked = true;
+                    break;
+                default:
+                    DigestRadioButton.Checked = true;
+                    break;
             }
+
+            // checks for empty default username/password which starts out unencrypted
+            string protectedUsername = Properties.Settings.Default.ProxyUsername;
+            ProxyUsernameTextBox.Text = string.IsNullOrEmpty(protectedUsername) ? "" : EncryptionUtils.Unprotect(Properties.Settings.Default.ProxyUsername);
+            string protectedPassword = Properties.Settings.Default.ProxyPassword;
+            ProxyPasswordTextBox.Text = string.IsNullOrEmpty(protectedPassword) ? "" : EncryptionUtils.Unprotect(Properties.Settings.Default.ProxyPassword);
             
             ConnectionTimeoutNud.Value = Properties.Settings.Default.ConnectionTimeout / 1000;
 
@@ -242,17 +228,14 @@ namespace XenAdmin.Dialogs.OptionsPages
             if (ProxyAddressTextBox.Text != Properties.Settings.Default.ProxyAddress && !string.IsNullOrEmpty(ProxyAddressTextBox.Text))
                 Properties.Settings.Default.ProxyAddress = ProxyAddressTextBox.Text;
 
-            if (Registry.ProxyAuthenticationEnabled)
-            {
-                Properties.Settings.Default.ProxyUsername = EncryptionUtils.Protect(ProxyUsernameTextBox.Text);
-                Properties.Settings.Default.ProxyPassword = EncryptionUtils.Protect(ProxyPasswordTextBox.Text);
-                Properties.Settings.Default.ProvideProxyAuthentication = AuthenticationCheckBox.Checked;
+            Properties.Settings.Default.ProxyUsername = EncryptionUtils.Protect(ProxyUsernameTextBox.Text);
+            Properties.Settings.Default.ProxyPassword = EncryptionUtils.Protect(ProxyPasswordTextBox.Text);
+            Properties.Settings.Default.ProvideProxyAuthentication = AuthenticationCheckBox.Checked;
 
-                HTTP.ProxyAuthenticationMethod new_auth_method = BasicRadioButton.Checked ?
-                    HTTP.ProxyAuthenticationMethod.Basic : HTTP.ProxyAuthenticationMethod.Digest;
-                if (Properties.Settings.Default.ProxyAuthenticationMethod != (int)new_auth_method)
-                    Properties.Settings.Default.ProxyAuthenticationMethod = (int)new_auth_method;
-            }
+            HTTP.ProxyAuthenticationMethod new_auth_method = BasicRadioButton.Checked ?
+                HTTP.ProxyAuthenticationMethod.Basic : HTTP.ProxyAuthenticationMethod.Digest;
+            if (Properties.Settings.Default.ProxyAuthenticationMethod != (int)new_auth_method)
+                Properties.Settings.Default.ProxyAuthenticationMethod = (int)new_auth_method;
 
             try
             {

--- a/XenAdmin/Program.cs
+++ b/XenAdmin/Program.cs
@@ -1005,15 +1005,7 @@ namespace XenAdmin
 
         public static void ReconfigureConnectionSettings()
         {
-            if (!Registry.ProxyAuthenticationEnabled)
-            {
-                Properties.Settings.Default.ProvideProxyAuthentication = false;
-                Properties.Settings.Default.Save();
-            }
-            else
-            {
-                ReconfigureProxyAuthenticationSettings();
-            }
+            ReconfigureProxyAuthenticationSettings();
             XenAPI.Session.Proxy = XenAdminConfigManager.Provider.GetProxyFromSettings(null);
         }
 


### PR DESCRIPTION
The ProxyAuthenticationEnabled registry key is no longer needed since
CAR-2214 is now in its own branch.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>