### PR TITLE
CP-27188: Filter out the SR-IOV network when configuring IP address

### DIFF
--- a/XenAdmin/Dialogs/NetworkingPropertiesPage.cs
+++ b/XenAdmin/Dialogs/NetworkingPropertiesPage.cs
@@ -258,7 +258,9 @@ namespace XenAdmin.Dialogs
 
             if (!AllowManagementOnVLAN && (type == Type.PRIMARY || type == Type.PRIMARY_WITH_HA))
                 networks.RemoveAll(network=>network.IsVLAN());
-            
+        
+            networks.RemoveAll(network => network.IsSriov());
+
             NetworkComboBox.Items.AddRange(networks.ToArray());
 
             SquelchNetworkComboBoxChange = true;

--- a/XenModel/XenAPI-Extensions/Network.cs
+++ b/XenModel/XenAPI-Extensions/Network.cs
@@ -293,6 +293,11 @@ namespace XenAPI
             return Connection.ResolveAll(PIFs).Find(pif => pif.VLAN >= 0) != null;
         }
 
+        public bool IsSriov()
+        {
+            return Connection.ResolveAll(PIFs).Find(pif => pif.IsSrIovLogicalPIF()) != null;
+        }
+
 
         #region IEquatable<Network> Members
 


### PR DESCRIPTION
Signed-off-by: Jisheng Xing <jisheng.xing@citrix.com>

As the requirement requested, the Mangement Interface shouldn't use the SR-IOV network because the Dom0 shouldn't use the VF(virtual function).