### PR TITLE
CA-263044: [XSO-765] Install Update fails because it tries to install the hotfix to one pool twice

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -506,7 +506,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 {
                     if (row.Tag is Pool)
                     {
-                        if (((int)row.Cells[POOL_CHECKBOX_COL].Value) != UNCHECKED)
+                        if (((int)row.Cells[POOL_CHECKBOX_COL].Value) != UNCHECKED && !pools.Contains((Pool)row.Tag))
                             pools.Add((Pool)row.Tag);
                     }
                     else if (row.Tag is Host)
@@ -515,7 +515,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                         {
                             Host host = (Host)row.Tag;
                             Pool pool = Helpers.GetPoolOfOne(host.Connection);
-                            if (pool != null)
+                            if (pool != null && !pools.Contains(pool))
                                 pools.Add(pool);
                         }
                     }


### PR DESCRIPTION
Fixed a bug that caused XenCenter to try to apply an update (that the user manually selected) multiple times and therefore failed. This was only present when the Select All button had been used.