### PR TITLE
[CP-24974] Avoid calculatingVM agility/failure tolerance twice

### DIFF
--- a/XenAdmin/Controls/HaNtolControl.cs
+++ b/XenAdmin/Controls/HaNtolControl.cs
@@ -179,6 +179,9 @@ namespace XenAdmin.Controls
 
             while (!exitNtolUpdateThread)
             {
+                waitingNtolUpdate.WaitOne();
+                log.Debug("Thread woken");
+
                 Program.Invoke(this, () =>
                     {
                         // Don't do GUI stuff if we've been told to exit
@@ -236,9 +239,6 @@ namespace XenAdmin.Controls
                                 LoadCalculationFailedMode();
                         });
                 }
-
-                waitingNtolUpdate.WaitOne();
-                log.Debug("Thread woken");
             }
 
             log.Debug("Thread exiting");
@@ -253,6 +253,7 @@ namespace XenAdmin.Controls
         internal void StartNtolUpdate()
         {
             StopNtolUpdate();
+            waitingNtolUpdate.Set();
             ntolUpdateThread = new Thread(updateNtol);
             ntolUpdateThread.IsBackground = true;
             ntolUpdateThread.Name = "Ntol updating thread for pool " + Helpers.GetName(connection);


### PR DESCRIPTION
This is caused by the `waitingNtolUpdate.waitOne()` call being at the end of the loop, not the beginning. The reason is that the `waitingNtolUpdate` is set during the first iteration (before the thread even gets loaded) - because the setter for Settings in this file sets it (and that's set by the setter for AssignPriorites.Connection, which is set in the HAWizard constructor). So when the thread first spawns we do the calculations, then get to the `waitOne` lock, which is set so we go back around the loop and calculate everything again before returning to the lock and waiting to be triggered. The correct behaviour is to trigger only once on the page load, and then only when re-triggered. To achieve that I've moved the `waitOne` call to the beginning of the loop, so that (assuming the `waitingNtolUpdate` lock is set before the thread is first started) we immediately run the calculations and then stop at the beginning of the loop waiting to be triggered again. This means that on page load (and after each re-trigger) we only calculate once.

The assumption that the lock is set before the thread is triggered is currently valid, because as mentioned above it's currently set by the setter for Settings which is indirectly called by the wizard constructor. I don't want to rely on that behaviour though because it's very indirect, so just to be safe I've added an explicit set just before the thread is triggered so that it's guaranteed to run the calculations the first time. This isn't strictly necessary but seems better than relying on the existing implicit setting. Since we use the same mechanism just in a different place, all the existing code that sets `waitingNtolUpdate` continues to trigger this thread as expected.