### PR TITLE
CA-40854: The Session's uuid is in reality its opaque_ref.

### DIFF
--- a/XenAdmin/Actions/GUIActions/ExternalPluginAction.cs
+++ b/XenAdmin/Actions/GUIActions/ExternalPluginAction.cs
@@ -260,7 +260,7 @@ namespace XenAdmin.Actions
                 WriteTrustedCertificates(master.Connection);
             }
 
-            string sessionRef = connection.Session != null ? connection.Session.uuid : EmptyParameter;
+            string sessionRef = connection.Session != null ? connection.Session.opaque_ref : EmptyParameter;
             string objCls = obj != null ? obj.GetType().Name : EmptyParameter;
             string objUuid = obj != null && connection.Session != null ? Helpers.GetUuid(obj) : EmptyParameter;
             return new List<string>(new string[] { masterAddress, sessionRef, objCls, objUuid });
@@ -278,7 +278,7 @@ namespace XenAdmin.Actions
                 WriteTrustedCertificates(master.Connection);
             }
 
-            string sessionRef = connection.Session != null ? connection.Session.uuid : EmptyParameter;
+            string sessionRef = connection.Session != null ? connection.Session.opaque_ref : EmptyParameter;
             string objCls = BlankParamter;
             string objUuid = BlankParamter;
             return new List<string>(new string[] { masterAddress, sessionRef, objCls, objUuid });

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -1087,17 +1087,17 @@ namespace XenAdmin.ConsoleView
             }
 
             Uri uri = new Uri(console.location);
-            String SessionUUID;
+            string sesssionRef;
 
             lock (activeSessionLock)
             {
                 // use the elevated credentials, if provided, for connecting to the console (CA-91132)
                 activeSession = (string.IsNullOrEmpty(ElevatedUsername) || string.IsNullOrEmpty(ElevatedPassword)) ?
                     console.Connection.DuplicateSession() : console.Connection.ElevatedSession(ElevatedUsername, ElevatedPassword);
-                SessionUUID = activeSession.uuid;
+                sesssionRef = activeSession.opaque_ref;
             }
 
-            Stream stream = HTTPHelper.CONNECT(uri, console.Connection, SessionUUID, false, true);
+            Stream stream = HTTPHelper.CONNECT(uri, console.Connection, sesssionRef, false, true);
 
             InvokeConnection(v, stream, console);
         }

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -321,9 +321,9 @@ namespace XenAdmin.Controls.CustomDataGraph
         {
             string query =
                 xo is Host ?
-                    string.Format(RrdHostUpdatesQuery, Uri.EscapeDataString(session.uuid), TimeFromInterval(interval), RrdCFAverage, ToSeconds(interval)) :
+                    string.Format(RrdHostUpdatesQuery, Uri.EscapeDataString(session.opaque_ref), TimeFromInterval(interval), RrdCFAverage, ToSeconds(interval)) :
                 xo is VM ?
-                    string.Format(RrdVmUpdatesQuery, Uri.EscapeDataString(session.uuid), TimeFromInterval(interval), RrdCFAverage, ToSeconds(interval), Helpers.GetUuid(xo)) :
+                    string.Format(RrdVmUpdatesQuery, Uri.EscapeDataString(session.opaque_ref), TimeFromInterval(interval), RrdCFAverage, ToSeconds(interval), Helpers.GetUuid(xo)) :
                     "";
             return BuildUri(host, RrdUpdatesPath, query);
         }
@@ -332,9 +332,9 @@ namespace XenAdmin.Controls.CustomDataGraph
         {
             string query =
                 xo is Host ?
-                    string.Format(RrdHostQuery, Uri.EscapeDataString(session.uuid)) :
+                    string.Format(RrdHostQuery, Uri.EscapeDataString(session.opaque_ref)) :
                 xo is VM ?
-                    string.Format(RrdVmQuery, Uri.EscapeDataString(session.uuid), Helpers.GetUuid(xo)) :
+                    string.Format(RrdVmQuery, Uri.EscapeDataString(session.opaque_ref), Helpers.GetUuid(xo)) :
                     "";
             return BuildUri(host, xo is Host ? RrdHostPath : RrdVmPath, query);
         }

--- a/XenAdmin/Diagnostics/Checks/DR/AssertCanBeRecoveredCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/DR/AssertCanBeRecoveredCheck.cs
@@ -103,10 +103,10 @@ namespace XenAdmin.Diagnostics.Checks.DR
             try
             {
                 if (xenObject is VM)
-                    VM.assert_can_be_recovered(MetadataSession, xenObject.opaque_ref, Pool.Connection.Session.uuid);
+                    VM.assert_can_be_recovered(MetadataSession, xenObject.opaque_ref, Pool.Connection.Session.opaque_ref);
                 if (xenObject is VM_appliance)
                     VM_appliance.assert_can_be_recovered(MetadataSession, xenObject.opaque_ref,
-                                                         Pool.Connection.Session.uuid);
+                                                         Pool.Connection.Session.opaque_ref);
             }
             catch (Failure f)
             {

--- a/XenAdmin/Dialogs/EvacuateHostDialog.cs
+++ b/XenAdmin/Dialogs/EvacuateHostDialog.cs
@@ -934,7 +934,7 @@ namespace XenAdmin.Dialogs
             
             deregisterVMEvents();
 
-            if (elevatedSession != null && elevatedSession.uuid != null)
+            if (elevatedSession != null && elevatedSession.opaque_ref != null)
             {
                 // NOTE: This doesnt happen currently, as we always scan once. Here as cheap insurance.
                 // we still have the session from the role elevation dialog

--- a/XenAdmin/Plugins/Features/TabPageFeature.cs
+++ b/XenAdmin/Plugins/Features/TabPageFeature.cs
@@ -880,7 +880,9 @@ namespace XenAdmin.Plugins
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         public const string JAVASCRIPT_CALLBACK_METHOD = "XenCenterXML";
 
+        [Obsolete("Use SessionOpaqueRef instead.")]
         public string SessionUuid;
+        public string SessionOpaqueRef;
         public string SessionUrl;
         private IXenConnection connection;
         public WebBrowser2 browser;
@@ -932,7 +934,10 @@ namespace XenAdmin.Plugins
             if (connection != null)
             {
                 SessionUrl = connection.Session.Url;
-                SessionUuid = connection.DuplicateSession().uuid;
+                SessionOpaqueRef = connection.DuplicateSession().opaque_ref;
+#pragma warning disable 612, 618
+                SessionUuid = SessionOpaqueRef;
+#pragma warning restore 612, 618
             }
         }
 

--- a/XenAdmin/Plugins/Placeholders.cs
+++ b/XenAdmin/Plugins/Placeholders.cs
@@ -81,7 +81,7 @@ namespace XenAdmin.Plugins
                     {
                         return NULL_PLACEHOLDER_KEY;
                     }
-                    return objs[0].Connection.Session.uuid;
+                    return objs[0].Connection.Session.opaque_ref;
                 }
                 else
                 {

--- a/XenAdmin/WinformsXenAdminConfigProvider.cs
+++ b/XenAdmin/WinformsXenAdminConfigProvider.cs
@@ -94,7 +94,7 @@ namespace XenAdmin
         {
             try
             {
-                if (connection != null && connection.Session != null && connection.Session.uuid == "dummy")
+                if (connection != null && connection.Session != null && connection.Session.opaque_ref == "dummy")
                     return new XenAdminSimulatorWebProxy(DbProxy.proxys[connection]);
 
                 switch ((HTTPHelper.ProxyStyle)XenAdmin.Properties.Settings.Default.ProxySetting)

--- a/XenModel/Actions/AsyncAction.cs
+++ b/XenModel/Actions/AsyncAction.cs
@@ -249,7 +249,7 @@ namespace XenAdmin.Actions
                     }
                     catch(Failure ex)
                     {
-                        log.Debug("Session.logout() failed for Session uuid " + Session.uuid, ex);
+                        log.Debug("Session.logout() failed for Session uuid " + Session.opaque_ref, ex);
                     }
                 }
 
@@ -262,7 +262,7 @@ namespace XenAdmin.Actions
         {
             //Program.AssertOffEventThread();
 
-            if (Session == null || string.IsNullOrEmpty(Session.uuid) || RelatedTask == null)
+            if (Session == null || string.IsNullOrEmpty(Session.opaque_ref) || RelatedTask == null)
                 return;
 
             try

--- a/XenModel/Actions/CancellingAction.cs
+++ b/XenModel/Actions/CancellingAction.cs
@@ -169,7 +169,7 @@ namespace XenAdmin.Actions
                 }
 
                 Session local_session = GetCancelSession();
-                if (local_session == null || string.IsNullOrEmpty(local_session.uuid))
+                if (local_session == null || string.IsNullOrEmpty(local_session.opaque_ref))
                 {
                     can_cancel = false;
                     return;

--- a/XenModel/Actions/DR/DrRecoverAction.cs
+++ b/XenModel/Actions/DR/DrRecoverAction.cs
@@ -72,11 +72,11 @@ namespace XenAdmin.Actions.DR
             if (MetadataSession != null)
             {
                 if (xenObject is VM)
-                    RelatedTask = VM.async_recover(MetadataSession, xenObject.opaque_ref, Session.uuid, true);
+                    RelatedTask = VM.async_recover(MetadataSession, xenObject.opaque_ref, Session.opaque_ref, true);
                 if (xenObject is VM_appliance)
                 {
                     // if appliance already exists in target pool, it will be replaced during recovery and the uuid is preserved
-                    RelatedTask = VM_appliance.async_recover(MetadataSession, xenObject.opaque_ref, Session.uuid, true);
+                    RelatedTask = VM_appliance.async_recover(MetadataSession, xenObject.opaque_ref, Session.opaque_ref, true);
                 }
                 PollToCompletion();
             }

--- a/XenModel/Actions/Host/HostBackupRestoreAction.cs
+++ b/XenModel/Actions/Host/HostBackupRestoreAction.cs
@@ -82,7 +82,7 @@ namespace XenAdmin.Actions
                         try
                         {
                             HTTPHelper.Get(this, true, DataReceived, filename, Host.address,
-                                (HTTP_actions.get_ss)HTTP_actions.get_host_backup, Session.uuid);
+                                (HTTP_actions.get_ss)HTTP_actions.get_host_backup, Session.opaque_ref);
                         }
                         finally
                         {
@@ -96,7 +96,7 @@ namespace XenAdmin.Actions
                         this.Description = String.Format(Messages.RESTORING_HOST, Host.Name());
 
                         HTTPHelper.Put(this, true, filename, Host.address,
-                            (HTTP_actions.put_ss)HTTP_actions.put_host_restore, Session.uuid);
+                            (HTTP_actions.put_ss)HTTP_actions.put_host_restore, Session.opaque_ref);
 
                         this.Description = String.Format(Messages.HOST_RESTORED, Host.Name());
                         break;

--- a/XenModel/Actions/Host/SingleHostStatusAction.cs
+++ b/XenModel/Actions/Host/SingleHostStatusAction.cs
@@ -82,7 +82,7 @@ namespace XenAdmin.Actions
 
                 HTTPHelper.Get(this, false, dataRxDelegate, filename, host.Host.address,
                     (HTTP_actions.get_ssss)HTTP_actions.get_system_status,
-                    Session.uuid, entries_string, "tar");
+                    Session.opaque_ref, entries_string, "tar");
 
                 log.DebugFormat("Getting system status from {0} successful", hostname);
 

--- a/XenModel/Actions/Pool_Patch/ApplyPatchAction.cs
+++ b/XenModel/Actions/Pool_Patch/ApplyPatchAction.cs
@@ -67,7 +67,7 @@ namespace XenAdmin.Actions
                 {
                     HTTPHelper.Get(this, true, filename, patch.Connection.Hostname,
                         (HTTP_actions.get_sss)HTTP_actions.get_pool_patch_download,
-                        Session.uuid, patch.uuid);
+                        Session.opaque_ref, patch.uuid);
                 }
                 catch (Exception e)
                 {
@@ -89,7 +89,7 @@ namespace XenAdmin.Actions
                 try
                 {
                     string result = HTTPHelper.Put(this, true, filename, host.Connection.Hostname,
-                        (HTTP_actions.put_ss)HTTP_actions.put_pool_patch_upload, Session.uuid);
+                        (HTTP_actions.put_ss)HTTP_actions.put_pool_patch_upload, Session.opaque_ref);
 
                     return new XenRef<Pool_patch>(result);
                 }

--- a/XenModel/Actions/Pool_Patch/UploadPatchAction.cs
+++ b/XenModel/Actions/Pool_Patch/UploadPatchAction.cs
@@ -156,7 +156,7 @@ namespace XenAdmin.Actions
                 try
                 {
                     result = HTTPHelper.Put(progressDelegate, GetCancelling, true, Connection, RelatedTask, ref session, retailPatchPath,
-                        h.address, (HTTP_actions.put_ss)HTTP_actions.put_pool_patch_upload, session.uuid);
+                        h.address, (HTTP_actions.put_ss)HTTP_actions.put_pool_patch_upload, session.opaque_ref);
                 }
                 catch(CancelledException)
                 {

--- a/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
+++ b/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
@@ -160,8 +160,8 @@ namespace XenAdmin.Actions
                 RelatedTask = Task.create(Session, "uploadTask", hostUrl);
 
                 result = HTTPHelper.Put(progressDelegate, GetCancelling, true, Connection, RelatedTask, ref session,  suppPackFilePath, hostUrl,
-                                        (HTTP_actions.put_sss)HTTP_actions.put_import_raw_vdi, 
-                                        session.uuid, vdiRef.opaque_ref);
+                                        (HTTP_actions.put_sss)HTTP_actions.put_import_raw_vdi,
+                                        session.opaque_ref, vdiRef.opaque_ref);
             }
             catch (Exception ex)
             {

--- a/XenModel/Actions/VM/ExportVmAction.cs
+++ b/XenModel/Actions/VM/ExportVmAction.cs
@@ -104,7 +104,7 @@ namespace XenAdmin.Actions
             UriBuilder uriBuilder = new UriBuilder(this.Session.Url);
             uriBuilder.Path = "export";
             uriBuilder.Query = string.Format("session_id={0}&uuid={1}&task_id={2}",
-                Uri.EscapeDataString(this.Session.uuid),
+                Uri.EscapeDataString(this.Session.opaque_ref),
                 Uri.EscapeDataString(this.VM.uuid),
                 Uri.EscapeDataString(this.RelatedTask.opaque_ref));
 

--- a/XenModel/Actions/VM/ImportVmAction.cs
+++ b/XenModel/Actions/VM/ImportVmAction.cs
@@ -401,7 +401,7 @@ namespace XenAdmin.Actions
 
             return HTTPHelper.Put(this, HTTP_PUT_TIMEOUT, m_filename, hostURL,
                                   (HTTP_actions.put_ssbbs)HTTP_actions.put_import,
-                                  Session.uuid, false, false, SR.opaque_ref);
+                                  Session.opaque_ref, false, false, SR.opaque_ref);
         }
 
 		public override void RecomputeCanCancel()

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -793,11 +793,11 @@ namespace XenAdmin.Network
         /// <param name="session">May be null, in which case nothing happens.</param>
         public void Logout(Session session, bool exiting = false)
         {
-            if (session == null || session.uuid == null)
+            if (session == null || session.opaque_ref == null)
                 return;
 
             Thread t = new Thread(Logout_);
-            t.Name = string.Format("Logging out session {0}", session.uuid);
+            t.Name = string.Format("Logging out session {0}", session.opaque_ref);
             if (exiting)
             {
                 t.IsBackground = false;

--- a/XenModel/WLB/WlbReportAction.cs
+++ b/XenModel/WLB/WlbReportAction.cs
@@ -86,7 +86,7 @@ namespace XenAdmin.Actions.Wlb
             UriBuilder uriBuilder = new UriBuilder(Session.Url);
             uriBuilder.Path = "wlb_report";
             uriBuilder.Query = string.Format("session_id={0}&report={1}&task_id={2}",
-                Uri.EscapeDataString(Session.uuid),
+                Uri.EscapeDataString(Session.opaque_ref),
                 Uri.EscapeDataString(report),
                 Uri.EscapeDataString(RelatedTask.opaque_ref));
 

--- a/XenModel/XenAPI-Extensions/Blob.cs
+++ b/XenModel/XenAPI-Extensions/Blob.cs
@@ -51,7 +51,7 @@ namespace XenAPI
             uri.Port = Connection.Port;
             uri.Path = BLOB_URI;
             uri.Query = String.Format("ref={0}&session_id={1}",
-                opaque_ref, Uri.EscapeDataString(session.uuid));
+                opaque_ref, Uri.EscapeDataString(session.opaque_ref));
 
             using (Stream outStream = HTTPHelper.PUT(uri.Uri, inStream.Length, true, true))
             {
@@ -72,7 +72,7 @@ namespace XenAPI
             uri.Port = Connection.Port;
             uri.Path = BLOB_URI;
             uri.Query = String.Format("ref={0}&session_id={1}",
-                opaque_ref, Uri.EscapeDataString(session.uuid));
+                opaque_ref, Uri.EscapeDataString(session.opaque_ref));
 
             return HTTPHelper.GET(uri.Uri, Connection, true, true);
         }

--- a/XenModel/XenAPI-Extensions/Session.cs
+++ b/XenModel/XenAPI-Extensions/Session.cs
@@ -95,7 +95,7 @@ namespace XenAPI
 
         private void InitAD(Session session)
         {
-            opaque_ref = session.uuid;
+            opaque_ref = session.opaque_ref;
             APIVersion = session.APIVersion;
             _userSid = session.UserSid;
             _subject = session.Subject;

--- a/XenModel/XenAPI-Extensions/Task.cs
+++ b/XenModel/XenAPI-Extensions/Task.cs
@@ -157,7 +157,7 @@ namespace XenAPI
                 try
                 {
                     // Try and logout the old session using the new session
-                    newSession.proxy.session_logout(session.uuid);
+                    newSession.proxy.session_logout(session.opaque_ref);
                 }
                 catch
                 {

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -1506,7 +1506,7 @@ namespace XenAPI
         public static List<XenRef<SR>> GetDRMissingSRs(Session session, string vm, Session sessionTo)
         {
             return Helpers.CreedenceOrGreater(sessionTo.Connection)
-                       ? VM.get_SRs_required_for_recovery(session, vm, sessionTo.uuid)
+                       ? VM.get_SRs_required_for_recovery(session, vm, sessionTo.opaque_ref)
                        : null;
         }
 

--- a/XenModel/XenAPI-Extensions/VM_appliance.cs
+++ b/XenModel/XenAPI-Extensions/VM_appliance.cs
@@ -91,7 +91,7 @@ namespace XenAPI
         public static List<XenRef<SR>> GetDRMissingSRs(Session session, string vm, Session sessionTo)
         {
             return Helpers.CreedenceOrGreater(sessionTo.Connection)
-                       ? VM_appliance.get_SRs_required_for_recovery(session, vm, sessionTo.uuid)
+                       ? VM_appliance.get_SRs_required_for_recovery(session, vm, sessionTo.opaque_ref)
                        : null;
         }
     }

--- a/XenModel/XenSearch/MetricUpdater.cs
+++ b/XenModel/XenSearch/MetricUpdater.cs
@@ -353,7 +353,7 @@ namespace XenAdmin.XenSearch
             builder.Host = host.address;
             builder.Port = host.Connection.Port;
             builder.Path = RrdUpdatesPath;
-            builder.Query = string.Format(RrdHostAndVmUpdatesQuery, Uri.EscapeDataString(session.uuid), TimeUtil.TicksToSecondsSince1970(DateTime.UtcNow.Ticks - (host.Connection.ServerTimeOffset.Ticks + TicksInTenSeconds)), RrdCFAverage, 5);
+            builder.Query = string.Format(RrdHostAndVmUpdatesQuery, Uri.EscapeDataString(session.opaque_ref), TimeUtil.TicksToSecondsSince1970(DateTime.UtcNow.Ticks - (host.Connection.ServerTimeOffset.Ticks + TicksInTenSeconds)), RrdCFAverage, 5);
             return builder.Uri;
         }
 

--- a/XenOvfTransport/Import.cs
+++ b/XenOvfTransport/Import.cs
@@ -1117,7 +1117,7 @@ namespace XenOvfTransport
 
             #region UPLOAD HTTP STREAM
             XenRef<Task> taskRef = Task.create(xenSession, "UpdateStream", "UpdateStream");
-			string p2VUri = string.Format("/import_raw_vdi?session_id={0}&task_id={1}&vdi={2}", xenSession.uuid, taskRef.opaque_ref, vdiRef.opaque_ref);
+            string p2VUri = string.Format("/import_raw_vdi?session_id={0}&task_id={1}&vdi={2}", xenSession.opaque_ref, taskRef.opaque_ref, vdiRef.opaque_ref);
             NameValueCollection headers = new NameValueCollection();
             headers.Add("Content-Length", Convert.ToString(capacity));
             headers.Add("Content-Type", "application/octet-stream");

--- a/XenOvfTransport/iSCSI.cs
+++ b/XenOvfTransport/iSCSI.cs
@@ -484,7 +484,7 @@ namespace XenOvfTransport
         {
             try
             {
-                string host = XenAPI.Session.get_this_host(xenSession, xenSession.uuid);
+                string host = XenAPI.Session.get_this_host(xenSession, xenSession.opaque_ref);
 
                 // Transfer VM for VDI <uuid>
                 Dictionary<string, string> args = new Dictionary<string, string>();
@@ -515,7 +515,7 @@ namespace XenOvfTransport
         {
             try
             {
-                string host = XenAPI.Session.get_this_host(xenSession, xenSession.uuid);
+                string host = XenAPI.Session.get_this_host(xenSession, xenSession.opaque_ref);
                 Dictionary<string, string> args = new Dictionary<string, string>();
 
                 string handle;

--- a/XenServerHealthCheck/XenServerHealthCheckConfigProvider.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckConfigProvider.cs
@@ -105,7 +105,7 @@ namespace XenServerHealthCheck
         {
             try
             {
-                if (connection != null && connection.Session != null && connection.Session.uuid == "dummy")
+                if (connection != null && connection.Session != null && connection.Session.opaque_ref == "dummy")
                     return new XenServerHealthCheckSimulatorWebProxy(DbProxy.proxys[connection]);
 
                 switch ((HTTPHelper.ProxyStyle)Properties.Settings.Default.ProxySetting)


### PR DESCRIPTION
 Use the opaque_ref so it's obvious what it is. The Session's uuid will be deprecated from the API bindings.

Note that I haven't included the changed bindings in this PR, it can be done next time we update them from the SDK in master.