### PR TITLE
 CA-293682: In the RPU wizard, only check the batch hotfix license restriction for Dundee or greater hosts

### DIFF
--- a/XenAdmin/Core/Updates.cs
+++ b/XenAdmin/Core/Updates.cs
@@ -265,8 +265,15 @@ namespace XenAdmin.Core
             if (CheckForUpdatesStarted != null)
                 CheckForUpdatesStarted();
 
-            using (var dialog = new ActionProgressDialog(action, ProgressBarStyle.Marquee))
-                dialog.ShowDialog(parentForProgressDialog);
+            if (parentForProgressDialog != null)
+            {
+                using (var dialog = new ActionProgressDialog(action, ProgressBarStyle.Marquee))
+                    dialog.ShowDialog(parentForProgressDialog);
+            }
+            else
+            {
+                action.RunExternal(action.Session);
+            }
 
             return action.Succeeded;
         }

--- a/XenAdmin/Diagnostics/Checks/AutomatedUpdatesLicenseCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/AutomatedUpdatesLicenseCheck.cs
@@ -49,7 +49,7 @@ namespace XenAdmin.Diagnostics.Checks
 
         protected override Problem RunHostCheck()
         {
-            if (_pool != null && _pool.Connection.Cache.Hosts.Any(Host.RestrictBatchHotfixApply))
+            if (_pool != null && _pool.Connection.Cache.Hosts.Any(h => Helpers.DundeeOrGreater(h) && Host.RestrictBatchHotfixApply(h)))
                 return new NotLicensedForAutomatedUpdatesWarning(this, _pool);
 
             return null;

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
@@ -152,6 +152,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             if (!MinimalPatches.ContainsKey(bgw))
             {
                 log.InfoFormat("Calculating minimal patches for {0}", host.Name());
+                Updates.CheckForUpdatesSync(null);
                 var mp = Updates.GetMinimalPatches(host);
                 log.InfoFormat("Minimal patches for {0}: {1}", host.Name(), mp == null ? "None" : string.Join(",", mp.Select(p => p.Name)));
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -31,7 +31,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Windows.Forms;
 using XenAdmin.Controls;
 using XenAdmin.Core;
 using XenAdmin.Diagnostics.Checks;
@@ -166,7 +165,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             groups.Add(new CheckGroup(Messages.CHECKING_HOST_LIVENESS_STATUS, livenessChecks));
 
             //HA checks - for each pool
-            var haChecks = (from Host server in SelectedServers
+            var haChecks = (from Host server in SelectedMasters
                 where server.IsMaster()
                 select new HAOffCheck(server) as Check).ToList();
             groups.Add(new CheckGroup(Messages.CHECKING_HA_STATUS, haChecks));
@@ -217,7 +216,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             //Checking automated updates are possible if apply updates checkbox is ticked
             if (ApplyUpdatesToNewVersion)
             {
-                var automatedUpdateChecks = (from Host server in SelectedServers
+                var automatedUpdateChecks = (from Host server in SelectedMasters
                     where server.IsMaster()
                     select new AutomatedUpdatesLicenseCheck(server) as Check).ToList();
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -166,7 +166,6 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
             //HA checks - for each pool
             var haChecks = (from Host server in SelectedMasters
-                where server.IsMaster()
                 select new HAOffCheck(server) as Check).ToList();
             groups.Add(new CheckGroup(Messages.CHECKING_HA_STATUS, haChecks));
 
@@ -217,7 +216,6 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             if (ApplyUpdatesToNewVersion)
             {
                 var automatedUpdateChecks = (from Host server in SelectedMasters
-                    where server.IsMaster()
                     select new AutomatedUpdatesLicenseCheck(server) as Check).ToList();
 
                 automatedUpdateChecks.Add(new CfuAvailabilityCheck());

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard_UpgradeMode.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard_UpgradeMode.cs
@@ -33,6 +33,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using XenAdmin.Controls;
+using XenAdmin.Core;
 using XenAPI;
 
 
@@ -81,7 +82,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                     continue;
 
                 poolCount++;
-                var automatedUpdatesRestricted = hosts.Any(Host.RestrictBatchHotfixApply); //if any host is not licensed for automated updates
+                var automatedUpdatesRestricted = hosts.Any(h => Helpers.DundeeOrGreater(h) && Host.RestrictBatchHotfixApply(h)); //if any host is not licensed for automated updates
                 if (!automatedUpdatesRestricted)
                     licensedPoolCount++;
             }


### PR DESCRIPTION

... because pre-Dundee hosts dont't have this license flag, but they might have it after the upgrade.

Also added a bit more logging in the function that generates the update plan actions

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>

