### PR TITLE
CP-26131: IP Address Configuration when clustering is enabled

### DIFF
--- a/XenModel/Actions/Network/NetworkingActionHelpers.cs
+++ b/XenModel/Actions/Network/NetworkingActionHelpers.cs
@@ -162,6 +162,7 @@ namespace XenAdmin.Actions
                 action.PollToCompletion(action.PercentComplete, hi);
                 log.DebugFormat("Plugging {0} {1} done.", pif.Name(), pif.uuid);
             }
+            action.PercentComplete = hi;
         }
 
         //private static void BringDown(AsyncAction action, PIF master, bool this_host, int hi)


### PR DESCRIPTION
When configuring the IP address on the cluster network, we need to temporarily unplug all GFS2 SRs and disable clustering.

This commit also includes a fix to the action progress calculation.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>