### PR TITLE
CA-249824: Unable to create vlan, bond using XenCenter

### DIFF
--- a/XenAdmin/Wizards/NewNetworkWizard.cs
+++ b/XenAdmin/Wizards/NewNetworkWizard.cs
@@ -211,6 +211,7 @@ namespace XenAdmin.Wizards
                 result.MTU = pageChinDetails.MTU;
             else if (pageNetworkDetails.MTU.HasValue) //Custom MTU may not be allowed if we are making a virtual network or something
                 result.MTU = pageNetworkDetails.MTU.Value;
+            result.managed = true;
             return result;
         }
 

--- a/XenModel/Actions/Network/CreateBondAction.cs
+++ b/XenModel/Actions/Network/CreateBondAction.cs
@@ -285,6 +285,7 @@ namespace XenAdmin.Actions
             if (network.other_config == null)
                 network.other_config = new Dictionary<string, string>();
             network.other_config[XenAPI.Network.CREATE_IN_PROGRESS] = "true";
+            network.managed = true;
 
             RelatedTask = XenAPI.Network.async_create(Session, network);
             PollToCompletion(lo, hi);


### PR DESCRIPTION
- set managed=true, otherwise the network creation fails with the error "The network is not managed by xapi"

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>