### PR TITLE
CA-289153: Do not attempt updating the licence status for disconnected hosts.

### DIFF
--- a/XenAdmin/Dialogs/LicenseManager/LicenseStatus.cs
+++ b/XenAdmin/Dialogs/LicenseManager/LicenseStatus.cs
@@ -150,20 +150,8 @@ namespace XenAdmin.Dialogs
             serverTime.Fetch(LicencedHost);
         }
 
-        private void ServerTimeUpdatedEventHandler(object sender, AsyncServerTimeEventArgs e)
+        private void ServerTimeUpdatedEventHandler()
         {
-            if (!e.Success)
-            {
-                if(e.QueriedHost == null)
-                {
-                    log.ErrorFormat("Couldn't get the server time because: {0}", e.Failure.Message);
-                    return;
-                }
-
-                log.ErrorFormat("Couldn't get the server time for {0} because: {1}", e.QueriedHost.name_label, e.Failure.Message);
-                return;
-            }
-
             if (LicencedHost != null)
             {
                 CalculateLicenseState();

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -207,6 +207,9 @@ namespace XenAdmin.TabPages
             if (licenseStatus != null)
                 licenseStatus.ItemUpdated -= licenseStatus_ItemUpdated;
 
+            if (xenObject.Connection != null && !xenObject.Connection.IsConnected)
+                return;
+
             if (xenObject is Host || xenObject is Pool)
             {
                 licenseStatus = new LicenseStatus(xenObject);


### PR DESCRIPTION
Also, no need to trigger an event when the host is null or when get_servertime
fails only to double-log it in the handling class.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>