### PR TITLE
Revert "Disable creation of SR-IOV network if the feature is disabled."

### DIFF
--- a/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWTypeSelect.cs
+++ b/XenAdmin/Wizards/NewNetworkWizard_Pages/NetWTypeSelect.cs
@@ -104,25 +104,21 @@ namespace XenAdmin.Wizards.NewNetworkWizard_Pages
             bool hasNicCanEnableSriov = pool.Connection.Cache.PIFs.Any(pif => pif.IsPhysical() && pif.SriovCapable() && !pif.IsSriovPhysicalPIF());
             bool sriovFeatureForbidden = Helpers.FeatureForbidden(connection, Host.RestrictSriovNetwork);
 
-            if (!Helpers.KolkataOrGreater(pool.Connection))
+            if( !Helpers.KolkataOrGreater(pool.Connection))
             {
                 iconWarningSriovOption.Visible = labelWarningSriovOption.Visible = false;
                 rbtnSriov.Visible = labelSriov.Visible = false;
             }
-            else if (Helpers.FeatureForbidden(pool.Connection, Host.SriovNetworkDisabled) ||
-                sriovFeatureForbidden || !pool.HasSriovNic() || !hasNicCanEnableSriov)
+            else if (sriovFeatureForbidden || !pool.HasSriovNic() || !hasNicCanEnableSriov)
             {
                 rbtnSriov.Checked = false;
                 rbtnSriov.Enabled = labelSriov.Enabled = false;
 
-                labelWarningSriovOption.Text =
-                    Helpers.FeatureForbidden(pool.Connection, Host.SriovNetworkDisabled)
-                        ? String.Format(Messages.FEATURE_EXPERIMENTAL, Messages.NETWORK_SRIOV)
-                        : sriovFeatureForbidden
-                            ? String.Format(Messages.FEATURE_DISABLED, Messages.NETWORK_SRIOV)
-                            : pool.HasSriovNic()
-                                ? Messages.NICS_ARE_SRIOV_ENABLED
-                                : Messages.SRIOV_NEED_NICSUPPORT;
+                labelWarningSriovOption.Text = sriovFeatureForbidden ?
+                                                    String.Format(Messages.FEATURE_DISABLED, Messages.NETWORK_SRIOV) :
+                                                    pool.HasSriovNic() ?
+                                                        Messages.NICS_ARE_SRIOV_ENABLED :
+                                                        Messages.SRIOV_NEED_NICSUPPORT;
 
                 iconWarningSriovOption.Visible = labelWarningSriovOption.Visible = true;
             }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -15300,15 +15300,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Feature &apos;{0}&apos; must be enabled on all hosts in the pool before use. See release notes..
-        /// </summary>
-        public static string FEATURE_EXPERIMENTAL {
-            get {
-                return ResourceManager.GetString("FEATURE_EXPERIMENTAL", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &amp;Next Section.
         /// </summary>
         public static string FETCH_EARLIER_DATA {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5374,9 +5374,6 @@ Warning: to prevent data loss you must ensure that the LUN is not in use by any 
   <data name="FEATURE_DISABLED_IN_REGISTER" xml:space="preserve">
     <value>Feature disabled in the registry</value>
   </data>
-  <data name="FEATURE_EXPERIMENTAL" xml:space="preserve">
-    <value>Feature '{0}' must be enabled on all hosts in the pool before use. See release notes.</value>
-  </data>
   <data name="FETCHED_POSSIBLE_HOSTS" xml:space="preserve">
     <value>Fetched possible hosts of VM {0}</value>
   </data>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -455,17 +455,10 @@ namespace XenAPI
         {
             return BoolKeyPreferTrue(h.license_params, "restrict_corosync");
         }
-
-        #region Experimental Features
-
+        
         public static bool CorosyncDisabled(Host h)
         {
             return  RestrictCorosync(h) && FeatureDisabled(h, "corosync");
-        }
-
-        public static bool SriovNetworkDisabled(Host h)
-        {
-            return RestrictSriovNetwork(h) && FeatureDisabled(h, "network_sriov");
         }
 
         public static bool FeatureDisabled(Host h, string featureName)
@@ -477,8 +470,6 @@ namespace XenAPI
             }
             return false;
         }
-
-        #endregion
 
         public bool HasPBDTo(SR sr)
         {


### PR DESCRIPTION
As SRIOV will release in Lima, remove the experimental flag and roll back the change in XenCenter for the check.
This reverts commit 3fc14c53441f1f4932dad7f00201b2f2f9a6d1b2.