### PR TITLE
CA-272150: Optimize destination page of cross-pool-migrate wizard.

### DIFF
--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
@@ -43,8 +43,12 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
     {
         private List<VM> selectedVMs;
         private WizardMode wizardMode;
+        // A 2-level cache to store the result of CrossPoolMigrateCanMigrateFilter.
+        // Cache structure is like: <vm-ref, <host-ref, fault-reason>>.
+        private IDictionary<string, IDictionary<string, string>> migrateFilterCache = 
+            new Dictionary<string, IDictionary<string, string>>();
 
-        
+
         public CrossPoolMigrateDestinationPage()
             : this(null, null, WizardMode.Migrate, null)
         {
@@ -142,7 +146,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             var filters = new List<ReasoningFilter>
             {
                 new ResidentHostIsSameAsSelectionFilter(xenItem, selectedVMs),
-                new CrossPoolMigrateCanMigrateFilter(xenItem, selectedVMs, wizardMode),
+                new CrossPoolMigrateCanMigrateFilter(xenItem, selectedVMs, wizardMode, migrateFilterCache),
                 new WlbEnabledFilter(xenItem, selectedVMs)
             };
             return new DelayLoadingOptionComboBoxItem(xenItem, filters);
@@ -159,7 +163,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                     vmList.Add(selectedVMs.Find(vm => vm.opaque_ref == opaqueRef));
 
                 filters.Add(new ResidentHostIsSameAsSelectionFilter(selectedItem.Item, vmList));
-                filters.Add(new CrossPoolMigrateCanMigrateFilter(selectedItem.Item, vmList, wizardMode));
+                filters.Add(new CrossPoolMigrateCanMigrateFilter(selectedItem.Item, vmList, wizardMode, migrateFilterCache));
                 filters.Add(new WlbEnabledFilter(selectedItem.Item, vmList));
             } 
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -45,15 +45,27 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
         private readonly WizardMode _wizardMode;
         private string disableReason = string.Empty;
         private readonly List<VM> preSelectedVMs;
+        private IDictionary<string, IDictionary<string, string>> cache;
+        private bool canceled = false;
+        private static readonly Object cacheLock = new Object();
 
-        public CrossPoolMigrateCanMigrateFilter(IXenObject itemAddedToComboBox, List<VM> preSelectedVMs, WizardMode wizardMode)
+        public CrossPoolMigrateCanMigrateFilter(IXenObject itemAddedToComboBox, List<VM> preSelectedVMs, WizardMode wizardMode, IDictionary<string, IDictionary<string, string>> cache = null)
             : base(itemAddedToComboBox)
         {
             _wizardMode = wizardMode;
+            if (cache == null)
+                this.cache = new Dictionary<string, IDictionary<string, string>>();
+            else
+                this.cache = cache;
 
             if (preSelectedVMs == null)
                 throw new ArgumentNullException("Pre-selected VMs are null");
             this.preSelectedVMs = preSelectedVMs;
+        }
+
+        public override void Cancel()
+        {
+            canceled = true;
         }
 
         public override bool FailureFound
@@ -73,6 +85,20 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
 
                     foreach (VM vm in preSelectedVMs)
                     {
+                        if (canceled)
+                            return excludedHosts.Count == targets.Count;
+
+                        // obtain the cache data for a vm
+                        IDictionary<string, string> vmCache;
+                        lock (cacheLock)
+                        {
+                            if (!cache.ContainsKey(vm.opaque_ref))
+                            {
+                                cache.Add(vm.opaque_ref, new Dictionary<string, string>());
+                            }
+                            vmCache = cache[vm.opaque_ref];
+                        }
+
                         try
                         {
                             //CA-220218: for intra-pool motion of halted VMs we do a move, so no need to assert we can migrate
@@ -91,6 +117,16 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                                 continue;
                             }
 
+                            if (vmCache.ContainsKey(host.opaque_ref))
+                            {
+                                disableReason = vmCache[host.opaque_ref];
+                                if (!disableReason.Equals(string.Empty))
+                                {
+                                    excludedHosts.Add(host.opaque_ref);
+                                }
+                                continue;
+                            }
+
                             PIF managementPif = host.Connection.Cache.PIFs.First(p => p.management);
                             XenAPI.Network network = host.Connection.Cache.Resolve(managementPif.network);
 
@@ -103,6 +139,11 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                                                   GetVdiMap(vm, targetSrs),
                                                   vm.Connection == host.Connection ? new Dictionary<XenRef<VIF>, XenRef<XenAPI.Network>>() : GetVifMap(vm, targetNetwork),
                                                   new Dictionary<string, string>());
+                            lock (cacheLock)
+                            {
+                                vmCache.Add(host.opaque_ref, string.Empty);
+                            }
+                            
                         }
                         catch (Failure failure)
                         {
@@ -110,6 +151,11 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                                 disableReason = failure.Message.Split('\n')[0].TrimEnd('\r'); // we want the first line only
                             else
                                 disableReason = failure.Message;
+
+                            lock (cacheLock)
+                            {
+                                vmCache.Add(host.opaque_ref, disableReason.Clone().ToString());
+                            }
 
                             log.ErrorFormat("VM: {0}, Host: {1} - Reason: {2};", vm.opaque_ref, host.opaque_ref, failure.Message);
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -120,7 +120,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                             if (vmCache.ContainsKey(host.opaque_ref))
                             {
                                 disableReason = vmCache[host.opaque_ref];
-                                if (!disableReason.Equals(string.Empty))
+                                if (!disableReason.Equals(string.Empty) && !excludedHosts.Contains(host.opaque_ref))
                                 {
                                     excludedHosts.Add(host.opaque_ref);
                                 }
@@ -143,7 +143,6 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                             {
                                 vmCache.Add(host.opaque_ref, string.Empty);
                             }
-                            
                         }
                         catch (Failure failure)
                         {
@@ -158,7 +157,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                             }
 
                             log.ErrorFormat("VM: {0}, Host: {1} - Reason: {2};", vm.opaque_ref, host.opaque_ref, failure.Message);
-
+                            
                             if (!excludedHosts.Contains(host.opaque_ref))
                                 excludedHosts.Add(host.opaque_ref);
                         }

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -120,7 +120,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                             if (vmCache.ContainsKey(host.opaque_ref))
                             {
                                 disableReason = vmCache[host.opaque_ref];
-                                if (!disableReason.Equals(string.Empty) && !excludedHosts.Contains(host.opaque_ref))
+                                if (!string.IsNullOrEmpty(disableReason) && !excludedHosts.Contains(host.opaque_ref))
                                 {
                                     excludedHosts.Add(host.opaque_ref);
                                 }

--- a/XenAdmin/Wizards/GenericPages/DelayLoadingOptionComboBoxItem.cs
+++ b/XenAdmin/Wizards/GenericPages/DelayLoadingOptionComboBoxItem.cs
@@ -116,6 +116,12 @@ namespace XenAdmin.Wizards.GenericPages
             ThreadPool.QueueUserWorkItem(delegate { FetchFailureReasonWithRetry(defaultRetries, defaultTimeOut); });
         }
 
+        public void CancelFilters()
+        {
+            foreach (ReasoningFilter filter in _filters)
+                filter.Cancel();
+        }
+
         private void FetchFailureReasonWithRetry(int retries, int timeOut)
         {
             string threadFailureReason = Messages.DELAY_LOADED_COMBO_BOX_ITEM_FAILURE_UNKOWN;

--- a/XenAdmin/Wizards/GenericPages/ReasoningFilter.cs
+++ b/XenAdmin/Wizards/GenericPages/ReasoningFilter.cs
@@ -56,5 +56,7 @@ namespace XenAdmin.Wizards.GenericPages
             ItemToFilterOn = xenObject;
             return FailureFound;
         }
+
+        public virtual void Cancel() { }
     } 
 }

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -415,8 +415,8 @@ namespace XenAdmin.Wizards.GenericPages
                             var item = new DelayLoadingOptionComboBoxItem(host, homeserverFilters);
                             item.LoadAndWait();
                             cb.Items.Add(item);
-                            if (item.Enabled && ((m_selectedObject != null && m_selectedObject.opaque_ref == item.Item.opaque_ref) ||
-                                                 (target != null && target.Item.opaque_ref == item.Item.opaque_ref)))
+                            if (item.Enabled && ((m_selectedObject != null && m_selectedObject.opaque_ref == host.opaque_ref) ||
+                                                 (target != null && target.Item.opaque_ref == host.opaque_ref)))
                                 cb.Value = item;
                         }
 

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -414,17 +414,12 @@ namespace XenAdmin.Wizards.GenericPages
                         {
                             var item = new DelayLoadingOptionComboBoxItem(host, homeserverFilters);
                             item.LoadAndWait();
-                            items.Add(item);
-                        }
-
-                        foreach (var item in items)
-                        { 
                             cb.Items.Add(item);
-                            var host = item.Item;
-                            if (item.Enabled && ((m_selectedObject != null && m_selectedObject.opaque_ref == host.opaque_ref) ||
-                                (target != null && target.Item.opaque_ref == host.opaque_ref)))
+                            if (item.Enabled && ((m_selectedObject != null && m_selectedObject.opaque_ref == item.Item.opaque_ref) ||
+                                                 (target != null && target.Item.opaque_ref == item.Item.opaque_ref)))
                                 cb.Value = item;
                         }
+
                     }
 
                     SetComboBoxPreSelection(cb);

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -405,15 +405,17 @@ namespace XenAdmin.Wizards.GenericPages
                             }
                         }
 
+                        var sortedHosts = new List<Host>(Connection.Cache.Hosts);
+                        sortedHosts.Sort();
+
                         var items = new List<DelayLoadingOptionComboBoxItem>();
 
-                        foreach (var host in Connection.Cache.Hosts)
+                        foreach (var host in sortedHosts)
                         {
                             var item = new DelayLoadingOptionComboBoxItem(host, homeserverFilters);
                             item.LoadAndWait();
                             items.Add(item);
                         }
-                        items.Sort(new DelayLoadingOptionComboboxItemCompare());
 
                         foreach (var item in items)
                         { 
@@ -656,12 +658,5 @@ namespace XenAdmin.Wizards.GenericPages
 	        }
         }
 
-	    private class DelayLoadingOptionComboboxItemCompare : IComparer<DelayLoadingOptionComboBoxItem>
-	    {
-	        public int Compare(DelayLoadingOptionComboBoxItem x, DelayLoadingOptionComboBoxItem y)
-	        {
-	            return string.Compare(x.ToString(), y.ToString());
-	        }
-	    }
     }
 }


### PR DESCRIPTION
Solution brief:
1. Add a cache for CrossPoolMigrateCanMigrateFilter to save the result of server call VM.assert_can_migrate().
2. Add cancel method to filter.
3. Don't change the update of server list combo-box from sync to async. No server call would be made in building the server list due to the introduction of cache.
4. Sort server list.

The solution was a little bit different (point 3 mentioned above) from the one described in CA-272150 solution slides on which we have discussed. 
