### PR TITLE
CP-21173: Show two latest XenCenter versions 

### DIFF
--- a/CFUValidator/CFUValidator.cs
+++ b/CFUValidator/CFUValidator.cs
@@ -115,7 +115,7 @@ namespace CFUValidator
             SetupMocks(xenServerPatches, xenServerVersions);
 
             Status = "Determining XenCenter update required...";
-            var xcupdateAlert = XenAdmin.Core.Updates.NewXenCenterUpdateAlert(xenCenterVersions, new Version(ServerVersion));
+            var xcupdateAlerts = XenAdmin.Core.Updates.NewXenCenterUpdateAlerts(xenCenterVersions, new Version(ServerVersion));
 
             Status = "Determining XenServer update required...";
             var updateAlert = XenAdmin.Core.Updates.NewXenServerVersionAlert(xenServerVersions);
@@ -135,7 +135,7 @@ namespace CFUValidator
             RunValidators(validators);
            
             Status = "Generating summary...";
-            GeneratePatchSummary(patchAlerts, validators, updateAlert, xcupdateAlert);
+            GeneratePatchSummary(patchAlerts, validators, updateAlert, xcupdateAlerts);
         }
 
         private void CheckProvidedVersionNumber(List<XenServerVersion> xenServerVersions)
@@ -196,10 +196,10 @@ namespace CFUValidator
         }
 
         private void GeneratePatchSummary(List<XenServerPatchAlert> alerts, List<AlertFeatureValidator> validators,
-                                          XenServerVersionAlert updateAlert, XenCenterUpdateAlert xcupdateAlert)
+                                          XenServerVersionAlert updateAlert, List<XenCenterUpdateAlert> xcupdateAlerts)
         {
             OuputComponent oc = new OutputTextOuputComponent(XmlLocation, ServerVersion);
-            XenCenterUpdateDecorator xcud = new XenCenterUpdateDecorator(oc, xcupdateAlert);
+            XenCenterUpdateDecorator xcud = new XenCenterUpdateDecorator(oc, xcupdateAlerts);
             XenServerUpdateDecorator xsud = new XenServerUpdateDecorator(xcud, updateAlert);
             PatchAlertDecorator pad = new PatchAlertDecorator(xsud, alerts);
             AlertFeatureValidatorDecorator afdCoreFields = new AlertFeatureValidatorDecorator(pad,

--- a/CFUValidator/OutputDecorators/XenCenterUpdateDecorator.cs
+++ b/CFUValidator/OutputDecorators/XenCenterUpdateDecorator.cs
@@ -30,6 +30,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using XenAdmin.Alerts;
 
@@ -37,21 +39,33 @@ namespace CFUValidator.OutputDecorators
 {
     class XenCenterUpdateDecorator: Decorator
     {
-        private readonly XenCenterUpdateAlert alert;
+        private readonly List<XenCenterUpdateAlert> alerts;
         private const string header = "XenCenter updates required:";
         private const string updateNotFound = "XenCenter update could not be found";
 
-        public XenCenterUpdateDecorator(OuputComponent ouputComponent, XenCenterUpdateAlert alert)
+        public XenCenterUpdateDecorator(OuputComponent ouputComponent, List<XenCenterUpdateAlert> alerts)
         {
             SetComponent(ouputComponent);
-            this.alert = alert;
+            this.alerts = alerts;
         }
 
         public override StringBuilder Generate()
         {
             StringBuilder sb = base.Generate();
             sb.AppendLine(header);
-            sb.AppendLine(alert == null ? updateNotFound : alert.NewVersion.VersionAndLang);
+            if (alerts == null || alerts.Count == 0)
+            {
+                sb.AppendLine(updateNotFound);
+            }
+            else
+            {
+                var versions = from XenCenterUpdateAlert a in alerts
+                               let v = a.NewVersion.VersionAndLang
+                               where a.NewVersion != null
+                               select v;
+                sb.AppendLine(string.Join(",", versions));
+            }
+            
             return sb.AppendLine(String.Empty);
         }
     }

--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -268,9 +268,9 @@ namespace XenAdmin.Core
                     XenServerPatches = action.XenServerPatches;
                 }
 
-                var xenCenterAlert = NewXenCenterUpdateAlert(XenCenterVersions, Program.Version);
-                if (xenCenterAlert != null && !xenCenterAlert.IsDismissed())
-                    updateAlerts.Add(xenCenterAlert);
+                var xenCenterAlerts = NewXenCenterUpdateAlerts(XenCenterVersions, Program.Version);
+                if (xenCenterAlerts != null)
+                    updateAlerts.AddRange(xenCenterAlerts.Where(a=>!a.IsDismissed()));
 
                 var xenServerUpdateAlert = NewXenServerVersionAlert(XenServerVersionsForAutoCheck);
                 if (xenServerUpdateAlert != null && !xenServerUpdateAlert.CanIgnore)
@@ -317,33 +317,47 @@ namespace XenAdmin.Core
         }
 
 
-        public static XenCenterUpdateAlert NewXenCenterUpdateAlert(List<XenCenterVersion> xenCenterVersions, Version currentProgramVersion)
+        public static List<XenCenterUpdateAlert> NewXenCenterUpdateAlerts(List<XenCenterVersion> xenCenterVersions,
+            Version currentProgramVersion)
         {
             if (Helpers.CommonCriteriaCertificationRelease)
                 return null;
-
-            XenCenterVersion toUse = null;
+            var alerts = new List<XenCenterUpdateAlert>();
+            XenCenterVersion latest = null, latestCr = null;
             if (xenCenterVersions.Count != 0 && currentProgramVersion != new Version(0, 0, 0, 0))
             {
-                var latest = from v in xenCenterVersions where v.IsLatest select v;
+                var latestVersions = from v in xenCenterVersions where v.Latest select v;
+                latest = latestVersions.FirstOrDefault(xcv => xcv.Lang == Program.CurrentLanguage) ??
+                         latestVersions.FirstOrDefault(xcv => string.IsNullOrEmpty(xcv.Lang));
 
-                toUse = latest.FirstOrDefault(xcv => xcv.Lang == Program.CurrentLanguage) ??
-                        latest.FirstOrDefault(xcv => string.IsNullOrEmpty(xcv.Lang));
+                if (IsSuitableForXenCenterAlert(latest, currentProgramVersion))
+                    alerts.Add(new XenCenterUpdateAlert(latest));
+
+                var latestCrVersions = from v in xenCenterVersions where v.LatestCr select v;
+                latestCr = latestCrVersions.FirstOrDefault(xcv => xcv.Lang == Program.CurrentLanguage) ??
+                           latestCrVersions.FirstOrDefault(xcv => string.IsNullOrEmpty(xcv.Lang));
+
+                if (latestCr != latest && IsSuitableForXenCenterAlert(latestCr, currentProgramVersion))
+                    alerts.Add(new XenCenterUpdateAlert(latestCr));
             }
 
-            if (toUse == null)
-                return null;
-
-            if (toUse.Version > currentProgramVersion ||
-                (toUse.Version == currentProgramVersion && toUse.Lang == Program.CurrentLanguage &&
-                 !PropertyManager.IsCultureLoaded(Program.CurrentCulture)))
+            if (alerts.Count == 0)
             {
-                return new XenCenterUpdateAlert(toUse);
+                log.Info(string.Format("Not alerting XenCenter update - latest = {0},  latestcr = {1}, detected = {2}", 
+                    latest != null ? latest.VersionAndLang : "", latestCr != null ? latestCr.VersionAndLang : "", Program.VersionAndLanguage));
             }
 
-            log.Info(string.Format("Not alerting XenCenter update - lastest = {0}, detected = {1}",
-                                   toUse.VersionAndLang, Program.VersionAndLanguage));
-            return null;
+            return alerts;
+        }
+
+        private static bool IsSuitableForXenCenterAlert(XenCenterVersion toUse, Version currentProgramVersion)
+        {
+            if (toUse == null)
+                return false;
+
+            return toUse.Version > currentProgramVersion ||
+                   (toUse.Version == currentProgramVersion && toUse.Lang == Program.CurrentLanguage &&
+                    !PropertyManager.IsCultureLoaded(Program.CurrentCulture));
         }
 
         public static List<XenServerPatchAlert> NewXenServerPatchAlerts(List<XenServerVersion> xenServerVersions,

--- a/XenAdminTests/UnitTests/AlertTests/XenCenterUpdateAlertTests.cs
+++ b/XenAdminTests/UnitTests/AlertTests/XenCenterUpdateAlertTests.cs
@@ -43,7 +43,7 @@ namespace XenAdminTests.UnitTests.AlertTests
         [Test]
         public void VerifyStoredDataWithDefaultConstructor()
         {
-            IUnitTestVerifier validator = new VerifyGetters(new XenCenterUpdateAlert(new XenCenterVersion("6.0.2", "xc", true, "http://url", new DateTime(2011, 12, 09).ToString())));
+            IUnitTestVerifier validator = new VerifyGetters(new XenCenterUpdateAlert(new XenCenterVersion("6.0.2", "xc", true, false, "http://url", new DateTime(2011, 12, 09).ToString())));
 
             validator.Verify(new AlertClassUnitTestData
             {

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -113,7 +113,8 @@ namespace XenAdmin.Actions
                 {
                     string version_lang = "";
                     string name = "";
-                    bool is_latest = false;
+                    bool latest = false;
+                    bool latest_cr = false;
                     string url = "";
                     string timestamp = "";
 
@@ -124,14 +125,16 @@ namespace XenAdmin.Actions
                         else if (attrib.Name == "name")
                             name = attrib.Value;
                         else if (attrib.Name == "latest")
-                            is_latest = attrib.Value.ToUpperInvariant() == bool.TrueString.ToUpperInvariant();
+                            latest = attrib.Value.ToUpperInvariant() == bool.TrueString.ToUpperInvariant();
+                        else if (attrib.Name == "latestcr")
+                            latest_cr = attrib.Value.ToUpperInvariant() == bool.TrueString.ToUpperInvariant();
                         else if (attrib.Name == "url")
                             url = attrib.Value;
                         else if (attrib.Name == "timestamp")
                             timestamp = attrib.Value;
                     }
 
-                    XenCenterVersions.Add(new XenCenterVersion(version_lang, name, is_latest, url, timestamp));
+                    XenCenterVersions.Add(new XenCenterVersion(version_lang, name, latest, latest_cr, url, timestamp));
                 }
             }
         }

--- a/XenModel/Actions/Updates/XenCenterVersion.cs
+++ b/XenModel/Actions/Updates/XenCenterVersion.cs
@@ -38,16 +38,18 @@ namespace XenAdmin.Core
     {
         public Version Version;
         public string Name;
-        public bool IsLatest;
+        public bool Latest;
+        public bool LatestCr;
         public string Url;
         public string Lang;
         public DateTime TimeStamp;
 
-        public XenCenterVersion(string version_lang, string name, bool is_latest, string url, string timestamp)
+        public XenCenterVersion(string version_lang, string name, bool latest, bool latest_cr, string url, string timestamp)
         {
             ParseVersion(version_lang);
             Name = name;
-            IsLatest = is_latest;
+            Latest = latest;
+            LatestCr = latest_cr;
             if (url.StartsWith("/XenServer"))
                 url = XenServerVersion.UpdateRoot + url;
             Url = url;


### PR DESCRIPTION
- Add "latestcr" field to the XenCenterVersion class
- Change the Updates class to cope with multiple latest XenCenter versions

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>