### PR TITLE
CP-25329: Refine API reference for PUSB & VUSB in xenadmin

### DIFF
--- a/XenAdmin/Dialogs/AttachUsbDialog.cs
+++ b/XenAdmin/Dialogs/AttachUsbDialog.cs
@@ -77,12 +77,13 @@ namespace XenAdmin.Dialogs
             treeUsbList.ClearAllNodes();
             treeUsbList.BeginUpdate();
             try
-            {   
+            {
+                List<UsbItem> usbNodeList = new List<UsbItem>();
                 foreach (Host host in possibleHosts)
                 {
                     // Add a host node to tree list.
                     HostItem hostNode = new HostItem(host);
-                    List<PUSB> pusbs = _vm.Connection.ResolveAll(host.PUSBs);
+                    List<PUSB> pusbs = host.Connection.ResolveAll(host.PUSBs);
                     foreach (PUSB pusb in pusbs)
                     {
                         // Add a USB in the host to tree list.
@@ -93,13 +94,19 @@ namespace XenAdmin.Dialogs
                         if (pusb.passthrough_enabled && !attached)
                         {
                             UsbItem usbNode = new UsbItem(pusb);
-                            treeUsbList.AddChildNode(hostNode, usbNode);
+                            usbNodeList.Add(usbNode);
                         }
                     }
                     // Show host node only when it contains available USB devices.
-                    if (hostNode.ChildNodes.Count > 0)
+                    if (usbNodeList.Count > 0)
+                    {
                         treeUsbList.AddNode(hostNode);
-                    
+                        foreach (UsbItem item in usbNodeList)
+                        {
+                            treeUsbList.AddChildNode(hostNode, item);
+                        }
+                    }
+                    usbNodeList.Clear();
                 }
                 
                 if (treeUsbList.Nodes.Count == 0)

--- a/XenAdmin/SettingsPanels/USBEditPage.cs
+++ b/XenAdmin/SettingsPanels/USBEditPage.cs
@@ -289,7 +289,7 @@ namespace XenAdmin.SettingsPanels
 
                 locationCell.Value = pusb.path;
                 descriptionCell.Value = pusb.Description();
-                attachedCell.Value = (_vusb.Connection.Resolve(_vusb.attached) != null).ToYesNoStringI18n();
+                attachedCell.Value = _vusb.currently_attached.ToYesNoStringI18n();
             }
 
             public void DeregisterEvents()

--- a/XenAdmin/TabPages/UsbPage.cs
+++ b/XenAdmin/TabPages/UsbPage.cs
@@ -239,7 +239,8 @@ namespace XenAdmin.TabPages
             {
                 if (_pusb != null)
                 {
-                    VUSB vusb = _pusb.Connection.Resolve(_pusb.attached);
+                    USB_group usbgroup = _pusb.Connection.Resolve(_pusb.USB_group);
+                    VUSB vusb = usbgroup.VUSBs.Count > 0 ? _pusb.Connection.Resolve(usbgroup.VUSBs[0]) : null;
                     _vm = vusb == null ? null : _pusb.Connection.Resolve(vusb.VM);
                     if (_vm != null)
                         _vm.PropertyChanged += Vm_PropertyChanged;

--- a/XenAdmin/TabPages/UsbPage.cs
+++ b/XenAdmin/TabPages/UsbPage.cs
@@ -224,7 +224,7 @@ namespace XenAdmin.TabPages
             public HostUsbRow(PUSB pusb)
             {
                 _pusb = pusb;
-                setVm();
+                SetVm();
 
                 _pusb.PropertyChanged += Pusb_PropertyChanged;
 
@@ -235,12 +235,12 @@ namespace XenAdmin.TabPages
                 UpdateDetails();
             }
 
-            private void setVm()
+            private void SetVm()
             {
                 if (_pusb != null)
                 {
                     USB_group usbgroup = _pusb.Connection.Resolve(_pusb.USB_group);
-                    VUSB vusb = usbgroup.VUSBs.Count > 0 ? _pusb.Connection.Resolve(usbgroup.VUSBs[0]) : null;
+                    VUSB vusb = (usbgroup != null && usbgroup.VUSBs != null && usbgroup.VUSBs.Count > 0) ? _pusb.Connection.Resolve(usbgroup.VUSBs[0]) : null;
                     _vm = vusb == null ? null : _pusb.Connection.Resolve(vusb.VM);
                     if (_vm != null)
                         _vm.PropertyChanged += Vm_PropertyChanged;
@@ -274,7 +274,7 @@ namespace XenAdmin.TabPages
                     if (_vm != null)  // Remove PropertyChanged handler for old VM
                         _vm.PropertyChanged -= Vm_PropertyChanged;
 
-                    setVm();
+                    SetVm();
                 }
                 UpdateDetails();
             }

--- a/XenModel/Actions/USB/DeleteVUSBAction.cs
+++ b/XenModel/Actions/USB/DeleteVUSBAction.cs
@@ -52,7 +52,7 @@ namespace XenAdmin.Actions
         {
             try
             {
-                if ((_vusb.Connection.Resolve(_vusb.attached) != null) &&
+                if ((_vusb.currently_attached) &&
                     XenAPI.VUSB.get_allowed_operations(Session, _vusb.opaque_ref).Contains(XenAPI.vusb_operations.unplug))
                 {
                     RelatedTask = VUSB.async_unplug(Session, _vusb.opaque_ref);

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -924,6 +924,9 @@
   <data name="PROVISION_ONLY_ALLOWED_ON_TEMPLATE" xml:space="preserve">
     <value>The provision call can only be invoked on templates, not regular VMs.</value>
   </data>
+  <data name="PUSB_VDI_CONFLICT" xml:space="preserve">
+    <value>The VDI corresponding to this PUSB has existing VBDs.</value>
+  </data>
   <data name="PVS_CACHE_STORAGE_ALREADY_PRESENT" xml:space="preserve">
     <value>The PVS site already has cache storage configured for the host.</value>
   </data>

--- a/XenModel/XenAPI/PUSB.cs
+++ b/XenModel/XenAPI/PUSB.cs
@@ -48,7 +48,6 @@ namespace XenAPI
 
         public PUSB(string uuid,
             XenRef<USB_group> USB_group,
-            XenRef<VUSB> attached,
             XenRef<Host> host,
             string path,
             string vendor_id,
@@ -63,7 +62,6 @@ namespace XenAPI
         {
             this.uuid = uuid;
             this.USB_group = USB_group;
-            this.attached = attached;
             this.host = host;
             this.path = path;
             this.vendor_id = vendor_id;
@@ -90,7 +88,6 @@ namespace XenAPI
         {
             uuid = update.uuid;
             USB_group = update.USB_group;
-            attached = update.attached;
             host = update.host;
             path = update.path;
             vendor_id = update.vendor_id;
@@ -108,7 +105,6 @@ namespace XenAPI
         {
             uuid = proxy.uuid == null ? null : (string)proxy.uuid;
             USB_group = proxy.USB_group == null ? null : XenRef<USB_group>.Create(proxy.USB_group);
-            attached = proxy.attached == null ? null : XenRef<VUSB>.Create(proxy.attached);
             host = proxy.host == null ? null : XenRef<Host>.Create(proxy.host);
             path = proxy.path == null ? null : (string)proxy.path;
             vendor_id = proxy.vendor_id == null ? null : (string)proxy.vendor_id;
@@ -127,7 +123,6 @@ namespace XenAPI
             Proxy_PUSB result_ = new Proxy_PUSB();
             result_.uuid = uuid ?? "";
             result_.USB_group = USB_group ?? "";
-            result_.attached = attached ?? "";
             result_.host = host ?? "";
             result_.path = path ?? "";
             result_.vendor_id = vendor_id ?? "";
@@ -150,7 +145,6 @@ namespace XenAPI
         {
             uuid = Marshalling.ParseString(table, "uuid");
             USB_group = Marshalling.ParseRef<USB_group>(table, "USB_group");
-            attached = Marshalling.ParseRef<VUSB>(table, "attached");
             host = Marshalling.ParseRef<Host>(table, "host");
             path = Marshalling.ParseString(table, "path");
             vendor_id = Marshalling.ParseString(table, "vendor_id");
@@ -173,7 +167,6 @@ namespace XenAPI
 
             return Helper.AreEqual2(this._uuid, other._uuid) &&
                 Helper.AreEqual2(this._USB_group, other._USB_group) &&
-                Helper.AreEqual2(this._attached, other._attached) &&
                 Helper.AreEqual2(this._host, other._host) &&
                 Helper.AreEqual2(this._path, other._path) &&
                 Helper.AreEqual2(this._vendor_id, other._vendor_id) &&
@@ -246,17 +239,6 @@ namespace XenAPI
         public static XenRef<USB_group> get_USB_group(Session session, string _pusb)
         {
             return XenRef<USB_group>.Create(session.proxy.pusb_get_usb_group(session.uuid, _pusb ?? "").parse());
-        }
-
-        /// <summary>
-        /// Get the attached field of the given PUSB.
-        /// First published in Unreleased.
-        /// </summary>
-        /// <param name="session">The session</param>
-        /// <param name="_pusb">The opaque_ref of the given pusb</param>
-        public static XenRef<VUSB> get_attached(Session session, string _pusb)
-        {
-            return XenRef<VUSB>.Create(session.proxy.pusb_get_attached(session.uuid, _pusb ?? "").parse());
         }
 
         /// <summary>
@@ -518,24 +500,6 @@ namespace XenAPI
             }
         }
         private XenRef<USB_group> _USB_group;
-
-        /// <summary>
-        /// VUSB running on this PUSB
-        /// </summary>
-        public virtual XenRef<VUSB> attached
-        {
-            get { return _attached; }
-            set
-            {
-                if (!Helper.AreEqual(value, _attached))
-                {
-                    _attached = value;
-                    Changed = true;
-                    NotifyPropertyChanged("attached");
-                }
-            }
-        }
-        private XenRef<VUSB> _attached;
 
         /// <summary>
         /// Physical machine that owns the USB device

--- a/XenModel/XenAPI/Proxy.cs
+++ b/XenModel/XenAPI/Proxy.cs
@@ -7668,10 +7668,6 @@ namespace XenAPI
         Response<string>
         pusb_get_usb_group(string session, string _pusb);
 
-        [XmlRpcMethod("PUSB.get_attached")]
-        Response<string>
-        pusb_get_attached(string session, string _pusb);
-
         [XmlRpcMethod("PUSB.get_host")]
         Response<string>
         pusb_get_host(string session, string _pusb);
@@ -7864,9 +7860,9 @@ namespace XenAPI
         Response<Object>
         vusb_get_other_config(string session, string _vusb);
 
-        [XmlRpcMethod("VUSB.get_attached")]
-        Response<string>
-        vusb_get_attached(string session, string _vusb);
+        [XmlRpcMethod("VUSB.get_currently_attached")]
+        Response<bool>
+        vusb_get_currently_attached(string session, string _vusb);
 
         [XmlRpcMethod("VUSB.set_other_config")]
         Response<string>
@@ -8876,7 +8872,6 @@ namespace XenAPI
     {
         public string uuid;
         public string USB_group;
-        public string attached;
         public string host;
         public string path;
         public string vendor_id;
@@ -8910,7 +8905,7 @@ namespace XenAPI
         public string VM;
         public string USB_group;
         public Object other_config;
-        public string attached;
+        public bool currently_attached;
     }
 
 }

--- a/XenModel/XenAPI/Relation.cs
+++ b/XenModel/XenAPI/Relation.cs
@@ -138,10 +138,6 @@ namespace XenAPI
                 new Relation("VMs", "VM", "protection_policy"),
             });
 
-            relations.Add(typeof(Proxy_PUSB), new Relation[] {
-                new Relation("attached", "VUSB", "attached"),
-            });
-
             relations.Add(typeof(Proxy_VM), new Relation[] {
                 new Relation("VUSBs", "VUSB", "VM"),
                 new Relation("VGPUs", "VGPU", "VM"),

--- a/XenModel/XenAPI/VUSB.cs
+++ b/XenModel/XenAPI/VUSB.cs
@@ -52,7 +52,7 @@ namespace XenAPI
             XenRef<VM> VM,
             XenRef<USB_group> USB_group,
             Dictionary<string, string> other_config,
-            XenRef<PUSB> attached)
+            bool currently_attached)
         {
             this.uuid = uuid;
             this.allowed_operations = allowed_operations;
@@ -60,7 +60,7 @@ namespace XenAPI
             this.VM = VM;
             this.USB_group = USB_group;
             this.other_config = other_config;
-            this.attached = attached;
+            this.currently_attached = currently_attached;
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace XenAPI
             VM = update.VM;
             USB_group = update.USB_group;
             other_config = update.other_config;
-            attached = update.attached;
+            currently_attached = update.currently_attached;
         }
 
         internal void UpdateFromProxy(Proxy_VUSB proxy)
@@ -91,7 +91,7 @@ namespace XenAPI
             VM = proxy.VM == null ? null : XenRef<VM>.Create(proxy.VM);
             USB_group = proxy.USB_group == null ? null : XenRef<USB_group>.Create(proxy.USB_group);
             other_config = proxy.other_config == null ? null : Maps.convert_from_proxy_string_string(proxy.other_config);
-            attached = proxy.attached == null ? null : XenRef<PUSB>.Create(proxy.attached);
+            currently_attached = (bool)proxy.currently_attached;
         }
 
         public Proxy_VUSB ToProxy()
@@ -103,7 +103,7 @@ namespace XenAPI
             result_.VM = VM ?? "";
             result_.USB_group = USB_group ?? "";
             result_.other_config = Maps.convert_to_proxy_string_string(other_config);
-            result_.attached = attached ?? "";
+            result_.currently_attached = currently_attached;
             return result_;
         }
 
@@ -119,7 +119,7 @@ namespace XenAPI
             VM = Marshalling.ParseRef<VM>(table, "VM");
             USB_group = Marshalling.ParseRef<USB_group>(table, "USB_group");
             other_config = Maps.convert_from_proxy_string_string(Marshalling.ParseHashTable(table, "other_config"));
-            attached = Marshalling.ParseRef<PUSB>(table, "attached");
+            currently_attached = Marshalling.ParseBool(table, "currently_attached");
         }
 
         public bool DeepEquals(VUSB other, bool ignoreCurrentOperations)
@@ -137,7 +137,7 @@ namespace XenAPI
                 Helper.AreEqual2(this._VM, other._VM) &&
                 Helper.AreEqual2(this._USB_group, other._USB_group) &&
                 Helper.AreEqual2(this._other_config, other._other_config) &&
-                Helper.AreEqual2(this._attached, other._attached);
+                Helper.AreEqual2(this._currently_attached, other._currently_attached);
         }
 
         public override string SaveChanges(Session session, string opaqueRef, VUSB server)
@@ -246,14 +246,14 @@ namespace XenAPI
         }
 
         /// <summary>
-        /// Get the attached field of the given VUSB.
+        /// Get the currently_attached field of the given VUSB.
         /// First published in Unreleased.
         /// </summary>
         /// <param name="session">The session</param>
         /// <param name="_vusb">The opaque_ref of the given vusb</param>
-        public static XenRef<PUSB> get_attached(Session session, string _vusb)
+        public static bool get_currently_attached(Session session, string _vusb)
         {
-            return XenRef<PUSB>.Create(session.proxy.vusb_get_attached(session.uuid, _vusb ?? "").parse());
+            return (bool)session.proxy.vusb_get_currently_attached(session.uuid, _vusb ?? "").parse();
         }
 
         /// <summary>
@@ -492,21 +492,21 @@ namespace XenAPI
         private Dictionary<string, string> _other_config;
 
         /// <summary>
-        /// The PUSB on which this VUSB is running
+        /// is the device currently attached
         /// </summary>
-        public virtual XenRef<PUSB> attached
+        public virtual bool currently_attached
         {
-            get { return _attached; }
+            get { return _currently_attached; }
             set
             {
-                if (!Helper.AreEqual(value, _attached))
+                if (!Helper.AreEqual(value, _currently_attached))
                 {
-                    _attached = value;
+                    _currently_attached = value;
                     Changed = true;
-                    NotifyPropertyChanged("attached");
+                    NotifyPropertyChanged("currently_attached");
                 }
             }
         }
-        private XenRef<PUSB> _attached;
+        private bool _currently_attached;
     }
 }


### PR DESCRIPTION
Change points from xapi:
1. Remove "attached" field in PUSB & VUSB.
2. Add "currently_attached" as a bool field in VUSB.

Signed-off-by: Kun Ma <kun.ma@citrix.com>