### PR TITLE
CA-289182: Corrections to sorting (clearer handling of null cases, non-XenObjects, logic path inconsistencies).

### DIFF
--- a/XenModel/XenSearch/Sort.cs
+++ b/XenModel/XenSearch/Sort.cs
@@ -119,37 +119,40 @@ namespace XenAdmin.XenSearch
             return node;
         }
 
-        public int Compare(Object _1, Object _2)
+        public int Compare(object one, object other)
         {
             // Comparison for the name column. If we need any other special cases,
             // it would be better to subclass Sort, but that involved too much
             // disruption especially in serializing and deserializing for this one case.
-            bool nameSort = (column == "name");
+            bool nameSort = column == "name";
 
-            IXenObject i1 = _1 as IXenObject;
-            IXenObject i2 = _2 as IXenObject;
+            IXenObject i1 = one as IXenObject;
+            IXenObject i2 = other as IXenObject;
 
             IComparable c1, c2;
 
             if (i1 != null)
                 c1 = property(i1);
             else if (nameSort)
-                c1 = (_1 is DateTime ? ((DateTime)_1).ToString("u", CultureInfo.InvariantCulture) : _1.ToString());  // CP-2036, CA-67113
+                c1 = one is DateTime ? ((DateTime)one).ToString("u", CultureInfo.InvariantCulture) : one.ToString(); // CP-2036, CA-67113
             else
                 c1 = null;
 
             if (i2 != null)
                 c2 = property(i2);
             else if (nameSort)
-                c2 = (_2 is DateTime ? ((DateTime)_2).ToString("u", CultureInfo.InvariantCulture) : _2.ToString());
+                c2 = other is DateTime ? ((DateTime)other).ToString("u", CultureInfo.InvariantCulture) : other.ToString();
             else
                 c2 = null;
 
-            if (c1 == null || c2 == null)
-                return c1 == null && c2 == null ? 0 :
-                    c1 == null ? 1 : -1;
+            if (c1 == null && c2 == null)
+                return 0;
+            if (c1 == null)
+                return ascending ? -1 : 1;
+            if (c2 == null)
+                return ascending ? 1 : -1;
 
-            int r = (nameSort ? StringUtility.NaturalCompare(c1.ToString(), c2.ToString()) : c1.CompareTo(c2));
+            int r = nameSort ? StringUtility.NaturalCompare(c1.ToString(), c2.ToString()) : c1.CompareTo(c2);
             if (!ascending)
                 r = -r;
             return r;


### PR DESCRIPTION
I believe the inconsistency here was that, when comparing a XenObject with a non-XenObject, there were two code paths with same circumstances but different results. For example, if _1 were a nonXenObject and _2 a XenObject, then line 177 in GroupAlg.cs would return -1, but line 186 would call Sort and line 150 in Sort.cs would return 1 (which was also wrong since non-XenObject come before XenObjects; this bit did not take account of ascending/descending order either). Other problems include calling GetType() and ToString() on null if all _1, _2 and search were null.