### PR TITLE
CA-287430: Fixed the issue where the "Install Update" page of the pat…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_AutomatedUpdatesPage.cs
@@ -287,14 +287,14 @@ namespace XenAdmin.Wizards.PatchingWizard
             {
                 if (pa.Visible)
                 {
-                    sb.Append(pa);
+                    sb.Append(pa.ProgressDescription ?? pa.ToString());
                     sb.AppendLine(Messages.DONE);
                 }
             }
 
             foreach (var pa in errorActions)
             {
-                sb.Append(pa);
+                sb.Append(pa.ProgressDescription ?? pa.ToString());
                 sb.AppendLine(Messages.ERROR);
             }
 

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RestartHostPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RestartHostPlanAction.cs
@@ -29,8 +29,8 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
+using System.Text;
 using XenAdmin.Core;
 using XenAPI;
 
@@ -54,8 +54,6 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
 
         protected override void RunWithSession(ref Session session)
         {
-            Visible = true;
-
             var hostObj = GetResolvedHost();
 
             if (Helpers.ElyOrGreater(hostObj))
@@ -71,7 +69,8 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 else if (_restartAgentFallback)
                 {
                     log.Debug("Live patching succeeded. Restarting agent.");
-                    Title = string.Format(Messages.UPDATES_WIZARD_RESTARTING_AGENT, hostObj.Name());
+                    Visible = true;
+                    Title = ProgressDescription = string.Format(Messages.UPDATES_WIZARD_RESTARTING_AGENT, hostObj.Name());
                     WaitForReboot(ref session, Host.AgentStartTime, s => Host.async_restart_agent(s, HostXenRef.opaque_ref));
                     return;
                 }
@@ -82,9 +81,24 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                     return;
                 }
             }
+            Visible = true;
+            var sb = new StringBuilder();
+
+            sb.Append(string.Format(Messages.PLANACTION_VMS_MIGRATING, hostObj.Name()));
+            ProgressDescription = sb.ToString();
 
             EvacuateHost(ref session);
+
+            sb.AppendLine(Messages.DONE);
+            sb.Append(string.Format(Messages.UPDATES_WIZARD_REBOOTING, hostObj.Name()));
+            ProgressDescription = sb.ToString();
+
             RebootHost(ref session);
+
+            sb.AppendLine(Messages.DONE);
+            sb.Append(string.Format(Messages.UPDATES_WIZARD_EXITING_MAINTENANCE_MODE, hostObj.Name()));
+            ProgressDescription = sb.ToString();
+
             BringBabiesBack(ref session, _vms, _enableOnly);
         }
     }

--- a/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
+++ b/XenModel/Actions/Updates/DownloadAndUnzipXenServerPatchAction.cs
@@ -253,13 +253,12 @@ namespace XenAdmin.Actions
             int pc = (int)(95.0 * e.BytesReceived / e.TotalBytesToReceive);
             if (pc != PercentComplete)
             {
-                PercentComplete = pc;
-
                 DownloadProgressDescription
                     = Description 
                     = string.Format(Messages.DOWNLOAD_AND_EXTRACT_ACTION_DOWNLOADING_DETAILS_DESC, updateName,
                                             Util.DiskSizeString(e.BytesReceived),
                                             Util.DiskSizeString(e.TotalBytesToReceive));
+                PercentComplete = pc;
             }
         }
 


### PR DESCRIPTION
…ching wizard does not show the information on the host reboot steps.

- use the plan action's ProgressDescription property to display the steps in RestartHostPlanAction (evacuate host, reboot host, bring babies back);
- the plan action should not be visible if the restart is skipped;

- The change to the DownloadAndUnzipXenServerPatchAction is to ensure that the download progress description is updated on the wizard with the correct description (in automated updates mode, via DownloadPatchPlanAction); DownloadPatchPlanAction is using the ActionChanged event to update its description based on the  action's DownloadProgressDescription property, but the ActionChanged event is called when the PercentComplete is updated, so this needs to happen after DownloadProgressDescription has been updated.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>