### PR TITLE
CA-272143: Import wizard stuck in "Waiting for Import template wizard…

### DIFF
--- a/XenModel/Actions/VM/ImportVmAction.cs
+++ b/XenModel/Actions/VM/ImportVmAction.cs
@@ -146,6 +146,15 @@ namespace XenAdmin.Actions
                     throw new CancelledException();
 
                 isTemplate = VM.get_is_a_template(Session, vmRef);
+                if (isTemplate && VM.get_is_default_template(Session, vmRef))
+                {
+                    var otherConfig = VM.get_other_config(Session, vmRef);
+                    if (!otherConfig.ContainsKey(IMPORT_TASK) || otherConfig[IMPORT_TASK] != RelatedTask.opaque_ref)
+                    {
+                        throw new Exception(Messages.IMPORT_TEMPLATE_ALREADY_EXISTS);
+                    }
+                }
+
                 Description = isTemplate ? Messages.IMPORT_TEMPLATE_UPDATING_TEMPLATE : Messages.IMPORTVM_UPDATING_VM;
                 VM.set_name_label(Session, vmRef, DefaultVMName(VM.get_name_label(Session, vmRef)));
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -18537,6 +18537,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The [Xenserver] Template that you are attempting to import already exists in the selected pool..
+        /// </summary>
+        public static string IMPORT_TEMPLATE_ALREADY_EXISTS {
+            get {
+                return ResourceManager.GetString("IMPORT_TEMPLATE_ALREADY_EXISTS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Configure storage for the new template.
         /// </summary>
         public static string IMPORT_TEMPLATE_CONFIGURE_STORAGE {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2737,11 +2737,11 @@ This action is final and unrecoverable.</value>
   <data name="CONFIRM_DISABLE_CBT_VMS" xml:space="preserve">
     <value>This will disable Changed Block Tracking on the disks of the selected VMs. If you are using any third-party solutions to back up the VMs, they might be affected. Note that Changed Block Tracking cannot be enabled again from [XenCenter]. Do you want to continue?</value>
   </data>
-  <data name="CONFIRM_DISABLE_CBT_VMs_TITLE" xml:space="preserve">
-    <value>Disable Changed Block Tracking on selected VMs</value>
-  </data>
   <data name="CONFIRM_DISABLE_CBT_VM_TITLE" xml:space="preserve">
     <value>Disable Changed Block Tracking on VM "{0}"</value>
+  </data>
+  <data name="CONFIRM_DISABLE_CBT_VMs_TITLE" xml:space="preserve">
+    <value>Disable Changed Block Tracking on selected VMs</value>
   </data>
   <data name="CONFIRM_DISABLE_HEALTH_CHECK_POOL" xml:space="preserve">
     <value>Are you sure you want to disable Health Check on the selected pool?</value>
@@ -6511,6 +6511,9 @@ Click Configure HA to alter the settings displayed below.</value>
   </data>
   <data name="IMPORT_SOURCE_PAGE_TITLE" xml:space="preserve">
     <value>Locate the file you want to import</value>
+  </data>
+  <data name="IMPORT_TEMPLATE_ALREADY_EXISTS" xml:space="preserve">
+    <value>The [Xenserver] Template that you are attempting to import already exists in the selected pool.</value>
   </data>
   <data name="IMPORT_TEMPLATE_CONFIGURE_STORAGE" xml:space="preserve">
     <value>Configure storage for the new template</value>


### PR DESCRIPTION
… to complete" when importing a default template

When trying to import a default template from xva, xapi notices that it is a default template, finds an existing one on the host and returns that one.
With these changes, XenCenter handles this case and displays an error, instead of waiting for the returned VM to be linked to the import task (which never happens).

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>