### PR TITLE
CA-255015: Network Name for newly created vlan needs renaming from XenCenter

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -35666,6 +35666,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Network {0} on VLAN {1}.
+        /// </summary>
+        public static string VLAN_NETWORK_NAME {
+            get {
+                return ResourceManager.GetString("VLAN_NETWORK_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to VM.
         /// </summary>
         public static string VM {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12358,6 +12358,9 @@ To learn more about the [XenServer] Dynamic Workload Balancing feature or to sta
   <data name="VIRTUAL_MACHINES" xml:space="preserve">
     <value>Virtual Machines</value>
   </data>
+  <data name="VLAN_NETWORK_NAME" xml:space="preserve">
+    <value>Network {0} on VLAN {1}</value>
+  </data>
   <data name="VM" xml:space="preserve">
     <value>VM</value>
   </data>

--- a/XenModel/XenAPI-Extensions/Network.cs
+++ b/XenModel/XenAPI-Extensions/Network.cs
@@ -116,7 +116,15 @@ namespace XenAPI
         private string PIFName(PIF pif)
         {
             bool bond;
-            return string.Format(Messages.NETWORK_NAME, pif.NICIdentifier(out bond));
+
+            if (pif.VLAN >= 0)
+            {
+                return string.Format(Messages.VLAN_NETWORK_NAME, pif.NICIdentifier(out bond), pif.VLAN);
+            }
+            else
+            {
+                return string.Format(Messages.NETWORK_NAME, pif.NICIdentifier(out bond));
+            }
         }
 
         public bool AutoPlug


### PR DESCRIPTION
Network name will be shown as Network <NIC_ID> on VLAN <VLAN_ID>

Signed-off-by: Sharath Babu <Sharat.Babu@citrix.com>