### PR TITLE
CP-22781: Change the Jenkinsfile and the dotnet-packages location in …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,7 @@ node("${params.BUILD_ON_NODE}") {
         returnStatus: true,
         script: """git ls-remote --heads ${BRANDING_REMOTE} | grep ${params.XC_BRANCH}"""
       )
-      String branchToCloneOnBranding = (branchExistsOnBranding == 0) ?  params.XC_BRANCH : 'master'
+      String branchToCloneOnBranding = (branchExistsOnBranding == 0) ?  params.XC_BRANCH : 'release/falcon/lcm'
 
       bat """git clone -b ${branchToCloneOnBranding} ${BRANDING_REMOTE} ${env.WORKSPACE}\\branding.git"""
 	  
@@ -147,7 +147,7 @@ node("${params.BUILD_ON_NODE}") {
           returnStatus: true,
           script: """git ls-remote --heads ${BRAND_REMOTE} | grep ${params.XC_BRANCH}"""
         )
-        String branchToClone = (branchExistsOnBrand == 0) ?  params.XC_BRANCH : 'master'
+        String branchToClone = (branchExistsOnBrand == 0) ?  params.XC_BRANCH : 'release/falcon/lcm'
 
         bat """
             git clone -b ${branchToClone} ${BRAND_REMOTE} ${env.WORKSPACE}\\xenadmin-branding.git

--- a/packages/DOTNET_BUILD_LOCATION
+++ b/packages/DOTNET_BUILD_LOCATION
@@ -1,1 +1,1 @@
-xc-local-release/dotnet-packages/release/falcon/staging/1
+xc-local-release/dotnet-packages/release/falcon/lcm/1

--- a/packages/DOTNET_BUILD_LOCATION_CTXSIGN
+++ b/packages/DOTNET_BUILD_LOCATION_CTXSIGN
@@ -1,1 +1,1 @@
-xc-local-release/dotnet-packages-ctxsign/release/falcon/staging/1
+xc-local-release/dotnet-packages-ctxsign/release/falcon/lcm/1


### PR DESCRIPTION
…the lcm branch

- Change the Jenkinsfile in the lcm branch to fallback to the release/falcon/lcm branch instead of master
- Change the dotnet-packages location in xenadmin (lcm branch) to point to a build from the release/falcon/lcm branch

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>