### PR TITLE
CA-220169 - Network heartbeat status initially shows 'Error' after en…

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -16404,6 +16404,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Initializing....
+        /// </summary>
+        public static string HA_HEARTBEAT_SERVERS_INITIALISING {
+            get {
+                return ResourceManager.GetString("HA_HEARTBEAT_SERVERS_INITIALISING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HA Heartbeat SR.
         /// </summary>
         public static string HA_HEARTBEAT_SR {
@@ -23322,6 +23331,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Asianux.
+        /// </summary>
+        public static string NEW_VM_WIZARD_TEMPLATEPAGE_ASIANUX {
+            get {
+                return ResourceManager.GetString("NEW_VM_WIZARD_TEMPLATEPAGE_ASIANUX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to NeoKylin.
         /// </summary>
         public static string NEW_VM_WIZARD_TEMPLATEPAGE_NEOKYLIN {
@@ -23329,35 +23347,15 @@ namespace XenAdmin {
                 return ResourceManager.GetString("NEW_VM_WIZARD_TEMPLATEPAGE_NEOKYLIN", resourceCulture);
             }
         }
-
-         /// <summary>
-        ///   Looks up a localized string similar to Asianux.
-        /// </summary>
-
-        public static string NEW_VM_WIZARD_TEMPLATEPAGE_ASIANUX {
-            get {
-                return ResourceManager.GetString("NEW_VM_WIZARD_TEMPLATEPAGE_ASIANUX", resourceCulture);
-            }
-        }        
-                
-        /// <summary>
-        ///   Looks up a localized string similar to YinheKylin.
-        /// </summary>
-        public static string NEW_VM_WIZARD_TEMPLATEPAGE_YINHEKYLIN {
-            get {
-                return ResourceManager.GetString("NEW_VM_WIZARD_TEMPLATEPAGE_YINHEKYLIN", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to Turbo.
         /// </summary>
-        
         public static string NEW_VM_WIZARD_TEMPLATEPAGE_TURBO {
             get {
                 return ResourceManager.GetString("NEW_VM_WIZARD_TEMPLATEPAGE_TURBO", resourceCulture);
             }
-        }        
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Ubuntu.
@@ -23365,6 +23363,15 @@ namespace XenAdmin {
         public static string NEW_VM_WIZARD_TEMPLATEPAGE_UBUNTU {
             get {
                 return ResourceManager.GetString("NEW_VM_WIZARD_TEMPLATEPAGE_UBUNTU", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to YinheKylin.
+        /// </summary>
+        public static string NEW_VM_WIZARD_TEMPLATEPAGE_YINHEKYLIN {
+            get {
+                return ResourceManager.GetString("NEW_VM_WIZARD_TEMPLATEPAGE_YINHEKYLIN", resourceCulture);
             }
         }
         
@@ -25013,6 +25020,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Linx.
+        /// </summary>
+        public static string NEWVMWIZARD_TEMPLATEPAGE_LINX {
+            get {
+                return ResourceManager.GetString("NEWVMWIZARD_TEMPLATEPAGE_LINX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Misc.
         /// </summary>
         public static string NEWVMWIZARD_TEMPLATEPAGE_MISC {
@@ -25054,15 +25070,6 @@ namespace XenAdmin {
         public static string NEWVMWIZARD_TEMPLATEPAGE_REDHAT {
             get {
                 return ResourceManager.GetString("NEWVMWIZARD_TEMPLATEPAGE_REDHAT", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Linx.
-        /// </summary>
-        public static string NEWVMWIZARD_TEMPLATEPAGE_LINX {
-            get {
-                return ResourceManager.GetString("NEWVMWIZARD_TEMPLATEPAGE_LINX", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5760,6 +5760,9 @@ not currently live:
   <data name="HA_HEARTBEAT_SERVERS" xml:space="preserve">
     <value>{0} out of {1} servers</value>
   </data>
+  <data name="HA_HEARTBEAT_SERVERS_INITIALISING" xml:space="preserve">
+    <value>Initialising...</value>
+  </data>
   <data name="HA_HEARTBEAT_SR" xml:space="preserve">
     <value>HA Heartbeat SR</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5761,7 +5761,7 @@ not currently live:
     <value>{0} out of {1} servers</value>
   </data>
   <data name="HA_HEARTBEAT_SERVERS_INITIALISING" xml:space="preserve">
-    <value>Initialising...</value>
+    <value>Initializing...</value>
   </data>
   <data name="HA_HEARTBEAT_SR" xml:space="preserve">
     <value>HA Heartbeat SR</value>


### PR DESCRIPTION
…abling HA

Network HB initially shown as error because it takes time for the status to be
read from xha by xapi. This adds a delay to allow the status to be updated
before XC displays it.