### PR TITLE
CP-26131: IP Address Configuration when clustering is enabled

### DIFF
--- a/XenAdmin/SettingsPanels/ClusteringEditPage.cs
+++ b/XenAdmin/SettingsPanels/ClusteringEditPage.cs
@@ -93,7 +93,7 @@ namespace XenAdmin.SettingsPanels
                 comboBoxNetwork.Enabled = labelNetwork.Enabled = false;
             }
 
-            var gfs2Attached = clone.Connection.Cache.SRs.Any(sr => sr.type.ToLower() == "gfs2" && !sr.IsDetached());
+            var gfs2Attached = clone.Connection.Cache.SRs.Any(sr => sr.GetSRType(true) == SR.SRTypes.gfs2 && !sr.IsDetached());
 
             if (clusteringEnabled && gfs2Attached)
             {

--- a/XenModel/Actions/Network/ChangeNetworkingAction.cs
+++ b/XenModel/Actions/Network/ChangeNetworkingAction.cs
@@ -270,7 +270,7 @@ namespace XenAdmin.Actions
             foreach (var pbd in Connection.ResolveAll(host.PBDs).Where(pbd => pbd.currently_attached))
             {
                 var sr = Connection.Resolve(pbd.SR);
-                if (sr != null && sr.type.ToLowerInvariant() == "gfs2")
+                if (sr != null && sr.GetSRType(true) == SR.SRTypes.gfs2)
                 {
                     gfs2Pbds.Add(pbd);
                     Description = string.Format(Messages.ACTION_SR_DETACHING, sr.Name(), host.Name());


### PR DESCRIPTION
When configuring the IP address on the cluster network, we need to temporarily unplug all GFS2 SRs and disable clustering.

This commit also includes a fix to the action progress calculation.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>