### PR TITLE
CA-271863: Can not automatically resolve autostart-enabled VM in RPU.

### DIFF
--- a/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
@@ -96,7 +96,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
                            {
                                vm.Locked = false;
                            }
-                           int wait = 1000; // wait up to 1 second for the cache to be updated
+                           int wait = 5000; // wait up to 5 seconds for the cache to be updated
                            while (wait > 0 && vm.GetAutoPowerOn() != autostartValue)
                            {
                                Thread.Sleep(100);

--- a/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
@@ -30,6 +30,7 @@
  */
 
 using System;
+using System.Threading;
 using XenAdmin.Actions;
 using XenAdmin.Core;
 using XenAdmin.Diagnostics.Checks;
@@ -95,7 +96,12 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
                            {
                                vm.Locked = false;
                            }
-
+                           int wait = 1000; // wait up to 1 second for the cache to be updated
+                           while (wait > 0 && vm.GetAutoPowerOn() != autostartValue)
+                           {
+                               Thread.Sleep(100);
+                               wait -= 100;
+                           }
                        };
         }
 


### PR DESCRIPTION
In RPU Precheck page, if user type Resolve or Resolve All to disable autostart-enabled VM, the refreshed listed can still contain autostart-enabled problem. Because the server update-and-notification took time, but the page was updated before server ready. 
Now a 1-second waiting is added before updating the Precheck page.
Note, in extreme situation, 1 second may not be enough to collect server response (for bad network, etc.). In that case, the fault can happen and user need to click "Check Again" or resolve again to update.