### PR TITLE
CA-255551: [SCTX-2553] Automated Updates - Slaves rebooted before Master - XenCenter 7.1.1

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
@@ -303,11 +303,13 @@ namespace XenAdmin.Wizards.PatchingWizard
                 }
 
                 // running delayed actions, but skipping the ones that should be skipped
-                // iterating through hosts
-                foreach (var kvp in bgw.DelayedActionsByHost)
+                // iterating through hosts, master first
+                var hostsOrdered = bgw.DelayedActionsByHost.Keys.ToList();
+                hostsOrdered.Sort(); //master first
+
+                foreach (var h in hostsOrdered)
                 {
-                    var h = kvp.Key;
-                    var actions = kvp.Value;
+                    var actions = bgw.DelayedActionsByHost[h];
 
                     //run all restart-alike plan actions
                     foreach (var a in actions.Where(a => a.IsRestartRelatedPlanAction()))


### PR DESCRIPTION
Due to a regression (introduced by [1]), XenCenter will not run delayed actions in the correct host-order at all times. This can cause the master to be not the first host to be rebooted what may result in connections being lost to slaves should the API change between restarts/updates in a way that it would not be compatible to the previous version. This would make the wizard fail and users would have to restart their master host manually to make it connect to its slaves again.

This commit fixes the order of the hosts when executing the delayed actions.

[1]: 15827512e1126e8a72d47aaa50ce7c8113262f5a

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>