### PR TITLE
CA-248920: The radiobutton selection on Select Update page is not preserved while navigating to the previous page in the Install Update wizard

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -54,6 +54,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         private bool CheckForUpdatesInProgress;
         public XenServerPatchAlert SelectedUpdateAlert;
         public XenServerPatchAlert FileFromDiskAlert;
+        private bool firstLoad = true;
         
         public PatchingWizard_SelectPatchPage()
         {
@@ -150,12 +151,22 @@ namespace XenAdmin.Wizards.PatchingWizard
                 labelWithAutomatedUpdates.Visible = automatedUpdatesOptionLabel.Visible = AutomatedUpdatesRadioButton.Visible = automatedUpdatesPossible;
                 labelWithoutAutomatedUpdates.Visible = !automatedUpdatesPossible;
 
-                AutomatedUpdatesRadioButton.Checked = automatedUpdatesPossible;
-                downloadUpdateRadioButton.Checked = !automatedUpdatesPossible;
+                if (firstLoad)
+                {
+                    AutomatedUpdatesRadioButton.Checked = automatedUpdatesPossible;
+                    downloadUpdateRadioButton.Checked = !automatedUpdatesPossible;
+                }
+                else if (!automatedUpdatesPossible && AutomatedUpdatesRadioButton.Checked)
+                {
+                    downloadUpdateRadioButton.Checked = true;
+                }
+
                 Updates.CheckServerPatches();
                 PopulatePatchesBox();
                 OnPageUpdated();
             }
+
+            firstLoad = false;
         }
 
         public bool IsInAutomatedUpdatesMode { get { return AutomatedUpdatesRadioButton.Visible && AutomatedUpdatesRadioButton.Checked; } }


### PR DESCRIPTION
Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>