### PR TITLE
Cherry-picking to Jura: CA-276976: Add a new precheck in the Update Wizard

### DIFF
--- a/XenAdmin/Diagnostics/Checks/ServerSelectionCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/ServerSelectionCheck.cs
@@ -1,0 +1,76 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using XenAdmin.Core;
+using XenAdmin.Diagnostics.Problems;
+using XenAdmin.Diagnostics.Problems.HostProblem;
+using XenAdmin.Diagnostics.Problems.PoolProblem;
+using XenAPI;
+
+namespace XenAdmin.Diagnostics.Checks
+{
+    class ServerSelectionCheck : Check
+    {
+        private readonly Pool_update update;
+        private readonly Pool pool;
+        private readonly List<Host> selectedServers;
+
+        public ServerSelectionCheck(Pool pool, Pool_update update, List<Host> selectedServers)
+            : base(Helpers.GetMaster(pool.Connection))
+        {
+            this.pool = pool;
+            this.update = update;
+            this.selectedServers = selectedServers;
+        }
+
+        protected override Problem RunCheck()
+        {
+            if (!Host.IsLive())
+                return new HostNotLiveWarning(this, Host);
+
+            if (update == null || !update.EnforceHomogeneity()) 
+                return null;
+
+            if (pool.Connection.Cache.Hosts.Any(h => !update.AppliedOn(h) && !selectedServers.Contains(h)))
+                return new ServerSelectionProblem(this, pool);
+
+            return null;
+        }
+
+        public override string Description
+        {
+            get { return Messages.SERVER_SELECTION_CHECK_DESCRIPTION; }
+        }
+    }
+}
+

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/ServerSelectionProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/ServerSelectionProblem.cs
@@ -1,0 +1,55 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using XenAdmin.Diagnostics.Checks;
+using XenAPI;
+
+
+namespace XenAdmin.Diagnostics.Problems.PoolProblem
+{
+    class ServerSelectionProblem : PoolProblem
+    {
+        public ServerSelectionProblem(Check check, Pool pool)
+            : base(check, pool)
+        {
+        }
+
+        public override string Description
+        {
+            get { return string.Format(Messages.UPDATES_WIZARD_SERVER_SELECTION_PROBLEM, Pool); }
+        }
+
+        public override string HelpMessage
+        {
+            get { return null; }
+        }
+    }
+}

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -514,6 +514,21 @@ namespace XenAdmin.Wizards.PatchingWizard
             List<KeyValuePair<string, List<Check>>> checks = GenerateCommonChecks(applicableServers);
             List<Check> checkGroup;
 
+            //Update Homogeneity check for InvernessOrGreater
+            if (update != null)
+            {
+                var homogeneityChecks = new List<Check>();
+                foreach (var pool in SelectedPools.Where(pool => Helpers.InvernessOrGreater(pool.Connection)))
+                {
+                    homogeneityChecks.Add(new ServerSelectionCheck(pool, update, SelectedServers));
+                }
+
+                if (homogeneityChecks.Count > 0)
+                {
+                    checks.Add(new KeyValuePair<string, List<Check>>(Messages.CHECKING_SERVER_SELECTION, homogeneityChecks));
+                }
+            }
+
             //Checking other things
             if (update != null)
             {

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -228,6 +228,7 @@
     <Compile Include="Diagnostics\Checks\HostNeedsRebootCheck.cs" />
     <Compile Include="Diagnostics\Checks\SafeToUpgradeCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostHasUnsupportedStorageLinkSRCheck.cs" />
+    <Compile Include="Diagnostics\Checks\ServerSelectionCheck.cs" />
     <Compile Include="Diagnostics\Checks\XenCenterVersionCheck.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\MasterIsPendingRestartProblems.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\PrerequisiteUpdateMissing.cs" />
@@ -237,6 +238,7 @@
     <Compile Include="Diagnostics\Problems\HostProblem\ConflictingUpdatePresent.cs" />
     <Compile Include="Diagnostics\Problems\Information.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\CPUIncompatibilityProblem.cs" />
+    <Compile Include="Diagnostics\Problems\PoolProblem\ServerSelectionProblem.cs" />
     <Compile Include="Diagnostics\Problems\ProblemWithInformationUrl.cs" />
     <Compile Include="Diagnostics\Problems\SRProblem\UnsupportedStorageLinkSrIsPresentProblem.cs" />
     <Compile Include="Diagnostics\Problems\VMProblem\InvalidVCPUConfiguration.cs" />

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -6930,6 +6930,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking server selection.
+        /// </summary>
+        public static string CHECKING_SERVER_SELECTION {
+            get {
+                return ResourceManager.GetString("CHECKING_SERVER_SELECTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Checking server side status.
         /// </summary>
         public static string CHECKING_SERVER_SIDE_STATUS {
@@ -30650,6 +30659,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Server selection check.
+        /// </summary>
+        public static string SERVER_SELECTION_CHECK_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("SERVER_SELECTION_CHECK_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disk space check.
         /// </summary>
         public static string SERVER_SIDE_CHECK_AUTO_MODE_DESCRIPTION {
@@ -34609,6 +34627,15 @@ namespace XenAdmin {
         public static string UPDATES_WIZARD_RUNNING_PRECHECK {
             get {
                 return ResourceManager.GetString("UPDATES_WIZARD_RUNNING_PRECHECK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: The update needs to be applied on all servers in the pool..
+        /// </summary>
+        public static string UPDATES_WIZARD_SERVER_SELECTION_PROBLEM {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_SERVER_SELECTION_PROBLEM", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2513,6 +2513,9 @@ Do you want to assign it to the schedule '{2}' instead?</value>
   <data name="CHECKING_SERVER_NEEDS_REBOOT" xml:space="preserve">
     <value>Checking reboots required</value>
   </data>
+  <data name="CHECKING_SERVER_SELECTION" xml:space="preserve">
+    <value>Checking server selection</value>
+  </data>
   <data name="CHECKING_SERVER_SIDE_STATUS" xml:space="preserve">
     <value>Checking server side status</value>
   </data>
@@ -10660,6 +10663,9 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
   <data name="SERVER_REQUEST_IN_PROGRESS" xml:space="preserve">
     <value>A server request is in progress</value>
   </data>
+  <data name="SERVER_SELECTION_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>Server selection check</value>
+  </data>
   <data name="SERVER_SIDE_CHECK_AUTO_MODE_DESCRIPTION" xml:space="preserve">
     <value>Disk space check</value>
   </data>
@@ -11937,6 +11943,9 @@ Check your settings and try again.</value>
   </data>
   <data name="UPDATES_WIZARD_RUNNING_PRECHECK" xml:space="preserve">
     <value>Precheck for {0} in {1}...</value>
+  </data>
+  <data name="UPDATES_WIZARD_SERVER_SELECTION_PROBLEM" xml:space="preserve">
+    <value>{0}: The update needs to be applied on all servers in the pool.</value>
   </data>
   <data name="UPDATES_WIZARD_SR_TITLE" xml:space="preserve">
     <value>Storage repository '{0}'</value>


### PR DESCRIPTION
- The new "server selection" precheck is added for Inverness or greater pools and checks if all the servers in the pool are selected (if update not already applied) when applying an update that has the "enforce-homogeneity" flag set to true

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>