### PR TITLE
CA-242918: Improve the exception shown in XenCenter if the hotfix upl…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.Designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.Designer.cs
@@ -56,6 +56,7 @@
             // 
             // labelProgress
             // 
+            this.labelProgress.AutoEllipsis = true;
             resources.ApplyResources(this.labelProgress, "labelProgress");
             this.labelProgress.Name = "labelProgress";
             // 

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -48,7 +48,7 @@ namespace XenAdmin.Wizards.PatchingWizard
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private DownloadAndUnzipXenServerPatchAction downloadAction = null;
-        private const int EllipsiseValueDownDescription = 50;
+        private const int EllipsiseValueDownDescription = 80;
 
         public PatchingWizard_UploadPage()
         {
@@ -597,7 +597,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             var poolOrHost = Helpers.GetPool(host.Connection) ?? (IXenObject)host;
 
-            string text = action == null ? Messages.UPLOAD_PATCH_ALREADY_UPLOADED : GetActionDescription(action);
+            string text = action == null ? Messages.UPLOAD_PATCH_ALREADY_UPLOADED : GetActionDescription(action).Ellipsise(EllipsiseValueDownDescription);
             drawActionText(Images.GetImage16For(poolOrHost),poolOrHost.Name, text, GetTextColor(action), e);
         }
 

--- a/XenModel/Actions/Pool_Patch/UploadPatchAction.cs
+++ b/XenModel/Actions/Pool_Patch/UploadPatchAction.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using XenAdmin.Network;
 using XenAdmin.Core;
 using XenAPI;
@@ -164,6 +165,13 @@ namespace XenAdmin.Actions
                         File.Delete(retailPatchPath);
                      }
                      throw;
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (ex.InnerException != null)
+                        throw ex.InnerException;
+                    else
+                        throw;
                 }
 
                 finally

--- a/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
+++ b/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
@@ -33,6 +33,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using XenAdmin.Network;
 using XenAdmin.Core;
 using XenAPI;
@@ -180,8 +181,12 @@ namespace XenAdmin.Actions
                         log.Error("Failed to remove the VDI.", removeEx);
                     }
                 }
-                
-                throw ex; //after having tried to remove the VDI, the original exception is thrown for the UI
+
+                //after having tried to remove the VDI, the original exception is thrown for the UI
+                if (ex is TargetInvocationException && ex.InnerException != null)
+                    throw ex.InnerException;
+                else
+                    throw ex; 
             }
             finally
             {


### PR DESCRIPTION
…oad fails

When a TargetInvocationException is raised, its InnerException property holds the underlying exception, which is what we should display.
Also ellipsise the action description (which could be an error thrown by the upload action) that is displayed on the Upload page.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>