### PR TITLE
CA-289150: Use a lock object to ensure that the hosts and connections…

### DIFF
--- a/XenAdmin/Alerts/Types/XenServerPatchAlert.cs
+++ b/XenAdmin/Alerts/Types/XenServerPatchAlert.cs
@@ -180,18 +180,9 @@ namespace XenAdmin.Alerts
             }
         }
 
-        public override bool IsDismissed()
+        protected override bool IsDismissed(IXenConnection connection)
         {
-            foreach (var connection in connections)
-                if (IsDismissed(connection))
-                    return true;
-
-            return false;
-        }
-
-        private bool IsDismissed(IXenConnection connection)
-        {
-            XenAPI.Pool pool = Helpers.GetPoolOfOne(connection);
+            Pool pool = Helpers.GetPoolOfOne(connection);
             if (pool == null)
                 return false;
 

--- a/XenAdmin/Alerts/Types/XenServerVersionAlert.cs
+++ b/XenAdmin/Alerts/Types/XenServerVersionAlert.cs
@@ -97,16 +97,7 @@ namespace XenAdmin.Alerts
             }
         }
 
-        public override bool IsDismissed()
-        {
-            foreach (var connection in connections)
-                if (IsDismissed(connection))
-                    return true;
-
-            return false;
-        }
-
-        private bool IsDismissed(IXenConnection connection)
+        protected override bool IsDismissed(IXenConnection connection)
         {
             Pool pool = Helpers.GetPoolOfOne(connection);
             if (pool == null)

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -230,7 +230,8 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                     if (downloadUpdateRadioButton.Checked)
                     {
-                        if (SelectedUpdateAlert != null && SelectedUpdateAlert.DistinctHosts != null && SelectedUpdateAlert.DistinctHosts.Any(Helpers.ElyOrGreater)) // this is to check whether the Alert represents an ISO update (Ely or greater)
+                        var distinctHosts = SelectedUpdateAlert != null ? SelectedUpdateAlert.DistinctHosts : null;
+                        if (distinctHosts != null && distinctHosts.Any(Helpers.ElyOrGreater)) // this is to check whether the Alert represents an ISO update (Ely or greater)
                         {
                             SelectedUpdateType = UpdateType.ISO;
                         }


### PR DESCRIPTION
… lists are safely accessed from separate threads

This change fixes the crash with IndexOutOfRangeException in XenServerUpdateAlert

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>