### PR TITLE
CA-271850: Increase the timeout of session for querying MaximumTolera…

### DIFF
--- a/XenAdmin/Controls/HaNtolControl.cs
+++ b/XenAdmin/Controls/HaNtolControl.cs
@@ -198,9 +198,9 @@ namespace XenAdmin.Controls
                     // Turn the settings dictionary into an api-level one we can pass to compute_hypothetical_max.
                     var config = Helpers.GetVmHaRestartPrioritiesForApi(settings);
 
-                    Session dupSess = connection.DuplicateSession(60 * 1000);
+                    Session dupSess = connection.DuplicateSession(10 * 60 * 1000);
 
-                    // Use a 1 minute timeout here (rather than the default 1 day)
+                    // Use a 10 minute timeout here (rather than the default 1 day)
                     ntolMax = Pool.GetMaximumTolerableHostFailures(dupSess, config);
 
                     if (exitNtolUpdateThread)


### PR DESCRIPTION
Currently the timeout of session is set to 1 minute for for querying MaximumTolerableFailures.
In case of a large pool (say 64) with a great many VMs (like 4096), the calculation could take more time than that.
So I'm going to enlarge the timeout to a safe enough value. That would be 10 minutes.
