### PR TITLE
CA-272769: Enable user to cancel URL testing in rolling upgrade wizard.

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -6787,7 +6787,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The VM &apos;{0}&apos; is already assigned to the snashot schedule &apos;{1}&apos;.
+        ///   Looks up a localized string similar to The VM &apos;{0}&apos; is already assigned to the snapshot schedule &apos;{1}&apos;.
         ///    
         ///Do you want to assign it to the schedule &apos;{2}&apos; instead?.
         /// </summary>
@@ -30034,6 +30034,24 @@ namespace XenAdmin {
         public static string ROLLING_POOL_UPGRADE_ELLIPSIS {
             get {
                 return ResourceManager.GetString("ROLLING_POOL_UPGRADE_ELLIPSIS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to S&amp;top.
+        /// </summary>
+        public static string ROLLING_UPGRADE_BUTTON_LABEL_STOP {
+            get {
+                return ResourceManager.GetString("ROLLING_UPGRADE_BUTTON_LABEL_STOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &amp;Test.
+        /// </summary>
+        public static string ROLLING_UPGRADE_BUTTON_LABEL_TEST {
+            get {
+                return ResourceManager.GetString("ROLLING_UPGRADE_BUTTON_LABEL_TEST", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2749,11 +2749,11 @@ This action is final and unrecoverable.</value>
   <data name="CONFIRM_DISABLE_CBT_VMS" xml:space="preserve">
     <value>This will disable Changed Block Tracking on the disks of the selected VMs. If you are using any third-party solutions to back up the VMs, they might be affected. Note that Changed Block Tracking cannot be enabled again from [XenCenter]. Do you want to continue?</value>
   </data>
-  <data name="CONFIRM_DISABLE_CBT_VMs_TITLE" xml:space="preserve">
-    <value>Disable Changed Block Tracking on selected VMs</value>
-  </data>
   <data name="CONFIRM_DISABLE_CBT_VM_TITLE" xml:space="preserve">
     <value>Disable Changed Block Tracking on VM "{0}"</value>
+  </data>
+  <data name="CONFIRM_DISABLE_CBT_VMs_TITLE" xml:space="preserve">
+    <value>Disable Changed Block Tracking on selected VMs</value>
   </data>
   <data name="CONFIRM_DISABLE_HEALTH_CHECK_POOL" xml:space="preserve">
     <value>Are you sure you want to disable Health Check on the selected pool?</value>
@@ -10438,6 +10438,12 @@ Click Server Status Report to open the Compile Server Status Report Wizard or cl
   <data name="ROLLING_POOL_UPGRADE_ELLIPSIS" xml:space="preserve">
     <value>Rolling Pool &amp;Upgrade...</value>
   </data>
+  <data name="ROLLING_UPGRADE_BUTTON_LABEL_STOP" xml:space="preserve">
+    <value>S&amp;top</value>
+  </data>
+  <data name="ROLLING_UPGRADE_BUTTON_LABEL_TEST" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
   <data name="ROLLING_UPGRADE_CAN_RESUME_UPGRADE" xml:space="preserve">
     <value>This upgrade can be resumed by launching the Rolling Pool Upgrade wizard again.</value>
   </data>
@@ -13615,11 +13621,5 @@ You will need to navigate to the Console on each of the selected VMs to complete
   </data>
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
-  </data>
-  <data name="ROLLING_UPGRADE_BUTTON_LABEL_STOP" xml:space="preserve">
-    <value>S&amp;top</value>
-  </data>
-  <data name="ROLLING_UPGRADE_BUTTON_LABEL_TEST" xml:space="preserve">
-    <value>&amp;Test</value>
   </data>
 </root>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13616,4 +13616,10 @@ You will need to navigate to the Console on each of the selected VMs to complete
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
   </data>
+  <data name="ROLLING_UPGRADE_BUTTON_LABEL_STOP" xml:space="preserve">
+    <value>S&amp;top</value>
+  </data>
+  <data name="ROLLING_UPGRADE_BUTTON_LABEL_TEST" xml:space="preserve">
+    <value>&amp;Test</value>
+  </data>
 </root>


### PR DESCRIPTION
Changes brief:
- Once the "Test" button is clicked, the button text is changed to "Stop" instead of being disabled. 
- User can click "Stop" button again to cancel the test.
- The test is also canceled when user type "Previous" and "Cancel" button.
- As the text may change in run, so the text was moved into Messages resource file.
- The "cancel" function also applies for HTTP and FTP.