### PR TITLE
[CA-269110] Stop calling assert_can_boot_here after migrate dropdown is closed

### DIFF
--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -73,9 +73,18 @@ namespace XenAdmin.Commands
             base.DropDownItems.Add(new ToolStripMenuItem());
         }
 
+        private bool _isDropDownClosed;
+
+        protected override void OnDropDownClosed(EventArgs e)
+        {
+            base.OnDropDownClosed(e);
+            _isDropDownClosed = true;
+        }
+
         protected override void OnDropDownOpening(EventArgs e)
         {
             base.DropDownItems.Clear();
+            _isDropDownClosed = false;
 
             // Work around bug in tool kit where disabled menu items show their dropdown menus
             if (!Enabled)
@@ -196,6 +205,12 @@ namespace XenAdmin.Commands
             
             foreach (VMOperationToolStripMenuSubItem item in dropDownItems)
             {
+                if (_isDropDownClosed)
+                {
+                    // Stop making requests to assert can start on each host after dropdown is closed
+                    break;
+                }
+
                 Host host = item.Tag as Host;
                 if (host != null)
                 {

--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -202,7 +202,10 @@ namespace XenAdmin.Commands
             });
 
             List<VMOperationToolStripMenuSubItem> dropDownItems = DropDownItems.Cast<VMOperationToolStripMenuSubItem>().ToList();
-            
+
+            // Adds the migrate wizard button, do this before the enable checks on the other items
+            Program.Invoke(Program.MainWindow, () => AddAdditionalMenuItems(selection));
+
             foreach (VMOperationToolStripMenuSubItem item in dropDownItems)
             {
                 if (_isDropDownClosed)
@@ -228,8 +231,6 @@ namespace XenAdmin.Commands
                                                             });
                 }
             }
-
-            Program.Invoke(Program.MainWindow, () => AddAdditionalMenuItems(selection));
         }
 
         /// <summary>


### PR DESCRIPTION
When we right click migrate a VM we load all the hosts in the pool into a dropdown, and then one-by-one assert whether the selected VM can boot on that host, enabling each option where this is positive. If the dropdown is exited then nothing stops these assert calls from continuing, and looking at the logs we can see that they do.

With a large pool this is problematic because the UI basically locks up until it's completed all these asserts, even if we've already selected a host to migrate to. If we try to migrate another host then we see in the logs that both the old thread and new thread are making `assert_can_boot_here` calls, and the UI for the new thread doesn't function until the old one has finished.

This commit adds a new property `_isDropDownClosed`, which is set by the new `OnDropDownClosed` event handler. In the loop enabling dropdown items, each iteration we check this property - and if it is true then the dropdown is no longer showing so we stop the loop and thus don't call any more `assert_can_boot_here` commands. This stops the UI locking up after the dropdown is closed.

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>