### PR TITLE
CP-22471: Add information on XenCenter help usage to the user settings

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -2553,6 +2553,9 @@ namespace XenAdmin
                     System.Windows.Forms.Help.ShowHelp(helpForm, chm, HelpNavigator.TopicId, topicID);
                 }
             }
+            // record help usage
+            Properties.Settings.Default.HelpLastUsed = DateTime.UtcNow.ToString("u");
+            Settings.TrySaveSettings();
         }
 
         public void MainWindow_HelpRequested(object sender, HelpEventArgs hlpevent)

--- a/XenAdmin/Properties/Settings.Designer.cs
+++ b/XenAdmin/Properties/Settings.Designer.cs
@@ -799,5 +799,18 @@ namespace XenAdmin.Properties {
                 this["DoNotConfirmDismissUpdates"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public string HelpLastUsed {
+            get {
+                return ((string)(this["HelpLastUsed"]));
+            }
+            set {
+                this["HelpLastUsed"] = value;
+            }
+        }
     }
 }

--- a/XenAdmin/Properties/Settings.settings
+++ b/XenAdmin/Properties/Settings.settings
@@ -185,5 +185,8 @@
     <Setting Name="DoNotConfirmDismissUpdates" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="HelpLastUsed" Roaming="true" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -180,6 +180,9 @@
             <setting name="DoNotConfirmDismissUpdates" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="HelpLastUsed" serializeAs="String">
+                <value />
+            </setting>
         </XenAdmin.Properties.Settings>
     </userSettings>
 


### PR DESCRIPTION
Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>