### PR TITLE
CA-281881: G11N: L10N: Hardcode issue in error messages when configur…

### DIFF
--- a/XenModel/XenAPI/FriendlyErrorNames.ja.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.ja.resx
@@ -946,7 +946,7 @@
     <value>以下のエラーにより、外部認証が無効になりました。資格情報が無効なため、一部の Active Directory マシン アカウントが Active Directory サーバー上で無効になっていません。</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED" xml:space="preserve">
-    <value>外部認証を有効にできません。{1}</value>
+    <value>外部認証を有効にできません。</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED_DOMAIN_LOOKUP_FAILED" xml:space="preserve">
     <value>サーバーでドメイン サーバーに接続できないため外部認証を有効にできません。設定を確認し、ドメイン サーバーに接続できることを確認してください。</value>

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -946,7 +946,7 @@
     <value>External authentication has been disabled with errors: Some AD machine accounts were not disabled on the AD server due to invalid credentials.</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED" xml:space="preserve">
-    <value>Could not enable external authentication: {1}</value>
+    <value>Could not enable external authentication.</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED_DOMAIN_LOOKUP_FAILED" xml:space="preserve">
     <value>The server was unable to contact your domain server to enable external authentication. Check that your settings are correct and a route to the server exists.</value>

--- a/XenModel/XenAPI/FriendlyErrorNames.zh-CN.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.zh-CN.resx
@@ -946,7 +946,7 @@
     <value>已禁用外部身份验证，错误消息如下: 由于凭据无效，因此未在 AD 服务器上禁用某些 AD 计算机帐户。</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED" xml:space="preserve">
-    <value>无法启用外部身份验证: {1}</value>
+    <value>无法启用外部身份验证。</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED_DOMAIN_LOOKUP_FAILED" xml:space="preserve">
     <value>此服务器无法与域服务器联系以启用外部身份验证。请检查您的设置是否正确以及是否存在到服务器的路由。</value>


### PR DESCRIPTION
…e AD for server

Refer to the CA ticket for details. Generall, there may be some messages (strings)
from the same error message and we cannot literally translate that in the current
framework nor can we split the error into multiple errors and make the translation
separately due to effort constrain. So we just remove the extra information/string
from the current error message to keep current message language(translation) consistent.

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>