### PR TITLE
[SCTX-2608] Honolulu Update - Server is still booting error

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/BringBabiesBackAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/BringBabiesBackAction.cs
@@ -91,7 +91,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             {
                 retries++;
 
-                Thread.Sleep(1000);
+                Thread.Sleep(5000);
 
                 try
                 {
@@ -102,7 +102,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                     if (retries > 60)
                         throw;
 
-                    log.Debug(string.Format("Cannot enable host {0}. Retrying in 1 sec.", _host.opaque_ref), e);
+                    log.Debug(string.Format("Cannot enable host {0}. Retrying in 5 sec.", _host.opaque_ref), e);
                 }
             }
 


### PR DESCRIPTION
Increased the wait between host_enable attempts, allowing to wait more for the host to reboot.

This will affect Automated Updates and other normal Patching Wizard
operations as well.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>