### PR TITLE
CP-24087: Parse the error parameters of the UPDATE_PRECHECK_FAILED_UN…

### DIFF
--- a/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
@@ -302,6 +302,13 @@ namespace XenAdmin.Diagnostics.Checks
                             return new HostOutOfSpaceProblem(this, Host, Patch, action.DiskSpaceRequirements);
                     }
                     break;
+                case "UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR":
+                    // try to find the problem from the error parameters as xml string
+                    // e.g.
+                    //   ErrorDescription[0] = "UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR"
+                    //   ErrorDescription[1] = "test-update"
+                    //   ErrorDescription[2] = "<?xml version="1.0" ?><error errorcode="LICENCE_RESTRICTION"></error>"
+                    return FindProblem(found);
             }
             return null;
         }


### PR DESCRIPTION
…KNOWN_ERROR precheck failure

When the update precheck fails with UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR, we try to find the actual error in the failure's parameters (in the form of an xml string containing the error code) and display that error instead of the "unknown error".

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>