### PR TITLE
CA-274150: Update RPU hotfixes in XenCenter

### DIFF
--- a/XenAdmin/Diagnostics/Hotfixing/HotfixFactory.cs
+++ b/XenAdmin/Diagnostics/Hotfixing/HotfixFactory.cs
@@ -42,7 +42,7 @@ namespace XenAdmin.Diagnostics.Hotfixing
             Clearwater,
             Creedence,
             Dundee,
-            Ely
+            ElyFalcon
         }
 
         private readonly Hotfix clearwaterHotfix = new SingleHotfix
@@ -63,7 +63,7 @@ namespace XenAdmin.Diagnostics.Hotfixing
             UUID = "474a0f28-0d33-4c9b-9e20-52baaea8ce5e"
         };
 
-        private readonly Hotfix elyHotfix = new SingleHotfix
+        private readonly Hotfix elyFalconHotfix = new SingleHotfix
         {
             Filename = "RPU004",
             UUID = "439235bf-48fa-4ee3-9c11-d67084a01205"
@@ -71,8 +71,8 @@ namespace XenAdmin.Diagnostics.Hotfixing
 
         public Hotfix Hotfix(Host host)
         {
-            if (Helpers.ElyOrGreater(host) && !Helpers.FalconOrGreater(host))
-                return Hotfix(HotfixableServerVersion.Ely);
+            if (Helpers.ElyOrGreater(host) && !Helpers.InvernessOrGreater(host))
+                return Hotfix(HotfixableServerVersion.ElyFalcon);
             if (Helpers.DundeeOrGreater(host) && !Helpers.ElyOrGreater(host))
                 return Hotfix(HotfixableServerVersion.Dundee);
             if (Helpers.CreedenceOrGreater(host) && !Helpers.DundeeOrGreater(host))
@@ -85,8 +85,8 @@ namespace XenAdmin.Diagnostics.Hotfixing
 
         public Hotfix Hotfix(HotfixableServerVersion version)
         {
-            if (version == HotfixableServerVersion.Ely)
-                return elyHotfix;
+            if (version == HotfixableServerVersion.ElyFalcon)
+                return elyFalconHotfix;
             if (version == HotfixableServerVersion.Dundee)
                 return dundeeHotfix; 
             if (version == HotfixableServerVersion.Creedence)

--- a/XenAdminTests/UnitTests/Diagnostics/HotFixFactoryTests.cs
+++ b/XenAdminTests/UnitTests/Diagnostics/HotFixFactoryTests.cs
@@ -59,7 +59,7 @@ namespace XenAdminTests.UnitTests.Diagnostics
             string[] enumNames = Enum.GetNames(typeof (HotfixFactory.HotfixableServerVersion));
             Array.Sort(enumNames);
 
-            string[] expectedNames = new []{"Clearwater", "Creedence", "Dundee", "Ely"};
+            string[] expectedNames = new []{"Clearwater", "Creedence", "Dundee", "ElyFalcon"};
             Array.Sort(expectedNames);
 
             CollectionAssert.AreEqual(expectedNames, enumNames, "Expected contents of HotfixableServerVersion enum");
@@ -81,8 +81,8 @@ namespace XenAdminTests.UnitTests.Diagnostics
                             "Dundee UUID lookup from enum");
 
             Assert.AreEqual("439235bf-48fa-4ee3-9c11-d67084a01205",
-                            factory.Hotfix(HotfixFactory.HotfixableServerVersion.Ely).UUID,
-                            "Ely UUID lookup from enum");
+                            factory.Hotfix(HotfixFactory.HotfixableServerVersion.ElyFalcon).UUID,
+                            "Ely/Falcon UUID lookup from enum");
         }
 
         [Test]
@@ -101,14 +101,14 @@ namespace XenAdminTests.UnitTests.Diagnostics
                             "Dundee Filename lookup from enum");
 
             Assert.AreEqual("RPU004",
-                            factory.Hotfix(HotfixFactory.HotfixableServerVersion.Ely).Filename,
-                            "Ely Filename lookup from enum");
+                            factory.Hotfix(HotfixFactory.HotfixableServerVersion.ElyFalcon).Filename,
+                            "Ely/Falcon Filename lookup from enum");
         }
 
         [Test]
-        [TestCase("2.2.50", Description = "Falcon")]
+        [TestCase("2.3.50", Description = "Inverness")]
         [TestCase("9999.9999.9999", Description = "Future")]
-        public void TestPlatformVersionNumbersFalconOrGreaterGiveNulls(string platformVersion)
+        public void TestPlatformVersionNumbersInvernessOrGreaterGiveNulls(string platformVersion)
         {
             Mock<Host> host = ObjectManager.NewXenObject<Host>(id);
             host.Setup(h => h.PlatformVersion()).Returns(platformVersion);
@@ -116,7 +116,8 @@ namespace XenAdminTests.UnitTests.Diagnostics
         }
 
         [Test]
-        [TestCase("2.2.50", Description = "Falcon", Result = false)]
+        [TestCase("2.3.50", Description = "Inverness", Result = false)]
+        [TestCase("2.3.0", Description = "Falcon", Result = true)]
         [TestCase("2.1.1", Description = "Ely", Result = true)]
         [TestCase("2.0.0", Description = "Dundee", Result = true)]
         [TestCase("1.9.0", Description = "Creedence", Result = true)]


### PR DESCRIPTION
- RPU004 is applicable to Falcon as well as Ely hosts

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>