### PR TITLE
CP-17253: [XC] Ability to select VLAN PIF as a management interface of a host/Pool

### DIFF
--- a/XenAdmin/Dialogs/NetworkingProperties.cs
+++ b/XenAdmin/Dialogs/NetworkingProperties.cs
@@ -53,6 +53,7 @@ namespace XenAdmin.Dialogs
 
         private List<PIF> ShownPIFs;
         private List<PIF> AllPIFs;
+        private bool AllowManagementOnVLAN;
 
         public NetworkingProperties()
         {
@@ -65,6 +66,7 @@ namespace XenAdmin.Dialogs
             Pool = null;
             connection = host.Connection;
             ObjectName = Helpers.GetName(host);
+            AllowManagementOnVLAN = !Helpers.FeatureForbidden(connection, Host.RestrictManagementOnVLAN);
 
             BlurbLabel.Text = string.Format(Messages.NETWORKING_PROPERTIES_BLURB_HOST, ObjectName);
 
@@ -78,6 +80,7 @@ namespace XenAdmin.Dialogs
             Pool = pool;
             connection = pool.Connection;
             ObjectName = Helpers.GetName(Pool);
+            AllowManagementOnVLAN = !Helpers.FeatureForbidden(connection, Host.RestrictManagementOnVLAN);
 
             Host =connection.Resolve(pool.master);
             if (Host == null)
@@ -192,7 +195,7 @@ namespace XenAdmin.Dialogs
 
         private void RefreshNetworkComboBox(Dictionary<XenAPI.Network, List<NetworkingPropertiesPage>> InUseMap, NetworkingPropertiesPage page)
         {
-            page.RefreshNetworkComboBox(InUseMap, ManagementNetwork());
+            page.RefreshNetworkComboBox(InUseMap, ManagementNetwork(), AllowManagementOnVLAN);
         }
 
         private List<PIF> GetKnownPIFs(bool include_invisible)

--- a/XenAdmin/Dialogs/NetworkingPropertiesPage.cs
+++ b/XenAdmin/Dialogs/NetworkingPropertiesPage.cs
@@ -245,7 +245,7 @@ namespace XenAdmin.Dialogs
             e.DrawFocusRectangle();
         }
 
-        internal void RefreshNetworkComboBox(Dictionary<XenAPI.Network, List<NetworkingPropertiesPage>> InUseMap, XenAPI.Network ManagementNetwork)
+        internal void RefreshNetworkComboBox(Dictionary<XenAPI.Network, List<NetworkingPropertiesPage>> InUseMap, XenAPI.Network ManagementNetwork, bool AllowManagementOnVLAN)
         {
             this.InUseMap = InUseMap;
             this.ManagementNetwork = ManagementNetwork;
@@ -256,7 +256,7 @@ namespace XenAdmin.Dialogs
             networks.Sort();
             NetworkComboBox.Items.Clear();
 
-            if (type == Type.PRIMARY || type == Type.PRIMARY_WITH_HA)
+            if (!AllowManagementOnVLAN && (type == Type.PRIMARY || type == Type.PRIMARY_WITH_HA))
                 networks.RemoveAll(
                     network=>network.IsVLAN);
             

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -424,6 +424,16 @@ namespace XenAPI
             return h._RestrictVgpu;
         }
 
+        public bool _RestrictManagementOnVLAN
+        {
+            get { return BoolKeyPreferTrue(license_params, "restrict_management_on_vlan"); }
+        }
+
+        public static bool RestrictManagementOnVLAN(Host h)
+        {
+            return h._RestrictManagementOnVLAN;
+        }
+
         private bool _RestrictIntegratedGpuPassthrough
         {
             get { return BoolKeyPreferTrue(license_params, "restrict_integrated_gpu_passthrough"); }


### PR DESCRIPTION
This is allowed for both host and pool (on a host by host basis).

Signed-Off-By: Sharath Babu <sharath.babu@xitrix.com>