### PR TITLE
CA-137249: Strange 'Completed' text shows while enabling or disabling HA

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -446,6 +446,8 @@ namespace XenAdmin
 
         void actionChanged_(ActionBase action)
         {
+            if (action.SuppressProgressReport) // suppress updates when the PureAsyncAction runs the action to populate the ApiMethodsToRoleCheck
+                return;
              var meddlingAction = action as MeddlingAction;
              if (meddlingAction == null)
                  statusProgressBar.Visible = action.ShowProgress && !action.IsCompleted;

--- a/XenModel/Actions/Action.cs
+++ b/XenModel/Actions/Action.cs
@@ -303,7 +303,7 @@ namespace XenAdmin.Actions
             }
         }
 
-        protected bool SuppressProgressReport { get; set; }
+        public bool SuppressProgressReport { get; set; }
         public void Tick(int percent, string description)
         {
             _description = description;

--- a/XenModel/Actions/PureAsyncAction.cs
+++ b/XenModel/Actions/PureAsyncAction.cs
@@ -75,8 +75,10 @@ namespace XenAdmin.Actions
                 RbacMethodList rbacMethods = new RbacMethodList();
                 Session = new Session(RbacCollectorProxy.GetProxy(rbacMethods), Connection);
                 base.SuppressProgressReport = true;
+                var startDescription = Description;
                 Run();
                 base.SuppressProgressReport = false;
+                Description = startDescription; // reset Description;
                 return rbacMethods;
             }
         }


### PR DESCRIPTION
Suppress updates to the status when the PureAsyncAction runs the action to populate the ApiMethodsToRoleCheck

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>