### PR TITLE
The check for hosts that are unlicensed for automated updates should …

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -225,8 +225,8 @@ namespace XenAdmin.Wizards.PatchingWizard
                     return;
                 }
 
-                //unlicensed servers are not enabled
-                if (Host.RestrictBatchHotfixApply(host))
+                //check all hosts are licensed for automated updates (there may be restrictions on individual hosts)
+                if (host.Connection.Cache.Hosts.Any(Host.RestrictBatchHotfixApply))
                 {
                     row.Enabled = false;
                     row.Cells[3].ToolTipText = Messages.PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED_FOR_AUTOMATED_UPDATES;

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -27654,7 +27654,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The server is not licensed for automated updates.
+        ///   Looks up a localized string similar to One or more servers in the pool are not licensed for automated updates.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED_FOR_AUTOMATED_UPDATES {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9532,7 +9532,7 @@ However, there is not enough space to perform the repartitioning, so the current
     <value>Subscription Advantage required</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED_FOR_AUTOMATED_UPDATES" xml:space="preserve">
-    <value>The server is not licensed for automated updates</value>
+    <value>One or more servers in the pool are not licensed for automated updates</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNREACHABLE" xml:space="preserve">
     <value>The server is unreachable</value>


### PR DESCRIPTION
…be on all pool hosts as there maybe individual restrictions (for example via a feature flag).