### PR TITLE
CP-25375: Remove double quotation marks around string USB_DEVICE_VEND…

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -35252,7 +35252,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;Vendor: {0}; Product: {1}&quot;.
+        ///   Looks up a localized string similar to Vendor: {0}; Product: {1}.
         /// </summary>
         public static string USB_DEVICE_VENDOR_PRODUCT {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12224,7 +12224,7 @@ To learn more about the [XenServer] Dynamic Workload Balancing feature or to sta
     <value>USB devices</value>
   </data>
   <data name="USB_DEVICE_VENDOR_PRODUCT" xml:space="preserve">
-    <value>"Vendor: {0}; Product: {1}"</value>
+    <value>Vendor: {0}; Product: {1}</value>
   </data>
   <data name="USB_EDIT_SUBTEXT_1_DEVICE" xml:space="preserve">
     <value>1 device attached</value>


### PR DESCRIPTION
CP-25375: Remove double quotation marks around string USB_DEVICE_VENDOR_PRODUCT.

Modified files:
- Messages.resx
- Messages.Designer.cs (auto-generated)

3 pages are impacted:
- USBPage
- UsbEditPage
- AttachUsbDialog