### PR TITLE
CP-21161: Do not call the disk-space plugin cleanup functions on Ely …

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -292,7 +292,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             canUpload = true;
             diskSpaceRequirements = null;
             var diskSpaceActions = new List<AsyncAction>();
-            foreach (Host master in SelectedMasters.Where(master => Helpers.CreamOrGreater(master.Connection)))
+            foreach (Host master in SelectedMasters.Where(master => Helpers.CreamOrGreater(master.Connection) && !Helpers.ElyOrGreater(master.Connection)))
             {
                 AsyncAction action = null;
                 switch (SelectedUpdateType)


### PR DESCRIPTION
…and above hosts

- Ensure that the disk-space plugin functions are not called on Ely or greater hosts, except for the 'get_avail_host_disk_space' function, which is still needed

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>