### PR TITLE
CA-292363: Do not show the DownloadAndUnzipXenServerPatchAction in action history.

### DIFF
--- a/XenAdmin/Dialogs/ThreeButtonDialog.cs
+++ b/XenAdmin/Dialogs/ThreeButtonDialog.cs
@@ -419,8 +419,8 @@ namespace XenAdmin.Dialogs
 
     public class NonModalThreeButtonDialog : ThreeButtonDialog
     {
-        public NonModalThreeButtonDialog(Icon icon, string msg, string button1Text, string button2Text)
-            : base(new Details(icon, msg),
+        public NonModalThreeButtonDialog(Icon icon, string msg, string title, string button1Text, string button2Text)
+            : base(new Details(icon, msg, title),
                 new TBDButton(button1Text, DialogResult.OK),
                 new TBDButton(button2Text, DialogResult.Cancel))
         {

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/DownloadPatchPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/DownloadPatchPlanAction.cs
@@ -85,7 +85,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             tempFileName = Path.GetTempFileName();
 
             var exts = Helpers.ElyOrGreater(Connection) ? Branding.UpdateIso : Branding.Update;
-            var downloadAction = new DownloadAndUnzipXenServerPatchAction(patch.Name, address, tempFileName, false, exts);
+            var downloadAction = new DownloadAndUnzipXenServerPatchAction(patch.Name, address, tempFileName, true, exts);
 
             downloadAction.Changed += downloadAndUnzipXenServerPatchAction_Changed;
             downloadAction.Completed += downloadAndUnzipXenServerPatchAction_Completed;
@@ -94,7 +94,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             downloadAction.RunExternal(session);
         }
 
-        private void downloadAndUnzipXenServerPatchAction_Changed(object sender)
+        private void downloadAndUnzipXenServerPatchAction_Changed(ActionBase sender)
         {
             var downloadAction = sender as DownloadAndUnzipXenServerPatchAction;
             if (downloadAction == null)

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/PlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/PlanAction.cs
@@ -114,7 +114,9 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 }
                 else
                 {
-                    ReplaceProgressStep(CurrentProgressStep + Messages.PLAN_ACTION_DONE);
+                    var curStep = CurrentProgressStep;
+                    if (!string.IsNullOrEmpty(curStep))
+                        ReplaceProgressStep(CurrentProgressStep + Messages.PLAN_ACTION_ERROR);
                     Error = e;
                     throw;
                 }

--- a/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/UpgradeManualHostPlanAction.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/UpgradeManualHostPlanAction.cs
@@ -65,7 +65,8 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
             Program.Invoke(invokingControl, () =>
             {
                 using (var dialog = new NonModalThreeButtonDialog(SystemIcons.Exclamation,
-                    Messages.ROLLING_UPGRADE_TIMEOUT, Messages.KEEP_WAITING_BUTTON_LABEL, Messages.CANCEL))
+                    Messages.ROLLING_UPGRADE_TIMEOUT, Messages.ROLLING_POOL_UPGRADE,
+                    Messages.KEEP_WAITING_BUTTON_LABEL, Messages.CANCEL))
                 {
                     if (dialog.ShowDialog(invokingControl) != DialogResult.OK)
                         Cancel();
@@ -125,7 +126,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
             {
                 using (var dialog = new NonModalThreeButtonDialog(SystemIcons.Information,
                     string.Format(Messages.ROLLING_UPGRADE_REBOOT_MESSAGE, GetResolvedHost().Name()),
-                    Messages.REBOOT, Messages.SKIP_SERVER))
+                    Messages.ROLLING_POOL_UPGRADE, Messages.REBOOT, Messages.SKIP_SERVER))
                 {
                     if (dialog.ShowDialog(invokingControl) != DialogResult.OK) // Cancel or Unknown
                     {
@@ -162,6 +163,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
                     {
                         using (var dialog = new NonModalThreeButtonDialog(SystemIcons.Exclamation,
                             string.Format(Messages.ROLLING_UPGRADE_REBOOT_AGAIN_MESSAGE, hostName),
+                            Messages.ROLLING_POOL_UPGRADE,
                             Messages.REBOOT_AGAIN_BUTTON_LABEL, Messages.SKIP_SERVER))
                         {
                             if (dialog.ShowDialog(invokingControl) == DialogResult.OK)

--- a/XenAdminTests/WizardTests/RollingUpgradeWizardTest.cs
+++ b/XenAdminTests/WizardTests/RollingUpgradeWizardTest.cs
@@ -32,7 +32,8 @@
 using System.Threading;
 using System.Windows.Forms;
 using NUnit.Framework;
-using XenAdmin.Core;
+using XenAdmin;
+using XenAdmin.Dialogs;
 using XenAdmin.Wizards.PatchingWizard;
 using XenAdmin.Wizards.RollingUpgradeWizard;
 
@@ -68,29 +69,20 @@ namespace XenAdminTests.WizardTests.state5_xml
                 Thread.Sleep(1000);
                 
             }
-            else if (pageName == "Apply Upgrade")
-            {
-                //It needs work
-                var page = TestUtils.GetXenTabPage(wizard, "RollingUpgradeUpgradePage");
-                var win32Page = new Win32Window(page.Handle);
-                while (win32Page.Children.Count == 0)
-                {
-                    Thread.Sleep(500);
-                }
-                foreach (var child in win32Page.Children)
-                {
-                    var dialog = Control.FromHandle(child.Handle) as Form;
-                    if (dialog != null)
-                        MW(dialog.CancelButton.PerformClick);
-                }
-                while (page.EnableNext() == false)
-                {
-                    Thread.Sleep(500);
-                }
-            }
             else if (pageName == "Upgrade Mode")
             {
                 MW(TestUtils.GetRadioButton(wizard, "RollingUpgradeWizardUpgradeModePage.radioButtonManual").PerformClick);
+            }
+            else if (pageName == "Apply Upgrade")
+            {
+                var window = WaitForWindowToAppear(Messages.ROLLING_POOL_UPGRADE,
+                    w => Control.FromHandle(w.Handle) is NonModalThreeButtonDialog);
+                MW(() =>
+                {
+                    var dialog = Control.FromHandle(window.Handle) as Form;
+                    if (dialog != null)
+                        dialog.CancelButton.PerformClick();
+                });
             }
         }
 


### PR DESCRIPTION
The reason why the confirmation dialog is launched in this case is that the DownloadPatchPlanAction starts a download action which is shown in the Action history. d3f761b070c5ac27091e83b33028a31a1f8b6b5a has corrected the behaviour in that we see a cancellation and not a failure error. Additionally, the download action should not be shown in history. This is fixed by this PR. Beyond this, the confirmation dialog should be checking whether there are _PlanActions_ active, to prevent the user from accidentally closing XenCenter thus interrupting their update. However, this is an improvement for master that goes beyond the current scope.