### PR TITLE
CA-249858: XenCenter gives different messages for migrate VM at diffe…

### DIFF
--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -200,13 +200,13 @@ namespace XenAdmin.Commands
                 if (host != null)
                 {
                     VMOperationCommand cmd = new VMOperationHostCommand(Command.MainWindowCommandInterface, selection, delegate { return host; }, host.Name.EscapeAmpersands(), _operation, session);
-                    VMOperationCommand cpmCmd = new CrossPoolMigrateCommand(Command.MainWindowCommandInterface, selection, host, _resumeAfter);
+                    CrossPoolMigrateCommand cpmCmd = new CrossPoolMigrateCommand(Command.MainWindowCommandInterface, selection, host, _resumeAfter);
 
                     VMOperationToolStripMenuSubItem tempItem = item;
                     Program.Invoke(Program.MainWindow, delegate
                                                            {
                                                                bool oldMigrateCmdCanRun = cmd.CanExecute();
-                                                               if (_operation == vm_operations.start_on || !oldMigrateCmdCanRun && !cpmCmd.CanExecute())
+                                                               if (_operation == vm_operations.start_on || (!oldMigrateCmdCanRun && !cpmCmd.CanExecute() && string.IsNullOrEmpty(cpmCmd.CantExecuteReason)))
                                                                    tempItem.Command = cmd;
                                                                else
                                                                    tempItem.Command = oldMigrateCmdCanRun ? cmd : cpmCmd;

--- a/XenAdmin/Commands/CrossPoolMigrateCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMigrateCommand.cs
@@ -71,7 +71,7 @@ namespace XenAdmin.Commands
                 var cantExecuteReason = CantExecuteReason;
                 return string.IsNullOrEmpty(cantExecuteReason)
                     ? preSelectedHost.Name.EscapeAmpersands()
-                    : string.Format(Messages.MAINWINDOW_CONTEXT_REASON, preSelectedHost.Name.EscapeAmpersands(), cantExecuteReason.TrimEnd('\n', '\r'));
+                    : string.Format(Messages.MAINWINDOW_CONTEXT_REASON, preSelectedHost.Name.EscapeAmpersands(), cantExecuteReason);
             }
         }
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -107,7 +107,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                         catch (Failure failure)
                         {
                             if (failure.ErrorDescription.Count > 0 && failure.ErrorDescription[0] == Failure.RBAC_PERMISSION_DENIED)
-                                disableReason = failure.Message.Split('\n')[0]; // we want the first line only
+                                disableReason = failure.Message.Split('\n')[0].TrimEnd('\r'); // we want the first line only
                             else
                                 disableReason = failure.Message;
 


### PR DESCRIPTION
…rent screens when pool connected with vm-operator user

Expose the reasons why a cross pool migration command cannot execute.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>