### PR TITLE
CA-284135: Issues with scheduled uploads in the Health Check service.

### DIFF
--- a/XenServerHealthCheck/RequestUploadTask.cs
+++ b/XenServerHealthCheck/RequestUploadTask.cs
@@ -144,17 +144,15 @@ namespace XenServerHealthCheck
                 {
                     DateTime LastFailedUpload = HealthCheckSettings.StringToDateTime(Get(config, HealthCheckSettings.LAST_FAILED_UPLOAD));
 
-                    if (haveSuccessfulUpload)
-                    {
-                        if (DateTime.Compare(lastSuccessfulUpload, LastFailedUpload) > 0)
-                            return false; //A retry is not needed
-                    }
-
                     int retryInterval = IntKey(config, HealthCheckSettings.RETRY_INTERVAL, HealthCheckSettings.DEFAULT_RETRY_INTERVAL);
                     if (DateTime.Compare(LastFailedUpload.AddDays(retryInterval), DateTime.UtcNow) <= 0)
                     {
-                        log.InfoFormat("Retry since retryInterval{0} - {1} > {2} meeted", LastFailedUpload, DateTime.UtcNow, retryInterval);
-                        needRetry = true;
+                        if ((!haveSuccessfulUpload) ||
+                            (DateTime.Compare(lastSuccessfulUpload, LastFailedUpload) < 0))
+                        {
+                            log.InfoFormat("Retry since retryInterval{0} - {1} > {2} meeted", LastFailedUpload, DateTime.UtcNow, retryInterval);
+                            needRetry = true;
+                        }
                     }
                     else
                         return false;
@@ -163,7 +161,6 @@ namespace XenServerHealthCheck
                 {
                     log.Error("Catch exception when check if retry was needed", exn);
                 }
-
             }
 
             DateTime currentTime = DateTime.Now;

--- a/XenServerHealthCheck/RequestUploadTask.cs
+++ b/XenServerHealthCheck/RequestUploadTask.cs
@@ -154,8 +154,6 @@ namespace XenServerHealthCheck
                             needRetry = true;
                         }
                     }
-                    else
-                        return false;
                 }
                 catch (Exception exn)
                 {


### PR DESCRIPTION
**Root cause:**
The logic here was: when a failed upload happened before a successful upload, scheduled upload would never happen again.
**Solution:**
We only take lastSuccessfulUpload into account when we are considering whether we need a retry after a previous failure:
- If no successful upload exists or the last successful upload is to early, we need to retry.
- If a successful upload existed and it happened after last failure, we don't retry.

Signed-off-by: Michael Zhao <michael.zhao@citrix.com>