### PR TITLE
CA-243640: XenCenter HealthCheck Analysis Status Refresh is failing

### DIFF
--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.cs
@@ -367,7 +367,7 @@ namespace XenAdmin.Dialogs.HealthCheck
             {
                 healthCheckSettings.NewUploadRequest = HealthCheckSettings.DateTimeToString(DateTime.UtcNow);
                 var token = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_TOKEN_SECRET);
-                var diagnosticToken = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_TOKEN_SECRET);
+                var diagnosticToken = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET);
                 var user = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET);
                 var password = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET);
                 new SaveHealthCheckSettingsAction(poolRow.Pool, healthCheckSettings, token, diagnosticToken, user, password, false).RunAsync();


### PR DESCRIPTION
XenCenter uses the wrong token (upload token instead of the diagnostic token) when the "Request an additional update" option is used

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>