### PR TITLE
CA-254480: XenCenter error message refine for CA-205515

### DIFF
--- a/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
+++ b/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
@@ -2291,6 +2291,15 @@ namespace XenAPI {
                 return ResourceManager.GetString("POOL_AUTH_ENABLE_FAILED_WRONG_CREDENTIALS", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to enable external authentication, the supplied account was invalid..
+        /// </summary>
+        public static string POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT {
+            get {
+                return ResourceManager.GetString("POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to The external authentication configuration of the server joining the pool must match the pool&apos;s own external authentication configuration..

--- a/XenModel/XenAPI/FriendlyErrorNames.ja.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.ja.resx
@@ -861,6 +861,9 @@
   <data name="POOL_AUTH_ENABLE_FAILED_WRONG_CREDENTIALS" xml:space="preserve">
     <value>外部認証を有効にできません。資格情報の指定が無効です。</value>
   </data>
+  <data name="POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Failed to enable external authentication, the supplied account was invalid.</value>
+  </data>
   <data name="POOL_JOINING_EXTERNAL_AUTH_MISMATCH" xml:space="preserve">
     <value>プールに追加するサーバーの外部認証の構成は、追加先プールの設定と同じである必要があります。</value>
   </data>

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -861,6 +861,9 @@
   <data name="POOL_AUTH_ENABLE_FAILED_WRONG_CREDENTIALS" xml:space="preserve">
     <value>Failed to enable external authentication, the supplied credentials were invalid.</value>
   </data>
+  <data name="POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Failed to enable external authentication, the supplied account was invalid.</value>
+  </data>
   <data name="POOL_JOINING_EXTERNAL_AUTH_MISMATCH" xml:space="preserve">
     <value>The external authentication configuration of the server joining the pool must match the pool's own external authentication configuration.</value>
   </data>

--- a/XenModel/XenAPI/FriendlyErrorNames.zh-CN.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.zh-CN.resx
@@ -861,6 +861,9 @@
   <data name="POOL_AUTH_ENABLE_FAILED_WRONG_CREDENTIALS" xml:space="preserve">
     <value>无法启用外部身份验证，所提供的凭据无效。</value>
   </data>
+  <data name="POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Failed to enable external authentication, the supplied account was invalid.</value>
+  </data>
   <data name="POOL_JOINING_EXTERNAL_AUTH_MISMATCH" xml:space="preserve">
     <value>加入池的服务器的外部身份验证配置必须与池自身的外部身份验证配置匹配。</value>
   </data>


### PR DESCRIPTION
This is another part of pull request on xapi-project/xen-api-sdk. 
https://github.com/xapi-project/xen-api-sdk/pull/107  => **[This pull request will be cancelled, as it is not needed to do there.]**
Both of them are for a new error message: POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT