### PR TITLE
CA-245345: XenCenter doesn't mark a host as unapplicable when an upda…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -233,7 +233,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             foreach (PatchGridViewRow row in dataGridViewPatches.Rows)
             {
-                if (row.UpdateAlert.Name == Path.GetFileNameWithoutExtension(fileName))
+                if (string.Equals(row.UpdateAlert.Name, Path.GetFileNameWithoutExtension(fileName), StringComparison.OrdinalIgnoreCase))
                 {
                     return (XenServerPatchAlert)row.UpdateAlert;
                 }


### PR DESCRIPTION
…te is installed via "Select update from disk" option

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>