### PR TITLE
CA-286291: Refactoring in VMOperationToolStripManuItem

### DIFF
--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -89,7 +89,8 @@ namespace XenAdmin.Commands
             }
 
             VisualMenuItemAlignData.ParentStrip = this;
-            IXenConnection connection = Command.GetSelection()[0].Connection;
+            var selection = Command.GetSelection();
+            IXenConnection connection = selection[0].Connection;
             bool wlb = Helpers.WlbEnabled(connection);
 
             if (wlb)
@@ -109,6 +110,9 @@ namespace XenAdmin.Commands
                 item.Tag = host;
                 base.DropDownItems.Add(item);
             }
+
+            // Adds the migrate wizard button, do this before the enable checks on the other items
+            AddAdditionalMenuItems(selection);
             
             UpdateHostList();
         }
@@ -231,8 +235,6 @@ namespace XenAdmin.Commands
             {
                 DropDownItems.Insert(hostMenuItems.IndexOf(menuItem) + 1, menuItem);
             }
-
-            AddAdditionalMenuItems(selection);
         }
 
         private void EnableAppropriateHostsNoWlb()
@@ -261,9 +263,6 @@ namespace XenAdmin.Commands
 
             if (Stopped)
                 return;
-
-            // Adds the migrate wizard button, do this before the enable checks on the other items
-            AddAdditionalMenuItems(selection);
 
             foreach (VMOperationToolStripMenuSubItem item in hostMenuItems)
             {

--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuSubItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuSubItem.cs
@@ -30,11 +30,8 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using XenAdmin.Controls;
 using System.Drawing;
-using XenAPI;
 
 namespace XenAdmin.Commands
 {
@@ -74,8 +71,8 @@ namespace XenAdmin.Commands
                     SecondImage = _command.SecondImage;
                 }
 
-                //null is allowed (CA-147657)
-                ToolTipText = _command.ToolTipText;
+                //No tooltip needed as the reason is included in the menu text
+                //ToolTipText = _command.ToolTipText;
 
                 StarRating = _command.StarRating;
             }

--- a/XenAdmin/Commands/Controls/WlbRecommendations.cs
+++ b/XenAdmin/Commands/Controls/WlbRecommendations.cs
@@ -44,27 +44,26 @@ namespace XenAdmin.Commands
     /// </summary>
     internal class WlbRecommendations
     {
-        private readonly static log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private readonly ReadOnlyCollection<VM> _vms;
-        private readonly Session _session;
-        private bool _initialized;
-        private readonly Dictionary<VM, Dictionary<XenRef<Host>, string[]>> _recommendations = new Dictionary<VM, Dictionary<XenRef<Host>, string[]>>();
-        private bool _isError;
+        private readonly bool _initialized;
+        private readonly Dictionary<VM, Dictionary<XenRef<Host>, string[]>> _recommendations;
+        private readonly bool _isError;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WlbRecommendations"/> class.
         /// </summary>
         /// <param name="vms">The VMs that the recommendations are required for.</param>
-        /// <param name="session">The session.</param>
-        public WlbRecommendations(IEnumerable<VM> vms, Session session)
+        /// <param name="recommendations"></param>
+        public WlbRecommendations(List<VM> vms, Dictionary<VM, Dictionary<XenRef<Host>, string[]>> recommendations)
         {
             Util.ThrowIfEnumerableParameterNullOrEmpty(vms, "vms");
-            Util.ThrowIfParameterNull(session, "session");
 
-            _vms = new ReadOnlyCollection<VM>(new List<VM>(vms));
-            _session = session;
+            _vms = new ReadOnlyCollection<VM>(vms);
+            _recommendations = recommendations;
+            _isError = recommendations == null;
+            _initialized = recommendations != null;
         }
-
+        /*
         /// <summary>
         /// Calls VM.retrieve_wlb_recommendations for each of the VMs specified in the constructor.
         /// </summary>
@@ -96,7 +95,7 @@ namespace XenAdmin.Commands
             {
                 _isError = true;
             }
-        }
+         }*/
 
         /// <summary>
         /// Gets a value indicating whether an exception was thrown when calling VM.retrieve_wlb_recommendations.

--- a/XenAdmin/Commands/Controls/WlbRecommendations.cs
+++ b/XenAdmin/Commands/Controls/WlbRecommendations.cs
@@ -31,7 +31,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using XenAPI;
 using System.Collections.ObjectModel;
 using XenAdmin.Core;
@@ -45,7 +44,6 @@ namespace XenAdmin.Commands
     internal class WlbRecommendations
     {
         private readonly ReadOnlyCollection<VM> _vms;
-        private readonly bool _initialized;
         private readonly Dictionary<VM, Dictionary<XenRef<Host>, string[]>> _recommendations;
         private readonly bool _isError;
 
@@ -61,41 +59,7 @@ namespace XenAdmin.Commands
             _vms = new ReadOnlyCollection<VM>(vms);
             _recommendations = recommendations;
             _isError = recommendations == null;
-            _initialized = recommendations != null;
         }
-        /*
-        /// <summary>
-        /// Calls VM.retrieve_wlb_recommendations for each of the VMs specified in the constructor.
-        /// </summary>
-        public void Initialize()
-        {
-            if (_initialized)
-            {
-                throw new InvalidOperationException("Already initialized");
-            }
-
-            _initialized = true;
-
-            if (Helpers.WlbEnabled(_vms[0].Connection))
-            {
-                try
-                {
-                    foreach (VM vm in _vms)
-                    {
-                        _recommendations[vm] = VM.retrieve_wlb_recommendations(_session, vm.opaque_ref);
-                    }
-                }
-                catch (Exception e)
-                {
-                    log.Error("Error getting WLB recommendations", e);
-                    _isError = true;
-                }
-            }
-            else
-            {
-                _isError = true;
-            }
-         }*/
 
         /// <summary>
         /// Gets a value indicating whether an exception was thrown when calling VM.retrieve_wlb_recommendations.
@@ -114,10 +78,6 @@ namespace XenAdmin.Commands
             if (_isError)
             {
                 throw new InvalidOperationException("There was an error getting the WLB recommendations.");
-            }
-            if (!_initialized)
-            {
-                throw new InvalidOperationException("Initialize() has not been called.");
             }
         }
 

--- a/XenModel/Actions/WLB/WlbRetrieveVmRecommendationsAction.cs
+++ b/XenModel/Actions/WLB/WlbRetrieveVmRecommendationsAction.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using XenAdmin.Core;
+using XenAdmin.Network;
+using XenAPI;
+
+namespace XenAdmin.Actions
+{
+    public class WlbRetrieveVmRecommendationsAction: PureAsyncAction
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private readonly List<VM> vms;
+        private readonly Dictionary<VM, Dictionary<XenRef<Host>, string[]>> recommendations = new Dictionary<VM, Dictionary<XenRef<Host>, string[]>>();
+        private bool isError;
+
+        public WlbRetrieveVmRecommendationsAction(IXenConnection connection, List<VM> vms)
+            : base(connection, Messages.WLB_RETRIEVING_VM_RECOMMENDATIONS, true)
+        {
+            this.vms = vms;
+        }
+
+        protected override void Run()
+        {
+            if (vms.Count == 0)
+            {
+                isError = true;
+                return;
+            }
+
+            if (Helpers.WlbEnabled(vms[0].Connection))
+            {
+                try
+                {
+                    foreach (var vm in vms)
+                    {
+                        recommendations[vm] = VM.retrieve_wlb_recommendations(Session, vm.opaque_ref);
+                    }
+                }
+                catch (Exception e)
+                {
+                    log.Error("Error getting WLB recommendations", e);
+                    isError = true;
+                }
+            }
+            else
+            {
+                isError = true;
+            }
+        }
+
+        public Dictionary<VM, Dictionary<XenRef<Host>, string[]>> Recommendations
+        {
+            get { return isError ? null : recommendations; }
+        }
+    }
+}

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -39237,6 +39237,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Retrieving WLB recommendations .
+        /// </summary>
+        public static string WLB_RETRIEVING_VM_RECOMMENDATIONS {
+            get {
+                return ResourceManager.GetString("WLB_RETRIEVING_VM_RECOMMENDATIONS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Saving Workload Balancing settings.
         /// </summary>
         public static string WLB_SAVING_SETTINGS {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13571,6 +13571,9 @@ Would you like to adjust the current Optimization Mode to match the schedule?</v
   <data name="WLB_RETRIEVING_RECOMMENDATIONS" xml:space="preserve">
     <value>Retrieving WLB recommendations for pool {0}</value>
   </data>
+  <data name="WLB_RETRIEVING_VM_RECOMMENDATIONS" xml:space="preserve">
+    <value>Retrieving WLB recommendations </value>
+  </data>
   <data name="WLB_SAVING_SETTINGS" xml:space="preserve">
     <value>Saving Workload Balancing settings</value>
   </data>

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Actions\VM\VMCrossPoolMigrateAction.cs" />
     <Compile Include="Actions\VM\VMSnapshotCreateAction.cs" />
     <Compile Include="Actions\VM\VMStartAction.cs" />
+    <Compile Include="Actions\WLB\WlbRetrieveVmRecommendationsAction.cs" />
     <Compile Include="Actions\ZipStatusReportAction.cs" />
     <Compile Include="Alerts\Types\Alert.cs" />
     <Compile Include="DockerContainers.cs" />


### PR DESCRIPTION
- added an action for the API call that retrieves the WLB VM recommendations
- removed the thread used for updating the menu items, so that we always access the menu items on the UI thread and do only the server calls on separate threads (for WLB, getting the recommendations now is done on the new action, for non-WLB we have the `workerQueueWithoutWlb`)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>