### PR TITLE
CA-252877: Precheck actions not reverted on upgrading to new XenServer version using an update

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/UnwindProblemsAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/UnwindProblemsAction.cs
@@ -40,10 +40,10 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
     {
         private readonly List<Problem> _problems;
 
-        public UnwindProblemsAction(List<Problem> problems)
+        public UnwindProblemsAction(List<Problem> problems, string TitleOverride = null)
             : base(Messages.PATCHINGWIZARD_PATCHINGPAGE_PRECHECK_REVERTING)
         {
-            base.TitlePlan = Messages.REVERTING_RESOLVED_PRECHECKS;
+            base._title = base.TitlePlan = TitleOverride ?? Messages.REVERTING_RESOLVED_PRECHECKS;
             _problems = problems;
         }
 

--- a/XenAdmin/Wizards/PatchingWizard/UpdateProgressBackgroundWorker.cs
+++ b/XenAdmin/Wizards/PatchingWizard/UpdateProgressBackgroundWorker.cs
@@ -44,6 +44,8 @@ namespace XenAdmin.Wizards.PatchingWizard
     {
         public List<PlanAction> PlanActions { get; private set; }
         public Dictionary<Host, List<PlanAction>> DelayedActionsByHost {get; private set; }
+        public List<PlanAction> FinalActions { get; private set; }
+
         private Host master;
 
         public List<PlanAction> FinsihedActions = new List<PlanAction>();
@@ -65,18 +67,20 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
         }
 
-        public UpdateProgressBackgroundWorker(Host master, List<PlanAction> planActions, Dictionary<Host, List<PlanAction>> delayedActionsByHost)
+        public UpdateProgressBackgroundWorker(Host master, List<PlanAction> planActions, Dictionary<Host, List<PlanAction>> delayedActionsByHost, 
+            List<PlanAction> finalActions)
         {
             this.master = master;
             this.PlanActions = planActions;
             this.DelayedActionsByHost = delayedActionsByHost;
+            this.FinalActions = finalActions;
         }
 
         public int ActionsCount
         {
             get
             {
-                return PlanActions.Count + DelayedActionsByHost.Sum(kvp => kvp.Value.Count);
+                return PlanActions.Count + DelayedActionsByHost.Sum(kvp => kvp.Value.Count) + FinalActions.Count;
             }
         }
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -29723,6 +29723,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reverting resolved prechecks in {0}....
+        /// </summary>
+        public static string REVERTING_RESOLVED_PRECHECKS_POOL {
+            get {
+                return ResourceManager.GetString("REVERTING_RESOLVED_PRECHECKS_POOL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Reverting all changes done by this wizard.
         /// </summary>
         public static string REVERTING_WIZARD_CHANGES {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10327,6 +10327,9 @@ Click Server Status Report to open the Compile Server Status Report Wizard or cl
   <data name="REVERTING_RESOLVED_PRECHECKS" xml:space="preserve">
     <value>Reverting resolved prechecks</value>
   </data>
+  <data name="REVERTING_RESOLVED_PRECHECKS_POOL" xml:space="preserve">
+    <value>Reverting resolved prechecks in {0}...</value>
+  </data>
   <data name="REVERTING_WIZARD_CHANGES" xml:space="preserve">
     <value>Reverting all changes done by this wizard</value>
   </data>


### PR DESCRIPTION
Automated Updates now undo pre-check actions once it's finished wit the updates

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>