### PR TITLE
[CA 272150] Cross-pool copy/move/migrate wizard performance issues

### DIFF
--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
@@ -63,7 +63,8 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
         public override void PageLoaded(PageLoadedDirection direction)
         {
             base.PageLoaded(direction);
-            PopulateComboBox();
+            if (direction.Equals(PageLoadedDirection.Forward) || ComboBoxEmpty())
+                PopulateComboBox();
         }
 
         public override bool EnableNext()

--- a/XenAdmin/Wizards/GenericPages/DelayLoadingOptionComboBoxItem.cs
+++ b/XenAdmin/Wizards/GenericPages/DelayLoadingOptionComboBoxItem.cs
@@ -44,11 +44,11 @@ namespace XenAdmin.Wizards.GenericPages
 
     public class DelayLoadingOptionComboBoxItem : IEnableableXenObjectComboBoxItem
     {
-        public delegate void ReasonUpdatedEventHandler(object sender, EventArgs args);
+        public delegate void ReasonChangedEventHandler(object sender, EventArgs args);
         /// <summary>
         /// Event raised when the reason is updated
         /// </summary>
-        public event ReasonUpdatedEventHandler ReasonUpdated;
+        public event ReasonChangedEventHandler ReasonChanged;
         private string failureReason;
         private IXenObject xenObject;
         private const int defaultRetries = 10;
@@ -86,7 +86,7 @@ namespace XenAdmin.Wizards.GenericPages
         /// As the items are threaded they may exist and be disabled but required
         /// as a selected item if they load successfully.
         /// 
-        /// Use this in the event handler for the ReasonUpdated flag to find out
+        /// Use this in the event handler for the ReasonChanged flag to find out
         /// which item should be the selected one and thus which to 
         /// set in the combo box
         /// </summary>
@@ -147,8 +147,8 @@ namespace XenAdmin.Wizards.GenericPages
         /// <param name="e"></param>
         private void OnReasonChanged(EventArgs e)
         {
-            if (ReasonUpdated != null)
-                ReasonUpdated(this, e);
+            if (ReasonChanged != null)
+                ReasonChanged(this, e);
         }
 
         public bool Enabled { get; private set; }

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -473,7 +473,7 @@ namespace XenAdmin.Wizards.GenericPages
 	        else
 	        {
 	            /* If we have a value, and it's enabled, then enable next button
-                 * This is hit when we step back (so have a default value), but at inital load all items are disabled. 
+                 * This is hit when we step back (so have a default value), but at initial load all items are disabled. 
                  * So when they're updated and hit this they don't trigger the normal enable because cb.value != null
                  */
 	            var value = (IEnableableComboBoxItem) cb.Value;

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -401,11 +401,19 @@ namespace XenAdmin.Wizards.GenericPages
                             }
                         }
 
+                        var items = new List<DelayLoadingOptionComboBoxItem>();
                         foreach (var host in Connection.Cache.Hosts)
                         {
-                            var item = new DelayLoadingOptionComboBoxItem(host, homeserverFilters);
+                            items.Add(new DelayLoadingOptionComboBoxItem(host, homeserverFilters));
+                        }
+                        items.Sort(new DelayLoadingOptionComboboxItemCompare());
+
+                        foreach (var item in items)
+                        {
                             item.LoadAndWait();
                             cb.Items.Add(item);
+
+                            var host = item.Item;
 
                             if ((m_selectedObject != null && m_selectedObject.opaque_ref == host.opaque_ref) ||
                                 (target != null && target.Item.opaque_ref == host.opaque_ref))
@@ -631,6 +639,18 @@ namespace XenAdmin.Wizards.GenericPages
                 xenConnection.CachePopulated -= xenConnection_CachePopulated;
                 xenConnection.Cache.DeregisterCollectionChanged<Host>(Host_CollectionChangedWithInvoke);
             }
-        } 
+        }
+
+        /// <summary>
+        /// This class is an implementation of the 'IComparer' interface 
+        /// for sorting the ordering of hosts represented by a ComboBoxItem
+        /// </summary>
+        private class DelayLoadingOptionComboboxItemCompare : IComparer<DelayLoadingOptionComboBoxItem>
+        {
+            public int Compare(DelayLoadingOptionComboBoxItem x, DelayLoadingOptionComboBoxItem y)
+            {
+                return Core.StringUtility.NaturalCompare(x.ToString(), y.ToString());
+            }
+        }
 	}
 }

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -96,7 +96,6 @@ namespace XenAdmin.Wizards.GenericPages
         public override void PageLeave(PageLoadedDirection direction, ref bool cancel)
         {
             SetDefaultTarget(ChosenItem);
-            Program.Invoke(Program.MainWindow, ClearComboBox);
             base.PageLeave(direction, ref cancel);
         }
 
@@ -262,6 +261,11 @@ namespace XenAdmin.Wizards.GenericPages
             m_dataGridView.Rows.Clear();
             m_dataGridView.Refresh();
         }
+
+	    protected bool ComboBoxEmpty()
+	    {
+	        return m_comboBoxConnection.Items.Count == 0;
+	    }
 
 		protected void PopulateComboBox()
 		{

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -245,7 +245,7 @@ namespace XenAdmin.Wizards.GenericPages
             {
                 DelayLoadingOptionComboBoxItem tempItem = item as DelayLoadingOptionComboBoxItem;
                 if (tempItem != null)
-                    tempItem.ReasonUpdated -= DelayLoadedComboBoxItem_ReasonChanged;
+                    tempItem.ReasonChanged -= DelayLoadedComboBoxItem_ReasonChanged;
             }
             m_comboBoxConnection.Items.Clear();
         }
@@ -290,7 +290,7 @@ namespace XenAdmin.Wizards.GenericPages
 					{
                         item = CreateDelayLoadingOptionComboBoxItem(host);
                         m_comboBoxConnection.Items.Add(item);
-                        item.ReasonUpdated += DelayLoadedComboBoxItem_ReasonChanged;
+                        item.ReasonChanged += DelayLoadedComboBoxItem_ReasonChanged;
                         item.Load();
 					    host.PropertyChanged -= PropertyChanged;
 					    host.PropertyChanged += PropertyChanged;
@@ -300,7 +300,7 @@ namespace XenAdmin.Wizards.GenericPages
 				{
                     item = CreateDelayLoadingOptionComboBoxItem(pool);
                     m_comboBoxConnection.Items.Add(item);
-                    item.ReasonUpdated += DelayLoadedComboBoxItem_ReasonChanged;
+                    item.ReasonChanged += DelayLoadedComboBoxItem_ReasonChanged;
                     item.Load();
 			        pool.PropertyChanged -= PropertyChanged;
 			        pool.PropertyChanged += PropertyChanged;
@@ -408,7 +408,7 @@ namespace XenAdmin.Wizards.GenericPages
                         foreach (var host in Connection.Cache.Hosts)
                         {
                             var item = new DelayLoadingOptionComboBoxItem(host, homeserverFilters);
-                            item.ReasonUpdated +=
+                            item.ReasonChanged +=
                                 (sender, args) =>
                                         Program.Invoke(Program.MainWindow, delegate { SetComboBoxPreSelection(cb); }); 
                             items.Add(item);
@@ -543,7 +543,7 @@ namespace XenAdmin.Wizards.GenericPages
                                                             if (tempItem.PreferAsSelectedItem)
                                                                 m_comboBoxConnection.SelectedItem = tempItem;
 
-                                                            item.ReasonUpdated -= DelayLoadedComboBoxItem_ReasonChanged;
+                                                            item.ReasonChanged -= DelayLoadedComboBoxItem_ReasonChanged;
                                                         });
             }
         }

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -352,11 +352,9 @@ namespace XenAdmin.Wizards.GenericPages
                     if (cbCell == null)
                         return;
 
-                    List<IEnableableXenObjectComboBoxItem> list =
-                        cbCell.Items.OfType<IEnableableXenObjectComboBoxItem>().ToList();
-
                     var item =
-                        list.FirstOrDefault(cbi => MatchingWithXenRefObject(cbi, mapping.XenRef));
+                        cbCell.Items.OfType<IEnableableXenObjectComboBoxItem>().ToList()
+                            .FirstOrDefault(cbi => MatchingWithXenRefObject(cbi, mapping.XenRef));
                     if (item != null)
                         cbCell.Value = item;
                 }

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -102,7 +102,8 @@ namespace XenAdmin.Wizards.ImportWizard
                 }
             }
 
-            PopulateComboBox();
+            if(direction.Equals(PageLoadedDirection.Forward) || ComboBoxEmpty())
+                PopulateComboBox();
         }
 
         #endregion


### PR DESCRIPTION
- Sort the hosts in the target server dropdown using a natural sort
- Use async load for hosts in the target server dropdown, instead of locking the UI waiting for them to calculate
- Fix behaviour when stepping backward to avoid reloading when we don't need to