### PR TITLE
CA-280329: Fix CrossPoolMigrateDestinationPage with Current Server showing

### DIFF
--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
@@ -148,15 +148,15 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             return new DelayLoadingOptionComboBoxItem(xenItem, filters);
         }
 
-        protected override List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem selectedItem)
+        protected override List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem selectedItem, List<VM> vmList)
         {
             var filters = new List<ReasoningFilter>();
 
             if(selectedItem != null)
             {
-                filters.Add(new ResidentHostIsSameAsSelectionFilter(selectedItem.Item, selectedVMs));
-                filters.Add(new CrossPoolMigrateCanMigrateFilter(selectedItem.Item, selectedVMs, wizardMode));
-                filters.Add(new WlbEnabledFilter(selectedItem.Item, selectedVMs));
+                filters.Add(new ResidentHostIsSameAsSelectionFilter(selectedItem.Item, vmList));
+                filters.Add(new CrossPoolMigrateCanMigrateFilter(selectedItem.Item, vmList, wizardMode));
+                filters.Add(new WlbEnabledFilter(selectedItem.Item, vmList));
             } 
 
             return filters;

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
@@ -148,12 +148,16 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             return new DelayLoadingOptionComboBoxItem(xenItem, filters);
         }
 
-        protected override List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem selectedItem, List<VM> vmList)
+        protected override List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem selectedItem, List<string> vmOpaqueRefs)
         {
             var filters = new List<ReasoningFilter>();
 
-            if(selectedItem != null)
+            if(selectedItem != null && vmOpaqueRefs != null && selectedVMs != null)
             {
+                List<VM> vmList = new List<VM>();
+                foreach (string opaqueRef in vmOpaqueRefs)
+                    vmList.Add(selectedVMs.Find(vm => vm.opaque_ref == opaqueRef));
+
                 filters.Add(new ResidentHostIsSameAsSelectionFilter(selectedItem.Item, vmList));
                 filters.Add(new CrossPoolMigrateCanMigrateFilter(selectedItem.Item, vmList, wizardMode));
                 filters.Add(new WlbEnabledFilter(selectedItem.Item, vmList));

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -360,7 +360,7 @@ namespace XenAdmin.Wizards.GenericPages
 
 	    private bool updatingHomeServerList;
 
-        private void PopulateDataGridView(List<ReasoningFilter> homeserverFilters)
+        private void PopulateDataGridView(IEnableableXenObjectComboBoxItem selectedItem)
         {
             Program.AssertOnEventThread();
 
@@ -383,6 +383,9 @@ namespace XenAdmin.Wizards.GenericPages
                 {
                     var tb = new DataGridViewTextBoxCell {Value = kvp.Value.VmNameLabel, Tag = kvp.Key};
                     var cb = new DataGridViewEnableableComboBoxCell{FlatStyle = FlatStyle.Flat};
+                    List<ReasoningFilter> homeserverFilters = CreateTargetServerFilterList(
+                                                                selectedItem,
+                                                                new List<VM> { Connection.Resolve(new XenRef<VM>(kvp.Key)) });
 
                     if (Connection != null)
                     {
@@ -407,8 +410,8 @@ namespace XenAdmin.Wizards.GenericPages
                             item.LoadAndWait();
                             cb.Items.Add(item);
 
-                            if ((m_selectedObject != null && m_selectedObject.opaque_ref == host.opaque_ref) ||
-                                (target != null && target.Item.opaque_ref == host.opaque_ref))
+                            if (item.Enabled && ((m_selectedObject != null && m_selectedObject.opaque_ref == host.opaque_ref) ||
+                                (target != null && target.Item.opaque_ref == host.opaque_ref)))
                                 cb.Value = item;
                         }
                     }
@@ -570,7 +573,7 @@ namespace XenAdmin.Wizards.GenericPages
 			    {
 			        Cursor.Current = Cursors.WaitCursor;
 			        ChosenItem = item == null ? null : item.Item;
-			        Program.Invoke(Program.MainWindow, ()=> PopulateDataGridView(CreateTargetServerFilterList(item)));
+			        Program.Invoke(Program.MainWindow, ()=> PopulateDataGridView(item));
 			    }
 			    finally
 			    {
@@ -587,6 +590,17 @@ namespace XenAdmin.Wizards.GenericPages
         /// <param name="item">selected item from the host combobox</param>
         /// <returns></returns>
         protected virtual List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem item)
+        {
+            return new List<ReasoningFilter>();
+        }
+
+        /// <summary>
+        /// Create a set of filters for the homeserver combo box selection
+        /// </summary>
+        /// <param name="item">selected item from the host combobox</param>
+        /// <param name="vmList">VMs which need to apply those filters</param>
+        /// <returns></returns>
+        protected virtual List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem item, List<VM> vmList)
         {
             return new List<ReasoningFilter>();
         }

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -385,7 +385,7 @@ namespace XenAdmin.Wizards.GenericPages
                     var cb = new DataGridViewEnableableComboBoxCell{FlatStyle = FlatStyle.Flat};
                     List<ReasoningFilter> homeserverFilters = CreateTargetServerFilterList(
                                                                 selectedItem,
-                                                                new List<VM> { Connection.Resolve(new XenRef<VM>(kvp.Key)) });
+                                                                new List<String> { kvp.Key });
 
                     if (Connection != null)
                     {
@@ -588,19 +588,9 @@ namespace XenAdmin.Wizards.GenericPages
         /// Create a set of filters for the homeserver combo box selection
         /// </summary>
         /// <param name="item">selected item from the host combobox</param>
+        /// <param name="vmOpaqueRefs">OpaqRefs of VMs which need to apply those filters</param>
         /// <returns></returns>
-        protected virtual List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem item)
-        {
-            return new List<ReasoningFilter>();
-        }
-
-        /// <summary>
-        /// Create a set of filters for the homeserver combo box selection
-        /// </summary>
-        /// <param name="item">selected item from the host combobox</param>
-        /// <param name="vmList">VMs which need to apply those filters</param>
-        /// <returns></returns>
-        protected virtual List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem item, List<VM> vmList)
+        protected virtual List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem item, List<string> vmOpaqueRefs)
         {
             return new List<ReasoningFilter>();
         }

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -157,7 +157,7 @@ namespace XenAdmin.Wizards.ImportWizard
             return new DelayLoadingOptionComboBoxItem(xenItem, filters);
         }
 
-        protected override List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem item)
+        protected override List<ReasoningFilter> CreateTargetServerFilterList(IEnableableXenObjectComboBoxItem item, List<string> vmOpaqueRefs)
         {
             var filters = new List<ReasoningFilter>();
 


### PR DESCRIPTION
Major modifications:
1. Create new overload of function `CreateTargetServerFilterList` in `SelectMultipleVMDestinationPage.cs` with one more argument, type `List<VM>` ;
2. Rewrite new overload function `CreateTargetServerFilterList` in sub-class `CrossPoolMigrateDestinationPage` ;
3. Call `CreateTargetServerFilterList ` with each `VM` later in function `PopulateDataGridView` ;

Signed-off-by: Kun Ma <kun.ma@citrix.com>