### PR TITLE
CA-272724: Missing user information in non-English XenCenter version.

### DIFF
--- a/XenAdmin/MainWindow.ja.resx
+++ b/XenAdmin/MainWindow.ja.resx
@@ -1054,7 +1054,7 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="TitleLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>

--- a/XenAdmin/MainWindow.zh-CN.resx
+++ b/XenAdmin/MainWindow.zh-CN.resx
@@ -1054,7 +1054,7 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="TitleLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>


### PR DESCRIPTION
The problem was caused by out-of-update of layout in Chinese/Japanese resource.
In MainWindow, columns of layout tableLayoutPanel1 shoud be changed to 4 (from 2) to accommodate title label, license label and log-in label of selected object.