### PR TITLE
CA-244655 - XenCenter shows the wrong message on the Updates page

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -184,17 +184,18 @@ namespace XenAdmin.Core
 
         /// <summary>
         /// If AutomaticCheck is enabled it checks for updates regardless the
-        /// value of the parameter force. If AutomaticCheck is disabled it only
-        /// checks if force is true.
+        /// value of the parameter force. If AutomaticCheck is disabled it 
+        /// checks for all update types if force is true; forceRefresh causes 
+        /// the check for update action to run and refresh the Updates page
         /// </summary>
-        public static void CheckForUpdates(bool force)
+        public static void CheckForUpdates(bool force, bool forceRefresh = false)
         {
             if (Helpers.CommonCriteriaCertificationRelease)
                 return;
 
             if (Properties.Settings.Default.AllowXenCenterUpdates ||
                 Properties.Settings.Default.AllowXenServerUpdates ||
-                Properties.Settings.Default.AllowPatchesUpdates || force)
+                Properties.Settings.Default.AllowPatchesUpdates || force || forceRefresh)
             {
                 DownloadUpdatesXmlAction action = new DownloadUpdatesXmlAction(
                     Properties.Settings.Default.AllowXenCenterUpdates || force,

--- a/XenAdmin/Dialogs/OptionsPages/UpdatesOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/UpdatesOptionsPage.cs
@@ -91,19 +91,19 @@ namespace XenAdmin.Dialogs.OptionsPages
 
             if(refreshUpdatesTab)
             {
-                Updates.CheckForUpdates(false);
+                Updates.CheckForUpdates(false, true);
             }
         }
 
         /// <summary>
-        /// Returns true if at least one other box has been checked in Updates Options. Otherwise returns false.
+        /// Returns true if at least one box has been changed in Updates Options. Otherwise returns false.
         /// </summary>
         /// <returns></returns>
         private bool IsCheckForUpdatesRequired()
         {
-            return (AllowXenCenterUpdatesCheckBox.Checked && !Properties.Settings.Default.AllowXenCenterUpdates) ||
-                   (AllowXenServerPatchesCheckBox.Checked && !Properties.Settings.Default.AllowPatchesUpdates) ||
-                   (AllowXenServerUpdatesCheckBox.Checked && !Properties.Settings.Default.AllowXenServerUpdates);
+            return (AllowXenCenterUpdatesCheckBox.Checked != Properties.Settings.Default.AllowXenCenterUpdates) ||
+                   (AllowXenServerPatchesCheckBox.Checked != Properties.Settings.Default.AllowPatchesUpdates) ||
+                   (AllowXenServerUpdatesCheckBox.Checked != Properties.Settings.Default.AllowXenServerUpdates);
         }
 
         #endregion

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -61,7 +61,6 @@ namespace XenAdmin.TabPages
         Dictionary<string, bool> expandedState = new Dictionary<string, bool>();
         private List<string> selectedUpdates = new List<string>();
         private int checksQueue;
-        private bool PageWasRefreshed;
         private bool CheckForUpdatesInProgress;
 
         public ManageUpdatesPage()
@@ -79,7 +78,6 @@ namespace XenAdmin.TabPages
             pictureBox1.Image = SystemIcons.Information.ToBitmap();
             toolStripSplitButtonDismiss.DefaultItem = dismissAllToolStripMenuItem;
             toolStripSplitButtonDismiss.Text = dismissAllToolStripMenuItem.Text;
-            PageWasRefreshed = false;
         }
 
         public void RefreshUpdateList()
@@ -238,7 +236,7 @@ namespace XenAdmin.TabPages
                     tableLayoutPanel3.Visible = true;
                     pictureBoxProgress.Image = SystemIcons.Information.ToBitmap();
 
-                    if (SomeOrAllUpdatesDisabled())
+                    if (AllUpdatesDisabled())
                     {
                         labelProgress.Text = Messages.DISABLED_UPDATE_AUTOMATIC_CHECK_WARNING;
                         checkForUpdatesNowButton.Visible = true;
@@ -247,6 +245,15 @@ namespace XenAdmin.TabPages
                     else
                     {
                         labelProgress.Text = Messages.AVAILABLE_UPDATES_NOT_FOUND;
+                        if (SomeButNotAllUpdatesDisabled())
+                        {
+                            this.dataGridViewUpdates.Location = new Point(this.dataGridViewUpdates.Location.X, 72);
+                            MakeWarningVisible();
+                        }
+                        else
+                        {
+                            MakeWarningInvisible();
+                        }
                     }
                     return;
                 }
@@ -321,6 +328,8 @@ namespace XenAdmin.TabPages
             checkForUpdatesNowButton2.Visible = false;
         }
 
+
+
         /// <summary>
         /// Checks if the automatic checking for updates in the Updates Options Page is disabled for some, but not all types of updates.
         /// </summary>
@@ -332,20 +341,18 @@ namespace XenAdmin.TabPages
                     !Properties.Settings.Default.AllowXenServerUpdates) &&
                     (Properties.Settings.Default.AllowPatchesUpdates ||
                     Properties.Settings.Default.AllowXenCenterUpdates ||
-                    Properties.Settings.Default.AllowXenServerUpdates) &&
-                    !PageWasRefreshed;
+                    Properties.Settings.Default.AllowXenServerUpdates);
         }
 
         /// <summary>
-        /// Checks if the automatic checking for updates in the Updates Options Page is disabled for some or all types of updates.
+        /// Checks if the automatic checking for updates in the Updates Options Page is disabled for all types of updates.
         /// </summary>
         /// <returns></returns>
-        private bool SomeOrAllUpdatesDisabled()
+        private bool AllUpdatesDisabled()
         {
-            return !((Properties.Settings.Default.AllowPatchesUpdates &&
-                   Properties.Settings.Default.AllowXenCenterUpdates &&
-                   Properties.Settings.Default.AllowXenServerUpdates) ||
-                   PageWasRefreshed);
+            return (!Properties.Settings.Default.AllowPatchesUpdates &&
+                   !Properties.Settings.Default.AllowXenCenterUpdates &&
+                   !Properties.Settings.Default.AllowXenServerUpdates);
         }
 
         /// <summary>
@@ -854,7 +861,6 @@ namespace XenAdmin.TabPages
         
         private void toolStripButtonRefresh_Click(object sender, EventArgs e)
         {
-            PageWasRefreshed = true;
             checkForUpdatesNowButton.Visible = false;
             Updates.CheckForUpdates(true);
         }
@@ -954,12 +960,10 @@ namespace XenAdmin.TabPages
         {
             checkForUpdatesNowButton.Visible = false;
             Updates.CheckForUpdates(true);
-            PageWasRefreshed = true;
         }
 
         private void toolStripButtonRestoreDismissed_Click(object sender, EventArgs e)
         {
-            PageWasRefreshed = true;
             checkForUpdatesNowButton.Visible = false;
             Updates.RestoreDismissedUpdates();
         }        
@@ -967,7 +971,6 @@ namespace XenAdmin.TabPages
         private void checkForUpdatesNowButton2_Click(object sender, EventArgs e)
         {            
             MakeWarningInvisible();
-            PageWasRefreshed = true;
             Updates.CheckForUpdates(true);
         }
 


### PR DESCRIPTION
XenCenter shows the wrong message on the Updates page when no updates are found