### PR TITLE
CA-280287: Fix the null reference exception on the Import wizard

### DIFF
--- a/XenAdmin/Wizards/ImportWizard/GlobalSelectHost.cs
+++ b/XenAdmin/Wizards/ImportWizard/GlobalSelectHost.cs
@@ -43,7 +43,7 @@ namespace XenAdmin.Wizards.ImportWizard
 		private IXenObject m_selectedObject;
         private bool m_buttonNextEnabled;
 
-        public event Action HostSelectionChanged;
+        public event Action<IXenConnection> ConnectionSelectionChanged;
 
 		public GlobalSelectHost()
 		{
@@ -101,8 +101,8 @@ namespace XenAdmin.Wizards.ImportWizard
 			m_buttonNextEnabled = e.SomethingSelected;
             OnPageUpdated();
 			IsDirty = true;
-            if (HostSelectionChanged != null)
-                HostSelectionChanged();
+            if (ConnectionSelectionChanged != null)
+                ConnectionSelectionChanged(SelectedHost != null ? SelectedHost.Connection : SelectedConnection);
         }
 
 		private void m_buttonAddNewServer_Click(object sender, EventArgs e)

--- a/XenAdmin/Wizards/ImportWizard/GlobalSelectHost.cs
+++ b/XenAdmin/Wizards/ImportWizard/GlobalSelectHost.cs
@@ -40,9 +40,10 @@ namespace XenAdmin.Wizards.ImportWizard
 {
 	internal partial class GlobalSelectHost : XenTabPage
     {
-		private Host m_selectedHost;
-		private IXenConnection m_selectedConnection;
+		private IXenObject m_selectedObject;
         private bool m_buttonNextEnabled;
+
+        public event Action HostSelectionChanged;
 
 		public GlobalSelectHost()
 		{
@@ -77,10 +78,11 @@ namespace XenAdmin.Wizards.ImportWizard
 		{
 			m_poolHostPicker.buildList();
 
-			if (m_selectedHost != null)
-				m_poolHostPicker.SelectHost(m_selectedHost);
-			else if (m_selectedConnection != null)
-				m_poolHostPicker.SelectConnection(m_selectedConnection);
+            var selectedHost = m_selectedObject as Host;
+            if (selectedHost != null)
+                m_poolHostPicker.SelectHost(selectedHost);
+			else if (m_selectedObject != null  && m_selectedObject.Connection != null)
+                m_poolHostPicker.SelectConnection(m_selectedObject.Connection);
 
 			IsDirty = true;
 		}
@@ -99,6 +101,8 @@ namespace XenAdmin.Wizards.ImportWizard
 			m_buttonNextEnabled = e.SomethingSelected;
             OnPageUpdated();
 			IsDirty = true;
+            if (HostSelectionChanged != null)
+                HostSelectionChanged();
         }
 
 		private void m_buttonAddNewServer_Click(object sender, EventArgs e)
@@ -112,20 +116,21 @@ namespace XenAdmin.Wizards.ImportWizard
 		{
 			get
 			{
-				m_selectedHost = m_poolHostPicker.ChosenHost;
-				return m_selectedHost;
+                return m_poolHostPicker.ChosenHost;
 			}
-			set { m_selectedHost = value; }
 		}
 
 		public IXenConnection SelectedConnection
 		{
 			get
 			{
-				m_selectedConnection = m_poolHostPicker.ChosenConnection;
-				return m_selectedConnection;
+                return m_poolHostPicker.ChosenConnection;
 			}
-			set { m_selectedConnection = value; }
 		}
+
+        public void SetDefaultTarget(IXenObject xenObject)
+        {
+            m_selectedObject = xenObject;
+        }
 	}
 }

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -36,6 +36,7 @@ using System.Text.RegularExpressions;
 
 using XenAdmin.Controls;
 using XenAdmin.Core;
+using XenAdmin.Network;
 using XenAdmin.Wizards.GenericPages;
 using XenAdmin.Wizards.ImportWizard.Filters;
 using XenAPI;
@@ -52,7 +53,7 @@ namespace XenAdmin.Wizards.ImportWizard
         private List<Xen_ConfigurationSettingData_Type> hardwarePlatformSettings = new List<Xen_ConfigurationSettingData_Type>();
         private List<Xen_ConfigurationSettingData_Type> vendorDeviceSettings = new List<Xen_ConfigurationSettingData_Type>();
 
-        public event Action HostSelectionChanged;
+        public event Action<IXenConnection> ConnectionSelectionChanged;
 
         #region XenTabPage overrides
 
@@ -143,8 +144,8 @@ namespace XenAdmin.Wizards.ImportWizard
 
             ShowWarning(string.Join("\n", warnings));
 
-            if (HostSelectionChanged != null)
-                HostSelectionChanged();
+            if (ConnectionSelectionChanged != null)
+                ConnectionSelectionChanged(ChosenItem != null ? ChosenItem.Connection : null);
         }
 
         protected override DelayLoadingOptionComboBoxItem CreateDelayLoadingOptionComboBoxItem(IXenObject xenItem)

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -50,6 +51,8 @@ namespace XenAdmin.Wizards.ImportWizard
         private List<Xen_ConfigurationSettingData_Type> vgpuSettings = new List<Xen_ConfigurationSettingData_Type>();
         private List<Xen_ConfigurationSettingData_Type> hardwarePlatformSettings = new List<Xen_ConfigurationSettingData_Type>();
         private List<Xen_ConfigurationSettingData_Type> vendorDeviceSettings = new List<Xen_ConfigurationSettingData_Type>();
+
+        public event Action HostSelectionChanged;
 
         #region XenTabPage overrides
 
@@ -139,6 +142,9 @@ namespace XenAdmin.Wizards.ImportWizard
             }
 
             ShowWarning(string.Join("\n", warnings));
+
+            if (HostSelectionChanged != null)
+                HostSelectionChanged();
         }
 
         protected override DelayLoadingOptionComboBoxItem CreateDelayLoadingOptionComboBoxItem(IXenObject xenItem)

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -111,6 +111,8 @@ namespace XenAdmin.Wizards.ImportWizard
 			m_pageImportSource.OvfModeOnly = ovfModeOnly;
             AddPages(m_pageImportSource, m_pageHost, m_pageStorage, m_pageNetwork, m_pageFinish);
 
+            m_pageHost.HostSelectionChanged += pageHost_HostSelectionChanged;
+            m_pageXvaHost.HostSelectionChanged += pageXvaHost_HostSelectionChanged;
             ShowXenAppXenDesktopWarning(con);
 		}
 
@@ -236,8 +238,7 @@ namespace XenAdmin.Wizards.ImportWizard
                             RemovePages(appliancePages);
                             AddAfterPage(m_pageImportSource, xvaPages);
 						}
-						m_pageXvaHost.SelectedHost = m_selectedObject as Host;
-						m_pageXvaHost.SelectedConnection = m_selectedObject != null ? m_selectedObject.Connection : null;
+				        m_pageXvaHost.SetDefaultTarget(m_selectedObject);
 						m_pageXvaStorage.FilePath = m_pageImportSource.FilePath;
 						break;
 				}
@@ -720,8 +721,20 @@ namespace XenAdmin.Wizards.ImportWizard
 
         private void ShowXenAppXenDesktopWarning(IXenConnection connection)
         {
-            if (connection.Cache.Hosts.Any(h => h.DesktopFeaturesEnabled() || h.DesktopPlusFeaturesEnabled() || h.DesktopCloudFeaturesEnabled()))
+            if (connection != null && connection.Cache.Hosts.Any(h => h.DesktopFeaturesEnabled() || h.DesktopPlusFeaturesEnabled() || h.DesktopCloudFeaturesEnabled()))
                 ShowInformationMessage(Helpers.GetPool(connection) != null ? Messages.NEWVMWIZARD_XENAPP_XENDESKTOP_INFO_MESSAGE_POOL : Messages.NEWVMWIZARD_XENAPP_XENDESKTOP_INFO_MESSAGE_SERVER);
+            else
+                HideInformationMessage();
+        }
+
+        private void pageHost_HostSelectionChanged()
+        {
+            ShowXenAppXenDesktopWarning(m_pageHost.ChosenItem == null ? null : m_pageHost.ChosenItem.Connection);
+        }
+
+        private void pageXvaHost_HostSelectionChanged()
+        {
+            ShowXenAppXenDesktopWarning(m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection : m_pageXvaHost.SelectedHost.Connection);
         }
 
 		#region Nested items

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -111,8 +111,8 @@ namespace XenAdmin.Wizards.ImportWizard
 			m_pageImportSource.OvfModeOnly = ovfModeOnly;
             AddPages(m_pageImportSource, m_pageHost, m_pageStorage, m_pageNetwork, m_pageFinish);
 
-            m_pageHost.HostSelectionChanged += pageHost_HostSelectionChanged;
-            m_pageXvaHost.HostSelectionChanged += pageXvaHost_HostSelectionChanged;
+            m_pageHost.ConnectionSelectionChanged += pageHost_ConnectionSelectionChanged;
+            m_pageXvaHost.ConnectionSelectionChanged += pageHost_ConnectionSelectionChanged;
             ShowXenAppXenDesktopWarning(con);
 		}
 
@@ -727,14 +727,9 @@ namespace XenAdmin.Wizards.ImportWizard
                 HideInformationMessage();
         }
 
-        private void pageHost_HostSelectionChanged()
+        private void pageHost_ConnectionSelectionChanged(IXenConnection connection)
         {
-            ShowXenAppXenDesktopWarning(m_pageHost.ChosenItem == null ? null : m_pageHost.ChosenItem.Connection);
-        }
-
-        private void pageXvaHost_HostSelectionChanged()
-        {
-            ShowXenAppXenDesktopWarning(m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection : m_pageXvaHost.SelectedHost.Connection);
+            ShowXenAppXenDesktopWarning(connection);
         }
 
 		#region Nested items

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -308,8 +308,10 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void ShowXenAppXenDesktopWarning(IXenConnection connection)
         {
-            if (connection.Cache.Hosts.Any(h => h.DesktopFeaturesEnabled() || h.DesktopPlusFeaturesEnabled() || h.DesktopCloudFeaturesEnabled()))
+            if (connection != null && connection.Cache.Hosts.Any(h => h.DesktopFeaturesEnabled() || h.DesktopPlusFeaturesEnabled() || h.DesktopCloudFeaturesEnabled()))
                 ShowInformationMessage(Helpers.GetPool(connection) != null ? Messages.NEWVMWIZARD_XENAPP_XENDESKTOP_INFO_MESSAGE_POOL : Messages.NEWVMWIZARD_XENAPP_XENDESKTOP_INFO_MESSAGE_SERVER);
+            else
+                HideInformationMessage();
         }
     }
 }

--- a/XenAdmin/Wizards/XenWizardBase.cs
+++ b/XenAdmin/Wizards/XenWizardBase.cs
@@ -407,5 +407,10 @@ namespace XenAdmin.Wizards
             labelGeneralInformationMessage.Text = message;
             panelGeneralInformationMessage.Visible = true;
         }
+
+        protected virtual void HideInformationMessage()
+        {
+            panelGeneralInformationMessage.Visible = false;
+        }
     }
 }


### PR DESCRIPTION
- Added a check so that we don't attempting to show the license warning if the wizard is open without a preselected host/pool.
- The license warning is now updated whenever the host selection changes; plus, we are not attempting to show it if the wizard is open without a preselected host/pool.

- Also a minor refactoring in the GlobalSelectHost page to fix this issue: when the wizard is open with a pre-selected host, we pass this to the page by assigning SelectedHost property, which in turn sets the m_selectedHost. The getter for SelectedHost  resets m_selectedHost to the selected item in the host list. If the getter is used before the host list selection is updated, then the desired pre-selection is lost, because m_selectedHost is reset to null.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>