### PR TITLE
CP-21174: Multiple dismissed XenCenterVersion alerts

### DIFF
--- a/XenAdmin/Alerts/Types/XenCenterUpdateAlert.cs
+++ b/XenAdmin/Alerts/Types/XenCenterUpdateAlert.cs
@@ -101,11 +101,15 @@ namespace XenAdmin.Alerts
             }
         }
 
+        static int DISMISSED_XC_VERSIONS_LIMIT = 5;
+
         public override void Dismiss()
         {
             List<string> current = new List<string>(Properties.Settings.Default.LatestXenCenterSeen.Split(','));
             if (current.Contains(NewVersion.VersionAndLang))
                 return;
+            if (current.Count >= DISMISSED_XC_VERSIONS_LIMIT)
+                current.RemoveRange(0, current.Count - DISMISSED_XC_VERSIONS_LIMIT + 1);
             current.Add(NewVersion.VersionAndLang);
             Properties.Settings.Default.LatestXenCenterSeen = string.Join(",", current.ToArray());
             Settings.TrySaveSettings();

--- a/XenAdmin/Alerts/Types/XenCenterUpdateAlert.cs
+++ b/XenAdmin/Alerts/Types/XenCenterUpdateAlert.cs
@@ -102,15 +102,20 @@ namespace XenAdmin.Alerts
         }
 
         public override void Dismiss()
-        {            
-            Properties.Settings.Default.LatestXenCenterSeen = NewVersion.VersionAndLang;
+        {
+            List<string> current = new List<string>(Properties.Settings.Default.LatestXenCenterSeen.Split(','));
+            if (current.Contains(NewVersion.VersionAndLang))
+                return;
+            current.Add(NewVersion.VersionAndLang);
+            Properties.Settings.Default.LatestXenCenterSeen = string.Join(",", current.ToArray());
             Settings.TrySaveSettings();
             Updates.RemoveUpdate(this);
         }
 
         public override bool IsDismissed()
         {
-            return Properties.Settings.Default.LatestXenCenterSeen == NewVersion.VersionAndLang;
+            List<string> current = new List<string>(Properties.Settings.Default.LatestXenCenterSeen.Split(','));
+            return current.Contains(NewVersion.VersionAndLang);
         }
 
         public override bool Equals(Alert other)


### PR DESCRIPTION
- save multiple dismissed alerts as a comma-separated list in Settings.Default.LatestXenCenterSeen

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>