### PR TITLE
CA-284090: Show a blank page in HTTP(S) plugin tab-page when a new object was selected

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -2068,6 +2068,8 @@ namespace XenAdmin
             else
                 DockerProcessPage.PauseRefresh();
 
+            pluginManager.SetSelectedTabIndexChanged();
+
             if (t != null)
                 SetLastSelectedPage(SelectionManager.Selection.First, t);
         }

--- a/XenAdmin/Plugins/PluginManager.cs
+++ b/XenAdmin/Plugins/PluginManager.cs
@@ -222,6 +222,22 @@ namespace XenAdmin.Plugins
             }
         }
 
+        public void SetSelectedTabIndexChanged()
+        {
+            foreach (PluginDescriptor plugin in Plugins)
+            {
+                foreach (Feature feature in plugin.Features)
+                {
+                    TabPageFeature tabPageFeature = feature as TabPageFeature;
+
+                    if (tabPageFeature != null)
+                    {
+                        tabPageFeature.SetSelectedTabIndexChanged();
+                    }
+                }
+            }
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
(PR 2017 was showing wrong state, so I closed it and created this new one.)
When a user switched from one object to another, Web Browser page could not be updated until the new page was available. The user could be confused, especially when it took a long time before the new page ready.
The solution of this PR is to show a blank page immediately after a new object is selected. Real page will be requested after the blank page is shown.