### PR TITLE
CA-254479,CA-223802,XSO-672: distinct the VM IP addresses which are r…

### DIFF
--- a/XenAdmin/Actions/GUIActions/ExportResourceReportAction.cs
+++ b/XenAdmin/Actions/GUIActions/ExportResourceReportAction.cs
@@ -803,6 +803,7 @@ namespace XenAdmin.Actions
                         }
                     }
                 }
+                addresses = new ComparableList<ComparableAddress>(addresses.Distinct());
                 if (MacInfo.Length == 0)
                     MacInfo = Messages.HYPHEN;
 

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -366,7 +366,7 @@ namespace XenAdmin.ConsoleView
                     PIF pif = Helpers.FindPIF(network, host);
                     foreach (var networkInfo in networks.Where(n => n.Key.StartsWith(String.Format("{0}/ip", vif.device))))
                     {
-                        if (networkInfo.Key.EndsWith("ip")) // IPv4 address
+                        if (networkInfo.Key.EndsWith("ip") || networkInfo.Key.Contains("ipv4")) // IPv4 address
                         {
                             if (pif == null)
                                 ipAddressesForNetworksWithoutPifs.Add(networkInfo.Value);
@@ -387,6 +387,7 @@ namespace XenAdmin.ConsoleView
                         }
                     }
                 }
+                ipAddresses = ipAddresses.Distinct().ToList();
 
                 ipAddresses.AddRange(ipv6Addresses); // make sure IPv4 addresses are scanned first (CA-102755)
                 // add IP addresses for networks without PIFs

--- a/XenModel/XenAPI-Extensions/VIF.cs
+++ b/XenModel/XenAPI-Extensions/VIF.cs
@@ -63,13 +63,15 @@ namespace XenAPI
                     if (vmGuestMetrics != null)
                     {
                         // PR-1373 - VM_guest_metrics.networks is a dictionary of IP addresses in the format:
-                        // [["0/ip", <IPv4 address>], ["0/ipv6/0", <IPv6 address>], ["0/ipv6/1", <IPv6 address>]]
+                        // [["0/ip", <IPv4 address>], 
+                        //  ["0/ipv4/0", <IPv4 address>], ["0/ipv4/1", <IPv4 address>],
+                        //  ["0/ipv6/0", <IPv6 address>], ["0/ipv6/1", <IPv6 address>]]
 
                         return
                             (from network in vmGuestMetrics.networks
                              where network.Key.StartsWith(string.Format("{0}/ip", this.device))
                              orderby network.Key
-                             select network.Value).ToList();
+                             select network.Value).Distinct().ToList();
                     }
                 }
 

--- a/XenModel/XenSearch/Common.cs
+++ b/XenModel/XenSearch/Common.cs
@@ -1123,7 +1123,9 @@ namespace XenAdmin.XenSearch
                 foreach (VIF vif in vifs)
                 {
                     // PR-1373 - VM_guest_metrics.networks is a dictionary of IP addresses in the format:
-                    // [["0/ip", <IPv4 address>], ["0/ipv6/0", <IPv6 address>], ["0/ipv6/1", <IPv6 address>]]
+                    // [["0/ip", <IPv4 address>], 
+                    //  ["0/ipv4/0", <IPv4 address>], ["0/ipv4/1", <IPv4 address>],
+                    //  ["0/ipv6/0", <IPv6 address>], ["0/ipv6/1", <IPv6 address>]]
                     foreach (var network in metrics.networks.Where(n => n.Key.StartsWith(String.Format("{0}/ip", vif.device))))
                     {
                         ComparableAddress ipAddress;
@@ -1133,6 +1135,7 @@ namespace XenAdmin.XenSearch
                         addresses.Add(ipAddress);
                     }
                 }
+                addresses =new ComparableList<ComparableAddress>(addresses.Distinct());
             }
             else if (o is Host)
             {


### PR DESCRIPTION
…etrieved from XAPI.

This change is to make the XenCenter de-duplicate the IPv4 addresses reported from XAPI. 
This is becasue that XAPI has been changed to used new xenstore protocol described in http://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=docs/misc/xenstore-paths.markdown;hb=HEAD#l491

For the sake of compatibility, XAPI will report one IPv4 address in both formats to XenCenter:
old: 0/ip -> [ip address]
new: 0/ipv4/0 -> [ip address]

This would cause duplicated IP address displayed in XenCenter. This PR aims to check-in the change to fix this issue.
