### PR TITLE
CA-249624: [XSO-707] Convert VM to Template from XenCenter is not wor…

### DIFF
--- a/XenModel/Actions/PureAsyncAction.cs
+++ b/XenModel/Actions/PureAsyncAction.cs
@@ -73,11 +73,13 @@ namespace XenAdmin.Actions
             {
                 System.Diagnostics.Trace.Assert(ApiMethodsToRoleCheck.Count == 0);  // shouldn't set ApiMethodsToRoleCheck for PureAsyncAction: it will be ignored
                 RbacMethodList rbacMethods = new RbacMethodList();
+                var session = Session;
                 Session = new Session(RbacCollectorProxy.GetProxy(rbacMethods), Connection);
                 base.SuppressProgressReport = true;
                 var startDescription = Description;
                 Run();
                 base.SuppressProgressReport = false;
+                Session = session; // reset Session
                 Description = startDescription; // reset Description;
                 return rbacMethods;
             }


### PR DESCRIPTION
…king if connected as an AD user

- Reset the action's Session after the PureAsyncAction is run to collect the RBAC method list.

Also fixes the bug where AD users cannot do multiple operations on the VMs [SCTX-2517]

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>