### PR TITLE
CA-286291: Fix the crash when quickly and repeatedly popping up Migrate-to-Server menu

### DIFF
--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -157,7 +157,7 @@ namespace XenAdmin.Commands
 
             public void Stop()
             {
-                _stopped = true;
+                Stopped = true;
                 if (workerQueueWithoutWlb != null)
                     workerQueueWithoutWlb.CancelWorkers(false);
             }


### PR DESCRIPTION
The PR aims to fix the crash when a user pops up Migrate-to-Server menu repeatedly and quickly. The problem is more probable to happen if the server list is long.
The root cause is two or more threads can be created to update the menu in parallel, if the user operates quickly enough, which definitely lead to a program crash.
The solution is to guarantee only one thread is working on menu update. If the previous menu has been closed and a new menu is to be made, we need to make sure the previous job quit safely (don't invoke main window any more) before starting a new job.
