### PR TITLE
CA-265410: Fix required updates for some hosts

### DIFF
--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -409,10 +409,11 @@ namespace XenAdmin.TabPages
 
                 foreach (Alert alert in alerts)
                 {
-                    if (!(alert is XenServerPatchAlert))
+                    var patchAlert = alert as XenServerPatchAlert;
+                    if (patchAlert == null)
                         continue;
-                    if (alert.AppliesTo.Contains(host.Name))
-                        updatesList.Add(alert.Name);
+                    if (patchAlert.DistinctHosts.Contains(host))
+                        updatesList.Add(patchAlert.Name);
                 }
 
                 updatesList.Sort(StringUtility.NaturalCompare);


### PR DESCRIPTION
The bug is required updates for slaves of pre-dundee pool don't show.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>