### PR TITLE
CA-251630: XenCenter update wizard incorrectly states that some hosts…

### DIFF
--- a/XenAdmin/Diagnostics/Checks/HAOffCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/HAOffCheck.cs
@@ -69,5 +69,14 @@ namespace XenAdmin.Diagnostics.Checks
                 return Messages.HA_CHECK_DESCRIPTION;
             }
         }
+
+        public override string SuccessfulCheckDescription
+        {
+            get
+            {
+                var pool = Helpers.GetPool(Host.Connection);
+                return string.Format(Messages.PATCHING_WIZARD_HOST_CHECK_OK, pool != null ? pool.Name : Host.Name, Description);
+            }
+        }
     }
 }

--- a/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
@@ -80,14 +80,6 @@ namespace XenAdmin.Diagnostics.Checks
 
         protected override Problem RunCheck()
         {
-            if (!Host.IsLive)
-                return new HostNotLiveWarning(this, Host);
-
-            if (!Host.Connection.IsConnected)
-                throw new EndOfStreamException(Helpers.GetName(Host.Connection));
-
-            Session session = Host.Connection.DuplicateSession();
-
             //
             // Check patch isn't already applied here
             //
@@ -96,6 +88,16 @@ namespace XenAdmin.Diagnostics.Checks
             {
                 return new PatchAlreadyApplied(this, Host);
             }
+            
+            if (!Host.IsLive)
+                return new HostNotLiveWarning(this, Host);
+
+            if (!Host.Connection.IsConnected)
+                throw new EndOfStreamException(Helpers.GetName(Host.Connection));
+
+            Session session = Host.Connection.DuplicateSession();
+
+            
 
             try
             {


### PR DESCRIPTION
… need rebooting and requires suspending VMs

Perform all the prechecks on applicable hosts only (i.e. the hosts that don't have the update applied already), with the following exceptions:
- The HA check, which is performed on the pool master
- The server-side precheck (PatchPrecheckCheck) which will still be performed on all servers in the pool and will show the warning if the update has already been applied on some servers

This commit also adds an override to the HAOffCheck.SuccessfulCheckDescription to show the pool name instead of the master's if the check is successful.
Also, in the PatchPrecheckCheck, I had moved the code that checks if the patch is already applied to the very beginning (before the host liveness check), so it will return the warning that the server will be skipped even if the server is not reachable

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>