### PR TITLE
CA-249845: Compiling the server status reports sometime fails with Sy…

### DIFF
--- a/XenModel/XenAPI/HTTP.cs
+++ b/XenModel/XenAPI/HTTP.cs
@@ -705,14 +705,11 @@ namespace XenAPI
                 CopyStream(fileStream, requestStream, dataCopiedDelegate, cancellingDelegate);
             }
         }
-        
-        private const int FILE_MOVE_MAX_RETRIES = 5;
-        private const int FILE_MOVE_SLEEP_BETWEEN_RETRIES = 100;
 
         /// <summary>
         /// A general HTTP GET method, with delegates for progress and cancelling. May throw various exceptions.
         /// </summary>
-        /// <param name="dataRxDelegate">Delegate called periodically (500 ms) with the number of bytes transferred</param>
+        /// <param name="dataCopiedDelegate">Delegate called periodically (500 ms) with the number of bytes transferred</param>
         /// <param name="cancellingDelegate">Delegate called periodically to see if need to cancel</param>
         /// <param name="uri">URI to GET from</param>
         /// <param name="proxy">A proxy to handle the HTTP connection</param>
@@ -732,29 +729,38 @@ namespace XenAPI
                 }
 
                 File.Delete(path);
-
-                // Rename the file, retrying a few times (MAX_RETRIES) with a short sleep (SLEEP_BETWEEN_RETRIES) between retries;
-                // If the it still fails after these retries, then throw the error
-                int retriesRemaining = FILE_MOVE_MAX_RETRIES;
-                do
-                {
-                    try
-                    {
-                        File.Move(tmpFile, path);
-                        break;
-                    }
-                    catch (IOException)
-                    {
-                        if (retriesRemaining <= 0)
-                            throw;
-                        System.Threading.Thread.Sleep(FILE_MOVE_SLEEP_BETWEEN_RETRIES);
-                    }
-                } while (retriesRemaining-- > 0);
+                MoveFileWithRetry(tmpFile, path);
             }
             finally
             {
                 File.Delete(tmpFile);
             }
+        }
+
+        private const int FILE_MOVE_MAX_RETRIES = 5;
+        private const int FILE_MOVE_SLEEP_BETWEEN_RETRIES = 100;
+
+        /// <summary>
+        /// Move a file, retrying a few times with a short sleep between retries.
+        /// If it still fails after these retries, then throw the error.
+        /// </summary>
+        public static void MoveFileWithRetry(string sourceFileName, string destFileName)
+        {
+            int retriesRemaining = FILE_MOVE_MAX_RETRIES;
+            do
+            {
+                try
+                {
+                    File.Move(sourceFileName, destFileName);
+                    break;
+                }
+                catch (IOException)
+                {
+                    if (retriesRemaining <= 0)
+                        throw;
+                    System.Threading.Thread.Sleep(FILE_MOVE_SLEEP_BETWEEN_RETRIES);
+                }
+            } while (retriesRemaining-- > 0);
         }
     }
 }


### PR DESCRIPTION
…stem.IO.IOException: The process cannot access the file because it is being used by another process

Add a retry mechanism around the File.Move, because the operation sometimes fails when there is an anti-virus running on the XenCenter machine (we are doing the move immediately after we finished writing the file and the anti-virus software might be checking the file at that point)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>