### PR TITLE
Some Enhancements to input stream handling in xva_verify

### DIFF
--- a/xva_verify/verify_main.cs
+++ b/xva_verify/verify_main.cs
@@ -58,7 +58,7 @@ class MainClass
                 f = new FileStream(filename, FileMode.Open, FileAccess.Read);
             } else
             {
-                f = new BufferedStream(Console.OpenStandardInput(), 1024);
+                f = Console.OpenStandardInput();
             }
 
             // check for gzip compression ( only on seekable inputs - i.e. not the stdin stream )

--- a/xva_verify/verify_main.cs
+++ b/xva_verify/verify_main.cs
@@ -67,9 +67,8 @@ class MainClass
                 try
                 {
                     GZipStream zip = new GZipStream(f, CompressionMode.Decompress);
-                    // try reading a few bytes
-                    byte[] buffer = new byte[10];
-                    zip.Read(buffer, 0, 5);
+                    // try reading a byte
+                    zip.ReadByte();
 
                     // success - reset stream, use the gunzipped stream from now on
                     f.Seek(0, SeekOrigin.Begin);
@@ -77,7 +76,8 @@ class MainClass
                 }
                 catch (InvalidDataException e)
                 {
-                    // we'll ignore that here - it means the stream is not compressed
+                    // just reset the stream - Exception means the stream is not compressed
+                    f.Seek(0, SeekOrigin.Begin);
                 }
             }
             


### PR DESCRIPTION
Changes:
- Open input file in read mode to allow readonly data
- Allow reading from stdin with filename "-"
- test for compressed data, use decompression if needed.

Needed because we use compress=true in vm-export and have the images on a read-only share.
