### PR TITLE
CA-279502: Added check for the server version before calling VM.get_i…

### DIFF
--- a/XenModel/Actions/VM/ImportVmAction.cs
+++ b/XenModel/Actions/VM/ImportVmAction.cs
@@ -146,7 +146,7 @@ namespace XenAdmin.Actions
                     throw new CancelledException();
 
                 isTemplate = VM.get_is_a_template(Session, vmRef);
-                if (isTemplate && VM.get_is_default_template(Session, vmRef))
+                if (isTemplate && Helpers.FalconOrGreater(Connection) && VM.get_is_default_template(Session, vmRef))
                 {
                     var otherConfig = VM.get_other_config(Session, vmRef);
                     if (!otherConfig.ContainsKey(IMPORT_TASK) || otherConfig[IMPORT_TASK] != RelatedTask.opaque_ref)

--- a/XenModel/XenAPI/VM.cs
+++ b/XenModel/XenAPI/VM.cs
@@ -1029,7 +1029,7 @@ namespace XenAPI
 
         /// <summary>
         /// Get the is_default_template field of the given VM.
-        /// First published in XenServer 7.1.
+        /// First published in XenServer 7.2.
         /// </summary>
         /// <param name="session">The session</param>
         /// <param name="_vm">The opaque_ref of the given vm</param>
@@ -4282,7 +4282,7 @@ namespace XenAPI
 
         /// <summary>
         /// true if this is a default template. Default template VMs can never be started or migrated, they are used only for cloning other VMs
-        /// First published in XenServer 7.1.
+        /// First published in XenServer 7.2.
         /// </summary>
         public virtual bool is_default_template
         {


### PR DESCRIPTION
…s_default_template

This fixes the error thrown when importing templates with XenCenter 7.3 on servers earlier than 7.2

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>