### PR TITLE
CP-21500: Updates wizard: Show new versions that are available as updates

### DIFF
--- a/XenAdmin/Alerts/NewVersionPriorityAlertComparer.cs
+++ b/XenAdmin/Alerts/NewVersionPriorityAlertComparer.cs
@@ -1,4 +1,35 @@
-﻿using System;
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/XenAdmin/Alerts/NewVersionPriorityAlertComparer.cs
+++ b/XenAdmin/Alerts/NewVersionPriorityAlertComparer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XenAdmin.Alerts
+{
+    public class NewVersionPriorityAlertComparer : IComparer<Alert>
+    {
+        public int Compare(Alert alert1, Alert alert2)
+        {
+            if (alert1 == null || alert2 == null)
+                return 0;
+
+            int sortResult = 0;
+
+            if (IsVersionOrVersionUpdateAlert(alert1) && !IsVersionOrVersionUpdateAlert(alert2))
+                sortResult = 1;
+
+            if (!IsVersionOrVersionUpdateAlert(alert1) && IsVersionOrVersionUpdateAlert(alert2))
+                sortResult = -1;
+
+            if (sortResult == 0)
+                sortResult = Alert.CompareOnDate(alert1, alert2);
+
+            return -sortResult;
+        }
+
+        private bool IsVersionOrVersionUpdateAlert(Alert alert)
+        {
+            return alert is XenServerPatchAlert && (alert as XenServerPatchAlert).NewServerVersion != null
+                || alert is XenServerVersionAlert
+                || alert is XenCenterUpdateAlert;
+        }
+    }
+}

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -1009,33 +1009,6 @@ namespace XenAdmin.TabPages
             labelProgress.MaximumSize = new Size(tableLayoutPanel3.Width - 60, tableLayoutPanel3.Size.Height);
         }
 
-        public class NewVersionPriorityAlertComparer : IComparer<Alert>
-        {
-            public int Compare(Alert alert1, Alert alert2)
-            {
-                if (alert1 == null || alert2 == null)
-                    return 0;
 
-                int sortResult = 0;
-
-                if (IsVersionOrVersionUpdateAlert(alert1) && !IsVersionOrVersionUpdateAlert(alert2))
-                    sortResult = 1;
-
-                if (!IsVersionOrVersionUpdateAlert(alert1) && IsVersionOrVersionUpdateAlert(alert2))
-                    sortResult = -1;
-
-                if (sortResult == 0)
-                    sortResult = Alert.CompareOnDate(alert1, alert2);
-
-                return -sortResult;
-            }
-
-            private bool IsVersionOrVersionUpdateAlert(Alert alert)
-            {
-                return alert is XenServerPatchAlert && (alert as XenServerPatchAlert).NewServerVersion != null
-                    || alert is XenServerVersionAlert
-                    || alert is XenCenterUpdateAlert;
-            }
-        }
     }
 }

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -254,13 +254,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             dataGridViewPatches.Rows.Clear();
 
-            var alerts = Updates.UpdateAlerts.ToList();
-            if (dataGridViewPatches.SortedColumn == null)
-            {
-                alerts.Sort(new NewVersionPriorityAlertComparer());
-            }
-
-            var updates = new List<Alert>(alerts);
+            var updates = Updates.UpdateAlerts.ToList();
 
             if (dataGridViewPatches.SortedColumn != null)
             {
@@ -273,6 +267,10 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 if (dataGridViewPatches.SortOrder == SortOrder.Descending)
                     updates.Reverse();
+            }
+            else
+            {
+                updates.Sort(new NewVersionPriorityAlertComparer());
             }
 
             foreach (Alert alert in updates)

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Actions\GUIActions\IgnorePatchAction.cs" />
     <Compile Include="Actions\GUIActions\SaveDataSourceStateAction.cs" />
     <Compile Include="Actions\GUIActions\SearchAction.cs" />
+    <Compile Include="Alerts\NewVersionPriorityAlertComparer.cs" />
     <Compile Include="Alerts\Types\AlarmMessageAlert.cs" />
     <Compile Include="Alerts\Types\XenServerUpdateAlert.cs" />
     <Compile Include="Alerts\Types\DuplicateIqnAlert.cs" />


### PR DESCRIPTION
In the Updates wizard:
New versions that are available as updates will be listed in the "Download Updates from Citrix" section, before any other updates.
If XenCenter is not the latest version, these rows will be greyed out, with a tooltip.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>