### PR TITLE
Fix the HealthCheck tests

### DIFF
--- a/XenAdminTests/HealthCheckTests/CredentialTests.cs
+++ b/XenAdminTests/HealthCheckTests/CredentialTests.cs
@@ -59,16 +59,26 @@ namespace XenAdminTests.HealthCheckTests
             string UserName = "User1";
             string Password = "password1";
 
-            //1. Empty list
+            // Empty list
             ServerListHelper.instance.ClearServerList();
             int conSize = 0;
             List<ServerInfo> con = ServerListHelper.instance.GetServerList();
             Assert.IsTrue(con.Count == conSize);
 
-            //2. Send credential and check result
+            //1. Empty credential 
             NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", HealthCheckSettings.HEALTH_CHECK_PIPE, PipeDirection.Out);
             pipeClient.Connect();
-            string credential = EncryptionUtils.ProtectForLocalMachine(String.Join(SEPARATOR.ToString(), new[] { HostName, UserName, Password }));
+            string credential = EncryptionUtils.ProtectForLocalMachine(String.Join(SEPARATOR.ToString(), new[] { HostName, null, null }));
+            pipeClient.Write(Encoding.UTF8.GetBytes(credential), 0, credential.Length);
+            pipeClient.Close();
+            System.Threading.Thread.Sleep(1000);
+            con = ServerListHelper.instance.GetServerList();
+            Assert.IsTrue(con.Count == conSize);
+
+            //2. Send credential and check result
+            pipeClient = new NamedPipeClientStream(".", HealthCheckSettings.HEALTH_CHECK_PIPE, PipeDirection.Out);
+            pipeClient.Connect();
+            credential = EncryptionUtils.ProtectForLocalMachine(String.Join(SEPARATOR.ToString(), new[] { HostName, UserName, Password }));
             pipeClient.Write(Encoding.UTF8.GetBytes(credential), 0, credential.Length);
             pipeClient.Close();
             System.Threading.Thread.Sleep(1000);

--- a/XenAdminTests/HealthCheckTests/CredentialTests.cs
+++ b/XenAdminTests/HealthCheckTests/CredentialTests.cs
@@ -58,20 +58,17 @@ namespace XenAdminTests.HealthCheckTests
             string HostName = "Host1";
             string UserName = "User1";
             string Password = "password1";
-            int conSize = ServerListHelper.instance.GetServerList().Count;
-            //1. Empty credential 
-            NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", HealthCheckSettings.HEALTH_CHECK_PIPE, PipeDirection.Out);
-            pipeClient.Connect();
-            string credential = EncryptionUtils.ProtectForLocalMachine(String.Join(SEPARATOR.ToString(), new[] { HostName, null, null }));
-            pipeClient.Write(Encoding.UTF8.GetBytes(credential), 0, credential.Length);
-            pipeClient.Close();
+
+            //1. Empty list
+            ServerListHelper.instance.ClearServerList();
+            int conSize = 0;
             List<ServerInfo> con = ServerListHelper.instance.GetServerList();
             Assert.IsTrue(con.Count == conSize);
 
             //2. Send credential and check result
-            pipeClient = new NamedPipeClientStream(".", HealthCheckSettings.HEALTH_CHECK_PIPE, PipeDirection.Out);
+            NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", HealthCheckSettings.HEALTH_CHECK_PIPE, PipeDirection.Out);
             pipeClient.Connect();
-            credential = EncryptionUtils.ProtectForLocalMachine(String.Join(SEPARATOR.ToString(), new[] { HostName, UserName, Password }));
+            string credential = EncryptionUtils.ProtectForLocalMachine(String.Join(SEPARATOR.ToString(), new[] { HostName, UserName, Password }));
             pipeClient.Write(Encoding.UTF8.GetBytes(credential), 0, credential.Length);
             pipeClient.Close();
             System.Threading.Thread.Sleep(1000);
@@ -122,7 +119,7 @@ namespace XenAdminTests.HealthCheckTests
             Assert.IsTrue(con.Count == conSize);
 
 
-            //7. semd 2 credential
+            //7. send 2 credentials
             pipeClient = new NamedPipeClientStream(".", HealthCheckSettings.HEALTH_CHECK_PIPE, PipeDirection.Out);
             pipeClient.Connect();
             HostName = "host3";
@@ -136,7 +133,7 @@ namespace XenAdminTests.HealthCheckTests
             con = ServerListHelper.instance.GetServerList();
             Assert.IsTrue(con.Count == conSize + 2);
 
-            //8. remove 2 credential
+            //8. remove 2 credentials
             pipeClient = new NamedPipeClientStream(".", HealthCheckSettings.HEALTH_CHECK_PIPE, PipeDirection.Out);
             pipeClient.Connect();
             HostName = "host3";

--- a/XenServerHealthCheck/ServerListHelper.cs
+++ b/XenServerHealthCheck/ServerListHelper.cs
@@ -181,6 +181,12 @@ namespace XenServerHealthCheck
             string decryptCredential = EncryptionUtils.UnprotectForLocalMachine(credential);
             string[] decryptCredentialComps = decryptCredential.Split(SEPARATOR);
 
+            if (decryptCredentialComps.Length != 1 && decryptCredentialComps.Length != 3)
+                return;
+
+            if (decryptCredentialComps.Length == 3 && (string.IsNullOrEmpty(decryptCredentialComps[1]) || string.IsNullOrEmpty(decryptCredentialComps[2])))
+                return; //ignore null or empty username and password
+
             lock (serverListLock)
             {
                 if (decryptCredentialComps.Length == 3)

--- a/XenServerHealthCheck/ServerListHelper.cs
+++ b/XenServerHealthCheck/ServerListHelper.cs
@@ -165,6 +165,15 @@ namespace XenServerHealthCheck
             }
         }
 
+        public void ClearServerList()
+        {
+            lock (serverListLock)
+            {
+                serverList.Clear();
+                updateServerList();
+            }
+        }
+
         public void UpdateServerCredential(string credential)
         {
             log.Info("Receive credential update message");


### PR DESCRIPTION
The problem with these tests was that XenServerHealthCheck/ServerListHelper class is reading the server list form the user config file, and it also saves it there on every update. Although this tests eventually remove the servers added, sometimes (e.g. the test fails midway through) the added server (e.g. "host1") remained in the config file. 
With this fix, we firstly clear the server list.
Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>