### PR TITLE
CA-280322: Space requirement calculation error in migration wizard.

### DIFF
--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
@@ -62,10 +62,20 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             return sr != null && !sr.HBALunPerVDI();
         }
 
-        /// <summary>
-        /// Gets the page's title (headline)
-        /// </summary>
-        public override string PageTitle { get { return Messages.CPM_WIZARD_SELECT_STORAGE_PAGE_TITLE; } }
+	    protected override bool IsExtraSpaceNeeded(XenRef<SR> sourceRef, XenRef<SR> targetRef)
+	    {
+			// No extra space is needed for Migrate or Move operation on same SR.
+			if (targetRef.Equals(sourceRef) &&
+				((wizardMode == WizardMode.Migrate) || (wizardMode == WizardMode.Move)))
+				return false;
+			else
+				return true;
+	    }
+
+		/// <summary>
+		/// Gets the page's title (headline)
+		/// </summary>
+		public override string PageTitle { get { return Messages.CPM_WIZARD_SELECT_STORAGE_PAGE_TITLE; } }
 
         /// <summary>
         /// Gets the page's label in the (left hand side) wizard progress panel

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationStorageResource.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationStorageResource.cs
@@ -83,7 +83,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             get { return vdi.opaque_ref; }
         }
 
-        public bool SRTypeInvalid
+		public bool SRTypeInvalid
         {
             get { return false;}
         }
@@ -97,6 +97,11 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
         {
             get { return Convert.ToUInt64(vdi.physical_utilisation); }
         }
-    }
+
+		public XenRef<SR> SR
+		{
+			get { return vdi.SR; }
+		}
+	}
 }
 

--- a/XenAdmin/Wizards/GenericPages/StorageResource.cs
+++ b/XenAdmin/Wizards/GenericPages/StorageResource.cs
@@ -30,6 +30,7 @@
  */
 
 using System.Collections;
+using XenAPI;
 
 namespace XenAdmin.Wizards.GenericPages
 {
@@ -40,6 +41,7 @@ namespace XenAdmin.Wizards.GenericPages
         bool SRTypeInvalid { get; }
         ulong RequiredDiskCapacity { get; }
         bool CanCalculateDiskCapacity { get; }
+		XenRef<SR> SR { get; }
     }
 
     public abstract class StorageResourceContainer : IEnumerable

--- a/XenAdmin/Wizards/ImportWizard/OVFStorageResource.cs
+++ b/XenAdmin/Wizards/ImportWizard/OVFStorageResource.cs
@@ -31,6 +31,7 @@
 
 using System;
 using XenAdmin.Wizards.GenericPages;
+using XenAPI;
 using XenOvf;
 using XenOvf.Definitions;
 
@@ -114,5 +115,10 @@ namespace XenAdmin.Wizards.ImportWizard
                                         : file.size;
             }
         }
-    }
+
+		public XenRef<SR> SR
+		{
+			get { return null; }
+		}
+	}
 }


### PR DESCRIPTION
Solution brief:
1. Add abstract method IsExtraSpaceNeeded() in SelectVMStorageWithMultipleVirtualDisksPage to calculate whether extra space is needed in the operation. No extra space is required if source and target SR is the same one and the operation is migrating or moving, not required otherwise.
2. In making each combobox item. Legacy behavior was to check if there is enough space on target SR to accommodate source disk(s). Now "is-extra-space-needed" condition is also taken into account.

Note:
1. SelectVMStorageWithMultipleVirtualDisksPage is common used for migrate/copy/move/import wizard.
2. There is interface update.

Signed-off-by: Michael Zhao <michael.zhao@citrix.com>