### PR TITLE
CA-252924: Updates on new version are not applied for licensed host on Partially licensed pool

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -27118,7 +27118,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Also apply all released updates on the new version (only on servers licensed for automated updates).
+        ///   Looks up a localized string similar to Also apply all released updates on the new version (only on pools licensed for automated updates).
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_APPLY_UPDATES_MIXED {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9357,7 +9357,7 @@ However, there is not enough space to perform the repartitioning, so the current
     <value>Also apply all released updates on the new version</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_APPLY_UPDATES_MIXED" xml:space="preserve">
-    <value>Also apply all released updates on the new version (only on servers licensed for automated updates)</value>
+    <value>Also apply all released updates on the new version (only on pools licensed for automated updates)</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_AUTOMATED_UPDATES_NOT_SUPPORTED_HOST_VERSION" xml:space="preserve">
     <value>Automated updates are not supported on this [XenServer] version</value>


### PR DESCRIPTION
Changed the text (on the checkbox) to make it clear that, after a version upgrade, XenCenter will apply updates only on licensed pools. This way it should be clear that servers of a partially licensed pool will not be updated. (The previous text suggested that any licensed server would be updated in general.)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>