### PR TITLE
CA-249860: Local root user can not restart the toolstack from XenCent…

### DIFF
--- a/XenModel/Actions/Host/RestartToolstackAction.cs
+++ b/XenModel/Actions/Host/RestartToolstackAction.cs
@@ -56,7 +56,7 @@ namespace XenAdmin.Actions
 
         protected override void Run()
         {
-            var session = Connection.DuplicateSession();
+            var session = NewSession();
 
             Description = string.Format(Messages.ACTION_TOOLSTACK_RESTARTING_ON, Host.Name.Ellipsise(30));
             RelatedTask = Host.async_restart_agent(session, Host.opaque_ref);


### PR DESCRIPTION
…er with AD enabled

Use the NewSession function which returns a session using the elevated credentials if they exist, otherwise using the connection's credentials

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>