### PR TITLE
CP-23967: Fix the same string sorting bug

### DIFF
--- a/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRowStableSorter.cs
+++ b/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRowStableSorter.cs
@@ -45,7 +45,7 @@ namespace XenAdmin.Controls.DataGridViewEx
     /// T is the sort of Row used which is a decendent of CollapsingPoolHostDataGridViewRow 
     /// </summary>
     /// <note>Base class takes care of the bi-direction behaviour</note>
-    public abstract class CollapsingPoolHostDataGridViewRowStableSorter<T> : CollapsingPoolHostDataGridViewRowSorter where T : PoolHostDataGridViewOneCheckboxRow
+    public abstract class CollapsingPoolHostDataGridViewRowStableSorter<T> : CollapsingPoolHostDataGridViewRowSorter where T : CollapsingPoolHostDataGridViewRow
     {
         private IComparer stableSorter = new CollapsingPoolHostDataGridViewRowDefaultSorter();
 

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -226,7 +226,7 @@ namespace XenAdmin.TabPages
                 RebuildHostView();
         }
 
-        private class LocalRowSorter : CollapsingPoolHostDataGridViewRowSorter
+        private class LocalRowSorter : CollapsingPoolHostDataGridViewRowStableSorter<UpdatePageDataGridViewRow>
         {
             private int columnClicked;
 
@@ -236,25 +236,19 @@ namespace XenAdmin.TabPages
                 this.columnClicked = columnClicked;
             }
 
-            protected override int PerformSort()
+            protected override int SortRowByColumnDetails(UpdatePageDataGridViewRow leftSide, UpdatePageDataGridViewRow rightSide)
             {
-                UpdatePageDataGridViewRow leftSide = Lhs as UpdatePageDataGridViewRow;
-                UpdatePageDataGridViewRow rightSide = Rhs as UpdatePageDataGridViewRow;
+                if (leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost)
+                    return -1;
 
-                if (leftSide != null && rightSide != null)
+                if (!leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost)
+                    return 1;
+
+                if ((leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost) ||
+                    (!leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost))
                 {
-                    if (leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost)
-                        return -1;
-
-                    if (!leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost)
-                        return 1;
-
-                    if ((leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost) ||
-                        (!leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost))
-                    {
-                        return string.Compare(leftSide.Cells[columnClicked].Value.ToString(),
-                            rightSide.Cells[columnClicked].Value.ToString(), true);
-                    }
+                    return string.Compare(leftSide.Cells[columnClicked].Value.ToString(),
+                        rightSide.Cells[columnClicked].Value.ToString(), true); 
                 }
 
                 return 0;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -611,32 +611,26 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         #region Nested items
 
-        private class LocalVersionSorter : CollapsingPoolHostDataGridViewRowSorter
+        private class LocalVersionSorter : CollapsingPoolHostDataGridViewRowStableSorter<PatchingHostsDataGridViewRow>
         {
             public LocalVersionSorter(ListSortDirection direction)
                 : base(direction)
             {
             }
 
-            protected override int PerformSort()
+            protected override int SortRowByColumnDetails(PatchingHostsDataGridViewRow leftSide, PatchingHostsDataGridViewRow rightSide)
             {
-                PatchingHostsDataGridViewRow leftSide = Lhs as PatchingHostsDataGridViewRow;
-                PatchingHostsDataGridViewRow rightSide = Rhs as PatchingHostsDataGridViewRow;
+                if (leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost)
+                    return -1;
 
-                if (leftSide != null && rightSide != null)
+                if (!leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost)
+                    return 1;
+
+                if ((leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost) ||
+                    (!leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost))
                 {
-                    if (leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost)
-                        return -1;
-
-                    if (!leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost)
-                        return 1;
-
-                    if ((leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost) ||
-                        (!leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost))
-                    {
-                        return string.Compare(leftSide.Cells[leftSide.VersionCellIndex].Value.ToString(),
-                            rightSide.Cells[rightSide.VersionCellIndex].Value.ToString(), true);
-                    }
+                    return string.Compare(leftSide.Cells[leftSide.VersionCellIndex].Value.ToString(),
+                        rightSide.Cells[rightSide.VersionCellIndex].Value.ToString(), true);
                 }
 
                 return 0;


### PR DESCRIPTION
The bug is that no sorting is performed when the strings are the same.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>