### PR TITLE
CA-147943: Scrollbar for list of hotfixes installed in a pool doesn't have scrollbar the first time it is expanded

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1733,7 +1733,7 @@ namespace XenAdmin.TabPages
 
             output.Sort(StringUtility.NaturalCompare);
 
-            return String.Join(",", output.ToArray());
+            return String.Join(", ", output.ToArray());
         }
 
         private string poolUpdateString(Predicate<Pool_update> predicate)
@@ -1748,7 +1748,7 @@ namespace XenAdmin.TabPages
 
             output.Sort(StringUtility.NaturalCompare);
 
-            return String.Join(",", output.ToArray());
+            return String.Join(", ", output.ToArray());
         }
 
         #endregion


### PR DESCRIPTION
General tab (Pool): In the list of updates, added a space after each comma
to let the control wrap the text into multiple lines. This way the text is
no longer cut, therefore no additional scrollbar is needed.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>