### PR TITLE
CP-28279: Corrections to the plan actions

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -488,7 +488,8 @@ namespace XenAdmin.Wizards.PatchingWizard
             RetryFailedActions();
         }
 
-        protected HostPlan GetUpdatePlanActionsForHost(Host host, List<Host> hosts, List<XenServerPatch> minimalPatches, List<XenServerPatch> uploadedPatches, KeyValuePair<XenServerPatch, string> patchFromDisk)
+        protected HostPlan GetUpdatePlanActionsForHost(Host host, List<Host> hosts, List<XenServerPatch> minimalPatches,
+            List<XenServerPatch> uploadedPatches, KeyValuePair<XenServerPatch, string> patchFromDisk, bool repatriateVms = true)
         {
             var patchSequence = Updates.GetPatchSequenceForHost(host, minimalPatches);
             if (patchSequence == null)
@@ -541,11 +542,14 @@ namespace XenAdmin.Wizards.PatchingWizard
                 }
             }
 
-            var lastRestart = delayedActionsPerHost.FindLast(a => a is RestartHostPlanAction)
-                              ?? planActionsPerHost.FindLast(a => a is RestartHostPlanAction);
+            if (repatriateVms)
+            {
+                var lastRestart = delayedActionsPerHost.FindLast(a => a is RestartHostPlanAction)
+                                  ?? planActionsPerHost.FindLast(a => a is RestartHostPlanAction);
 
-            if (lastRestart != null)
-                ((RestartHostPlanAction)lastRestart).EnableOnly = false;
+                if (lastRestart != null)
+                    ((RestartHostPlanAction) lastRestart).EnableOnly = false;
+            }
 
             return new HostPlan(host, null, planActionsPerHost, delayedActionsPerHost);
         }

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RestartHostPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RestartHostPlanAction.cs
@@ -84,14 +84,10 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             Visible = true;
             var sb = new StringBuilder();
             
-            var vms = hostObj.GetRunningVMs();
-            if (vms.Count > 0)
-            {
-                sb.Append(string.Format(Messages.PLANACTION_VMS_MIGRATING, hostObj.Name()));
-                ProgressDescription = sb.ToString();
-                EvacuateHost(ref session);
-                sb.AppendLine(Messages.DONE);
-            }
+            sb.Append(string.Format(Messages.PLANACTION_VMS_MIGRATING, hostObj.Name()));
+            ProgressDescription = sb.ToString();
+            EvacuateHost(ref session);
+            sb.AppendLine(Messages.DONE);
 
             sb.AppendIndented(string.Format(Messages.UPDATES_WIZARD_REBOOTING, hostObj.Name()), sb.Length > 0 ? 2 : 0);
             ProgressDescription = sb.ToString();

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
@@ -156,7 +156,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 AllUploadedPatches.Add(bgw, new List<XenServerPatch>());
             var uploadedPatches = AllUploadedPatches[bgw];
 
-            var hp = GetUpdatePlanActionsForHost(host, hosts, minimalPatches, uploadedPatches, new KeyValuePair<XenServerPatch, string>());
+            var hp = GetUpdatePlanActionsForHost(host, hosts, minimalPatches, uploadedPatches, new KeyValuePair<XenServerPatch, string>(), false);
             if (hp.UpdatesPlanActions != null && hp.UpdatesPlanActions.Count > 0)
             {
                 theHostPlan.UpdatesPlanActions.AddRange(hp.UpdatesPlanActions);
@@ -179,14 +179,11 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             var initialPlanActions = new List<PlanAction>()
             {
                 new EvacuateHostPlanAction(host),
-                upgradeAction
-            };
-
-            var delayedActions = new List<PlanAction>()
-            {
+                upgradeAction,
                 new BringBabiesBackAction(runningVMs, host, true)
             };
-            return new HostPlan(host, initialPlanActions, null, delayedActions);
+
+            return new HostPlan(host, initialPlanActions, null, new List<PlanAction>());
         }
 
         #endregion


### PR DESCRIPTION
- In the RPU case, re-enable the host after the upgrade is done, as the host will be put back into maintenance mode when needed during the update process.
- The VMs should not be repatriated during the RPU
- When a host is rebooted, it needs to be disabled first (even if an evacuation is not needed), otherwise the reboot won't happen

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>