### PR TITLE
CA-224724: VBD edit page: show 'position in use' message on the dropdown items

### DIFF
--- a/XenAdmin/SettingsPanels/VBDEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/VBDEditPage.Designer.cs
@@ -33,7 +33,6 @@ namespace XenAdmin.SettingsPanels
             this.deviceLabel = new System.Windows.Forms.Label();
             this.devicePositionComboBox = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
-            this.labelDevicePositionMsg = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label2 = new System.Windows.Forms.Label();
             this.toolTipContainer1 = new XenAdmin.Controls.ToolTipContainer();
@@ -65,20 +64,11 @@ namespace XenAdmin.SettingsPanels
             this.devicePositionComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.devicePositionComboBox.FormattingEnabled = true;
             this.devicePositionComboBox.Name = "devicePositionComboBox";
-            this.devicePositionComboBox.SelectedIndexChanged += new System.EventHandler(this.comboBoxDevicePosition_SelectedIndexChanged);
             // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
             this.label1.Name = "label1";
-            // 
-            // labelDevicePositionMsg
-            // 
-            resources.ApplyResources(this.labelDevicePositionMsg, "labelDevicePositionMsg");
-            this.labelDevicePositionMsg.AutoEllipsis = true;
-            this.labelDevicePositionMsg.ForeColor = System.Drawing.SystemColors.Highlight;
-            this.labelDevicePositionMsg.MaximumSize = new System.Drawing.Size(320, 32000);
-            this.labelDevicePositionMsg.Name = "labelDevicePositionMsg";
             // 
             // tableLayoutPanel1
             // 
@@ -143,7 +133,6 @@ namespace XenAdmin.SettingsPanels
             this.Controls.Add(this.toolTipContainer1);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.PriorityToolTipContainer);
-            this.Controls.Add(this.labelDevicePositionMsg);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.devicePositionComboBox);
             this.Controls.Add(this.deviceLabel);
@@ -168,7 +157,6 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.ComboBox modeComboBox;
         private System.Windows.Forms.ComboBox devicePositionComboBox;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label labelDevicePositionMsg;
         private System.Windows.Forms.Label lblLowest;
         private System.Windows.Forms.Label lblHighest;
         private XenAdmin.Controls.TransparentTrackBar diskAccessPriorityTrackBar;

--- a/XenAdmin/SettingsPanels/VBDEditPage.cs
+++ b/XenAdmin/SettingsPanels/VBDEditPage.cs
@@ -391,7 +391,7 @@ namespace XenAdmin.SettingsPanels
                     return position;
 
                 if (vdi != null)
-                    return string.Format(Messages.VBD_EDIT_CURRENTLY_IN_USE_BY, position, vdi.ToString());
+                    return string.Format(Messages.VBD_EDIT_CURRENTLY_IN_USE_BY, position, vdi.ToString().Ellipsise(30));
 
                 return string.Format(Messages.VBD_EDIT_CURRENTLY_IN_USE, position);
             }

--- a/XenAdmin/SettingsPanels/VBDEditPage.cs
+++ b/XenAdmin/SettingsPanels/VBDEditPage.cs
@@ -42,6 +42,7 @@ using XenAdmin.Core;
 using XenAdmin.Network;
 using XenAPI;
 using XenAdmin.Dialogs;
+using System.Linq;
 
 
 namespace XenAdmin.SettingsPanels
@@ -149,16 +150,30 @@ namespace XenAdmin.SettingsPanels
                 {
                     devicePositionComboBox.Items.Clear();
 
-                    devicePositionComboBox.Items.AddRange(devices.ToArray());
+                    var comboBoxItems = vm.Connection.ResolveAll(vm.VBDs).Select(d => new DevicePositionComboBoxItem(d.userdevice, d));
+
+                    foreach (var devicePosition in devices)
+                    {
+                        var comboBoxItemWithVdi = comboBoxItems.FirstOrDefault(ci => ci.VBD.userdevice == devicePosition);
+                        if (comboBoxItemWithVdi != null)
+                        {
+                            devicePositionComboBox.Items.Add(comboBoxItemWithVdi);
+                        }
+                        else
+                        {
+                            devicePositionComboBox.Items.Add(new DevicePositionComboBoxItem(devicePosition));
+                        }
+                    }
 
                     // Make sure the userdevice for the selected VBD is the one selected in the combobox
-                    foreach (String position in devicePositionComboBox.Items)
+                    foreach (DevicePositionComboBoxItem item in devicePositionComboBox.Items)
                     {
-                        if (position != vbd.userdevice)
-                            continue;
+                        if (item.VBD != null && item.VBD.userdevice == vbd.userdevice)
+                        {
+                            devicePositionComboBox.SelectedItem = item;
 
-                        devicePositionComboBox.SelectedItem = position;
-                        break;
+                            break;
+                        }
                     }
                 }
                 finally
@@ -212,28 +227,6 @@ namespace XenAdmin.SettingsPanels
             }
         }
 
-        private void comboBoxDevicePosition_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (DevicePosition == vbd.userdevice)
-            {
-                labelDevicePositionMsg.Visible = false;
-                return;
-            }
-
-            foreach (VBD otherVBD in vm.Connection.ResolveAll(vm.VBDs))
-            {
-                if (otherVBD.userdevice != DevicePosition)
-                    continue;
-
-                labelDevicePositionMsg.Text = string.Format(Messages.DEVICE_POSITION_IN_USE);
-                labelDevicePositionMsg.Visible = true;
-                return;
-            }
-
-            // No conflict found.
-            labelDevicePositionMsg.Visible = false;
-        }
-
         public bool HasChanged
         {
             get
@@ -258,7 +251,7 @@ namespace XenAdmin.SettingsPanels
             get
             {
                 if (devicePositionComboBox.SelectedItem != null)
-                    return devicePositionComboBox.SelectedItem.ToString();
+                    return ((DevicePositionComboBoxItem)devicePositionComboBox.SelectedItem).Position;
 
                 return String.Empty;
             }
@@ -284,9 +277,9 @@ namespace XenAdmin.SettingsPanels
                         Messages.EDIT_SYS_DISK_WARNING_TITLE),
                     ThreeButtonDialog.ButtonYes,
                     ThreeButtonDialog.ButtonNo))
-                    {
-                        dialogResult = dlg.ShowDialog(this);
-                    }
+                {
+                    dialogResult = dlg.ShowDialog(this);
+                }
                 if (DialogResult.Yes != dialogResult)
                 {
                     return null;
@@ -303,7 +296,7 @@ namespace XenAdmin.SettingsPanels
             {
                 priorityToSet = diskAccessPriority;
             }
-                
+
 
             bool changeDevicePosition = false;
             VBD other = null;
@@ -351,7 +344,7 @@ namespace XenAdmin.SettingsPanels
                 )
                 )
             {
-                Program.Invoke(Program.MainWindow, () => 
+                Program.Invoke(Program.MainWindow, () =>
                 {
                     using (var dlg = new ThreeButtonDialog(
                                     new ThreeButtonDialog.Details(SystemIcons.Information, Messages.DEVICE_POSITION_RESTART_REQUIRED, Messages.XENCENTER)))
@@ -368,6 +361,39 @@ namespace XenAdmin.SettingsPanels
             {
                 return String.Format(Messages.DEVICE_POSITION, DevicePosition,
                     modeComboBox.SelectedItem);
+            }
+        }
+
+        public class DevicePositionComboBoxItem
+        {
+            private VBD vbd;
+            private string position;
+
+            public VBD VBD { get { return vbd; } }
+            public string Position { get { return position; } }
+
+            public DevicePositionComboBoxItem(string position, VBD vbd = null)
+            {
+                this.vbd = vbd;
+                this.position = position;
+            }
+
+            public override string ToString()
+            {
+                VDI vdi = null;
+
+                if (vbd != null && vbd.Connection != null)
+                {
+                    vdi = vbd.Connection.Resolve(vbd.VDI);
+                }
+
+                if (vbd == null)
+                    return position;
+
+                if (vdi != null)
+                    return string.Format(Messages.VBD_EDIT_CURRENTLY_IN_USE_BY, position, vdi.ToString());
+
+                return string.Format(Messages.VBD_EDIT_CURRENTLY_IN_USE, position);
             }
         }
     }

--- a/XenAdmin/SettingsPanels/VBDEditPage.cs
+++ b/XenAdmin/SettingsPanels/VBDEditPage.cs
@@ -158,21 +158,13 @@ namespace XenAdmin.SettingsPanels
                         if (comboBoxItemWithVdi != null)
                         {
                             devicePositionComboBox.Items.Add(comboBoxItemWithVdi);
+
+                            if (vbd != null && comboBoxItemWithVdi.VBD.userdevice == vbd.userdevice)
+                                devicePositionComboBox.SelectedItem = comboBoxItemWithVdi;
                         }
                         else
                         {
                             devicePositionComboBox.Items.Add(new DevicePositionComboBoxItem(devicePosition));
-                        }
-                    }
-
-                    // Make sure the userdevice for the selected VBD is the one selected in the combobox
-                    foreach (DevicePositionComboBoxItem item in devicePositionComboBox.Items)
-                    {
-                        if (item.VBD != null && item.VBD.userdevice == vbd.userdevice)
-                        {
-                            devicePositionComboBox.SelectedItem = item;
-
-                            break;
                         }
                     }
                 }

--- a/XenAdmin/SettingsPanels/VBDEditPage.resx
+++ b/XenAdmin/SettingsPanels/VBDEditPage.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="modeLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="modeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="modeLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>-3, 51</value>
   </data>
@@ -148,13 +148,13 @@
     <value>modeLabel</value>
   </data>
   <data name="&gt;&gt;modeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;modeLabel.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;modeLabel.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="deviceLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -184,13 +184,13 @@
     <value>deviceLabel</value>
   </data>
   <data name="&gt;&gt;deviceLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;deviceLabel.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;deviceLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="devicePositionComboBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -208,13 +208,13 @@
     <value>devicePositionComboBox</value>
   </data>
   <data name="&gt;&gt;devicePositionComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;devicePositionComboBox.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;devicePositionComboBox.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -241,48 +241,12 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="labelDevicePositionMsg.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="labelDevicePositionMsg.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8pt</value>
-  </data>
-  <data name="labelDevicePositionMsg.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelDevicePositionMsg.Location" type="System.Drawing.Point, System.Drawing">
-    <value>119, 108</value>
-  </data>
-  <data name="labelDevicePositionMsg.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 41</value>
-  </data>
-  <data name="labelDevicePositionMsg.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="labelDevicePositionMsg.Text" xml:space="preserve">
-    <value>The selected device position is currently in use by disk 'xyz'.</value>
-  </data>
-  <data name="labelDevicePositionMsg.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;labelDevicePositionMsg.Name" xml:space="preserve">
-    <value>labelDevicePositionMsg</value>
-  </data>
-  <data name="&gt;&gt;labelDevicePositionMsg.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelDevicePositionMsg.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;labelDevicePositionMsg.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -319,7 +283,7 @@
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -343,7 +307,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -373,7 +337,7 @@
     <value>modeComboBox</value>
   </data>
   <data name="&gt;&gt;modeComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;modeComboBox.Parent" xml:space="preserve">
     <value>toolTipContainer1</value>
@@ -457,7 +421,7 @@
     <value>lblHighest</value>
   </data>
   <data name="&gt;&gt;lblHighest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblHighest.Parent" xml:space="preserve">
     <value>DiskPriorityPanel</value>
@@ -490,7 +454,7 @@
     <value>lblLowest</value>
   </data>
   <data name="&gt;&gt;lblLowest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblLowest.Parent" xml:space="preserve">
     <value>DiskPriorityPanel</value>
@@ -514,7 +478,7 @@
     <value>DiskPriorityPanel</value>
   </data>
   <data name="&gt;&gt;DiskPriorityPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DiskPriorityPanel.Parent" xml:space="preserve">
     <value>PriorityToolTipContainer</value>
@@ -543,7 +507,7 @@
   <data name="&gt;&gt;PriorityToolTipContainer.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -559,6 +523,6 @@
     <value>VBDEditPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/XenAdmin/SettingsPanels/VBDEditPage.resx
+++ b/XenAdmin/SettingsPanels/VBDEditPage.resx
@@ -195,8 +195,14 @@
   <data name="devicePositionComboBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
+  <data name="devicePositionComboBox.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="devicePositionComboBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>122, 84</value>
+  </data>
+  <data name="devicePositionComboBox.MaxDropDownItems" type="System.Int32, mscorlib">
+    <value>15</value>
   </data>
   <data name="devicePositionComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>281, 21</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -10953,15 +10953,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The selected device position is currently in use..
-        /// </summary>
-        public static string DEVICE_POSITION_IN_USE {
-            get {
-                return ResourceManager.GetString("DEVICE_POSITION_IN_USE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to You will have to restart the VM for changes in device position to take effect..
         /// </summary>
         public static string DEVICE_POSITION_RESTART_REQUIRED {
@@ -34986,6 +34977,24 @@ namespace XenAdmin {
         public static string VBD_EDIT_CURRENTLY_ATTACHED {
             get {
                 return ResourceManager.GetString("VBD_EDIT_CURRENTLY_ATTACHED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} - currently in use.
+        /// </summary>
+        public static string VBD_EDIT_CURRENTLY_IN_USE {
+            get {
+                return ResourceManager.GetString("VBD_EDIT_CURRENTLY_IN_USE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} - currently in use by &apos;{1}&apos;.
+        /// </summary>
+        public static string VBD_EDIT_CURRENTLY_IN_USE_BY {
+            get {
+                return ResourceManager.GetString("VBD_EDIT_CURRENTLY_IN_USE_BY", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3913,9 +3913,6 @@ This will also delete its subfolders.</value>
   <data name="DEVICE_POSITION_CONFLICT" xml:space="preserve">
     <value>Position {0} is already in use. Your VM will not boot with two disks in the same position. Do you want to swap the disk at '{0}' with this disk?</value>
   </data>
-  <data name="DEVICE_POSITION_IN_USE" xml:space="preserve">
-    <value>The selected device position is currently in use.</value>
-  </data>
   <data name="DEVICE_POSITION_RESTART_REQUIRED" xml:space="preserve">
     <value>You will have to restart the VM for changes in device position to take effect.</value>
   </data>
@@ -12125,6 +12122,12 @@ To learn more about the [XenServer] Dynamic Workload Balancing feature or to sta
   </data>
   <data name="VBD_EDIT_CURRENTLY_ATTACHED" xml:space="preserve">
     <value>The disk is attached to a VM that is not in halted state.</value>
+  </data>
+  <data name="VBD_EDIT_CURRENTLY_IN_USE" xml:space="preserve">
+    <value>{0} - currently in use</value>
+  </data>
+  <data name="VBD_EDIT_CURRENTLY_IN_USE_BY" xml:space="preserve">
+    <value>{0} - currently in use by '{1}'</value>
   </data>
   <data name="VCPU_ONLY_WHEN_HALTED" xml:space="preserve">
     <value>The VCPUs can only be changed when the VM is shut down.</value>


### PR DESCRIPTION
This commit changes the dropdown control to not only show the available
positions, but also mark the ones that are already being used.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>