### PR TITLE
CA-267671: Fix Configure HA wizard display text

### DIFF
--- a/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
+++ b/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
@@ -420,6 +420,8 @@ namespace XenAdmin.Wizards.HAWizard_Pages
 
             if (!haNtolIndicator.UpdateInProgress)
             {
+                pictureBoxStatus.Visible = true;
+
                 if (haNtolIndicator.Ntol == -1)
                 {
                     labelHaStatus.Text = Messages.HA_UNABLE_TO_CALCULATE_MESSAGE;

--- a/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.resx
+++ b/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.resx
@@ -141,6 +141,9 @@
   <data name="pictureBoxStatus.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
+  <data name="pictureBoxStatus.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="&gt;&gt;pictureBoxStatus.Name" xml:space="preserve">
     <value>pictureBoxStatus</value>
   </data>
@@ -169,13 +172,10 @@
     <value>2, 2, 0, 0</value>
   </data>
   <data name="labelHaStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 15</value>
+    <value>2, 15</value>
   </data>
   <data name="labelHaStatus.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="labelHaStatus.Text" xml:space="preserve">
-    <value>HA is guaranteed. The maximum  number of servers failures that HA can protect against is {0}</value>
   </data>
   <data name="&gt;&gt;labelHaStatus.Name" xml:space="preserve">
     <value>labelHaStatus</value>


### PR DESCRIPTION
when the max tolerance is being calculated, the text and icon on top of HA
wizard is no longer visible after this fix.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>