### PR TITLE
CA-230621: Disk space calculation is logged incorrectly in the XenCen…

### DIFF
--- a/XenModel/Actions/Pool_Patch/GetDiskSpaceRequirementsAction.cs
+++ b/XenModel/Actions/Pool_Patch/GetDiskSpaceRequirementsAction.cs
@@ -154,7 +154,8 @@ namespace XenAdmin.Actions
 
             DiskSpaceRequirements = new DiskSpaceRequirements(operation, Host, updateName, requiredDiskSpace, availableDiskSpace, reclaimableDiskSpace);
 
-            log.WarnFormat("Cleanup message: \r\n{0}", DiskSpaceRequirements.GetSpaceRequirementsMessage());
+            if (availableDiskSpace < requiredDiskSpace)
+                log.WarnFormat("Cleanup message: \r\n{0}", DiskSpaceRequirements.GetSpaceRequirementsMessage());
         }
     }
 


### PR DESCRIPTION
…ter log

Only log the cleanup message if the available space is less than the required space

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>