### PR TITLE
download_packages: Check version of powershell before executing

### DIFF
--- a/devtools/download_packages.ps1
+++ b/devtools/download_packages.ps1
@@ -30,6 +30,12 @@
 
 # help script to download third party binaries to local dev environment
 
+if ($PSVersionTable.PSVersion.Major -lt 3)
+{
+    Write-Host "Failed to execute: Powershell version 3.x (or above) is required"
+    exit 1
+}
+
 $DOMAIN = Read-Host "Artifactory domain (e.g. artifactory.domain.com): "
 $DOMAIN = $DOMAIN.Trim()
 $CREDENTIALS = Get-Credential


### PR DESCRIPTION
Windows 7 (without sp1) comes with powershell v2.x and
download_packages.ps1 doesn't work with powershell v2.x.

Check for powershell version and bail out if Major version is less than
3.

Signed-off-by: Anoob Soman <anoob.soman@citrix.com>