### PR TITLE
CA-284226: Optimize performance of menu Start-on-Server and Migrate-to-Server

### DIFF
--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -134,8 +134,9 @@ namespace XenAdmin.Commands
                         EnableAppropriateHostsWlb(session, recommendations);
                 }
                 else
+                {
                     EnableAppropriateHostsNoWlb(session);
-
+                }
             });
         }
 
@@ -152,9 +153,7 @@ namespace XenAdmin.Commands
                 firstItem.Command = firstItemCmd;
                 firstItem.Enabled = firstItemCmdCanExecute;
             });
-
-            Program.Invoke(Program.MainWindow, () => AddAdditionalMenuItems(selection));
-
+    
             List<VMOperationToolStripMenuSubItem> hostMenuItems = new List<VMOperationToolStripMenuSubItem>();
             foreach (VMOperationToolStripMenuSubItem item in base.DropDownItems)
             {
@@ -187,6 +186,9 @@ namespace XenAdmin.Commands
                     base.DropDownItems.Insert(hostMenuItems.IndexOf(menuItem) + 1, menuItem);
                 });
             }
+
+            Program.Invoke(Program.MainWindow, () => AddAdditionalMenuItems(selection));
+
         }
 
         private void EnableAppropriateHostsNoWlb(Session session)

--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -169,8 +169,8 @@ namespace XenAdmin.Commands
                     {
                         item.Command = cmd;
                         item.Enabled = canExecute;
-                        hostMenuItems.Add(item);
                     });
+                    hostMenuItems.Add(item);
                 }
             }
             
@@ -200,7 +200,6 @@ namespace XenAdmin.Commands
             
             VMOperationCommand cmdHome = new VMOperationHomeServerCommand(Command.MainWindowCommandInterface, selection, _operation, session);
             Host affinityHost = connection.Resolve(((VM)Command.GetSelection()[0].XenObject).affinity);
-            VMOperationCommand cpmCmdHome = new CrossPoolMigrateToHomeCommand(Command.MainWindowCommandInterface, selection, affinityHost);
 
             Program.Invoke(Program.MainWindow, delegate
             {
@@ -214,6 +213,8 @@ namespace XenAdmin.Commands
                 }
                 else
                 {
+                    VMOperationCommand cpmCmdHome = new CrossPoolMigrateToHomeCommand(Command.MainWindowCommandInterface, selection, affinityHost);
+
                     if (cpmCmdHome.CanExecute())
                     {
                         firstItem.Command = cpmCmdHome;
@@ -249,6 +250,8 @@ namespace XenAdmin.Commands
                     //   2. Limit the count of concurrent threads (now it's 25).
                     workerQueueWithouWlb.EnqueueItem(() =>
                     {
+                        if (_isDropDownClosed)
+                            return;
                         VMOperationCommand cmd = new VMOperationHostCommand(Command.MainWindowCommandInterface, selection, delegate { return host; }, host.Name().EscapeAmpersands(), _operation, session);
                         CrossPoolMigrateCommand cpmCmd = new CrossPoolMigrateCommand(Command.MainWindowCommandInterface, selection, host, _resumeAfter);
 

--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuSubItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuSubItem.cs
@@ -52,6 +52,7 @@ namespace XenAdmin.Commands
         {
             Util.ThrowIfParameterNull(command, "command");
             Command = command;
+            Enabled = command != null && command.CanExecute();
         }
 
         private void Update()

--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuSubItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuSubItem.cs
@@ -56,8 +56,6 @@ namespace XenAdmin.Commands
 
         private void Update()
         {
-            Enabled = _command != null && _command.CanExecute();
-
             if (_command != null)
             {
                 if (_command.MenuText != null)

--- a/XenAdmin/Controls/VisualMenuItem.cs
+++ b/XenAdmin/Controls/VisualMenuItem.cs
@@ -68,7 +68,7 @@ namespace XenAdmin.Controls
             {
                 base.Text = value;
                 UpdateWidths();
-                VisualMenuItemAlignData.Refresh();
+                VisualMenuItemAlignData.Refresh(this);
                 RefreshPadding();
             }
         }
@@ -93,7 +93,7 @@ namespace XenAdmin.Controls
             set
             {
                 secondImage = value;
-                VisualMenuItemAlignData.Refresh();
+                VisualMenuItemAlignData.Refresh(this);
                 RefreshPadding();
                 this.Invalidate();
             }
@@ -229,15 +229,22 @@ namespace XenAdmin.Controls
                     }
                 }
                 maxCombinedWidth = maxImageWidth + maxStringLength;
-                foreach (ToolStripItem item in parentStrip.DropDownItems)
-                {
-                    VisualMenuItem visItem;
-                    if ((visItem = item as VisualMenuItem) != null)
-                    {
-                        visItem.RefreshPadding();
-                    }
-                }
             }     
+        }
+
+        public static void Refresh(VisualMenuItem visItem)
+        {
+            if (visItem != null)
+            {
+                lock (locker)
+                {
+                    int imageWidth = visItem.ImageWidth();
+                    if (visItem.TextWidth > maxStringLength)
+                        maxStringLength = visItem.TextWidth;
+                    if ((imageWidth + maxStringLength) > maxCombinedWidth)
+                        maxCombinedWidth = imageWidth + maxStringLength;
+                }
+            }
         }
     }
     

--- a/XenAdmin/Controls/VisualMenuItem.cs
+++ b/XenAdmin/Controls/VisualMenuItem.cs
@@ -68,7 +68,7 @@ namespace XenAdmin.Controls
             {
                 base.Text = value;
                 UpdateWidths();
-                VisualMenuItemAlignData.Refresh(this);
+                VisualMenuItemAlignData.Refresh();
                 RefreshPadding();
             }
         }
@@ -93,7 +93,7 @@ namespace XenAdmin.Controls
             set
             {
                 secondImage = value;
-                VisualMenuItemAlignData.Refresh(this);
+                VisualMenuItemAlignData.Refresh();
                 RefreshPadding();
                 this.Invalidate();
             }
@@ -230,21 +230,6 @@ namespace XenAdmin.Controls
                 }
                 maxCombinedWidth = maxImageWidth + maxStringLength;
             }     
-        }
-
-        public static void Refresh(VisualMenuItem visItem)
-        {
-            if (visItem != null)
-            {
-                lock (locker)
-                {
-                    int imageWidth = visItem.ImageWidth();
-                    if (visItem.TextWidth > maxStringLength)
-                        maxStringLength = visItem.TextWidth;
-                    if ((imageWidth + maxStringLength) > maxCombinedWidth)
-                        maxCombinedWidth = imageWidth + maxStringLength;
-                }
-            }
         }
     }
     

--- a/XenModel/Actions/ProduceConsumerQueue.cs
+++ b/XenModel/Actions/ProduceConsumerQueue.cs
@@ -56,6 +56,15 @@ public class ProduceConsumerQueue
                 worker.Join();
     }
 
+    public void CancelWorkers(bool waitForWorkers)
+    {
+        lock (_locker)
+        {
+            _itemQ.Clear();
+        }
+        StopWorkers(waitForWorkers);
+    }
+
     public void EnqueueItem(Action item)
     {
         lock (_locker)


### PR DESCRIPTION
This PR covers 3 CA's exactly: CA-284226, CA-277201 and CA-273151. It improves the performance of the menus by:
1. Reduce the count of API calls (triggered by CanExecute()) for updating each menu item by 1.
2. Make API calls for each menu item concurrent.
3. Optimize the algorithm in updating menu UI.