### PR TITLE
Updated unit test: AppliesTo is filled from the host's name, which in…

### DIFF
--- a/XenAdminTests/UnitTests/AlertTests/MissingIqnAlertTests.cs
+++ b/XenAdminTests/UnitTests/AlertTests/MissingIqnAlertTests.cs
@@ -46,7 +46,7 @@ namespace XenAdminTests.UnitTests.AlertTests
 
             validator.Verify(new AlertClassUnitTestData
             {
-                AppliesTo = null,
+                AppliesTo = "",
                 FixLinkText = "Edit IQN",
                 HelpID = "MissingIqnAlert",
                 Description = " has no iSCSI-IQN. This could cause problems with iSCSI storage on this network.",


### PR DESCRIPTION
… this case

is the name_label's default value. The default value is now taken from the API
and it is an empty string rather than null.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>