### PR TITLE
CP-21130: Move the test for InvernessOrGreater outside the VNCGraphic…

### DIFF
--- a/XenAdmin/ConsoleView/VNCGraphicsClient.cs
+++ b/XenAdmin/ConsoleView/VNCGraphicsClient.cs
@@ -156,6 +156,8 @@ namespace XenAdmin.ConsoleView
 
         public event EventHandler DesktopResized = null;
 
+        public bool UseQemuExtKeyEncoding { set; private get; }
+
         public VNCGraphicsClient(ContainerControl parent)
         {
             Program.AssertOnEventThread();
@@ -964,7 +966,7 @@ namespace XenAdmin.ConsoleView
 
                 foreach (int key in pressedScans)
                 {
-                    this.vncStream.keyScanEvent(false, key, -1, Helpers.InvernessOrGreater(this.SourceVM.Connection));
+                    this.vncStream.keyScanEvent(false, key, -1, UseQemuExtKeyEncoding);
                 }
             });
 
@@ -1312,7 +1314,7 @@ namespace XenAdmin.ConsoleView
         {
             DoIfConnected(delegate()
             {
-                this.vncStream.keyScanEvent(pressed, scanCode, keySym, Helpers.InvernessOrGreater(this.SourceVM.Connection));
+                this.vncStream.keyScanEvent(pressed, scanCode, keySym, UseQemuExtKeyEncoding);
             });
         }
 

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -1117,6 +1117,7 @@ namespace XenAdmin.ConsoleView
                     v.SendScanCodes = UseSource && !this.sourceIsPV;
                     v.SourceVM = sourceVM;
                     v.Console = console;
+                    v.UseQemuExtKeyEncoding = sourceVM != null && Helpers.InvernessOrGreater(sourceVM.Connection);
                     v.connect(stream, this.vncPassword);
                 }
             });


### PR DESCRIPTION
…sClient class

- This is needed because this class is shared with the VNCControl solution which doesn't have access to the Helpers class

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>