### PR TITLE
CP-266755 & CA-266843: Fix XC brand string

### DIFF
--- a/XenAdmin/Dialogs/AboutDialog.ja.resx
+++ b/XenAdmin/Dialogs/AboutDialog.ja.resx
@@ -262,7 +262,7 @@
     <value>1</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Copyright © Citrix Systems, Inc. All rights reserved.</value>
+    <value>Copyright © [Citrix] Systems, Inc. All rights reserved.</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>

--- a/XenAdmin/Dialogs/AboutDialog.resx
+++ b/XenAdmin/Dialogs/AboutDialog.resx
@@ -262,7 +262,7 @@
     <value>1</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Copyright © Citrix Systems, Inc. All rights reserved.</value>
+    <value>Copyright © [Citrix] Systems, Inc. All rights reserved.</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>

--- a/XenAdmin/Dialogs/AboutDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/AboutDialog.zh-CN.resx
@@ -262,7 +262,7 @@
     <value>1</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>版权所有 © Citrix Systems, Inc. 保留所有权利。</value>
+    <value>版权所有 © [Citrix] Systems, Inc. 保留所有权利。</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>

--- a/XenAdmin/Dialogs/DuplicateTemplateNameDialog.ja.resx
+++ b/XenAdmin/Dialogs/DuplicateTemplateNameDialog.ja.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblInstructions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblInstructions.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 14</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblInstructions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>
   </data>
@@ -253,6 +253,6 @@
     <value>DuplicateTemplateNameDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenter, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/DuplicateTemplateNameDialog.resx
+++ b/XenAdmin/Dialogs/DuplicateTemplateNameDialog.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblInstructions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblInstructions.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 14</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblInstructions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>
   </data>
@@ -253,6 +253,6 @@
     <value>DuplicateTemplateNameDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenter, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/DuplicateTemplateNameDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/DuplicateTemplateNameDialog.zh-CN.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblInstructions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblInstructions.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 14</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblInstructions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 5, 3, 3</value>
   </data>
@@ -253,6 +253,6 @@
     <value>DuplicateTemplateNameDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenter, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.ja.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.ja.resx
@@ -832,7 +832,7 @@
     <value>4</value>
   </data>
   <data name="decentGroupBox1.Text" xml:space="preserve">
-    <value>Citrix Insight Services による認証</value>
+    <value>[Citrix] Insight Services による認証</value>
   </data>
   <data name="&gt;&gt;decentGroupBox1.Name" xml:space="preserve">
     <value>decentGroupBox1</value>
@@ -871,7 +871,7 @@
     <value>10</value>
   </data>
   <data name="rubricLabel.Text" xml:space="preserve">
-    <value>ヘルス チェックでは、XenServer プールで設定された事前定義済みのスケジュールに基づいて、サーバーの状態レポートが Citrix Insight Services に自動的にアップロードされます。</value>
+    <value>ヘルス チェックでは、[XenServer] プールで設定された事前定義済みのスケジュールに基づいて、サーバーの状態レポートが [Citrix] Insight Services に自動的にアップロードされます。</value>
   </data>
   <data name="&gt;&gt;rubricLabel.Name" xml:space="preserve">
     <value>rubricLabel</value>
@@ -1153,7 +1153,7 @@
     <value>24</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>ヘルス チェック サービスが XenServer に接続するための資格情報を入力してください。</value>
+    <value>ヘルス チェック サービスが [XenServer] に接続するための資格情報を入力してください。</value>
   </data>
   <data name="label3.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -1456,7 +1456,7 @@
     <value>3</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Text" xml:space="preserve">
-    <value>XenServer の資格情報</value>
+    <value>[XenServer] の資格情報</value>
   </data>
   <data name="&gt;&gt;decentGroupBoxXSCredentials.Name" xml:space="preserve">
     <value>decentGroupBoxXSCredentials</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
@@ -832,7 +832,7 @@
     <value>5</value>
   </data>
   <data name="decentGroupBox1.Text" xml:space="preserve">
-    <value>Authentication with Citrix Insight Services</value>
+    <value>Authentication with [Citrix] Insight Services</value>
   </data>
   <data name="&gt;&gt;decentGroupBox1.Name" xml:space="preserve">
     <value>decentGroupBox1</value>
@@ -871,7 +871,7 @@
     <value>0</value>
   </data>
   <data name="rubricLabel.Text" xml:space="preserve">
-    <value>Health Check will automatically upload a server status report to Citrix Insight Services, based on a predefined schedule configured on your XenServer pool.</value>
+    <value>Health Check will automatically upload a server status report to [Citrix] Insight Services, based on a predefined schedule configured on your [XenServer] pool.</value>
   </data>
   <data name="&gt;&gt;rubricLabel.Name" xml:space="preserve">
     <value>rubricLabel</value>
@@ -1153,7 +1153,7 @@
     <value>0</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>Enter the credentials the Health Check Service will use to connect to XenServer.</value>
+    <value>Enter the credentials the Health Check Service will use to connect to [XenServer].</value>
   </data>
   <data name="label3.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -1456,7 +1456,7 @@
     <value>4</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Text" xml:space="preserve">
-    <value>XenServer Credentials</value>
+    <value>[XenServer] Credentials</value>
   </data>
   <data name="&gt;&gt;decentGroupBoxXSCredentials.Name" xml:space="preserve">
     <value>decentGroupBoxXSCredentials</value>

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.zh-CN.resx
@@ -832,7 +832,7 @@
     <value>4</value>
   </data>
   <data name="decentGroupBox1.Text" xml:space="preserve">
-    <value>通过 Citrix Insight Services 进行身份验证</value>
+    <value>通过 [Citrix] Insight Services 进行身份验证</value>
   </data>
   <data name="&gt;&gt;decentGroupBox1.Name" xml:space="preserve">
     <value>decentGroupBox1</value>
@@ -871,7 +871,7 @@
     <value>10</value>
   </data>
   <data name="rubricLabel.Text" xml:space="preserve">
-    <value>运行状况检查会自动将服务器状态报告上载到 Citrix Insight Services，具体取决于您的 XenServer 池上配置的预定义计划。</value>
+    <value>运行状况检查会自动将服务器状态报告上载到 [Citrix] Insight Services，具体取决于您的 [XenServer] 池上配置的预定义计划。</value>
   </data>
   <data name="&gt;&gt;rubricLabel.Name" xml:space="preserve">
     <value>rubricLabel</value>
@@ -1153,7 +1153,7 @@
     <value>24</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>请输入运行状况检查服务连接到 XenServer 时使用的凭据。</value>
+    <value>请输入运行状况检查服务连接到 [XenServer] 时使用的凭据。</value>
   </data>
   <data name="label3.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -1456,7 +1456,7 @@
     <value>3</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Text" xml:space="preserve">
-    <value>XenServer 凭据</value>
+    <value>[XenServer] 凭据</value>
   </data>
   <data name="&gt;&gt;decentGroupBoxXSCredentials.Name" xml:space="preserve">
     <value>decentGroupBoxXSCredentials</value>

--- a/XenAdmin/Dialogs/LegalNoticesDialog.ja.resx
+++ b/XenAdmin/Dialogs/LegalNoticesDialog.ja.resx
@@ -250,7 +250,7 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 
 
-Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citrix Systems, Inc. in the United States and other countries.</value>
+Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of [Citrix] Systems, Inc. in the United States and other countries.</value>
   </data>
   <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
     <value>textBox1</value>
@@ -283,7 +283,7 @@ Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citr
     <value>5</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>Citrix、Citrix XenServer、Xen、Xen のロゴ、XenCenter、XenMotion は、米国およびその他の国の Citrix Systems, Inc. の商標または登録商標です。</value>
+    <value>[Citrix]、[Citrix] [XenServer]、Xen、Xen のロゴ、[XenCenter]、XenMotion は、米国およびその他の国の [Citrix] Systems, Inc. の商標または登録商標です。</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -355,7 +355,7 @@ Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citr
     <value>4</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Copyright © Citrix Systems, Inc. All rights reserved.</value>
+    <value>Copyright © [Citrix] Systems, Inc. All rights reserved.</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>

--- a/XenAdmin/Dialogs/LegalNoticesDialog.resx
+++ b/XenAdmin/Dialogs/LegalNoticesDialog.resx
@@ -250,7 +250,7 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 
 
-Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citrix Systems, Inc. in the United States and other countries.</value>
+Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of [Citrix] Systems, Inc. in the United States and other countries.</value>
   </data>
   <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
     <value>textBox1</value>
@@ -283,7 +283,7 @@ Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citr
     <value>5</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>Citrix, Citrix XenServer, Xen, the Xen logo, XenCenter, XenMotion are trademarks and/or registered trademarks of Citrix Systems, Inc. in the United States and other countries.</value>
+    <value>[Citrix], [Citrix] [XenServer], Xen, the Xen logo, [XenCenter], XenMotion are trademarks and/or registered trademarks of [Citrix] Systems, Inc. in the United States and other countries.</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -355,7 +355,7 @@ Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citr
     <value>4</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Copyright © Citrix Systems, Inc. All rights reserved.</value>
+    <value>Copyright © [Citrix] Systems, Inc. All rights reserved.</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>

--- a/XenAdmin/Dialogs/LegalNoticesDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/LegalNoticesDialog.zh-CN.resx
@@ -250,7 +250,7 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 
 
-Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citrix Systems, Inc. in the United States and other countries.</value>
+Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of [Citrix] Systems, Inc. in the United States and other countries.</value>
   </data>
   <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
     <value>textBox1</value>
@@ -283,7 +283,7 @@ Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citr
     <value>5</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>Citrix、Citrix XenServer、Xen、Xen 徽标、XenCenter、XenMotion 是 Citrix Systems, Inc. 在美国及其他国家/地区的商标和/或注册商标。</value>
+    <value>[Citrix]、[Citrix] [XenServer]、Xen、Xen 徽标、[XenCenter]、XenMotion 是 [Citrix] Systems, Inc. 在美国及其他国家/地区的商标和/或注册商标。</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -355,7 +355,7 @@ Xen, the Xen logo, XenMotion are trademarks and/or registered trademarks of Citr
     <value>4</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>版权所有 © Citrix Systems, Inc. 保留所有权利。</value>
+    <value>版权所有 © [Citrix] Systems, Inc. 保留所有权利。</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>

--- a/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.ja.resx
+++ b/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.ja.resx
@@ -164,7 +164,7 @@
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 32</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>AutoSize</value>
   </data>
@@ -372,6 +372,6 @@ VM のパフォーマンスを最適化するために、VCPU の数を物理 CP
     <value>VcpuWarningDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenter, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.resx
+++ b/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.resx
@@ -164,7 +164,7 @@
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 32</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>AutoSize</value>
   </data>
@@ -175,7 +175,7 @@
     <value>pictureBox1</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -240,7 +240,7 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>panel1</value>
   </data>
   <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -273,7 +273,7 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>checkBox1</value>
   </data>
   <data name="&gt;&gt;checkBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;checkBox1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -309,7 +309,7 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>btnOK</value>
   </data>
   <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -336,7 +336,7 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -347,7 +347,7 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="panel1" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="checkBox1" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnOK" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;Rows Styles="Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
@@ -372,6 +372,6 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>VcpuWarningDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenter, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.zh-CN.resx
@@ -164,7 +164,7 @@
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 32</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>AutoSize</value>
   </data>
@@ -371,6 +371,6 @@
     <value>VcpuWarningDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenter, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -3942,7 +3942,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The XenServer license you are using does not allow you to use the Scheduled Snapshots feature..
+        ///   Looks up a localized string similar to The [XenServer] license you are using does not allow you to use the Scheduled Snapshots feature..
         /// </summary>
         public static string Message_body_vmss_license_error {
             get {

--- a/XenModel/FriendlyNames.ja.resx
+++ b/XenModel/FriendlyNames.ja.resx
@@ -1104,7 +1104,7 @@
     <value>仮想マシン '{0}' のメモリ使用が要求どおりに減少しませんでした。</value>
   </data>
   <data name="Message.body-vmss_license_error" xml:space="preserve">
-    <value>使用中の XenServer ライセンスでは、スナップショット スケジュール機能を使用できません。</value>
+    <value>使用中の [XenServer] ライセンスでは、スナップショット スケジュール機能を使用できません。</value>
   </data>
   <data name="Message.body-vmss_snapshot_failed" xml:space="preserve">
     <value>スナップショットが作成できなかったため、スナップショット スケジュール '{0}' が失敗しました。</value>

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1113,7 +1113,7 @@
     <value>Virtual machine '{0}' did not reduce its memory usage when requested.</value>
   </data>
   <data name="Message.body-vmss_license_error" xml:space="preserve">
-    <value>The XenServer license you are using does not allow you to use the Scheduled Snapshots feature.</value>
+    <value>The [XenServer] license you are using does not allow you to use the Scheduled Snapshots feature.</value>
   </data>
   <data name="Message.body-vmss_snapshot_failed" xml:space="preserve">
     <value>The snapshot schedule '{0}' failed because a snapshot could not be created.</value>

--- a/XenModel/FriendlyNames.zh-CN.resx
+++ b/XenModel/FriendlyNames.zh-CN.resx
@@ -1104,7 +1104,7 @@
     <value>虚拟机“{0}”在收到请求时未降低其内存使用量。</value>
   </data>
   <data name="Message.body-vmss_license_error" xml:space="preserve">
-    <value>正在使用的 XenServer 许可证不允许您使用计划快照功能。</value>
+    <value>正在使用的 [XenServer] 许可证不允许您使用计划快照功能。</value>
   </data>
   <data name="Message.body-vmss_snapshot_failed" xml:space="preserve">
     <value>快照计划“{0}”失败，因为无法创建快照。</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -34863,7 +34863,7 @@ namespace XenAdmin {
         /// <summary>
         ///   Looks up a localized string similar to 
         ///
-        ///To learn more about the [XenServer] VM Scheduled Snapshots feature or to start a XenServer trial, click the button below..
+        ///To learn more about the [XenServer] VM Scheduled Snapshots feature or to start a [XenServer] trial, click the button below..
         /// </summary>
         public static string UPSELL_BLURB_VMSS_MORE {
             get {
@@ -36395,7 +36395,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to XenServer can send you email notifications when alerts associated with snapshot schedule jobs are raised, such as when a VM snapshot is created or when a snapshot operation fails..
+        ///   Looks up a localized string similar to [XenServer] can send you email notifications when alerts associated with snapshot schedule jobs are raised, such as when a VM snapshot is created or when a snapshot operation fails..
         /// </summary>
         public static string VMSS_EMAIL_PAGE_TEXT {
             get {

--- a/XenModel/Messages.ja.resx
+++ b/XenModel/Messages.ja.resx
@@ -11968,7 +11968,7 @@ VM が再起動したら、[[XenServer product] Tools のインストール] を
   </data>
   <data name="UPSELL_BLURB_VMSS_MORE" xml:space="preserve">
     <value>
-下のボタンを使用して、[XenServer] VM の定期的なスナップショット機能や XenServer の試用についての情報を参照できます。</value>
+下のボタンを使用して、[XenServer] VM の定期的なスナップショット機能や [XenServer] の試用についての情報を参照できます。</value>
   </data>
   <data name="UPSELL_BLURB_VM_APPLIANCES" xml:space="preserve">
     <value>vApp 機能を使用するには、[XenServer] ライセンスをアップグレードしてください。この機能では、いくつかの VM を単一の仮想アプライアンスとしてグループ化して、それらを一緒に起動したり停止したりできます。また、プライマリの本稼働サイトに障害が発生した場合に、それらの VM を障害回復 (DR) サイトに簡単にフェイルオーバーできます。</value>
@@ -12273,7 +12273,7 @@ VM が再起動したら、[[XenServer product] Tools のインストール] を
     <value>スナップショット スケジュール ジョブのアラートをメールで送信する(&amp;E)</value>
   </data>
   <data name="VMSS_EMAIL_PAGE_TEXT" xml:space="preserve">
-    <value>XenServer でスナップショット スケジュール ジョブに関するアラート (VM スナップショットが作成された場合や、スナップショット作成が失敗した場合など) が生成されたときに、通知メールが送信されるように設定できます。</value>
+    <value>[XenServer] でスナップショット スケジュール ジョブに関するアラート (VM スナップショットが作成された場合や、スナップショット作成が失敗した場合など) が生成されたときに、通知メールが送信されるように設定できます。</value>
   </data>
   <data name="VMSS_FINISH_PAGE_CHECKBOX_TEXT" xml:space="preserve">
     <value>[完了] をクリックして新規スナップショット スケジュール処理を実行する(&amp;R)</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12076,7 +12076,7 @@ To learn more about the [XenServer] Role Based Access Control feature or to star
   <data name="UPSELL_BLURB_VMSS_MORE" xml:space="preserve">
     <value>
 
-To learn more about the [XenServer] VM Scheduled Snapshots feature or to start a XenServer trial, click the button below.</value>
+To learn more about the [XenServer] VM Scheduled Snapshots feature or to start a [XenServer] trial, click the button below.</value>
   </data>
   <data name="UPSELL_BLURB_VM_APPLIANCES" xml:space="preserve">
     <value>Upgrade your [XenServer] license to enable vApps. The vApps feature allows you to place your VMs into groups, allowing them to be started or stopped as a unit, and also allowing them to be easily recovered at your DR site in the event of a disaster at your primary production site.</value>
@@ -12377,7 +12377,7 @@ To learn more about the [XenServer] Dynamic Workload Balancing feature or to sta
     <value>Send &amp;email notifications about snapshot schedule job alerts</value>
   </data>
   <data name="VMSS_EMAIL_PAGE_TEXT" xml:space="preserve">
-    <value>XenServer can send you email notifications when alerts associated with snapshot schedule jobs are raised, such as when a VM snapshot is created or when a snapshot operation fails.</value>
+    <value>[XenServer] can send you email notifications when alerts associated with snapshot schedule jobs are raised, such as when a VM snapshot is created or when a snapshot operation fails.</value>
   </data>
   <data name="VMSS_FINISH_PAGE_CHECKBOX_TEXT" xml:space="preserve">
     <value>&amp;Run the new snapshot schedule job when I click Finish</value>

--- a/XenModel/Messages.zh-CN.resx
+++ b/XenModel/Messages.zh-CN.resx
@@ -11930,7 +11930,7 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
 要了解与 [XenServer] 灾难恢复功能有关的更多信息或启动 [XenServer] 试用版，请单击下面的按钮。</value>
   </data>
   <data name="UPSELL_BLURB_ENHANCEDSR" xml:space="preserve">
-    <value>升级 [XenServer] 许可证以启用 StorageLink™ 技术。StorageLink 使 XenServer 能够充分利用现有存储硬件并自动卸载存储操作。这样便可以使用存储硬件固有的特性，在硬件层面实现具有高性能和空间效率的存储置备、克隆和快照功能。</value>
+    <value>升级 [XenServer] 许可证以启用 StorageLink™ 技术。StorageLink 使 [XenServer] 能够充分利用现有存储硬件并自动卸载存储操作。这样便可以使用存储硬件固有的特性，在硬件层面实现具有高性能和空间效率的存储置备、克隆和快照功能。</value>
   </data>
   <data name="UPSELL_BLURB_GPU" xml:space="preserve">
     <value>升级您的 [XenServer] 许可证以启用 GPU 直通功能。通过 GPU 直通功能，可以为 VM 分配专用图形处理器以提高图形性能。</value>
@@ -11969,7 +11969,7 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
   </data>
   <data name="UPSELL_BLURB_VMSS_MORE" xml:space="preserve">
     <value>
-要了解与 [XenServer] VM 计划快照功能有关的更多信息或者启动 XenServer 试用版，请单击下面的按钮。</value>
+要了解与 [XenServer] VM 计划快照功能有关的更多信息或者启动 [XenServer] 试用版，请单击下面的按钮。</value>
   </data>
   <data name="UPSELL_BLURB_VM_APPLIANCES" xml:space="preserve">
     <value>升级您的 [XenServer] 许可证以启用 vApp。通过 vApp 功能，您可以将 VM 放置到组中，从而允许这些 VM 作为一个单元来启动或停止，同时还允许这些 VM 在主生产站点出现灾难性故障时在 DR 站点上轻松恢复。</value>
@@ -12274,7 +12274,7 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
     <value>发送与快照计划作业警报有关的电子邮件通知(&amp;E)</value>
   </data>
   <data name="VMSS_EMAIL_PAGE_TEXT" xml:space="preserve">
-    <value>XenServer 可以在引发了与快照计划作业有关的警报时向您发送电子邮件通知，例如创建 VM 快照时或快照操作失败时。</value>
+    <value>[XenServer] 可以在引发了与快照计划作业有关的警报时向您发送电子邮件通知，例如创建 VM 快照时或快照操作失败时。</value>
   </data>
   <data name="VMSS_FINISH_PAGE_CHECKBOX_TEXT" xml:space="preserve">
     <value>当我单击“完成”时运行新快照计划作业(&amp;R)</value>

--- a/XenModel/XenAPI/FriendlyErrorNames.ja.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.ja.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ACTIVATION_WHILE_NOT_FREE" xml:space="preserve">
     <value>アクティブ化キーを適用するには、エディションの設定が free である必要があります。</value>
@@ -1875,7 +1875,7 @@
     <value>古いバージョンのホストをアップグレードするときにこの VM 処理は実行できません。</value>
   </data>
   <data name="VM_HOST_INCOMPATIBLE_VERSION_MIGRATE" xml:space="preserve">
-    <value>移行元ホストより古いバージョンの XenServer を実行している移行先のホストに VM を移行しようとしました。</value>
+    <value>移行元ホストより古いバージョンの [XenServer] を実行している移行先のホストに VM を移行しようとしました。</value>
   </data>
   <data name="VM_HOST_INCOMPATIBLE_VIRTUAL_HARDWARE_PLATFORM_VERSION" xml:space="preserve">
     <value>VM のこのバージョンの仮想ハードウェア プラットフォームには、このホストとの互換性がありません。</value>

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -1857,7 +1857,7 @@ Authorized Roles: {1}</value>
     <value>You attempted an operation on a VM that needed it to be in state &apos;{1}&apos; but was in state &apos;{2}&apos;.</value>
   </data>
   <data name="VM_BIOS_STRINGS_ALREADY_SET" xml:space="preserve">
-    <value>The BIOS strings for this VM have already been set and cannot be changed anymore.</value>
+    <value>The BIOS strings for this VM have already been set and cannot be changed.</value>
   </data>
   <data name="VM_CALL_PLUGIN_RATE_LIMIT" xml:space="preserve">
     <value>There is a minimal interval required between consecutive plugin calls made on the same VM, please wait before retry.</value>
@@ -1902,7 +1902,7 @@ Authorized Roles: {1}</value>
     <value>This VM operation cannot be performed on an older-versioned host during an upgrade.</value>
   </data>
   <data name="VM_HOST_INCOMPATIBLE_VERSION_MIGRATE" xml:space="preserve">
-    <value>You attempted to migrate a VM to a destination host running a version of XenServer older than the source host.</value>
+    <value>You attempted to migrate a VM to a destination host which is older than the source host.</value>
   </data>
   <data name="VM_HOST_INCOMPATIBLE_VIRTUAL_HARDWARE_PLATFORM_VERSION" xml:space="preserve">
     <value>The VM&apos;s Virtual Hardware Platform version is incompatible with this host.</value>

--- a/XenModel/XenAPI/FriendlyErrorNames.zh-CN.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.zh-CN.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ACTIVATION_WHILE_NOT_FREE" xml:space="preserve">
     <value>仅当版本设置为“免费”时，才能应用激活密钥。</value>
@@ -1875,7 +1875,7 @@
     <value>在升级期间无法对旧版本的主机执行该 VM 操作。</value>
   </data>
   <data name="VM_HOST_INCOMPATIBLE_VERSION_MIGRATE" xml:space="preserve">
-    <value>您尝试将 VM 迁移到的目标主机运行的 XenServer 版本低于源主机。</value>
+    <value>您尝试将 VM 迁移到的目标主机运行的 [XenServer] 版本低于源主机。</value>
   </data>
   <data name="VM_HOST_INCOMPATIBLE_VIRTUAL_HARDWARE_PLATFORM_VERSION" xml:space="preserve">
     <value>VM 的虚拟硬件平台版本与此主机不兼容。</value>

--- a/devtools/spellcheck/spellcheck-brand-file.sh
+++ b/devtools/spellcheck/spellcheck-brand-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (c) Citrix Systems, Inc. 
 # All rights reserved.
@@ -32,19 +32,16 @@
 
 set -eu
 
-echo "INFO:	spellcheck"
+WORDS="[^[\/"]XenCenter\|XenCenter[[:space:]][^p].*\|.*[[:space:]]XenCenter\|XenCenter[,].*\|^XenCenter\|XenCenter$\|[^[\/"]XenServer\|XenServer[[:space:]][^p].*\|.*[[:space:]]XenServer\|XenServer[,].*\|^XenServer\|XenServer$\|[^[\/]Citrix\|Citrix[[:space:]][^p].*\|.*[[:space:]]Citrix\|Citrix[,].*\|^Citrix\|Citrix$"
 
-dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-src="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+FOUND_TYPO=$(grep -iow $WORDS $1)
+if [ "${FOUND_TYPO}" != "" ]
+then
+  echo "$1 contains $FOUND_TYPO"
+fi
 
-output=$(/usr/bin/find "$src/XenAdmin" "$src/XenModel" "$src/XenOvfApi" "$src/XenOvfTransport" \( -name \*.cs -o -name \*.resx \) -exec sh "$dir/spellcheck-file.sh" \{\} \;)
-
-output_brand=$(/usr/bin/find "$src/XenAdmin" "$src/XenModel" "$src/XenOvfApi" "$src/XenOvfTransport" \( -name \*.resx \) -exec sh "$dir/spellcheck-brand-file.sh" \{\} \;)
-
-echo "$output" | sed -e "s,$src/,,g"
-
-echo "$output_brand" | sed -e "s,$src/,,g"
-
-test -z "$output"
-
-test -z "$output_brand"
+for w in "operation system" "goto " "TODO[: ]*[rR]emove
+"
+do
+  grep -qi "$w" "$1" && echo "$1 contains $w"
+done

--- a/mk/re-branding.sh
+++ b/mk/re-branding.sh
@@ -152,7 +152,7 @@ RESX_rebranding "${REPO}/XenAdmin/Properties/Resources"
 rebranding_global ${REPO}/XenAdmin/app.config
 
 #XenModel rebranding
-RESX_rebranding "${REPO}/XenModel/Messages ${REPO}/XenModel/InvisibleMessages ${REPO}/XenModel/FriendlyNames"
+RESX_rebranding "${REPO}/XenModel/Messages ${REPO}/XenModel/InvisibleMessages ${REPO}/XenModel/FriendlyNames ${REPO}/XenModel/XenAPI/FriendlyErrorNames"
 
 #XenOvfApi rebranding
 RESX_rebranding "${REPO}/XenOvfApi/Messages ${REPO}/XenOvfApi/Content"


### PR DESCRIPTION
Following pattern would be caught when using "XenCenter" "XenServer" and
"Citrix":
1) not "[" or "/" or """ on left of the brand string
2) brand string followed by space followed by not "p", and optional letter
3) optional letter followed by space followed by the brand string
4) brand string followed by "," and optional letter
5) begin with the brand string
6) end with the brand string

tested with all .resx files

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>