### PR TITLE
CA-281646: Do not download the update again when using an update from disk

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -154,6 +154,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 PatchingWizard_AutomatedUpdatesPage.WizardMode = wizardMode;
                 PatchingWizard_AutomatedUpdatesPage.UpdateAlert = alertPatch ?? fileFromDiskAlertPatch;
+                PatchingWizard_AutomatedUpdatesPage.PatchFromDisk = PatchingWizard_SelectPatchPage.PatchFromDisk;
 
                 PatchingWizard_PatchingPage.SelectedUpdateType = updateType;
                 PatchingWizard_PatchingPage.Patch = existPatch;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
@@ -69,6 +69,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         private List<PoolPatchMapping> patchMappings = new List<PoolPatchMapping>();
         public Dictionary<XenServerPatch, string> AllDownloadedPatches = new Dictionary<XenServerPatch, string>();
+        public KeyValuePair<XenServerPatch, string> PatchFromDisk { private get; set; }
 
         private List<UpdateProgressBackgroundWorker> backgroundWorkers = new List<UpdateProgressBackgroundWorker>();
 
@@ -182,8 +183,8 @@ namespace XenAdmin.Wizards.PatchingWizard
                         var hostsToApply = us.Where(u => u.Value.Contains(patch)).Select(u => u.Key).ToList();
                         hostsToApply.Sort();
 
-                        planActions.Add(new DownloadPatchPlanAction(master.Connection, patch, AllDownloadedPatches));
-                        planActions.Add(new UploadPatchToMasterPlanAction(master.Connection, patch, patchMappings, AllDownloadedPatches));
+                        planActions.Add(new DownloadPatchPlanAction(master.Connection, patch, AllDownloadedPatches, PatchFromDisk));
+                        planActions.Add(new UploadPatchToMasterPlanAction(master.Connection, patch, patchMappings, AllDownloadedPatches, PatchFromDisk));
                         planActions.Add(new PatchPrechecksOnMultipleHostsInAPoolPlanAction(master.Connection, patch, hostsToApply, patchMappings));
 
                         foreach (var host in hostsToApply)

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -31,7 +31,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing.Reader;
 using System.Windows.Forms;
 using XenAdmin.Controls;
 using XenAdmin.Controls.DataGridViewEx;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -31,14 +31,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics.Eventing.Reader;
 using System.Windows.Forms;
 using XenAdmin.Controls;
 using XenAdmin.Controls.DataGridViewEx;
 using XenAdmin.Core;
 using XenAdmin.Properties;
 using XenAPI;
-using System.ComponentModel;
 using System.IO;
 using XenAdmin.Dialogs;
 using System.Drawing;
@@ -179,12 +178,21 @@ namespace XenAdmin.Wizards.PatchingWizard
                 var updateAlert = downloadUpdateRadioButton.Checked && dataGridViewPatches.SelectedRows.Count > 0
                     ? (XenServerPatchAlert) ((PatchGridViewRow) dataGridViewPatches.SelectedRows[0]).UpdateAlert
                     : selectFromDiskRadioButton.Checked
-                        ? GetAlertFromFileName(fileNameTextBox.Text.ToLowerInvariant())
+                        ? GetAlertFromFileName(isValidFile(unzippedUpdateFilePath) ? unzippedUpdateFilePath.ToLowerInvariant() : fileNameTextBox.Text.ToLowerInvariant())
                         : null;
                 if (updateAlert != null && updateAlert.NewServerVersion != null)
                     return WizardMode.NewVersion;
                 return WizardMode.SingleUpdate;
             } 
+        }
+
+        public KeyValuePair<XenServerPatch, string> PatchFromDisk
+        {
+            get {
+                return selectFromDiskRadioButton.Checked && FileFromDiskAlert != null
+                    ? new KeyValuePair<XenServerPatch, string>(FileFromDiskAlert.Patch, SelectedNewPatch)
+                    : new KeyValuePair<XenServerPatch, string>(null, null);
+            }
         }
 
         public override void PageLeave(PageLoadedDirection direction, ref bool cancel)

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/UploadPatchToMasterPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/UploadPatchToMasterPlanAction.cs
@@ -46,19 +46,23 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
         private readonly XenServerPatch patch;
         private readonly List<PoolPatchMapping> mappings;
         private Dictionary<XenServerPatch, string> AllDownloadedPatches = new Dictionary<XenServerPatch, string>();
+        private KeyValuePair<XenServerPatch, string> patchFromDisk;
         private AsyncAction inProgressAction = null;
 
-        public UploadPatchToMasterPlanAction(IXenConnection connection, XenServerPatch patch, List<PoolPatchMapping> mappings, Dictionary<XenServerPatch, string> allDownloadedPatches)
+        public UploadPatchToMasterPlanAction(IXenConnection connection, XenServerPatch patch, List<PoolPatchMapping> mappings, Dictionary<XenServerPatch, string> allDownloadedPatches, KeyValuePair<XenServerPatch, string> patchFromDisk)
             : base(connection, string.Format(Messages.UPDATES_WIZARD_UPLOADING_UPDATE, patch.Name, connection.Name))
         {
             this.patch = patch;
             this.mappings = mappings;
             this.AllDownloadedPatches = allDownloadedPatches;
+            this.patchFromDisk = patchFromDisk;
         }
 
         protected override void RunWithSession(ref Session session)
         {
-            var path = AllDownloadedPatches[patch];
+            var path = AllDownloadedPatches.ContainsKey(patch) 
+                ? AllDownloadedPatches[patch]
+                : patchFromDisk.Key == patch ? patchFromDisk.Value : null;
 
             var poolPatches = new List<Pool_patch>(session.Connection.Cache.Pool_patches);
             var poolUpdates = new List<Pool_update>(session.Connection.Cache.Pool_updates);


### PR DESCRIPTION

When applying a "new version" update, XenCenter starts an automated updates sequence that by default downloads all the updates. However, when using an update from disk, we shouldn't download it again.

With these changes, when an update from disk is used we save the [update, path] mapping, which we then use in the automated updates sequence, so we don't download that update again.

Also fixed a bug where a zipped update file from disk is not identified as a new version.