### PR TITLE
Snapshot view: Treeview as default (like in the past)

### DIFF
--- a/XenAdmin/TabPages/SnapshotsPage.cs
+++ b/XenAdmin/TabPages/SnapshotsPage.cs
@@ -131,10 +131,10 @@ namespace XenAdmin.TabPages
                     //Version setup
                     toolStripMenuItemScheduledSnapshots.Available = toolStripSeparatorView.Available = !Helpers.FeatureForbidden(VM.Connection, Host.RestrictVMSnapshotSchedule);
 
-                    if (_storedViewsPerVm.ContainsKey(m_VM.opaque_ref) && _storedViewsPerVm[m_VM.opaque_ref] != SnapshotsView.ListView)
-                        TreeViewChecked();
-                    else
+                    if (_storedViewsPerVm.ContainsKey(m_VM.opaque_ref) && _storedViewsPerVm[m_VM.opaque_ref] == SnapshotsView.ListView)
                         GridViewChecked();
+                    else
+                        TreeViewChecked();
 
                     toolStripButtonTreeView.Enabled = true;
                     toolStripButtonTreeView.ToolTipText = "";


### PR DESCRIPTION
Till XenCenter Version 7.4 (my feeling, can be wrong) the default view on the snapshot page was Treeview.

With commit https://github.com/xenserver/xenadmin/pull/1767/commits/4825b60a60d74c2d7b32f3291747b78dc09e4d72#r200793051 the behaviour changed to Listview as default, maybe without intention :-)

The if-statement `if (_storedViewsPerVm.ContainsKey(m_VM.opaque_ref) && _storedViewsPerVm[m_VM.opaque_ref] != SnapshotsView.ListView)` is always false if I open the snapshot page the first time after start of XenCenter, so it jumps always to the else-branch which opens the Listview/Gridview.


I changed it, so that Treeview is the default again (https://github.com/xcp-ng/xenadmin/issues/62)