### PR TITLE
CA-284090: Show a blank page in HTTP(S) plugin tab-page when a new object was selected

### DIFF
--- a/XenAdmin/Plugins/Features/TabPageFeature.cs
+++ b/XenAdmin/Plugins/Features/TabPageFeature.cs
@@ -105,7 +105,7 @@ namespace XenAdmin.Plugins
 
         private readonly Dictionary<IXenObject, BrowserState> BrowserStates = new Dictionary<IXenObject, BrowserState>();
         private BrowserState lastBrowserState = null;
-        private bool ResettingPage = false;
+        private bool resettingPage = false;
 
         private TabControl tabControl;
         private IXenObject selectedXenObject;
@@ -307,7 +307,7 @@ namespace XenAdmin.Plugins
             if (tabControl != null && tabControl.SelectedTab != null && tabControl.SelectedTab.Tag == this)
             {
                 if (Program.MainWindow.StatusBarAction == null 
-                    || Program.MainWindow.StatusBarAction.IsCompleted && MainWindowActionAtNavigateTime.Equals(Program.MainWindow.StatusBarAction))
+                    || Program.MainWindow.StatusBarAction.IsCompleted && Program.MainWindow.StatusBarAction.Equals(MainWindowActionAtNavigateTime))
                 {
                     // we still have 'control' of the status bar
                     Program.MainWindow.SetProgressBar(false, 0);
@@ -318,7 +318,7 @@ namespace XenAdmin.Plugins
             if (!XenCenterOnly && lastBrowserState != null)
             {
                 log.DebugFormat("url for '{0}' set to '{1}'", Helpers.GetName(lastBrowserState.Obj), e.Url);
-                if (ResettingPage == false)
+                if (!resettingPage)
                     lastBrowserState.Urls = new List<Uri> { e.Url };
             }
         }
@@ -370,7 +370,7 @@ namespace XenAdmin.Plugins
                 DeleteUrlCacheEntry(e.Url.AbsoluteUri);
             }
 
-            if (ResettingPage == false)
+            if (!resettingPage)
                 lastBrowserState.Urls = new List<Uri> { e.Url };
         }
 
@@ -439,13 +439,13 @@ namespace XenAdmin.Plugins
                     if (ShowTab)
                     {
                         Browser.Navigate("about:blank");
-                        ResettingPage = true;
+                        resettingPage = true;
                         while (Browser.ReadyState != WebBrowserReadyState.Complete)
                         {
                             Application.DoEvents();
                             System.Threading.Thread.Sleep(10);
                         }
-                        ResettingPage = false;
+                        resettingPage = false;
                         SetUrl();
                     }
                 }
@@ -461,7 +461,7 @@ namespace XenAdmin.Plugins
             if (!XenCenterOnly && lastBrowserState != null)
             {
                 log.DebugFormat("url for '{0}' set to '{1}'", Helpers.GetName(lastBrowserState.Obj), e.Url);
-                if (ResettingPage == false)
+                if (!resettingPage)
                     lastBrowserState.Urls = new List<Uri> { e.Url };
 
                 if (lastBrowserState.IsError != navigationError)

--- a/XenAdmin/Plugins/Features/TabPageFeature.cs
+++ b/XenAdmin/Plugins/Features/TabPageFeature.cs
@@ -282,9 +282,6 @@ namespace XenAdmin.Plugins
                 BrowserStates[selectedXenObject] = state;
             }
 
-            if (lastBrowserState == state)
-                return;
-
             try
             {
                 if (state.ObjectForScripting != null)
@@ -429,7 +426,6 @@ namespace XenAdmin.Plugins
                 lastXenModelObject = SelectedXenObject;
                 if (ShowTab)
                 {
-                    //Browser.Navigate("about:blank");
                     SetUrl();
                 }  
             }


### PR DESCRIPTION
(PR 2017 was showing wrong state, so I closed it and created this new one.)
When a user switched from one object to another, Web Browser page could not be updated until the new page was available. The user could be confused, especially when it took a long time before the new page ready.
The solution of this PR is to show a blank page immediately after a new object is selected. Real page will be requested after the blank page is shown.
