### PR TITLE
CP-22787: Backport CA-249084 from master

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -829,7 +829,7 @@ namespace XenAdmin
 
             log.InfoFormat("Connected to {0} (version {1}, build {2}.{3}) with {4} {5} (build {6}.{7})",
                 Helpers.GetName(master), Helpers.HostProductVersionText(master), Helpers.HostProductVersion(master),
-                Helpers.HostBuildNumber(master), Messages.XENCENTER, Branding.PRODUCT_VERSION_TEXT,
+                master.BuildNumberRaw, Messages.XENCENTER, Branding.PRODUCT_VERSION_TEXT,
                 Branding.XENCENTER_VERSION, Program.Version.Revision);
 
             // Check the PRODUCT_BRAND

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1071,7 +1071,7 @@ namespace XenAdmin.TabPages
             bool isXCP = host.IsXCP;
             if (host.software_version.ContainsKey("date"))
                 pdSectionVersion.AddEntry(isXCP ? Messages.SOFTWARE_VERSION_XCP_DATE : Messages.SOFTWARE_VERSION_DATE, host.software_version["date"]);
-            if (!Helpers.FalconOrGreater(host) && host.software_version.ContainsKey("build_number"))
+            if (!Helpers.ElyOrGreater(host) && host.software_version.ContainsKey("build_number"))
                 pdSectionVersion.AddEntry(isXCP ? Messages.SOFTWARE_VERSION_XCP_BUILD_NUMBER : Messages.SOFTWARE_VERSION_BUILD_NUMBER, host.software_version["build_number"]);
             if (isXCP && host.software_version.ContainsKey("platform_version"))
                 pdSectionVersion.AddEntry(Messages.SOFTWARE_VERSION_XCP_PLATFORM_VERSION, host.software_version["platform_version"]);

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1071,7 +1071,7 @@ namespace XenAdmin.TabPages
             bool isXCP = host.IsXCP;
             if (host.software_version.ContainsKey("date"))
                 pdSectionVersion.AddEntry(isXCP ? Messages.SOFTWARE_VERSION_XCP_DATE : Messages.SOFTWARE_VERSION_DATE, host.software_version["date"]);
-            if (host.software_version.ContainsKey("build_number"))
+            if (!Helpers.FalconOrGreater(host) && host.software_version.ContainsKey("build_number"))
                 pdSectionVersion.AddEntry(isXCP ? Messages.SOFTWARE_VERSION_XCP_BUILD_NUMBER : Messages.SOFTWARE_VERSION_BUILD_NUMBER, host.software_version["build_number"]);
             if (isXCP && host.software_version.ContainsKey("platform_version"))
                 pdSectionVersion.AddEntry(Messages.SOFTWARE_VERSION_XCP_PLATFORM_VERSION, host.software_version["platform_version"]);

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardStoragePage.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardStoragePage.cs
@@ -322,8 +322,7 @@ namespace XenAdmin.Wizards.DRWizards
 
             Host master = Helpers.GetMaster(Connection);
 
-            if (master != null && (Helpers.HostBuildNumber(master) >= 9633
-                                || Helpers.HostBuildNumber(master) == Helpers.CUSTOM_BUILD_NUMBER))
+            if (master != null)
             {
                 dconf[SrProbeAction.SCSIid] = device.SCSIid;
             }

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardStoragePage.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardStoragePage.cs
@@ -318,14 +318,8 @@ namespace XenAdmin.Wizards.DRWizards
             if (device == null)
                 return null;
 
-            Dictionary<String, String> dconf = new Dictionary<String, String>();
-
-            Host master = Helpers.GetMaster(Connection);
-
-            if (master != null)
-            {
-                dconf[SrProbeAction.SCSIid] = device.SCSIid;
-            }
+            var dconf = new Dictionary<string, string>();
+            dconf[SrProbeAction.SCSIid] = device.SCSIid;
 
             return dconf;
         }

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardStoragePage.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardStoragePage.cs
@@ -326,10 +326,6 @@ namespace XenAdmin.Wizards.DRWizards
             {
                 dconf[SrProbeAction.SCSIid] = device.SCSIid;
             }
-            else
-            {
-                dconf[SrProbeAction.DEVICE] = device.Path;
-            }
 
             return dconf;
         }

--- a/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
@@ -57,15 +57,8 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
     {
         public LvmOhbaSrDescriptor(FibreChannelDevice device, IXenConnection connection)
         {
-            Host master = Helpers.GetMaster(connection);
             Device = device;
-
-            // CA-19025: Change XenCenter SR.create for LVMoHBA to use the
-            // updated SCSIid parameter rather than the device path
-            if (master != null)
-            {
-                DeviceConfig[SrProbeAction.SCSIid] = device.SCSIid;
-            }
+            DeviceConfig[SrProbeAction.SCSIid] = device.SCSIid;
 
             Description = string.Format(Messages.NEWSR_LVMOHBA_DESCRIPTION, device.Vendor, device.Serial);
         }

--- a/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
@@ -62,8 +62,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
 
             // CA-19025: Change XenCenter SR.create for LVMoHBA to use the
             // updated SCSIid parameter rather than the device path
-            if (master != null && (Helpers.HostBuildNumber(master) >= 9633
-                                   || Helpers.HostBuildNumber(master) == Helpers.CUSTOM_BUILD_NUMBER))
+            if (master != null)
             {
                 DeviceConfig[SrProbeAction.SCSIid] = device.SCSIid;
             }

--- a/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/SrWizardType.cs
@@ -66,10 +66,6 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
             {
                 DeviceConfig[SrProbeAction.SCSIid] = device.SCSIid;
             }
-            else
-            {
-                DeviceConfig[SrProbeAction.DEVICE] = device.Path;
-            }
 
             Description = string.Format(Messages.NEWSR_LVMOHBA_DESCRIPTION, device.Vendor, device.Serial);
         }

--- a/XenModel/PoolJoinRules.cs
+++ b/XenModel/PoolJoinRules.cs
@@ -377,7 +377,7 @@ namespace XenAdmin.Core
             // mimic the test on the server side (xen-api.hg:ocaml/xapi/xapi_pool.ml).
             return
                 slave.hg_id != master.hg_id ||
-                !Helpers.FalconOrGreater(master) && slave.BuildNumber != master.BuildNumber ||
+                !Helpers.ElyOrGreater(master) && slave.BuildNumber != master.BuildNumber ||
                 slave.ProductVersion != master.ProductVersion ||
                 slave.ProductBrand != master.ProductBrand;
         }

--- a/XenModel/PoolJoinRules.cs
+++ b/XenModel/PoolJoinRules.cs
@@ -377,7 +377,7 @@ namespace XenAdmin.Core
             // mimic the test on the server side (xen-api.hg:ocaml/xapi/xapi_pool.ml).
             return
                 slave.hg_id != master.hg_id ||
-                slave.BuildNumberRaw != master.BuildNumberRaw ||
+                !Helpers.FalconOrGreater(master) && slave.BuildNumber != master.BuildNumber ||
                 slave.ProductVersion != master.ProductVersion ||
                 slave.ProductBrand != master.ProductBrand;
         }

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -59,8 +59,6 @@ namespace XenAdmin.Core
         
         public const string GuiTempObjectPrefix = "__gui__";
 
-        public const int CUSTOM_BUILD_NUMBER = 6666;
-
         public static NumberFormatInfo _nfi = new CultureInfo("en-US", false).NumberFormat;
 
         public static readonly Regex SessionRefRegex = new Regex(@"OpaqueRef:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -77,25 +77,6 @@ namespace XenAdmin.Core
         }
 
         /// <summary>
-        /// Return the build number of the given host, or the build number of the master if the
-        /// given host does not have a build number, or -1 if we can't find one.  This will often be
-        /// 0 or -1 for developer builds, so comparisons should generally treat those numbers as if
-        /// they were brand new.
-        /// </summary>
-        public static int HostBuildNumber(Host host)
-        {
-            if (host.BuildNumber <= 0)
-            {
-                Host master = GetMaster(host.Connection);
-                return master == null ? -1 : master.BuildNumber;
-            }
-            else
-            {
-                return host.BuildNumber;
-            }
-        }
-
-        /// <summary>
         /// Return the given host's product version, or the pool master's product version if
         /// the host does not have one, or null if none can be found.
         /// </summary>
@@ -347,8 +328,7 @@ namespace XenAdmin.Core
             
             string platform_version = Helpers.HostPlatformVersion(host);
             return
-                platform_version != null && Helpers.productVersionCompare(platform_version, "1.5.50") >= 0 ||
-                Helpers.HostBuildNumber(host) == CUSTOM_BUILD_NUMBER;
+                platform_version != null && Helpers.productVersionCompare(platform_version, "1.5.50") >= 0;
         }
 
         public static bool SanibelOrGreater(IXenConnection conn)
@@ -360,8 +340,7 @@ namespace XenAdmin.Core
         {
             return
                 TampaOrGreater(host) ||  // CP-2480
-                Helpers.productVersionCompare(Helpers.HostProductVersion(host), "6.0.1") >= 0 ||
-                Helpers.HostBuildNumber(host) == CUSTOM_BUILD_NUMBER;
+                Helpers.productVersionCompare(Helpers.HostProductVersion(host), "6.0.1") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -379,8 +358,7 @@ namespace XenAdmin.Core
 
             string platform_version = HostPlatformVersion(host);
             return
-                platform_version != null && productVersionCompare(platform_version, "1.8.90") >= 0 ||
-                HostBuildNumber(host) == CUSTOM_BUILD_NUMBER;
+                platform_version != null && productVersionCompare(platform_version, "1.8.90") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -398,8 +376,7 @@ namespace XenAdmin.Core
 
             string platform_version = HostPlatformVersion(host);
             return
-                platform_version != null && productVersionCompare(platform_version, "2.0.0") >= 0 ||
-                HostBuildNumber(host) == CUSTOM_BUILD_NUMBER;
+                platform_version != null && productVersionCompare(platform_version, "2.0.0") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -417,8 +394,7 @@ namespace XenAdmin.Core
 
             string platform_version = HostPlatformVersion(host);
             return
-                platform_version != null && productVersionCompare(platform_version, "2.1.1") >= 0 ||
-                HostBuildNumber(host) == CUSTOM_BUILD_NUMBER;
+                platform_version != null && productVersionCompare(platform_version, "2.1.1") >= 0;
         }
 
         /// <summary>
@@ -462,8 +438,7 @@ namespace XenAdmin.Core
 
             string platform_version = HostPlatformVersion(host);
             return
-                platform_version != null && productVersionCompare(platform_version, "1.6.900") >= 0 ||
-                HostBuildNumber(host) == CUSTOM_BUILD_NUMBER;
+                platform_version != null && productVersionCompare(platform_version, "1.6.900") >= 0;
         }
 
         /// <summary>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -716,7 +716,7 @@ namespace XenAPI
         {
             get
             {
-                Debug.Assert(!Helpers.FalconOrGreater(this));
+                Debug.Assert(!Helpers.ElyOrGreater(this));
 
                 string bn = BuildNumberRaw;
                 if (bn == null)
@@ -752,7 +752,7 @@ namespace XenAPI
             get
             {
                 string productVersion = ProductVersion;
-                return productVersion != null ? string.Format("{0}.{1}", productVersion, Helpers.FalconOrGreater(this) ? BuildNumberRaw : BuildNumber.ToString()) : null;
+                return productVersion != null ? string.Format("{0}.{1}", productVersion, Helpers.ElyOrGreater(this) ? BuildNumberRaw : BuildNumber.ToString()) : null;
             }
         }
 

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -703,11 +703,15 @@ namespace XenAPI
         }
 
         /// <summary>
+        /// For legacy build numbers only (used to be integers + one char at the end)
+        /// From Falcon, this property is not used.
+        /// </summary>
+        /// <remarks>
         /// Return the build number of this host, or -1 if none can be found.  This will often be
         /// 0 or -1 for developer builds, so comparisons should generally treat those numbers as if
         /// they were brand new.
-        /// </summary>
-        public int BuildNumber
+        /// </remarks>
+        internal int BuildNumber
         {
             get
             {
@@ -727,8 +731,11 @@ namespace XenAPI
         }
 
         /// <summary>
-        /// Return the build number of this host, without stripping off the final letter etc.; or null if none can be found.
+        /// Return the exact build_number of this host
         /// </summary>
+        /// <remarks>
+        /// null if not found
+        /// </remarks>
         public virtual string BuildNumberRaw
         {
             get { return Get(software_version, "build_number"); }
@@ -742,7 +749,7 @@ namespace XenAPI
             get
             {
                 string productVersion = ProductVersion;
-                return productVersion != null ? string.Format("{0}.{1}", productVersion, BuildNumber) : null;
+                return productVersion != null ? string.Format("{0}.{1}", productVersion, Helpers.FalconOrGreater(this) ? BuildNumberRaw : BuildNumber.ToString()) : null;
             }
         }
 

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -38,6 +38,7 @@ using Citrix.XenCenter;
 using XenAdmin;
 using XenAdmin.Core;
 using XenAdmin.Network;
+using System.Diagnostics;
 
 
 namespace XenAPI
@@ -715,6 +716,8 @@ namespace XenAPI
         {
             get
             {
+                Debug.Assert(!Helpers.FalconOrGreater(this));
+
                 string bn = BuildNumberRaw;
                 if (bn == null)
                     return -1;


### PR DESCRIPTION
Neither FalconOrGreater nor HonoluluOrGreater has been implemented in Honolulu. We can't implement the latter as the platform_version is not expected to change between Ely and Honolulu. To be able to backport the changes in CA-249084 (PR #1536), the consensus reached was to use ElyOrGreater instead. This way, from Ely, the PoolJoinRules will be less strict (fail later) and the build number will be hidden, although this seems to be the minimal impact and most straightforward solution. This PR implements these.