### PR TITLE
CA-260304: WLB Configuration parameters can not be reset in XenCenter 7.2

### DIFF
--- a/XenAdmin/SettingsPanels/Wlb/WlbAdvancedSettingsPage.cs
+++ b/XenAdmin/SettingsPanels/Wlb/WlbAdvancedSettingsPage.cs
@@ -318,9 +318,7 @@ namespace XenAdmin.SettingsPanels
         {
             get
             {
-                return (IsValidSmtpAddress());
-                //BL: Disable it for now, will enable it after adding the port to WLB side
-                //return IsValidSmtpAddress() && PerfmonAlertOptionsPage.IsValidPort(TextBoxSMTPServerPort.Text);
+                return true; //this has been true since Boston
             }
         }
 


### PR DESCRIPTION
Fixed the regression

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>