### PR TITLE
Check and plug PBDs for VMs only if and when there are VMs to migrate;

### DIFF
--- a/XenAdmin/Diagnostics/Checks/PBDsPluggedCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PBDsPluggedCheck.cs
@@ -52,40 +52,40 @@ namespace XenAdmin.Diagnostics.Checks
             if (!Host.IsLive())
                 return new HostNotLiveWarning(this, Host);
 
-            IEnumerable<VM> runningOrPausedVMs = GetRunningOrPausedVMs(Host);
-            IEnumerable<SR> brokenSRs = PBD.GetSRs(PBD.GetUnpluggedPBDsFor(runningOrPausedVMs));
-
-            foreach (SR sr in brokenSRs)
+            foreach (VM vm in Host.Connection.Cache.VMs)
             {
-                if ((sr.shared && !sr.CanBeSeenFrom(Host)) || (!sr.shared && sr.GetStorageHost() == Host && !sr.CanBeSeenFrom(Host)))
-                    return new BrokenSR(this, sr, Host);
+                if (vm.power_state != vm_power_state.Running && vm.power_state != vm_power_state.Paused)
+                    continue;
+
+                foreach (var vbdRef in vm.VBDs)
+                {
+                    var vbd = Host.Connection.Resolve(vbdRef);
+                    if (vbd == null)
+                        continue;
+
+                    VDI vdi = Host.Connection.Resolve(vbd.VDI);
+                    if (vdi == null)
+                        continue;
+
+                    SR sr = Host.Connection.Resolve(vdi.SR);
+                    if (sr == null)
+                        continue;
+
+                    if ((sr.shared && !sr.CanBeSeenFrom(Host)) ||
+                        (!sr.shared && sr.GetStorageHost().Equals(Host) && !sr.CanBeSeenFrom(Host)))
+                        return new BrokenSR(this, sr, Host);
+                }
             }
 
             if (srUploadedUpdates != null
                 && ((srUploadedUpdates.shared && !srUploadedUpdates.CanBeSeenFrom(Host))
-                 || (!srUploadedUpdates.shared && srUploadedUpdates.IsBroken())))
+                    || (!srUploadedUpdates.shared && srUploadedUpdates.IsBroken())))
             {
                 return new BrokenSR(this, srUploadedUpdates, Host);
             }
 
             return null;
         }
-
-        private static IEnumerable<VM> GetRunningOrPausedVMs(Host host)
-        {
-            List<VM> runningOrPausedVMs = new List<VM>();
-
-
-                foreach (VM vm in host.Connection.Cache.VMs)
-                {
-                    if (vm.power_state == vm_power_state.Running || vm.power_state == vm_power_state.Paused)
-                        runningOrPausedVMs.Add(vm);
-                }
-            
-
-            return runningOrPausedVMs;
-        }
-
 
         public override string Description
         {

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootPlanAction.cs
@@ -81,6 +81,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             Connection.ExpectDisruption = true;
             try
             {
+                AddProgressStep(Messages.PLAN_ACTION_STATUS_RECONNECTING_STORAGE);
                 WaitForReboot(ref session, Host.BootTime, s => Host.async_reboot(s, HostXenRef.opaque_ref));
                 foreach (var host in Connection.Cache.Hosts)
                     host.CheckAndPlugPBDs();  // Wait for PBDs to become plugged on all hosts

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootVMsPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootVMsPlanAction.cs
@@ -43,8 +43,9 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
         }
 
-        protected override XenRef<Task> DoPerVM(Session session, VM vm)
+        protected override XenRef<Task> DoPerVM(Session session, XenRef<VM> vmRef)
         {
+            var vm = Connection.TryResolveWithTimeout(vmRef);
             AddProgressStep(string.Format(Messages.PLANACTION_VMS_REBOOTING, vm.Name()));
             return VM.async_clean_reboot(session, vm.opaque_ref);
         }

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/VMsPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/VMsPlanAction.cs
@@ -46,31 +46,24 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             this._vms = vms;
         }
 
-        protected abstract XenRef<Task> DoPerVM(Session session, VM vm);
+        protected abstract XenRef<Task> DoPerVM(Session session, XenRef<VM> vmRef);
 
         protected override void RunWithSession(ref Session session)
         {
-            List<VM> vmObjs = new List<VM>();
-            foreach (XenRef<VM> vm in _vms)
-                vmObjs.Add(Connection.TryResolveWithTimeout(vm));
-
-            PBD.CheckAndPlugPBDsFor(vmObjs);
+            PBD.CheckPlugPBDsForVMs(Connection, _vms);
 
             int vmCount = _vms.Count;
-            int i = 0;
 
-            foreach (VM vm in vmObjs)
+            for (int i = 0; i < _vms.Count; i++)
             {
-                XenRef<Task> task = DoPerVM(session, vm);
+                var vmRef = _vms[i];
+                XenRef<Task> task = DoPerVM(session, vmRef);
 
                 try
                 {
-                    PollTaskForResult(Connection, ref session, task, delegate(int progress)
-                    {
-                        PercentComplete = progress/vmCount + 100*i/vmCount;
-                    });
-
-                    i++;
+                    var j = i;
+                    PollTaskForResult(Connection, ref session, task,
+                        progress => PercentComplete = (progress + 100 * j) / vmCount);
                 }
                 finally
                 {

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -1887,7 +1887,7 @@ namespace XenAdmin.Network
                     return obj;
 
                 Thread.Sleep(1000);
-                timeout = timeout - 1;
+                timeout--;
             }
 
             if (typeof(T) == typeof(Host))


### PR DESCRIPTION
...do not log a message in this case as the SRs are reconnected after reboot and this may lead
to duplicate messages. Also, simplified check-and-plug methods for PBDs to avoid
repetition of iterations.