### PR TITLE
CA-285215: Cancel button should be enabled on the Patching wizard whe…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -384,7 +384,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             if (PatchingWizard_UploadPage.AllIntroducedPoolUpdates != null && PatchingWizard_UploadPage.AllIntroducedPoolUpdates.Count > 0)
             {
-                return PatchingWizard_UploadPage.AllIntroducedPoolUpdates.Keys.Select(GetCleanUpPoolUpdateAction).ToList();
+                return PatchingWizard_UploadPage.AllIntroducedPoolUpdates.Keys.Where(u => u.Connection != null && u.Connection.IsConnected).Select(GetCleanUpPoolUpdateAction).ToList();
             }
 
             return new List<AsyncAction>();

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
@@ -105,7 +105,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             return _nextEnabled;
         }
 
-        private bool _cancelEnabled;
+        private bool _cancelEnabled = true;
         public override bool EnableCancel()
         {
             return _cancelEnabled;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
@@ -114,7 +114,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             return _nextEnabled;
         }
 
-        private bool _cancelEnabled;
+        private bool _cancelEnabled = true;
         public override bool EnableCancel()
         {
             return _cancelEnabled;


### PR DESCRIPTION
…n the update installation is in progress

- also fixing an error on the patching wizard where a null reference exception is thrown if, when the wizard is cancelled, the host where an update has been uploaded is not connected anymore

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>