### PR TITLE
CP-23967: Fix and unify sorting in different views

### DIFF
--- a/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridView.cs
+++ b/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridView.cs
@@ -94,7 +94,7 @@ namespace XenAdmin.Controls.DataGridViewEx
         /// Hook in order that sorting may be added for additional columns rather than those
         /// provided by the base class
         /// </summary>
-        protected virtual void SortAdditionalColumns() { }
+        protected virtual void SortColumns() { }
 
         /// <summary>
         /// Sort the rows but then remove and read the rows that should be expandable to be placed back under
@@ -169,12 +169,7 @@ namespace XenAdmin.Controls.DataGridViewEx
 
             DetermineSortDirection(e);
 
-            if (columnToBeSortedIndex == firstRow.NameCellIndex)
-            {
-                SortAndRebuildTree(new CollapsingPoolHostDataGridViewRowDefaultSorter(direction));
-            }
-
-            SortAdditionalColumns();
+            SortColumns();
 
             Columns[columnToBeSortedIndex].HeaderCell.SortGlyphDirection =
                 direction == ListSortDirection.Ascending

--- a/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRow.cs
+++ b/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRow.cs
@@ -93,6 +93,11 @@ namespace XenAdmin.Controls.DataGridViewEx
             get { return Tag is Host; }
         }
 
+        public bool IsPoolOrStandaloneHost
+        {
+            get { return IsAPoolRow || (IsAHostRow && !HasPool); }
+        }
+
         /// <summary>
         /// Get the underlying pool if a pool row otherwise returns null
         /// </summary>

--- a/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRowSorter.cs
+++ b/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRowSorter.cs
@@ -64,6 +64,11 @@ namespace XenAdmin.Controls.DataGridViewEx
             this.direction = direction;
         }
 
+        protected ListSortDirection Direction
+        {
+            get { return direction; }
+        }
+
         /// <summary>
         /// Interface member correcting the sort for the direction required
         /// </summary>

--- a/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRowStableSorter.cs
+++ b/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostDataGridViewRowStableSorter.cs
@@ -45,11 +45,13 @@ namespace XenAdmin.Controls.DataGridViewEx
     /// T is the sort of Row used which is a decendent of CollapsingPoolHostDataGridViewRow 
     /// </summary>
     /// <note>Base class takes care of the bi-direction behaviour</note>
-    public abstract class CollapsingPoolHostDataGridViewRowStableSorter<T> : CollapsingPoolHostDataGridViewRowSorter where T : PoolHostDataGridViewOneCheckboxRow
+    public abstract class CollapsingPoolHostDataGridViewRowStableSorter<T> : CollapsingPoolHostDataGridViewRowSorter where T : CollapsingPoolHostDataGridViewRow
     {
-        private IComparer stableSorter = new CollapsingPoolHostDataGridViewRowDefaultSorter();
-
         protected CollapsingPoolHostDataGridViewRowStableSorter(){}
+
+        protected CollapsingPoolHostDataGridViewRowStableSorter(ListSortDirection direction) : base(direction) { }
+
+        private IComparer stableSorter = new CollapsingPoolHostDataGridViewRowDefaultSorter();
 
         /// <summary>
         /// Use this IComparer to sort any values where the implementations sorter 
@@ -59,8 +61,6 @@ namespace XenAdmin.Controls.DataGridViewEx
         {
             set { stableSorter = value;  }
         }
-
-        protected CollapsingPoolHostDataGridViewRowStableSorter(ListSortDirection direction) : base(direction) { }
 
         protected override int PerformSort()
         {

--- a/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostRowSorter.cs
+++ b/XenAdmin/Controls/DataGridViewEx/CollapsingPoolHostRowSorter.cs
@@ -1,0 +1,75 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XenAdmin.Core;
+
+namespace XenAdmin.Controls.DataGridViewEx
+{
+    /// <summary>
+    /// A class implementation to do sorting of CollapsingPoolHostDataGridViewRow derived types based on the input column index and direction
+    public class CollapsingPoolHostRowSorter<T> : CollapsingPoolHostDataGridViewRowStableSorter<T> where T : CollapsingPoolHostDataGridViewRow
+    {
+        private int columnClicked;
+
+        public CollapsingPoolHostRowSorter(ListSortDirection direction, int columnClicked)
+            : base(direction)
+        {
+            this.columnClicked = columnClicked;
+
+            // In case of same string, default sorting should be still in order under Descending direction
+            StableSorter = new CollapsingPoolHostDataGridViewRowDefaultSorter(Direction);
+        }
+
+        protected override int SortRowByColumnDetails(T leftSide, T rightSide)
+        {
+            if (leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost)
+                return -1;
+
+            if (!leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost)
+                return 1;
+
+            if ((leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost) ||
+                (!leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost))
+            {
+                return StringUtility.NaturalCompare(leftSide.Cells[columnClicked].Value.ToString(),
+                    rightSide.Cells[columnClicked].Value.ToString());
+            }
+
+            return 0;
+        }
+    }
+}

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -30,6 +30,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -226,52 +227,18 @@ namespace XenAdmin.TabPages
                 RebuildHostView();
         }
 
-        private class LocalRowSorter : CollapsingPoolHostDataGridViewRowSorter
-        {
-            private int columnClicked;
-
-            public LocalRowSorter(ListSortDirection direction, int columnClicked)
-                : base(direction)
-            {
-                this.columnClicked = columnClicked;
-            }
-
-            protected override int PerformSort()
-            {
-                UpdatePageDataGridViewRow leftSide = Lhs as UpdatePageDataGridViewRow;
-                UpdatePageDataGridViewRow rightSide = Rhs as UpdatePageDataGridViewRow;
-
-                if (leftSide != null && rightSide != null)
-                {
-                    if (leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost)
-                        return -1;
-
-                    if (!leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost)
-                        return 1;
-
-                    if ((leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost) ||
-                        (!leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost))
-                    {
-                        return string.Compare(leftSide.Cells[columnClicked].Value.ToString(),
-                            rightSide.Cells[columnClicked].Value.ToString(), true);
-                    }
-                }
-
-                return 0;
-            }
-        }
-
         private class UpdatePageByHostDataGridView : CollapsingPoolHostDataGridView
         {
-            protected override void SortAdditionalColumns()
+            protected override void SortColumns()
             {
                 UpdatePageDataGridViewRow firstRow = Rows[0] as UpdatePageDataGridViewRow;
                 if (firstRow == null)
                     return;
 
-                if (columnToBeSortedIndex == firstRow.VersionCellIndex ||
+                if (columnToBeSortedIndex == firstRow.NameCellIndex ||
+                    columnToBeSortedIndex == firstRow.VersionCellIndex ||
                     columnToBeSortedIndex == firstRow.StatusCellIndex)
-                    SortAndRebuildTree(new LocalRowSorter(direction, columnToBeSortedIndex));
+                    SortAndRebuildTree(new CollapsingPoolHostRowSorter<UpdatePageDataGridViewRow>(direction, columnToBeSortedIndex));
             }
         }
 
@@ -294,11 +261,6 @@ namespace XenAdmin.TabPages
                 : base(host, hasPool)
             {
                 SetupCells();
-            }
-
-            public bool IsPoolOrStandaloneHost
-            {
-                get { return IsAPoolRow || (IsAHostRow && !HasPool); }
             }
 
             public int VersionCellIndex

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -611,38 +611,6 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         #region Nested items
 
-        private class LocalVersionSorter : CollapsingPoolHostDataGridViewRowSorter
-        {
-            public LocalVersionSorter(ListSortDirection direction)
-                : base(direction)
-            {
-            }
-
-            protected override int PerformSort()
-            {
-                PatchingHostsDataGridViewRow leftSide = Lhs as PatchingHostsDataGridViewRow;
-                PatchingHostsDataGridViewRow rightSide = Rhs as PatchingHostsDataGridViewRow;
-
-                if (leftSide != null && rightSide != null)
-                {
-                    if (leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost)
-                        return -1;
-
-                    if (!leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost)
-                        return 1;
-
-                    if ((leftSide.IsPoolOrStandaloneHost && rightSide.IsPoolOrStandaloneHost) ||
-                        (!leftSide.IsPoolOrStandaloneHost && !rightSide.IsPoolOrStandaloneHost))
-                    {
-                        return string.Compare(leftSide.Cells[leftSide.VersionCellIndex].Value.ToString(),
-                            rightSide.Cells[rightSide.VersionCellIndex].Value.ToString(), true);
-                    }
-                }
-
-                return 0;
-            }
-        }
-
         private class PatchingHostsDataGridView : CollapsingPoolHostDataGridView
         {
             protected override void OnCellPainting(DataGridViewCellPaintingEventArgs e)
@@ -776,14 +744,15 @@ namespace XenAdmin.Wizards.PatchingWizard
                 }
             }
 
-            protected override void SortAdditionalColumns()
+            protected override void SortColumns()
             {
                 PatchingHostsDataGridViewRow firstRow = Rows[0] as PatchingHostsDataGridViewRow;
                 if (firstRow == null)
                     return;
 
-                if (columnToBeSortedIndex == firstRow.VersionCellIndex)
-                    SortAndRebuildTree(new LocalVersionSorter(direction));
+                if (columnToBeSortedIndex == firstRow.NameCellIndex ||
+                    columnToBeSortedIndex == firstRow.VersionCellIndex)
+                    SortAndRebuildTree(new CollapsingPoolHostRowSorter<PatchingHostsDataGridViewRow>(direction, columnToBeSortedIndex));
             }
         }
 
@@ -925,11 +894,6 @@ namespace XenAdmin.Wizards.PatchingWizard
                                ? (int) Cells[POOL_CHECKBOX_COL].Value
                                : (int) Cells[POOL_ICON_HOST_CHECKBOX_COL].Value;
                 }
-            }
-
-            public bool IsPoolOrStandaloneHost
-            {
-                get { return IsAPoolRow || (IsAHostRow && !HasPool); }
             }
 
             public bool IsSelectableHost

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.cs
@@ -261,43 +261,20 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             return clearAllButtonEnabled;
         }
 
-        private class LocalRowSorter : CollapsingPoolHostDataGridViewRowStableSorter<UpgradeDataGridViewRow>
-        {
-            private int columnClicked;
-
-            public LocalRowSorter(ListSortDirection direction, int columnClicked)
-                : base(direction)
-            {
-                this.columnClicked = columnClicked;
-            }
-
-            protected override int SortRowByColumnDetails(UpgradeDataGridViewRow leftSide, UpgradeDataGridViewRow rightSide)
-            {
-                if (columnClicked == leftSide.DescriptionCellIndex)
-                {
-                    return leftSide.DescriptionText.CompareTo(rightSide.DescriptionText);
-                }
-                else if (columnClicked == leftSide.VersionCellIndex)
-                {
-                    return Helpers.productVersionCompare(leftSide.VersionText, rightSide.VersionText);
-                }
-                return 0;
-            }
-        }
-
         private class UpgradeDataGridView : PoolHostDataGridViewOneCheckbox
         {
             public UpgradeDataGridView(){}
             public UpgradeDataGridView(IContainer container) : base(container){}
             
-            protected override void SortAdditionalColumns()
+            protected override void SortColumns()
             {
                 UpgradeDataGridViewRow firstRow = Rows[0] as UpgradeDataGridViewRow;
                 if (firstRow == null) return;
 
-                if (columnToBeSortedIndex == firstRow.DescriptionCellIndex ||
+                if (columnToBeSortedIndex == firstRow.NameCellIndex ||
+                    columnToBeSortedIndex == firstRow.DescriptionCellIndex ||
                     columnToBeSortedIndex == firstRow.VersionCellIndex)
-                    SortAndRebuildTree(new LocalRowSorter(direction, columnToBeSortedIndex));
+                    SortAndRebuildTree(new CollapsingPoolHostRowSorter<UpgradeDataGridViewRow>(direction, columnToBeSortedIndex));
             }
         }
 

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Controls\ConsolePanel.Designer.cs">
       <DependentUpon>ConsolePanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\DataGridViewEx\CollapsingPoolHostRowSorter.cs" />
     <Compile Include="Controls\DataGridViewEx\DataGridViewEx.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
The commit fixes bug and unify sorting rules in ManageUpdatesPage,
PatchingWizard_SelectServers and RollingUpgradeWizardSelectPool data
grid views.

The rules are:
1) Name column sorted purely by name.
2) Other columns sorted by string value, if the same, sorted by default,
which is still in order even in reverse direction.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>