### PR TITLE
CA-286458: Fix latestcr XC requirement when apply CR update

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -503,9 +503,10 @@ namespace XenAdmin.Core
 
 
         /// <summary>
-        /// Returns the latest XenCenter version or null, if the current version is the latest. 
-        /// If a server version is provided, it returns the XenCenter version that is required to work with that server. 
-        /// If no server version is provided it will return the latestCr XenCenter.
+        /// If parameter is null, it returns latestcr XenCenter version if it is greater than current XC version,
+        /// or null, if the current XC version is latestcr.
+        /// If parameter is not null, it returns the minimum XenCenter version if it is greater than the current XC version,
+        /// or null, if the minimum XC version couldn't be found or the current XC version is enough.
         /// </summary>
         /// <param name="serverVersion"></param>
         /// <returns></returns>
@@ -518,17 +519,17 @@ namespace XenAdmin.Core
             if (currentProgramVersion == new Version(0, 0, 0, 0))
                 return null;
 
-            var latestVersions = from v in XenCenterVersions where v.Latest select v;
-            var latest = latestVersions.FirstOrDefault(xcv => xcv.Lang == Program.CurrentLanguage) ??
-                         latestVersions.FirstOrDefault(xcv => string.IsNullOrEmpty(xcv.Lang));
+            if (serverVersion == null)
+                return XenCenterVersions.FirstOrDefault(xcv => xcv.LatestCr && xcv.Version > currentProgramVersion);
 
-            var latestCrVersions = from v in XenCenterVersions where v.LatestCr select v;
-            var latestCr = latestCrVersions.FirstOrDefault(xcv => xcv.Lang == Program.CurrentLanguage) ??
-                           latestCrVersions.FirstOrDefault(xcv => string.IsNullOrEmpty(xcv.Lang));
+            var minXcVersion = serverVersion.MinimumXcVersion;
+            if (String.IsNullOrEmpty(minXcVersion))
+                return null;
 
-            if (serverVersion != null && serverVersion.Latest && latest != null)
-                return latest.Version > currentProgramVersion ? latest : null;
-            return latestCr != null && latestCr.Version > currentProgramVersion ? latestCr : null;  
+            var minimumXcVersion = XenCenterVersions.FirstOrDefault(xcv => xcv.Version.ToString() == minXcVersion);
+            return minimumXcVersion != null && minimumXcVersion.Version > currentProgramVersion
+                ? minimumXcVersion
+                : null;
         }
         
         /// <summary>

--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -523,10 +523,10 @@ namespace XenAdmin.Core
                 return XenCenterVersions.FirstOrDefault(xcv => xcv.LatestCr && xcv.Version > currentProgramVersion);
 
             var minXcVersion = serverVersion.MinimumXcVersion;
-            if (String.IsNullOrEmpty(minXcVersion))
+            if (minXcVersion == null)
                 return null;
 
-            var minimumXcVersion = XenCenterVersions.FirstOrDefault(xcv => xcv.Version.ToString() == minXcVersion);
+            var minimumXcVersion = XenCenterVersions.FirstOrDefault(xcv => xcv.Version == minXcVersion);
             return minimumXcVersion != null && minimumXcVersion.Version > currentProgramVersion
                 ? minimumXcVersion
                 : null;

--- a/XenAdminTests/UnitTests/AlertTests/XenServerUpdateAlertTests.cs
+++ b/XenAdminTests/UnitTests/AlertTests/XenServerUpdateAlertTests.cs
@@ -55,7 +55,7 @@ namespace XenAdminTests.UnitTests.AlertTests
         [Test]
         public void TestAlertWithConnectionAndHosts()
         {
-            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false);
+            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false, "");
             var alert = new XenServerVersionAlert(ver);
             alert.IncludeConnection(connA.Object);
             alert.IncludeConnection(connB.Object);
@@ -83,7 +83,7 @@ namespace XenAdminTests.UnitTests.AlertTests
         [Test]
         public void TestAlertWithHostsAndNoConnection()
         {
-            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false);
+            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false, "");
             var alert = new XenServerVersionAlert(ver);
             alert.IncludeHosts(new List<Host> { hostA.Object, hostB.Object });
 
@@ -109,7 +109,7 @@ namespace XenAdminTests.UnitTests.AlertTests
         [Test]
         public void TestAlertWithConnectionAndNoHosts()
         {
-            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false);
+            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false, "");
             var alert = new XenServerVersionAlert(ver);
             alert.IncludeConnection(connA.Object);
             alert.IncludeConnection(connB.Object);
@@ -136,7 +136,7 @@ namespace XenAdminTests.UnitTests.AlertTests
         [Test]
         public void TestAlertWithNoConnectionAndNoHosts()
         {
-            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false);
+            XenServerVersion ver = new XenServerVersion("1.2.3", "name", true, false, "http://url", new List<XenServerPatch>(), new List<XenServerPatch>(), new DateTime(2011, 4, 1).ToString(), "123", "", false, "");
             var alert = new XenServerVersionAlert(ver);
 
             IUnitTestVerifier validator = new VerifyGetters(alert);

--- a/XenAdminTests/UnitTests/BatchUpdatesTests/BatchUpdatesTests.cs
+++ b/XenAdminTests/UnitTests/BatchUpdatesTests/BatchUpdatesTests.cs
@@ -76,7 +76,7 @@ namespace XenAdminTests.UnitTests
         {
             var serverVersions = new List<XenServerVersion>();
 
-            var version = new XenServerVersion("7.0.0", "XenServer Test 7", true, false, "", new List<XenServerPatch>(), new List<XenServerPatch>(), DateTime.MinValue.ToString(), "buildNo", "", false);
+            var version = new XenServerVersion("7.0.0", "XenServer Test 7", true, false, "", new List<XenServerPatch>(), new List<XenServerPatch>(), DateTime.MinValue.ToString(), "buildNo", "", false, "");
             for (int ii = 0; ii < numberOfPatches; ii++)
             {
                 var patch = new XenServerPatch("patch_uuid_" + ii, "patch name " + ii, "patch description" + ii, "", "", "1.0", "", "", "1970-01-01T00:00:00Z", "", "1000");

--- a/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
+++ b/XenModel/Actions/Updates/DownloadUpdatesXmlAction.cs
@@ -245,6 +245,7 @@ namespace XenAdmin.Actions
                     string buildNumber = "";
                     string patchUuid = "";
                     bool presentAsUpdate = false;
+                    string minXcVersion = "";
 
                     foreach (XmlAttribute attrib in version.Attributes)
                     {
@@ -266,6 +267,8 @@ namespace XenAdmin.Actions
                             patchUuid = attrib.Value;
                         else if (attrib.Name == "present-as-update")
                             presentAsUpdate = attrib.Value.ToUpperInvariant() == bool.TrueString.ToUpperInvariant();
+                        else if (attrib.Name == "minimum-xc-version")
+                            minXcVersion = attrib.Value;
                     }
 
                     List<XenServerPatch> patches = new List<XenServerPatch>();
@@ -301,7 +304,7 @@ namespace XenAdmin.Actions
                     }
 
                     XenServerVersions.Add(new XenServerVersion(version_oem, name, is_latest, is_latest_cr, url, patches, minimalPatches, timestamp,
-                                                               buildNumber, patchUuid, presentAsUpdate));
+                                                               buildNumber, patchUuid, presentAsUpdate, minXcVersion));
                 }
             }
         }

--- a/XenModel/Actions/Updates/XenServerVersion.cs
+++ b/XenModel/Actions/Updates/XenServerVersion.cs
@@ -47,7 +47,7 @@ namespace XenAdmin.Core
         public List<XenServerPatch> Patches;
         public string PatchUuid;
         public bool PresentAsUpdate;
-        public string MinimumXcVersion;
+        public Version MinimumXcVersion;
         
         /// <summary>
         /// A host of this version is considered up-to-date when it has all the patches in this list installed on it
@@ -86,7 +86,7 @@ namespace XenAdmin.Core
             BuildNumber = buildNumber;
             PatchUuid = patchUuid;
             PresentAsUpdate = presentAsUpdate;
-            MinimumXcVersion = minXcVersion;
+            ParseMinXcVersion(minXcVersion);
         }
 
         private void ParseVersion(string version_oem)
@@ -102,6 +102,13 @@ namespace XenAdmin.Core
                     Oem = bit;
             }
             Version = new Version(string.Join(".", ver.ToArray()));
+        }
+
+        private void ParseMinXcVersion(string minXcVersion)
+        {
+            Version ver;
+            Version.TryParse(minXcVersion, out ver);
+            MinimumXcVersion = ver;
         }
 
         public string VersionAndOEM

--- a/XenModel/Actions/Updates/XenServerVersion.cs
+++ b/XenModel/Actions/Updates/XenServerVersion.cs
@@ -47,6 +47,7 @@ namespace XenAdmin.Core
         public List<XenServerPatch> Patches;
         public string PatchUuid;
         public bool PresentAsUpdate;
+        public string MinimumXcVersion;
         
         /// <summary>
         /// A host of this version is considered up-to-date when it has all the patches in this list installed on it
@@ -72,7 +73,7 @@ namespace XenAdmin.Core
         /// <param name="patchUuid"></param>
         /// <param name="presentAsUpdate">Indicates that the new version (usually a CU) should be presented as an update where possible</param>
         public XenServerVersion(string version_oem, string name, bool latest, bool latestCr, string url, List<XenServerPatch> patches, List<XenServerPatch> minimumPatches,
-            string timestamp, string buildNumber, string patchUuid, bool presentAsUpdate)
+            string timestamp, string buildNumber, string patchUuid, bool presentAsUpdate, string minXcVersion)
         {
             ParseVersion(version_oem);
             Name = name;
@@ -85,6 +86,7 @@ namespace XenAdmin.Core
             BuildNumber = buildNumber;
             PatchUuid = patchUuid;
             PresentAsUpdate = presentAsUpdate;
+            MinimumXcVersion = minXcVersion;
         }
 
         private void ParseVersion(string version_oem)


### PR DESCRIPTION
Using minimum_xc_version attribute in xenserver version to
determine which xencenter version is required.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>