### PR TITLE
Show pool host memory relative to each other

### DIFF
--- a/XenAdmin/Controls/Ballooning/HostMemoryControls.cs
+++ b/XenAdmin/Controls/Ballooning/HostMemoryControls.cs
@@ -111,15 +111,13 @@ namespace XenAdmin.Controls.Ballooning
             // relative memory view
             if (memory_of_biggest_host > 0)
             {
-                hostShinyBar.Dock = DockStyle.Top | DockStyle.Left; // undock right
-                int barMaxLength = labelTotal.Left;
-                int fixedPart = 45; // to calulate just the drawn bar, not the gap at the end
-                int hostmem = (int)(total / 1000000000); //GB
-                int hostmem_max_in_pool = (int)(memory_of_biggest_host / 1000000000); //GB
-                
-                int barRelativeLength = (((hostmem * 1000 / hostmem_max_in_pool) * (barMaxLength - fixedPart)) / 1000) + fixedPart;
+                int barMaxLength = labelTotal.Left - 70;
+                int fixedPart = 45; // to calulate just the drawn bar, not the gap's at the ends
+                int hostmem = (int)(total / 1000000000); // calculate GB
+                int hostmem_max_in_pool = (int)(memory_of_biggest_host / 1000000000); // calculate GB
 
                 // set length relative to host with the most memory
+                int barRelativeLength = (((hostmem * 1000 / hostmem_max_in_pool) * (barMaxLength - fixedPart)) / 1000) + fixedPart;              
                 hostShinyBar.Width = barRelativeLength;
             }
 

--- a/XenAdmin/Controls/Ballooning/HostMemoryControls.cs
+++ b/XenAdmin/Controls/Ballooning/HostMemoryControls.cs
@@ -52,6 +52,15 @@ namespace XenAdmin.Controls.Ballooning
 
         private Host _host;
         private Host_metrics host_metrics;
+        private long memory_of_biggest_host;
+
+        [Browsable(false)]
+        public void SetHost(Host host, long memory_of_biggest_host)
+        {
+            this.memory_of_biggest_host = memory_of_biggest_host;
+            this.host = host;
+        }
+
         [Browsable(false)]
         public Host host
         {
@@ -100,7 +109,7 @@ namespace XenAdmin.Controls.Ballooning
                 : 0;
 
             // Initialize the shiny bar
-            hostShinyBar.Initialize(host, xen_memory, dom0);
+            hostShinyBar.Initialize(host, xen_memory, dom0, this.memory_of_biggest_host);
 
             // Set the text values
             valueTotal.Text = Util.MemorySizeStringSuitableUnits(total, true);

--- a/XenAdmin/Controls/Ballooning/HostMemoryControls.cs
+++ b/XenAdmin/Controls/Ballooning/HostMemoryControls.cs
@@ -108,8 +108,23 @@ namespace XenAdmin.Controls.Ballooning
                 ? (long)Math.Round((double)tot_dyn_max / (double)total * 100.0)
                 : 0;
 
+            // relative memory view
+            if (memory_of_biggest_host > 0)
+            {
+                hostShinyBar.Dock = DockStyle.Top | DockStyle.Left; // undock right
+                int barMaxLength = labelTotal.Left;
+                int fixedPart = 45; // to calulate just the drawn bar, not the gap at the end
+                int hostmem = (int)(total / 1000000000); //GB
+                int hostmem_max_in_pool = (int)(memory_of_biggest_host / 1000000000); //GB
+                
+                int barRelativeLength = (((hostmem * 1000 / hostmem_max_in_pool) * (barMaxLength - fixedPart)) / 1000) + fixedPart;
+
+                // set length relative to host with the most memory
+                hostShinyBar.Width = barRelativeLength;
+            }
+
             // Initialize the shiny bar
-            hostShinyBar.Initialize(host, xen_memory, dom0, this.memory_of_biggest_host);
+            hostShinyBar.Initialize(host, xen_memory, dom0);
 
             // Set the text values
             valueTotal.Text = Util.MemorySizeStringSuitableUnits(total, true);

--- a/XenAdmin/Controls/Ballooning/HostMemoryRow.cs
+++ b/XenAdmin/Controls/Ballooning/HostMemoryRow.cs
@@ -49,10 +49,10 @@ namespace XenAdmin.Controls.Ballooning
             this.host = host;
         }
 
-        public HostMemoryRow(Host host, long maxmemory)
+        public HostMemoryRow(Host host, long memory_of_biggest_host)
             : this()
         {
-            this.memory_of_biggest_host = maxmemory;
+            this.memory_of_biggest_host = memory_of_biggest_host;
             this.host = host;
         }
 
@@ -63,7 +63,6 @@ namespace XenAdmin.Controls.Ballooning
                 // For a host, the labelPanel only ever has one row, so we don't need
                 // to worry about all the sizing stuff like in the VM case.
                 memoryRowLabel.Initialize(false, value);
-                //hostMemoryControls.host = value;
                 hostMemoryControls.SetHost(value, memory_of_biggest_host);
                 Refresh();
             }

--- a/XenAdmin/Controls/Ballooning/HostMemoryRow.cs
+++ b/XenAdmin/Controls/Ballooning/HostMemoryRow.cs
@@ -36,6 +36,8 @@ namespace XenAdmin.Controls.Ballooning
 {
     public partial class HostMemoryRow : UserControl
     {
+        long memory_of_biggest_host;
+
         public HostMemoryRow()
         {
             InitializeComponent();
@@ -47,6 +49,13 @@ namespace XenAdmin.Controls.Ballooning
             this.host = host;
         }
 
+        public HostMemoryRow(Host host, long maxmemory)
+            : this()
+        {
+            this.memory_of_biggest_host = maxmemory;
+            this.host = host;
+        }
+
         private Host host
         {
             set
@@ -54,7 +63,8 @@ namespace XenAdmin.Controls.Ballooning
                 // For a host, the labelPanel only ever has one row, so we don't need
                 // to worry about all the sizing stuff like in the VM case.
                 memoryRowLabel.Initialize(false, value);
-                hostMemoryControls.host = value;
+                //hostMemoryControls.host = value;
+                hostMemoryControls.SetHost(value, memory_of_biggest_host);
                 Refresh();
             }
         }

--- a/XenAdmin/Controls/Ballooning/HostShinyBar.cs
+++ b/XenAdmin/Controls/Ballooning/HostShinyBar.cs
@@ -54,13 +54,22 @@ namespace XenAdmin.Controls.Ballooning
         Dictionary<VM, VM_metrics> vm_metrics;
         long xen_memory;
         long dom0_memory;
+        long memory_of_biggest_host;
 
-        public void Initialize(Host host, long xen_memory, long dom0_memory)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="host"></param>
+        /// <param name="xen_memory"></param>
+        /// <param name="dom0_memory"></param>
+        /// <param name="memory_of_biggest_host">If set > 0, calculate the width of the shiny bar along the host with most memory for relative display</param>
+        public void Initialize(Host host, long xen_memory, long dom0_memory, long memory_of_biggest_host = 0)
         {
             this.host = host;
             this.host_metrics = host.Connection.Resolve(host.metrics);
             this.xen_memory = xen_memory;
             this.dom0_memory = dom0_memory;
+            this.memory_of_biggest_host = memory_of_biggest_host;
             vms = host.Connection.ResolveAll(host.resident_VMs);
             vm_metrics = new Dictionary<VM, VM_metrics>();
             foreach (VM vm in vms)
@@ -74,7 +83,15 @@ namespace XenAdmin.Controls.Ballooning
 
             Graphics g = e.Graphics;
             Rectangle barArea = barRect;
-            double bytesPerPixel = (double)host_metrics.memory_total / (double)barArea.Width;
+
+            long reverece_memory;
+            if (memory_of_biggest_host > 0)
+                reverece_memory = memory_of_biggest_host;
+            else
+                reverece_memory = host_metrics.memory_total;
+
+
+            double bytesPerPixel = (double)reverece_memory / (double)barArea.Width;
 
             // Grid
             DrawGrid(g, barArea, bytesPerPixel, host_metrics.memory_total);
@@ -104,7 +121,9 @@ namespace XenAdmin.Controls.Ballooning
             }
 
             // One final bar for free space
-            Rectangle rectFree = new Rectangle((int)left, barArea.Top, barArea.Right - (int)left, barArea.Height);
+            long factor_percent = (host_metrics.memory_total*100) / memory_of_biggest_host;
+
+            Rectangle rectFree = new Rectangle((int)left, barArea.Top, (int)(((barArea.Right - (int)left) * factor_percent)/100), barArea.Height);
             DrawToTarget(g, barArea, rectFree, BallooningColors.HostShinyBar_Unused);
         }
 

--- a/XenAdmin/Controls/Ballooning/HostShinyBar.cs
+++ b/XenAdmin/Controls/Ballooning/HostShinyBar.cs
@@ -54,22 +54,13 @@ namespace XenAdmin.Controls.Ballooning
         Dictionary<VM, VM_metrics> vm_metrics;
         long xen_memory;
         long dom0_memory;
-        long memory_of_biggest_host;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="host"></param>
-        /// <param name="xen_memory"></param>
-        /// <param name="dom0_memory"></param>
-        /// <param name="memory_of_biggest_host">If set > 0, calculate the width of the shiny bar along the host with most memory for relative display</param>
-        public void Initialize(Host host, long xen_memory, long dom0_memory, long memory_of_biggest_host = 0)
+        public void Initialize(Host host, long xen_memory, long dom0_memory)
         {
             this.host = host;
             this.host_metrics = host.Connection.Resolve(host.metrics);
             this.xen_memory = xen_memory;
             this.dom0_memory = dom0_memory;
-            this.memory_of_biggest_host = memory_of_biggest_host;
             vms = host.Connection.ResolveAll(host.resident_VMs);
             vm_metrics = new Dictionary<VM, VM_metrics>();
             foreach (VM vm in vms)
@@ -83,15 +74,7 @@ namespace XenAdmin.Controls.Ballooning
 
             Graphics g = e.Graphics;
             Rectangle barArea = barRect;
-
-            long reverece_memory;
-            if (memory_of_biggest_host > 0)
-                reverece_memory = memory_of_biggest_host;
-            else
-                reverece_memory = host_metrics.memory_total;
-
-
-            double bytesPerPixel = (double)reverece_memory / (double)barArea.Width;
+            double bytesPerPixel = (double)host_metrics.memory_total / (double)barArea.Width;
 
             // Grid
             DrawGrid(g, barArea, bytesPerPixel, host_metrics.memory_total);
@@ -121,9 +104,7 @@ namespace XenAdmin.Controls.Ballooning
             }
 
             // One final bar for free space
-            long factor_percent = (host_metrics.memory_total*100) / memory_of_biggest_host;
-
-            Rectangle rectFree = new Rectangle((int)left, barArea.Top, (int)(((barArea.Right - (int)left) * factor_percent)/100), barArea.Height);
+            Rectangle rectFree = new Rectangle((int)left, barArea.Top, barArea.Right - (int)left, barArea.Height);
             DrawToTarget(g, barArea, rectFree, BallooningColors.HostShinyBar_Unused);
         }
 

--- a/XenAdmin/Dialogs/OptionsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/OptionsDialog.Designer.cs
@@ -32,6 +32,7 @@ namespace XenAdmin.Dialogs
             this.connectionOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.ConnectionOptionsPage();
             this.consolesOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.ConsolesOptionsPage();
             this.graphsOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.DisplayOptionsPage();
+            this.graphsOptions2Page1 = new XenAdmin.Dialogs.OptionsPages.DisplayOptions2Page();
             this.updatesOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.UpdatesOptionsPage();
             this.securityOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.SecurityOptionsPage();
             this.saveAndRestoreOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.SaveAndRestoreOptionsPage();
@@ -54,6 +55,7 @@ namespace XenAdmin.Dialogs
             this.ContentPanel.Controls.Add(this.securityOptionsPage1);
             this.ContentPanel.Controls.Add(this.updatesOptionsPage1);
             this.ContentPanel.Controls.Add(this.graphsOptionsPage1);
+            this.ContentPanel.Controls.Add(this.graphsOptions2Page1);
             this.ContentPanel.Controls.Add(this.consolesOptionsPage1);
             this.ContentPanel.Controls.Add(this.connectionOptionsPage1);
             // 
@@ -64,6 +66,7 @@ namespace XenAdmin.Dialogs
             this.securityOptionsPage1,
             this.updatesOptionsPage1,
             this.graphsOptionsPage1,
+            this.graphsOptions2Page1,
             this.consolesOptionsPage1,
             this.connectionOptionsPage1,
             this.saveAndRestoreOptionsPage1,
@@ -102,6 +105,11 @@ namespace XenAdmin.Dialogs
             // 
             resources.ApplyResources(this.graphsOptionsPage1, "graphsOptionsPage1");
             this.graphsOptionsPage1.Name = "graphsOptionsPage1";
+            // 
+            // graphsOptions2Page1
+            // 
+            resources.ApplyResources(this.graphsOptions2Page1, "graphsOptions2Page1");
+            this.graphsOptions2Page1.Name = "graphsOptions2Page1";
             // 
             // updatesOptionsPage1
             // 
@@ -149,6 +157,7 @@ namespace XenAdmin.Dialogs
         private XenAdmin.Dialogs.OptionsPages.ConsolesOptionsPage consolesOptionsPage1;
         private XenAdmin.Dialogs.OptionsPages.UpdatesOptionsPage updatesOptionsPage1;
         private XenAdmin.Dialogs.OptionsPages.DisplayOptionsPage graphsOptionsPage1;
+        private XenAdmin.Dialogs.OptionsPages.DisplayOptions2Page graphsOptions2Page1;
         private XenAdmin.Dialogs.OptionsPages.SecurityOptionsPage securityOptionsPage1;
         private XenAdmin.Dialogs.OptionsPages.SaveAndRestoreOptionsPage saveAndRestoreOptionsPage1;
         private XenAdmin.Dialogs.OptionsPages.PluginOptionsPage pluginOptionsPage1;

--- a/XenAdmin/Dialogs/OptionsDialog.cs
+++ b/XenAdmin/Dialogs/OptionsDialog.cs
@@ -88,6 +88,7 @@ namespace XenAdmin.Dialogs
             if (!Helpers.CommonCriteriaCertificationRelease)
                 UpdatesOptionsPage.Log();
             DisplayOptionsPage.Log();
+            DisplayOptions2Page.Log();
             SaveAndRestoreOptionsPage.Log();
             PluginOptionsPage.Log();
             ConfirmationOptionsPage.Log();

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.Designer.cs
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.Designer.cs
@@ -1,0 +1,55 @@
+namespace XenAdmin.Dialogs.OptionsPages
+{
+    partial class DisplayOptions2Page
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DisplayOptions2Page));
+            this.ViewMemoryRelativeToEachOtherCheckbox = new System.Windows.Forms.CheckBox();
+            this.SuspendLayout();
+            // 
+            // ViewMemoryRelativeToEachOtherCheckbox
+            // 
+            resources.ApplyResources(this.ViewMemoryRelativeToEachOtherCheckbox, "ViewMemoryRelativeToEachOtherCheckbox");
+            this.ViewMemoryRelativeToEachOtherCheckbox.Name = "ViewMemoryRelativeToEachOtherCheckbox";
+            this.ViewMemoryRelativeToEachOtherCheckbox.UseVisualStyleBackColor = true;
+            // 
+            // DisplayOptions2Page
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.ViewMemoryRelativeToEachOtherCheckbox);
+            this.Name = "DisplayOptions2Page";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.CheckBox ViewMemoryRelativeToEachOtherCheckbox;
+    }
+}

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.cs
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.cs
@@ -1,0 +1,96 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Text;
+using System.Windows.Forms;
+using XenAdmin.Properties;
+
+
+namespace XenAdmin.Dialogs.OptionsPages
+{
+    public partial class DisplayOptions2Page : UserControl, IOptionsPage
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        public DisplayOptions2Page()
+        {
+            InitializeComponent();
+
+            build();
+        }
+
+        private void build()
+        {
+            ViewMemoryRelativeToEachOtherCheckbox.Checked = Properties.Settings.Default.ViewMemoryRelativeToEachOther;
+        }
+
+        public static void Log()
+        {
+            log.Info("=== ViewMemoryRelativeToEachOther: " + Properties.Settings.Default.ViewMemoryRelativeToEachOther.ToString());
+        }
+
+        #region IOptions2Page Members
+
+        public void Save()
+        {
+            if (ViewMemoryRelativeToEachOtherCheckbox.Checked != Properties.Settings.Default.ViewMemoryRelativeToEachOther)
+            {
+                Properties.Settings.Default.ViewMemoryRelativeToEachOther = ViewMemoryRelativeToEachOtherCheckbox.Checked;
+            }
+        }
+
+        #endregion
+
+        #region VerticalTab Members
+
+        public override string Text
+        {
+            get { return Messages.DISPLAY2; }
+        }
+
+        public string SubText
+        {
+            get { return Messages.DISPLAY2_DETAILS; }
+        }
+
+        public Image Image
+        {
+            get { return Resources._001_PerformanceGraph_h32bit_16; }
+        }
+
+        #endregion
+    }
+}

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.ja.resx
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.ja.resx
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element msdata:IsDataSet="true" name="root">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="GraphsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="GraphsTableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="SearchGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="SearchGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="label1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 0, 5</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>609, 18</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>リソース ペインでホストが選択されたときに何を [検索] タブに表示するかを選択します。</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 44</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 0, 10</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>218, 27</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Text" xml:space="preserve">
+    <value>プール全体に関する情報を表示(&amp;P)</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.Name" xml:space="preserve">
+    <value>showWholePoolOptionForSearchRadioButton</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 21</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 0, 0</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 17</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Text" xml:space="preserve">
+    <value>そのホストのみに関する情報を表示 (&amp;H)</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.Name" xml:space="preserve">
+    <value>showHostOnlyOptionForSearchRadioButton</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 20</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>609, 74</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>SearchGroupBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="showWholePoolOptionForSearchRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="showHostOnlyOptionForSearchRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0" />&lt;/TableLayoutSettings></value>
+  </data>
+  <data name="SearchGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="SearchGroupBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="SearchGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 307</value>
+  </data>
+  <data name="SearchGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
+  </data>
+  <data name="SearchGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>7, 7, 7, 7</value>
+  </data>
+  <data name="SearchGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 101</value>
+  </data>
+  <data name="SearchGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="SearchGroupBox.Text" xml:space="preserve">
+    <value>検索オプション</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.Name" xml:space="preserve">
+    <value>SearchGroupBox</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.Parent" xml:space="preserve">
+    <value>GraphsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GraphTypeGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GraphTypeGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label5.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 7</value>
+  </data>
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 3</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>597, 13</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>[パフォーマンス] タブに表示するパフォーマンス グラフの種類を構成します。</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GraphAreasRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GraphAreasRadioButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphAreasRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GraphAreasRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 26</value>
+  </data>
+  <data name="GraphAreasRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 0, 0</value>
+  </data>
+  <data name="GraphAreasRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 17</value>
+  </data>
+  <data name="GraphAreasRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="GraphAreasRadioButton.Text" xml:space="preserve">
+    <value>面グラフ(&amp;A)</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.Name" xml:space="preserve">
+    <value>GraphAreasRadioButton</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="pictureBox2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="pictureBox2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 167</value>
+  </data>
+  <data name="pictureBox2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>19, 0, 0, 10</value>
+  </data>
+  <data name="pictureBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>420, 99</value>
+  </data>
+  <data name="pictureBox2.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="pictureBox2.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Name" xml:space="preserve">
+    <value>pictureBox2</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="GraphLinesRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GraphLinesRadioButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphLinesRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GraphLinesRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 144</value>
+  </data>
+  <data name="GraphLinesRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 0, 0</value>
+  </data>
+  <data name="GraphLinesRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 17</value>
+  </data>
+  <data name="GraphLinesRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="GraphLinesRadioButton.Text" xml:space="preserve">
+    <value>折れ線グラフ(&amp;L)</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.Name" xml:space="preserve">
+    <value>GraphLinesRadioButton</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="pictureBox1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 49</value>
+  </data>
+  <data name="pictureBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>19, 0, 0, 0</value>
+  </data>
+  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>420, 89</value>
+  </data>
+  <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="tableLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>7, 7, 7, 7</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>617, 276</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>GraphTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="GraphAreasRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="pictureBox2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="GraphLinesRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="pictureBox1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" />&lt;/TableLayoutSettings></value>
+  </data>
+  <data name="GraphTypeGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="GraphTypeGroupBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="GraphTypeGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
+  </data>
+  <data name="GraphTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 298</value>
+  </data>
+  <data name="GraphTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="GraphTypeGroupBox.Text" xml:space="preserve">
+    <value>グラフの種類</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.Name" xml:space="preserve">
+    <value>GraphTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.Parent" xml:space="preserve">
+    <value>GraphsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>629, 411</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.Name" xml:space="preserve">
+    <value>GraphsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="SearchGroupBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="GraphTypeGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" />&lt;/TableLayoutSettings></value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>629, 411</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>DisplayOptionsPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.resx
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.resx
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ViewMemoryRelativeToEachOtherCheckbox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ViewMemoryRelativeToEachOtherCheckbox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 46</value>
+  </data>
+  <data name="ViewMemoryRelativeToEachOtherCheckbox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>204, 17</value>
+  </data>
+  <data name="ViewMemoryRelativeToEachOtherCheckbox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="ViewMemoryRelativeToEachOtherCheckbox.Text" xml:space="preserve">
+    <value>View Memory Relative To Each Other</value>
+  </data>
+  <data name="&gt;&gt;ViewMemoryRelativeToEachOtherCheckbox.Name" xml:space="preserve">
+    <value>ViewMemoryRelativeToEachOtherCheckbox</value>
+  </data>
+  <data name="&gt;&gt;ViewMemoryRelativeToEachOtherCheckbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ViewMemoryRelativeToEachOtherCheckbox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ViewMemoryRelativeToEachOtherCheckbox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>408, 219</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>DisplayOptions2Page</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.zh-CN.resx
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptions2Page.zh-CN.resx
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element msdata:IsDataSet="true" name="root">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="GraphsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="GraphsTableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="SearchGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="SearchGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="label1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 0, 5</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>609, 18</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>选择在“资源”窗格中选择了某个主机时要在“搜索”选项卡上显示的内容。</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 44</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 0, 10</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>218, 27</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="showWholePoolOptionForSearchRadioButton.Text" xml:space="preserve">
+    <value>显示与整个池有关的信息(&amp;P)</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.Name" xml:space="preserve">
+    <value>showWholePoolOptionForSearchRadioButton</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;showWholePoolOptionForSearchRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 21</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 0, 0</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 17</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="showHostOnlyOptionForSearchRadioButton.Text" xml:space="preserve">
+    <value>仅显示与该主机有关的信息(&amp;H)</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.Name" xml:space="preserve">
+    <value>showHostOnlyOptionForSearchRadioButton</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;showHostOnlyOptionForSearchRadioButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 20</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>609, 74</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>SearchGroupBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="showWholePoolOptionForSearchRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="showHostOnlyOptionForSearchRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0" />&lt;/TableLayoutSettings></value>
+  </data>
+  <data name="SearchGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="SearchGroupBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="SearchGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 307</value>
+  </data>
+  <data name="SearchGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
+  </data>
+  <data name="SearchGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>7, 7, 7, 7</value>
+  </data>
+  <data name="SearchGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 101</value>
+  </data>
+  <data name="SearchGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="SearchGroupBox.Text" xml:space="preserve">
+    <value>搜索选项</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.Name" xml:space="preserve">
+    <value>SearchGroupBox</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.Parent" xml:space="preserve">
+    <value>GraphsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;SearchGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GraphTypeGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GraphTypeGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label5.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 7</value>
+  </data>
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 3</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>597, 13</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>配置在“性能”选项卡上显示的性能图表的外观。</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GraphAreasRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GraphAreasRadioButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphAreasRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GraphAreasRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 26</value>
+  </data>
+  <data name="GraphAreasRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 0, 0</value>
+  </data>
+  <data name="GraphAreasRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 17</value>
+  </data>
+  <data name="GraphAreasRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="GraphAreasRadioButton.Text" xml:space="preserve">
+    <value>面积图(&amp;A)</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.Name" xml:space="preserve">
+    <value>GraphAreasRadioButton</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;GraphAreasRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="pictureBox2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="pictureBox2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 167</value>
+  </data>
+  <data name="pictureBox2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>19, 0, 0, 10</value>
+  </data>
+  <data name="pictureBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>420, 99</value>
+  </data>
+  <data name="pictureBox2.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="pictureBox2.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Name" xml:space="preserve">
+    <value>pictureBox2</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox2.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="GraphLinesRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GraphLinesRadioButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphLinesRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GraphLinesRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 144</value>
+  </data>
+  <data name="GraphLinesRadioButton.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 0, 0</value>
+  </data>
+  <data name="GraphLinesRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 17</value>
+  </data>
+  <data name="GraphLinesRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="GraphLinesRadioButton.Text" xml:space="preserve">
+    <value>折线图(&amp;L)</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.Name" xml:space="preserve">
+    <value>GraphLinesRadioButton</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;GraphLinesRadioButton.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="pictureBox1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 49</value>
+  </data>
+  <data name="pictureBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>19, 0, 0, 0</value>
+  </data>
+  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>420, 89</value>
+  </data>
+  <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="tableLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>7, 7, 7, 7</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>617, 276</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>GraphTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="GraphAreasRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="pictureBox2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="GraphLinesRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="pictureBox1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" />&lt;/TableLayoutSettings></value>
+  </data>
+  <data name="GraphTypeGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="GraphTypeGroupBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="GraphTypeGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
+  </data>
+  <data name="GraphTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 298</value>
+  </data>
+  <data name="GraphTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="GraphTypeGroupBox.Text" xml:space="preserve">
+    <value>图表类型</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.Name" xml:space="preserve">
+    <value>GraphTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.Parent" xml:space="preserve">
+    <value>GraphsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;GraphTypeGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>629, 411</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.Name" xml:space="preserve">
+    <value>GraphsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GraphsTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GraphsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="SearchGroupBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="GraphTypeGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" />&lt;/TableLayoutSettings></value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>629, 411</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>DisplayOptionsPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/XenAdmin/Properties/Settings.Designer.cs
+++ b/XenAdmin/Properties/Settings.Designer.cs
@@ -499,7 +499,23 @@ namespace XenAdmin.Properties {
                 this["FillAreaUnderGraphs"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool ViewMemoryRelativeToEachOther
+        {
+            get
+            {
+                return ((bool)(this["ViewMemoryRelativeToEachOther"]));
+            }
+            set
+            {
+                this["ViewMemoryRelativeToEachOther"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("null")]

--- a/XenAdmin/TabPages/BallooningPage.Designer.cs
+++ b/XenAdmin/TabPages/BallooningPage.Designer.cs
@@ -41,6 +41,7 @@ namespace XenAdmin.TabPages
             resources.ApplyResources(this, "$this");
             this.Name = "BallooningPage";
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 

--- a/XenAdmin/TabPages/BallooningPage.cs
+++ b/XenAdmin/TabPages/BallooningPage.cs
@@ -347,9 +347,9 @@ namespace XenAdmin.TabPages
                 settingsToVMs[settings].Add(vm);
             }
 
-            // find the host with the most memory as a reference to the max witdh
+            // find the host with the most memory as a reference to the max witdh; only if there are more than 1 host and no VMs
             long maxmem = 0;
-            if (Properties.Settings.Default.ViewMemoryRelativeToEachOther)
+            if (hosts.Count > 1 & vms.Count == 0 & Properties.Settings.Default.ViewMemoryRelativeToEachOther)
             {
                 foreach (Host host in hosts)
                 {

--- a/XenAdmin/TabPages/BallooningPage.cs
+++ b/XenAdmin/TabPages/BallooningPage.cs
@@ -46,7 +46,6 @@ namespace XenAdmin.TabPages
     public partial class BallooningPage : BaseTabPage
     {
         private const int ROW_GAP = 10;
-        private const bool MEM_RELATIVE_VIEW = true;
 
         public BallooningPage()
         {
@@ -350,7 +349,7 @@ namespace XenAdmin.TabPages
 
             // find the host with the most memory as a reference to the max witdh
             long maxmem = 0;
-            if (MEM_RELATIVE_VIEW)
+            if (Properties.Settings.Default.ViewMemoryRelativeToEachOther)
             {
                 foreach (Host host in hosts)
                 {
@@ -371,7 +370,8 @@ namespace XenAdmin.TabPages
                 Host_metrics metrics = host.Connection.Resolve(host.metrics);
                 if (metrics == null || !metrics.live)
                     continue;
-                if (MEM_RELATIVE_VIEW)
+
+                if (Properties.Settings.Default.ViewMemoryRelativeToEachOther)
                 {
                     AddRowToPanel(new HostMemoryRow(host, maxmem), ref top);
                 }

--- a/XenAdmin/TabPages/BallooningPage.resx
+++ b/XenAdmin/TabPages/BallooningPage.resx
@@ -112,20 +112,27 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pageContainerPanel.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 91</value>
+  </data>
+  <data name="pageContainerPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>482, 368</value>
   </data>
   <data name="&gt;&gt;pageContainerPanel.Name" xml:space="preserve">
     <value>pageContainerPanel</value>
   </data>
   <data name="&gt;&gt;pageContainerPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pageContainerPanel.Parent" xml:space="preserve">
     <value>$this</value>
@@ -133,10 +140,9 @@
   <data name="&gt;&gt;pageContainerPanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -6995,8 +6995,6 @@
     <PostBuildEvent Condition=" '$(Configuration)' == 'Release' ">mt.exe -nologo -manifest "$(ProjectDir)$(ProjectName).manifest" -outputresource:"$(TargetDir)..\..\bin\$(Configuration)\$(TargetFileName)";#1</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>copy "$(ProjectDir)\ReportViewer\resource_report.rdlc" "$(TargetDir)"
-
-copy "$(ProjectDir)\..\packages\putty.exe" "$(TargetDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(ProjectDir)\ReportViewer\resource_report.rdlc" "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -262,6 +262,12 @@
     <Compile Include="Dialogs\OptionsPages\ConfirmationOptionsPage.Designer.cs">
       <DependentUpon>ConfirmationOptionsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="Dialogs\OptionsPages\DisplayOptions2Page.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Dialogs\OptionsPages\DisplayOptions2Page.Designer.cs">
+      <DependentUpon>DisplayOptions2Page.cs</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\PvsCacheConfigurationDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1711,6 +1717,16 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\OptionsPages\ConfirmationOptionsPage.zh-CN.resx">
       <DependentUpon>ConfirmationOptionsPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\OptionsPages\DisplayOptions2Page.ja.resx">
+      <DependentUpon>DisplayOptions2Page.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\OptionsPages\DisplayOptions2Page.resx">
+      <DependentUpon>DisplayOptions2Page.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\OptionsPages\DisplayOptions2Page.zh-CN.resx">
+      <DependentUpon>DisplayOptions2Page.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\PvsCacheConfigurationDialog.ja.resx">
       <DependentUpon>PvsCacheConfigurationDialog.cs</DependentUpon>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -4156,6 +4156,12 @@ This will also delete its subfolders.</value>
   <data name="DISPLAY" xml:space="preserve">
     <value>Display</value>
   </data>
+  <data name="DISPLAY2" xml:space="preserve">
+    <value>Display 2</value>
+  </data>
+  <data name="DISPLAY2_DETAILS" xml:space="preserve">
+    <value>Display options 2</value>
+  </data>
   <data name="DISPLAY_DETAILS" xml:space="preserve">
     <value>Display options</value>
   </data>


### PR DESCRIPTION
This new feature shows the memory of all pool hosts in relation to each other.

**Scenario**: Your pool hosts have not the same amount of memory.

This helps to determine the real used memory of your vm's and the free memory of your hosts, if you upgrade your pools and have to migrate all vm's around.

Also usefull to "see" the real actual memory status.


-------------------

New Option:

![grafik](https://user-images.githubusercontent.com/5782951/39098114-1b400c5c-4666-11e8-8011-1635642d4cb9.png)


Option disabled (default): All hosts have the same length, but different amount of memory

![grafik](https://user-images.githubusercontent.com/5782951/39098194-5e8fd770-4667-11e8-823c-4f4b76791cb0.png)


Option enabled: All hosts are just as long as they have memory :-)

![grafik](https://user-images.githubusercontent.com/5782951/39098181-4709caac-4667-11e8-8734-b0f15828be25.png)




https://github.com/xcp-ng/xenadmin/issues/19 Pool Memory Tab: show memory in relation to each other