### PR TITLE
CA-255458: Fix the HealthCheck tests - RequestUploadTaskTests

### DIFF
--- a/XenAdminTests/HealthCheckTests/CredentialTests.cs
+++ b/XenAdminTests/HealthCheckTests/CredentialTests.cs
@@ -50,11 +50,22 @@ namespace XenAdminTests.HealthCheckTests
     {
         private const char SEPARATOR = '\x202f'; // narrow non-breaking space.
 
-        [Test]
-        public void CredentialOp()
+        [TestFixtureSetUp]
+        public void FixtureSetup()
         {
             CredentialReceiver.instance.Init();
             ServerListHelper.instance.Init();
+        }
+
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            CredentialReceiver.instance.UnInit();
+        }
+
+        [Test]
+        public void CredentialOp()
+        {
             string HostName = "Host1";
             string UserName = "User1";
             string Password = "password1";
@@ -156,8 +167,6 @@ namespace XenAdminTests.HealthCheckTests
             System.Threading.Thread.Sleep(1000);
             con = ServerListHelper.instance.GetServerList();
             Assert.IsTrue(con.Count == conSize);
-
-            CredentialReceiver.instance.UnInit();
         }
     }
 }


### PR DESCRIPTION
- Now that the credential receiver ignores empty credentials, this test needed to be updated to not send an empty password
- Moved initializing code in TestFixtureSetUp (and similarly tear-down code in TestFixtureTearDown) for both RequestUploadTaskTests and CredentialTests classes
- Also removed unnecessary calls to CreateNewConnection and LoadCache

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>