### PR TITLE
CA-220047: Show proper precheck error when a VM cannot be migrated

### DIFF
--- a/XenAdmin/Diagnostics/Checks/AssertCanEvacuateCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/AssertCanEvacuateCheck.cs
@@ -98,7 +98,7 @@ namespace XenAdmin.Diagnostics.Checks
 
                 if (restrictMigration && residentVM.is_a_real_vm && !VMsWithProblems.Contains(residentVM.opaque_ref))
                 {
-                    problems.Add(new CannotMigrateVM(this, residentVM, true));
+                    problems.Add(new CannotMigrateVM(this, residentVM, CannotMigrateVM.CannotMigrateVMReason.LicenseRestriction));
                     VMsWithProblems.Add(residentVM.opaque_ref);
                 }
             }
@@ -183,6 +183,22 @@ namespace XenAdmin.Diagnostics.Checks
                             throw new NullReferenceException(Failure.VM_MISSING_PV_DRIVERS);
 
                         return new NoPVDrivers(this, vm);
+
+                    case Failure.VM_LACKS_FEATURE:
+                        vm = connection.Resolve<VM>(vmRef);
+
+                        if (vm == null)
+                            throw new NullReferenceException(Failure.VM_LACKS_FEATURE);
+
+                        return new CannotMigrateVM(this, vm, CannotMigrateVM.CannotMigrateVMReason.LacksFeature);
+
+                    case Failure.VM_LACKS_FEATURE_SUSPEND:
+                        vm = connection.Resolve<VM>(vmRef);
+
+                        if (vm == null)
+                            throw new NullReferenceException(Failure.VM_LACKS_FEATURE_SUSPEND);
+
+                        return new CannotMigrateVM(this, vm, CannotMigrateVM.CannotMigrateVMReason.LacksFeatureSuspend);
 
                     case "VM_OLD_PV_DRIVERS":
                         vm = connection.Resolve<VM>(vmRef);

--- a/XenAdmin/Diagnostics/Checks/AssertCanEvacuateCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/AssertCanEvacuateCheck.cs
@@ -147,16 +147,16 @@ namespace XenAdmin.Diagnostics.Checks
             {
                 System.Diagnostics.Trace.Assert(exception.Length > 0);
 
-                VM vm;
+                var vm = connection.Resolve<VM>(vmRef);
+
+                if (vm == null)
+                {
+                    throw new NullReferenceException(exception[0]);
+                }
 
                 switch (exception[0])
                 {
                     case Failure.VM_REQUIRES_SR:
-                        vm = connection.Resolve<VM>(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.VM_REQUIRES_SR);
-
                         XenRef<SR> srRef = new XenRef<SR>(exception[2]);
                         SR sr = connection.Resolve<SR>(srRef);
 
@@ -177,52 +177,22 @@ namespace XenAdmin.Diagnostics.Checks
                         return null;
 
                     case Failure.VM_MISSING_PV_DRIVERS:
-                        vm = connection.Resolve<VM>(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.VM_MISSING_PV_DRIVERS);
-
                         return new NoPVDrivers(this, vm);
 
                     case Failure.VM_LACKS_FEATURE:
-                        vm = connection.Resolve<VM>(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.VM_LACKS_FEATURE);
-
                         return new CannotMigrateVM(this, vm, CannotMigrateVM.CannotMigrateVMReason.LacksFeature);
 
                     case Failure.VM_LACKS_FEATURE_SUSPEND:
-                        vm = connection.Resolve<VM>(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.VM_LACKS_FEATURE_SUSPEND);
-
                         return new CannotMigrateVM(this, vm, CannotMigrateVM.CannotMigrateVMReason.LacksFeatureSuspend);
 
                     case "VM_OLD_PV_DRIVERS":
-                        vm = connection.Resolve<VM>(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException("VM_OLD_PV_DRIVERS");
-
                         return new PVDriversOutOfDate(this, vm);
 
                     case Failure.NO_HOSTS_AVAILABLE:
                         //CA-63531: Boston server will come here in case of single host pool or standalone host
-                        vm = connection.Resolve<VM>(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.NO_HOSTS_AVAILABLE);
-
                         return new NoHosts(this, vm);
 
                     case Failure.HOST_NOT_ENOUGH_FREE_MEMORY:
-                        vm = connection.Resolve<VM>(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.HOST_NOT_ENOUGH_FREE_MEMORY);
-
                         Pool pool = Helpers.GetPool(vm.Connection);
 
                         if (pool == null || pool.Connection.Cache.HostCount == 1)
@@ -235,11 +205,6 @@ namespace XenAdmin.Diagnostics.Checks
                         return new NotEnoughMem(this, host);
 
                     case Failure.VM_REQUIRES_NETWORK:
-                        vm = connection.Resolve(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.VM_REQUIRES_NETWORK);
-
                         XenRef<XenAPI.Network> netRef = new XenRef<XenAPI.Network>(exception[2]);
                         XenAPI.Network network = connection.Resolve(netRef);
 
@@ -249,11 +214,6 @@ namespace XenAdmin.Diagnostics.Checks
                         return new VMCannotSeeNetwork(this, vm, network);
 
                     case Failure.VM_HAS_VGPU:
-                        vm = connection.Resolve(vmRef);
-
-                        if (vm == null)
-                            throw new NullReferenceException(Failure.VM_HAS_VGPU);
-
                         return new VmHasVgpu(this, vm);
 
                     default:

--- a/XenAdmin/Diagnostics/Problems/VMProblem/CannotMigrateVM.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/CannotMigrateVM.cs
@@ -38,21 +38,42 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 {
     public class CannotMigrateVM : VMProblem
     {
-        private readonly bool licenseRestriction;
+        private readonly CannotMigrateVMReason reason;
 
-        public CannotMigrateVM(Check check, VM vm, bool licenseRestriction = false)
+        public enum CannotMigrateVMReason { Unknown, LicenseRestriction, LacksFeature, LacksFeatureSuspend }
+
+        public CannotMigrateVM(Check check, VM vm, CannotMigrateVMReason licenseRestriction = CannotMigrateVMReason.Unknown)
             : base(check, vm) 
         {
-            this.licenseRestriction = licenseRestriction;
+            this.reason = licenseRestriction;
         }
 
         public override string Description
         {
             get 
             {
-                return String.Format(licenseRestriction
-                    ? Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_LICENSE_REASON           
-                    : Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_UNKNOWN_REASON, VM.Name); 
+                string descriptionFormat;
+
+                switch (reason)
+                {
+                    case CannotMigrateVMReason.LacksFeature:
+                        descriptionFormat = Messages.UPDATES_WIZARD_VM_MISSING_FEATURE;
+                        break;
+
+                    case CannotMigrateVMReason.LacksFeatureSuspend:
+                        descriptionFormat = Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON;
+                        break;
+
+                    case CannotMigrateVMReason.LicenseRestriction :
+                        descriptionFormat = Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_LICENSE_REASON;
+                        break;
+
+                    default :
+                        descriptionFormat = Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_UNKNOWN_REASON;
+                        break;
+                }
+
+                return String.Format(descriptionFormat, VM.Name); 
             }
         }
     }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/CannotMigrateVM.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/CannotMigrateVM.cs
@@ -40,7 +40,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
     {
         private readonly CannotMigrateVMReason reason;
 
-        public enum CannotMigrateVMReason { Unknown, LicenseRestriction, LacksFeature, LacksFeatureSuspend }
+        public enum CannotMigrateVMReason { Unknown, LicenseRestriction, CannotMigrateVm, CannotMigrateVmNoTools, LacksFeatureSuspend }
 
         public CannotMigrateVM(Check check, VM vm, CannotMigrateVMReason licenseRestriction = CannotMigrateVMReason.Unknown)
             : base(check, vm) 
@@ -56,8 +56,12 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
                 switch (reason)
                 {
-                    case CannotMigrateVMReason.LacksFeature:
-                        descriptionFormat = Messages.UPDATES_WIZARD_VM_MISSING_FEATURE;
+                    case CannotMigrateVMReason.CannotMigrateVm:
+                        descriptionFormat = Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM;
+                        break;
+
+                    case CannotMigrateVMReason.CannotMigrateVmNoTools:
+                        descriptionFormat = Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_NO_TOOLS;
                         break;
 
                     case CannotMigrateVMReason.LacksFeatureSuspend:

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -33681,7 +33681,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;, because it lacks the ability to suspend..
+        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;, because it cannot be suspended..
         /// </summary>
         public static string UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -33672,7 +33672,16 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;, because it lacks the ability to suspend. Please ensure it has up-to-date drivers installed..
+        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;, because it doesn&apos;t have up-to-date drivers installed..
+        /// </summary>
+        public static string UPDATES_WIZARD_CANNOT_MIGRATE_VM_NO_TOOLS {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_CANNOT_MIGRATE_VM_NO_TOOLS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;, because it lacks the ability to suspend..
         /// </summary>
         public static string UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON {
             get {
@@ -34293,15 +34302,6 @@ namespace XenAdmin {
         public static string UPDATES_WIZARD_VM_HAS_VGPU {
             get {
                 return ResourceManager.GetString("UPDATES_WIZARD_VM_HAS_VGPU", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;: please ensure it has up-to-date drivers installed..
-        /// </summary>
-        public static string UPDATES_WIZARD_VM_MISSING_FEATURE {
-            get {
-                return ResourceManager.GetString("UPDATES_WIZARD_VM_MISSING_FEATURE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -33672,6 +33672,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;, because it lacks the ability to suspend. Please ensure it has up-to-date drivers installed..
+        /// </summary>
+        public static string UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos; for an unknown reason. See application logs for more details..
         /// </summary>
         public static string UPDATES_WIZARD_CANNOT_MIGRATE_VM_UNKNOWN_REASON {
@@ -34284,6 +34293,15 @@ namespace XenAdmin {
         public static string UPDATES_WIZARD_VM_HAS_VGPU {
             get {
                 return ResourceManager.GetString("UPDATES_WIZARD_VM_HAS_VGPU", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot migrate VM &apos;{0}&apos;: please ensure it has up-to-date drivers installed..
+        /// </summary>
+        public static string UPDATES_WIZARD_VM_MISSING_FEATURE {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_VM_MISSING_FEATURE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -11628,7 +11628,7 @@ Check your settings and try again.</value>
     <value>Cannot migrate VM '{0}' due to license restrictions.</value>
   </data>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON" xml:space="preserve">
-    <value>Cannot migrate VM '{0}', because it lacks the ability to suspend.</value>
+    <value>Cannot migrate VM '{0}', because it cannot be suspended.</value>
   </data>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_UNKNOWN_REASON" xml:space="preserve">
     <value>Cannot migrate VM '{0}' for an unknown reason. See application logs for more details.</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -11627,6 +11627,9 @@ Check your settings and try again.</value>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_LICENSE_REASON" xml:space="preserve">
     <value>Cannot migrate VM '{0}' due to license restrictions.</value>
   </data>
+  <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON" xml:space="preserve">
+    <value>Cannot migrate VM '{0}', because it lacks the ability to suspend. Please ensure it has up-to-date drivers installed.</value>
+  </data>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_UNKNOWN_REASON" xml:space="preserve">
     <value>Cannot migrate VM '{0}' for an unknown reason. See application logs for more details.</value>
   </data>
@@ -13587,5 +13590,8 @@ You will need to navigate to the Console on each of the selected VMs to complete
   </data>
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
+  </data>
+  <data name="UPDATES_WIZARD_VM_MISSING_FEATURE" xml:space="preserve">
+    <value>Cannot migrate VM '{0}': please ensure it has up-to-date drivers installed.</value>
   </data>
 </root>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -11628,7 +11628,7 @@ Check your settings and try again.</value>
     <value>Cannot migrate VM '{0}' due to license restrictions.</value>
   </data>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON" xml:space="preserve">
-    <value>Cannot migrate VM '{0}', because it lacks the ability to suspend. Please ensure it has up-to-date drivers installed.</value>
+    <value>Cannot migrate VM '{0}', because it lacks the ability to suspend.</value>
   </data>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_UNKNOWN_REASON" xml:space="preserve">
     <value>Cannot migrate VM '{0}' for an unknown reason. See application logs for more details.</value>
@@ -13591,7 +13591,7 @@ You will need to navigate to the Console on each of the selected VMs to complete
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
   </data>
-  <data name="UPDATES_WIZARD_VM_MISSING_FEATURE" xml:space="preserve">
-    <value>Cannot migrate VM '{0}': please ensure it has up-to-date drivers installed.</value>
+  <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_NO_TOOLS" xml:space="preserve">
+    <value>Cannot migrate VM '{0}', because it doesn't have up-to-date drivers installed.</value>
   </data>
 </root>

--- a/XenModel/XenAPI-Extensions/Failure.cs
+++ b/XenModel/XenAPI-Extensions/Failure.cs
@@ -84,6 +84,8 @@ namespace XenAPI
         public const string VM_HAS_VGPU = "VM_HAS_VGPU";
         public const string OUT_OF_SPACE = "OUT_OF_SPACE";
         public const string PVS_SITE_CONTAINS_RUNNING_PROXIES = "PVS_SITE_CONTAINS_RUNNING_PROXIES";
+        public const string VM_LACKS_FEATURE = "VM_LACKS_FEATURE";
+        public const string VM_LACKS_FEATURE_SUSPEND = "VM_LACKS_FEATURE_SUSPEND";
 
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 


### PR DESCRIPTION
Detect both VM_LACKS_FEATURE and VM_LACKS_FEATURE_SUSPEND, show proper error message on the pre-check page in the Install Updates Wizard

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>