### PR TITLE
Return null if the string to deserialize to a XenRef<T> or DateTime is null

### DIFF
--- a/XenModel/XenAPI/Converters.cs
+++ b/XenModel/XenAPI/Converters.cs
@@ -55,7 +55,7 @@ namespace XenAPI
         {
             JToken jToken = JToken.Load(reader);
             var str = jToken.ToObject<string>();
-            return new XenRef<T>(str);
+            return string.IsNullOrEmpty(str) ? null : new XenRef<T>(str);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -392,7 +392,20 @@ namespace XenAPI
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             JToken jToken = JToken.Load(reader);
-            return DateTime.ParseExact(jToken.ToString(), DateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None);
+            var str = jToken.ToObject<string>();
+
+            try
+            {
+                return DateTime.ParseExact(str, DateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None);
+            }
+            catch (FormatException)
+            {
+                return DateTime.MinValue;
+            }
+            catch (ArgumentException)
+            {
+                return DateTime.MinValue;
+            }
         }
     }
 
@@ -402,7 +415,7 @@ namespace XenAPI
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             JToken jToken = JToken.Load(reader);
-            return Helper.EnumParseDefault(objectType, jToken.ToString());
+            return Helper.EnumParseDefault(objectType, jToken.ToObject<string>());
         }
     }
 }


### PR DESCRIPTION
The SDK counterpart: https://github.com/xapi-project/xen-api-sdk/pull/143