### PR TITLE
CA-253047: Wrong prechecks are performed in Automated Updates mode if…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -144,6 +144,8 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 PatchingWizard_PrecheckPage.IsInAutomatedUpdatesMode = wizardIsInAutomatedUpdatesMode;
                 PatchingWizard_PrecheckPage.Patch = existPatch;
+                PatchingWizard_PrecheckPage.PoolUpdate = null; //reset the PoolUpdate property; it will be updated on leaving the Upload page, if this page is visible
+
                 PatchingWizard_PatchingPage.Patch = existPatch;
 
                 PatchingWizard_PrecheckPage.SelectedUpdateType = updateType;


### PR DESCRIPTION
… an update has been previously uploaded

Reset the PrecheckPage.PoolUpdate property on leaving the SelectPatch page, because it needs to be null for the Automated Updates mode and for the single update mode it will be updated on leaving the Upload page.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>