### PR TITLE
CA-249858: Fix build warning as error

### DIFF
--- a/XenAdmin/Commands/CrossPoolCopyVMCommand.cs
+++ b/XenAdmin/Commands/CrossPoolCopyVMCommand.cs
@@ -73,7 +73,7 @@ namespace XenAdmin.Commands
             return CanExecute(vm, preSelectedHost);
         }
 
-        public new static bool CanExecute(VM vm, Host preSelectedHost)
+        public static bool CanExecute(VM vm, Host preSelectedHost)
         {
             if (vm == null || vm.is_a_template || vm.Locked || vm.power_state != vm_power_state.Halted)
                 return false;

--- a/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
+++ b/XenAdmin/Commands/CrossPoolMoveVMCommand.cs
@@ -74,7 +74,7 @@ namespace XenAdmin.Commands
             return CanExecute(vm, preSelectedHost);
         }
 
-        public new static bool CanExecute(VM vm, Host preSelectedHost)
+        public static bool CanExecute(VM vm, Host preSelectedHost)
         {
             if (vm == null || vm.is_a_template || vm.Locked || vm.power_state == vm_power_state.Running)
                 return false;


### PR DESCRIPTION
(The member 'CanExecute()' does not hide an inherited member. The new keyword is not required)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>