### PR TITLE
CP-24498: RPU wizard to block the selection of unlicensed hosts

### DIFF
--- a/XenAdmin/Controls/DataGridViewEx/PoolHostDataGridViewOneCheckboxRow.cs
+++ b/XenAdmin/Controls/DataGridViewEx/PoolHostDataGridViewOneCheckboxRow.cs
@@ -56,33 +56,34 @@ namespace XenAdmin.Controls.DataGridViewEx
             protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates cellState, object value, object formattedValue, string errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts)
             {
                 PoolHostDataGridViewOneCheckboxRow row = (PoolHostDataGridViewOneCheckboxRow)this.OwningRow;
-                Host host = value as Host;
-                if (host != null)
+                if (value is Host || value is Pool)
                 {
-                    Image hostIcon = Images.GetImage16For(host);
+                    Image hostIcon = Images.GetImage16For(value as IXenObject);
+                    var iconIndent = row.IsCheckable ? 0 : 16;
+                    var textIndent = iconIndent + 16;
                     base.Paint(graphics, clipBounds,
-                               new Rectangle(cellBounds.X + 16, cellBounds.Y, cellBounds.Width - 16,
+                               new Rectangle(cellBounds.X + textIndent, cellBounds.Y, cellBounds.Width - textIndent,
                                              cellBounds.Height), rowIndex, cellState, value, formattedValue,
                                errorText, cellStyle, advancedBorderStyle, paintParts);
                     if ((cellState & DataGridViewElementStates.Selected) != 0 && row.Enabled )
                     {
                         using (var brush = new SolidBrush(DataGridView.DefaultCellStyle.SelectionBackColor))
                             graphics.FillRectangle(
-                                brush, cellBounds.X, cellBounds.Y, hostIcon.Width, cellBounds.Height);
+                                brush, cellBounds.X, cellBounds.Y, hostIcon.Width + iconIndent, cellBounds.Height);
                     }
                     else
                     {
                         //Background behind the host icon
                         using (var brush = new SolidBrush(this.DataGridView.DefaultCellStyle.BackColor))
                             graphics.FillRectangle(brush,
-                                                   cellBounds.X, cellBounds.Y, hostIcon.Width, cellBounds.Height);
+                                                   cellBounds.X, cellBounds.Y, hostIcon.Width + iconIndent, cellBounds.Height);
                     }
 
                     if (row.Enabled)
-                        graphics.DrawImage(hostIcon, cellBounds.X, cellBounds.Y + 3, hostIcon.Width, hostIcon.Height);
+                        graphics.DrawImage(hostIcon, cellBounds.X + iconIndent, cellBounds.Y + 3, hostIcon.Width, hostIcon.Height);
                     else
                         graphics.DrawImage(hostIcon,
-                                           new Rectangle(cellBounds.X, cellBounds.Y + 3, hostIcon.Width, hostIcon.Height),
+                                           new Rectangle(cellBounds.X + iconIndent, cellBounds.Y + 3, hostIcon.Width, hostIcon.Height),
                                            0, 0, hostIcon.Width, hostIcon.Height, GraphicsUnit.Pixel,
                                            Drawing.GreyScaleAttributes);
                 }

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.Designer.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.Designer.cs
@@ -66,7 +66,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             this.expansionColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             dataGridViewCellStyle1.NullValue = ((object)(resources.GetObject("dataGridViewCellStyle1.NullValue")));
-            dataGridViewCellStyle1.Padding = new System.Windows.Forms.Padding(3, 0, 3, 0);
+            dataGridViewCellStyle1.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.expansionColumn.DefaultCellStyle = dataGridViewCellStyle1;
             this.expansionColumn.FillWeight = 25.80645F;
             resources.ApplyResources(this.expansionColumn, "expansionColumn");

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.resx
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.resx
@@ -147,10 +147,10 @@
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="expansionColumn.MinimumWidth" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>18</value>
   </data>
   <data name="expansionColumn.Width" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>18</value>
   </data>
   <metadata name="checkBoxColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -159,10 +159,10 @@
     <value />
   </data>
   <data name="checkBoxColumn.MinimumWidth" type="System.Int32, mscorlib">
-    <value>24</value>
+    <value>20</value>
   </data>
   <data name="checkBoxColumn.Width" type="System.Int32, mscorlib">
-    <value>24</value>
+    <value>20</value>
   </data>
   <metadata name="NameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -29597,6 +29597,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The server is not licensed for rolling pool upgrade.
+        /// </summary>
+        public static string ROLLING_UPGRADE_UNLICENSED_HOST {
+            get {
+                return ResourceManager.GetString("ROLLING_UPGRADE_UNLICENSED_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The pool is not licensed for rolling pool upgrade.
+        /// </summary>
+        public static string ROLLING_UPGRADE_UNLICENSED_POOL {
+            get {
+                return ResourceManager.GetString("ROLLING_UPGRADE_UNLICENSED_POOL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rolling pool upgrade is complete..
         /// </summary>
         public static string ROLLING_UPGRADE_UPGRADE_COMPLETED {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -29597,7 +29597,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The server is not licensed for rolling pool upgrade.
+        ///   Looks up a localized string similar to This server is not licensed for rolling pool upgrade.
         /// </summary>
         public static string ROLLING_UPGRADE_UNLICENSED_HOST {
             get {
@@ -29606,7 +29606,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The pool is not licensed for rolling pool upgrade.
+        ///   Looks up a localized string similar to This pool is not licensed for rolling pool upgrade.
         /// </summary>
         public static string ROLLING_UPGRADE_UNLICENSED_POOL {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10301,10 +10301,10 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
     <value>Upgrade Mode</value>
   </data>
   <data name="ROLLING_UPGRADE_UNLICENSED_HOST" xml:space="preserve">
-    <value>The server is not licensed for rolling pool upgrade</value>
+    <value>This server is not licensed for rolling pool upgrade</value>
   </data>
   <data name="ROLLING_UPGRADE_UNLICENSED_POOL" xml:space="preserve">
-    <value>The pool is not licensed for rolling pool upgrade</value>
+    <value>This pool is not licensed for rolling pool upgrade</value>
   </data>
   <data name="ROLLING_UPGRADE_UPGRADE_COMPLETED" xml:space="preserve">
     <value>Rolling pool upgrade is complete.</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10300,6 +10300,12 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
   <data name="ROLLING_UPGRADE_TITLE_MODE" xml:space="preserve">
     <value>Upgrade Mode</value>
   </data>
+  <data name="ROLLING_UPGRADE_UNLICENSED_HOST" xml:space="preserve">
+    <value>The server is not licensed for rolling pool upgrade</value>
+  </data>
+  <data name="ROLLING_UPGRADE_UNLICENSED_POOL" xml:space="preserve">
+    <value>The pool is not licensed for rolling pool upgrade</value>
+  </data>
   <data name="ROLLING_UPGRADE_UPGRADE_COMPLETED" xml:space="preserve">
     <value>Rolling pool upgrade is complete.</value>
   </data>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -402,6 +402,17 @@ namespace XenAPI
             return true;
         }
 
+        /// <summary>
+        /// The feature is restricted if the "restrict_rpu" key exists and it is true
+        /// or if the key is absent and the host is unlicensed
+        /// </summary>
+        public static bool RestrictRpu(Host h)
+        {
+            return h.license_params.ContainsKey("restrict_rpu")
+                ? BoolKey(h.license_params, "restrict_rpu")
+                : GetEdition(h.edition) == Edition.Free || h.LicenseExpiryUTC() < DateTime.UtcNow - h.Connection.ServerTimeOffset; // restrict on Free edition or if the license has expired
+        }
+
         public bool HasPBDTo(SR sr)
         {
             foreach (XenRef<PBD> pbd in PBDs)

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -263,6 +263,13 @@ namespace XenAPI
             return edition == "free";
         }
 
+        public virtual bool IsFreeLicenseOrExpired()
+        {
+            if (Connection != null && Connection.CacheIsPopulated)
+                return IsFreeLicense() || LicenseExpiryUTC() < DateTime.UtcNow - Connection.ServerTimeOffset;
+            return true;
+        }
+
         public static bool RestrictHA(Host h)
         {
             return !BoolKey(h.license_params, "enable_xha");
@@ -410,7 +417,7 @@ namespace XenAPI
         {
             return h.license_params.ContainsKey("restrict_rpu")
                 ? BoolKey(h.license_params, "restrict_rpu")
-                : GetEdition(h.edition) == Edition.Free || h.LicenseExpiryUTC() < DateTime.UtcNow - h.Connection.ServerTimeOffset; // restrict on Free edition or if the license has expired
+                : h.IsFreeLicenseOrExpired(); // restrict on Free edition or if the license has expired
         }
 
         public bool HasPBDTo(SR sr)


### PR DESCRIPTION
Also includes some improvements to the Select Pools page of the RPU wizard
- do not show the checkbox if the item is disabled
- show the icon for the pool items, not only for hosts (making this consistent with the similar page in the Update Wizard)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>