### PR TITLE
CA-260365: Hide the build number from the General Tab for Ely and new…

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1055,7 +1055,7 @@ namespace XenAdmin.TabPages
 
             if (host.software_version.ContainsKey("date"))
                 pdSectionVersion.AddEntry(Messages.SOFTWARE_VERSION_DATE, host.software_version["date"]);
-            if (!Helpers.FalconOrGreater(host) && host.software_version.ContainsKey("build_number"))
+            if (!Helpers.ElyOrGreater(host) && host.software_version.ContainsKey("build_number"))
                 pdSectionVersion.AddEntry(Messages.SOFTWARE_VERSION_BUILD_NUMBER, host.software_version["build_number"]);
             if (host.software_version.ContainsKey("product_version"))
                 pdSectionVersion.AddEntry(Messages.SOFTWARE_VERSION_PRODUCT_VERSION, host.ProductVersionText);

--- a/XenModel/PoolJoinRules.cs
+++ b/XenModel/PoolJoinRules.cs
@@ -387,12 +387,11 @@ namespace XenAdmin.Core
             if (Helpers.FalconOrGreater(master) && string.IsNullOrEmpty(master.GetDatabaseSchema()))
                 return true;
 
-            if (Helpers.FalconOrGreater(slave) && Helpers.FalconOrGreater(master) &&
-                slave.GetDatabaseSchema() != master.GetDatabaseSchema())
+            if (slave.GetDatabaseSchema() != master.GetDatabaseSchema())
                 return true;
-            
+
             return
-                !Helpers.FalconOrGreater(master) && !Helpers.FalconOrGreater(slave) && slave.BuildNumber != master.BuildNumber ||
+                !Helpers.ElyOrGreater(master) && !Helpers.ElyOrGreater(slave) && slave.BuildNumber != master.BuildNumber ||
                 slave.PlatformVersion != master.PlatformVersion ||
                 slave.ProductBrand != master.ProductBrand;
         }

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -706,7 +706,7 @@ namespace XenAPI
         {
             get
             {
-                Debug.Assert(!Helpers.FalconOrGreater(this));
+                Debug.Assert(!Helpers.ElyOrGreater(this));
 
                 string bn = BuildNumberRaw;
                 if (bn == null)
@@ -742,7 +742,7 @@ namespace XenAPI
             get
             {
                 string productVersion = ProductVersion;
-                return productVersion != null ? string.Format("{0}.{1}", productVersion, Helpers.FalconOrGreater(this) ? BuildNumberRaw : BuildNumber.ToString()) : null;
+                return productVersion != null ? string.Format("{0}.{1}", productVersion, Helpers.ElyOrGreater(this) ? BuildNumberRaw : BuildNumber.ToString()) : null;
             }
         }
 


### PR DESCRIPTION
…er hosts (to cover the Honolulu case)

Also restrict the use of build number as an integer to pre-Ely hosts (because a Honolulu host has a non-numeric build number and XenCenter doesn't know the difference between Ely and Honolulu)
And a small update to the pool join rule to match what we have in Honolulu XenCenter (check the database schema regardless of the version)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>