### PR TITLE
CP-24210: fix the patch sorting in newer version

### DIFF
--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -430,7 +430,6 @@ namespace XenAdmin.TabPages
                 foreach (var patch in requiredUpdates)
                     result.Add(patch.Name);
 
-                result.Sort(StringUtility.NaturalCompare);
                 return string.Join(", ", result.ToArray());
             }
         }


### PR DESCRIPTION
Keep order consistency with general tab for newer version servers.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>