### PR TITLE
CA-231518: Manage updates page - the last datagridview column is not …

### DIFF
--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -233,6 +233,8 @@ namespace XenAdmin.TabPages
 
                 if (updates.Count == 0)
                 {
+                    ColumnWebPage.AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader;
+
                     tableLayoutPanel3.Visible = true;
                     pictureBoxProgress.Image = SystemIcons.Information.ToBitmap();
 
@@ -257,6 +259,8 @@ namespace XenAdmin.TabPages
                     }
                     return;
                 }
+
+                ColumnWebPage.AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
 
                 checkForUpdatesNowButton.Visible = false;
 


### PR DESCRIPTION
…autoresized properly after dismissing all the updates

- Change the AutoSizeMode to ColumnHeader if the grid is empty, to force the column to auto resize

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>