### PR TITLE
CA-292377: Show warning if no cluster network found

### DIFF
--- a/XenAdmin/SettingsPanels/ClusteringEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/ClusteringEditPage.Designer.cs
@@ -30,20 +30,25 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ClusteringEditPage));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.labelTitle = new XenAdmin.Controls.Common.AutoHeightLabel();
             this.CheckBoxEnableClustering = new System.Windows.Forms.CheckBox();
             this.labelNetwork = new System.Windows.Forms.Label();
+            this.comboBoxNetwork = new XenAdmin.Controls.NetworkComboBox();
             this.tableLayoutInfo = new System.Windows.Forms.TableLayoutPanel();
+            this.pictureBoxInfo2 = new System.Windows.Forms.PictureBox();
             this.pictureBoxInfo1 = new System.Windows.Forms.PictureBox();
             this.labelWarning = new System.Windows.Forms.Label();
             this.labelInfo = new System.Windows.Forms.Label();
             this.labelHostCountWarning = new System.Windows.Forms.Label();
-            this.pictureBoxInfo2 = new System.Windows.Forms.PictureBox();
-            this.labelTitle = new XenAdmin.Controls.Common.AutoHeightLabel();
-            this.comboBoxNetwork = new XenAdmin.Controls.NetworkComboBox();
+            this.tableLayoutPanelNetworkWarning = new System.Windows.Forms.TableLayoutPanel();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.labelInconsistentNetwork = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutInfo.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo1)).BeginInit();
+            this.tableLayoutPanelNetworkWarning.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -53,8 +58,15 @@
             this.tableLayoutPanel1.Controls.Add(this.CheckBoxEnableClustering, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.labelNetwork, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxNetwork, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutInfo, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutInfo, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanelNetworkWarning, 1, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // labelTitle
+            // 
+            resources.ApplyResources(this.labelTitle, "labelTitle");
+            this.tableLayoutPanel1.SetColumnSpan(this.labelTitle, 2);
+            this.labelTitle.Name = "labelTitle";
             // 
             // CheckBoxEnableClustering
             // 
@@ -68,16 +80,34 @@
             resources.ApplyResources(this.labelNetwork, "labelNetwork");
             this.labelNetwork.Name = "labelNetwork";
             // 
+            // comboBoxNetwork
+            // 
+            this.comboBoxNetwork.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxNetwork.FormattingEnabled = true;
+            this.comboBoxNetwork.IncludeOnlyEnabledNetworksInComboBox = false;
+            this.comboBoxNetwork.IncludeOnlyNetworksWithIPAddresses = false;
+            this.comboBoxNetwork.IncludePoolNameInComboBox = false;
+            resources.ApplyResources(this.comboBoxNetwork, "comboBoxNetwork");
+            this.comboBoxNetwork.Name = "comboBoxNetwork";
+            this.comboBoxNetwork.SelectedIndexChanged += new System.EventHandler(this.comboBoxNetwork_SelectedIndexChanged);
+            // 
             // tableLayoutInfo
             // 
             resources.ApplyResources(this.tableLayoutInfo, "tableLayoutInfo");
             this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutInfo, 2);
-            this.tableLayoutInfo.Controls.Add(this.pictureBoxInfo2, 0, 2);
+            this.tableLayoutInfo.Controls.Add(this.pictureBoxInfo2, 0, 1);
             this.tableLayoutInfo.Controls.Add(this.pictureBoxInfo1, 0, 0);
             this.tableLayoutInfo.Controls.Add(this.labelWarning, 1, 0);
-            this.tableLayoutInfo.Controls.Add(this.labelInfo, 1, 2);
-            this.tableLayoutInfo.Controls.Add(this.labelHostCountWarning, 1, 3);
+            this.tableLayoutInfo.Controls.Add(this.labelInfo, 1, 1);
+            this.tableLayoutInfo.Controls.Add(this.labelHostCountWarning, 1, 2);
             this.tableLayoutInfo.Name = "tableLayoutInfo";
+            // 
+            // pictureBoxInfo2
+            // 
+            resources.ApplyResources(this.pictureBoxInfo2, "pictureBoxInfo2");
+            this.pictureBoxInfo2.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
+            this.pictureBoxInfo2.Name = "pictureBoxInfo2";
+            this.pictureBoxInfo2.TabStop = false;
             // 
             // pictureBoxInfo1
             // 
@@ -101,28 +131,24 @@
             resources.ApplyResources(this.labelHostCountWarning, "labelHostCountWarning");
             this.labelHostCountWarning.Name = "labelHostCountWarning";
             // 
-            // pictureBoxInfo2
+            // tableLayoutPanelNetworkWarning
             // 
-            resources.ApplyResources(this.pictureBoxInfo2, "pictureBoxInfo2");
-            this.pictureBoxInfo2.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
-            this.pictureBoxInfo2.Name = "pictureBoxInfo2";
-            this.pictureBoxInfo2.TabStop = false;
+            resources.ApplyResources(this.tableLayoutPanelNetworkWarning, "tableLayoutPanelNetworkWarning");
+            this.tableLayoutPanelNetworkWarning.Controls.Add(this.pictureBox1, 0, 0);
+            this.tableLayoutPanelNetworkWarning.Controls.Add(this.labelInconsistentNetwork, 1, 0);
+            this.tableLayoutPanelNetworkWarning.Name = "tableLayoutPanelNetworkWarning";
             // 
-            // labelTitle
+            // pictureBox1
             // 
-            resources.ApplyResources(this.labelTitle, "labelTitle");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelTitle, 2);
-            this.labelTitle.Name = "labelTitle";
+            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.pictureBox1, "pictureBox1");
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.TabStop = false;
             // 
-            // comboBoxNetwork
+            // labelInconsistentNetwork
             // 
-            this.comboBoxNetwork.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxNetwork.FormattingEnabled = true;
-            this.comboBoxNetwork.IncludeOnlyEnabledNetworksInComboBox = false;
-            this.comboBoxNetwork.IncludeOnlyNetworksWithIPAddresses = false;
-            this.comboBoxNetwork.IncludePoolNameInComboBox = false;
-            resources.ApplyResources(this.comboBoxNetwork, "comboBoxNetwork");
-            this.comboBoxNetwork.Name = "comboBoxNetwork";
+            resources.ApplyResources(this.labelInconsistentNetwork, "labelInconsistentNetwork");
+            this.labelInconsistentNetwork.Name = "labelInconsistentNetwork";
             // 
             // ClusteringEditPage
             // 
@@ -134,8 +160,11 @@
             this.tableLayoutPanel1.PerformLayout();
             this.tableLayoutInfo.ResumeLayout(false);
             this.tableLayoutInfo.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInfo1)).EndInit();
+            this.tableLayoutPanelNetworkWarning.ResumeLayout(false);
+            this.tableLayoutPanelNetworkWarning.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -153,6 +182,9 @@
         private System.Windows.Forms.Label labelInfo;
         private System.Windows.Forms.Label labelHostCountWarning;
         private System.Windows.Forms.PictureBox pictureBoxInfo2;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelNetworkWarning;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label labelInconsistentNetwork;
 
     }
 }

--- a/XenAdmin/SettingsPanels/ClusteringEditPage.cs
+++ b/XenAdmin/SettingsPanels/ClusteringEditPage.cs
@@ -29,11 +29,10 @@
  * SUCH DAMAGE.
  */
 
-using System.Collections.Generic;
+using System;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using System.Windows.Forms.VisualStyles;
 using XenAdmin.Actions;
 using XenAdmin.Controls;
 using XenAdmin.Core;
@@ -45,11 +44,20 @@ namespace XenAdmin.SettingsPanels
     {
         private Pool pool;
         private bool clusteringEnabled;
+        private XenRef<XenAPI.Network> commonNetwork;
+        private readonly ToolTip SelectNetworkToolTip;
 
         public ClusteringEditPage()
         {
             InitializeComponent();
             Text = Messages.CLUSTERING;
+            tableLayoutPanelNetworkWarning.Visible = false;
+            SelectNetworkToolTip = new ToolTip
+                {
+                    IsBalloon = true,
+                    ToolTipIcon = ToolTipIcon.Warning,
+                    ToolTipTitle = Messages.MUST_SELECT_NETWORK
+                };
         }
 
         public string SubText
@@ -82,39 +90,27 @@ namespace XenAdmin.SettingsPanels
         public void SetXenObjects(IXenObject orig, IXenObject clone)
         {
             pool = Helpers.GetPoolOfOne(clone.Connection);
-            labelWarning.Visible = false;
-            pictureBoxInfo1.Visible = false;
-
             var existingCluster = pool.Connection.Cache.Clusters.FirstOrDefault();
             clusteringEnabled = existingCluster != null;
-            CheckBoxEnableClustering.Checked = clusteringEnabled;
+            labelWarning.Visible = pictureBoxInfo1.Visible = false;
             LoadNetworks(existingCluster);
-
-            if (clusteringEnabled)
-            {
-                comboBoxNetwork.Enabled = labelNetwork.Enabled = false;
-            }
-
-            var gfs2Attached = clone.Connection.Cache.SRs.Any(sr => sr.GetSRType(true) == SR.SRTypes.gfs2 && !sr.IsDetached());
-
-            if (clusteringEnabled && gfs2Attached)
-            {
-                DisableControls(Messages.GFS2_SR_ATTACHED);
-            }
-
-            if (!clusteringEnabled && pool.ha_enabled)
-            {
-                DisableControls(Messages.GFS2_HA_ENABLED);
-            }
-
-            labelHostCountWarning.Visible = clone.Connection.Cache.HostCount < 3;
+            SetPage();
         }
 
-        public bool ValidToSave { get { return true; }}
+        public bool ValidToSave
+        {
+            get
+            {
+                return clusteringEnabled || comboBoxNetwork.SelectedItem != null || !CheckBoxEnableClustering.Checked;
+            }
+        }
 
         public void ShowLocalValidationMessages()
         {
-           
+            if (!ValidToSave)
+            {
+                HelpersGUI.ShowBalloonMessage(comboBoxNetwork, SelectNetworkToolTip);
+            }
         }
 
         public void Cleanup()
@@ -135,17 +131,58 @@ namespace XenAdmin.SettingsPanels
         {
             comboBoxNetwork.IncludeOnlyEnabledNetworksInComboBox = false;
             comboBoxNetwork.IncludeOnlyNetworksWithIPAddresses = true;
-            var clusterHostOnMaster = cluster == null
-                ? null
-                : pool.Connection.ResolveAll(cluster.cluster_hosts).FirstOrDefault(c => c.host.opaque_ref == pool.master.opaque_ref);
-            
-            comboBoxNetwork.PopulateComboBox(pool.Connection, item => clusterHostOnMaster != null && item.Network.PIFs.Any(pif => pif.opaque_ref == clusterHostOnMaster.PIF.opaque_ref));
 
-            if (comboBoxNetwork.Items.Count == 0)
+            if (cluster == null)
             {
-                DisableControls(Messages.GFS2_NO_NETWORK);
+                comboBoxNetwork.PopulateComboBox(pool.Connection, item => false);
+                if (comboBoxNetwork.Items.Count == 0)
+                    DisableControls(Messages.GFS2_NO_NETWORK);
             }
+            else
+            {
+                DelegatedAsyncAction action = new DelegatedAsyncAction(pool.Connection,
+                    string.Empty, string.Empty, string.Empty,
+                    delegate(Session session)
+                    {
+                        commonNetwork = Cluster.get_network(session, cluster.opaque_ref);
+                    },
+                    true);
 
+                action.Completed += action_Completed;
+
+                action.RunAsync();
+            }
+        }
+
+        private void action_Completed(ActionBase sender)
+        {
+            var action = (AsyncAction) sender;
+            if (!action.Succeeded)
+                commonNetwork = null;
+
+            Program.Invoke(ParentForm, delegate
+            {
+                comboBoxNetwork.PopulateComboBox(pool.Connection, item => commonNetwork != null && item.Network.opaque_ref.Equals(commonNetwork.opaque_ref));
+                tableLayoutPanelNetworkWarning.Visible = commonNetwork == null || comboBoxNetwork.SelectedItem == null;
+            });
+        }
+
+        private void SetPage()
+        {
+            CheckBoxEnableClustering.Checked = clusteringEnabled;
+
+            if (clusteringEnabled)
+            {
+                var gfs2Attached = pool.Connection.Cache.SRs.Any(sr => sr.GetSRType(true) == SR.SRTypes.gfs2 && !sr.IsDetached());
+                if (gfs2Attached)
+                    DisableControls(Messages.GFS2_SR_ATTACHED);
+                else
+                    comboBoxNetwork.Enabled = labelNetwork.Enabled = false;
+            }
+            else if (pool.ha_enabled)
+                DisableControls(Messages.GFS2_HA_ENABLED);
+
+            labelHostCountWarning.Visible = pool.Connection.Cache.HostCount < 3;
         }
 
         private void DisableControls(string message)
@@ -156,5 +193,11 @@ namespace XenAdmin.SettingsPanels
         }
 
         #endregion 
+
+        private void comboBoxNetwork_SelectedIndexChanged(object sender, System.EventArgs e)
+        {
+            if (!clusteringEnabled)
+                CheckBoxEnableClustering.Checked = comboBoxNetwork.SelectedItem != null;
+        }
     }
 }

--- a/XenAdmin/SettingsPanels/ClusteringEditPage.resx
+++ b/XenAdmin/SettingsPanels/ClusteringEditPage.resx
@@ -166,10 +166,7 @@
     <value>NoControl</value>
   </data>
   <data name="CheckBoxEnableClustering.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 75</value>
-  </data>
-  <data name="CheckBoxEnableClustering.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>7, 3, 3, 3</value>
+    <value>3, 75</value>
   </data>
   <data name="CheckBoxEnableClustering.Size" type="System.Drawing.Size, System.Drawing">
     <value>107, 17</value>
@@ -202,10 +199,10 @@
     <value>NoControl</value>
   </data>
   <data name="labelNetwork.Location" type="System.Drawing.Point, System.Drawing">
-    <value>22, 102</value>
+    <value>20, 102</value>
   </data>
   <data name="labelNetwork.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>22, 0, 3, 0</value>
+    <value>20, 3, 3, 3</value>
   </data>
   <data name="labelNetwork.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 13</value>
@@ -229,7 +226,7 @@
     <value>2</value>
   </data>
   <data name="comboBoxNetwork.Location" type="System.Drawing.Point, System.Drawing">
-    <value>78, 98</value>
+    <value>76, 98</value>
   </data>
   <data name="comboBoxNetwork.Size" type="System.Drawing.Size, System.Drawing">
     <value>223, 21</value>
@@ -249,6 +246,9 @@
   <data name="&gt;&gt;comboBoxNetwork.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="tableLayoutInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="tableLayoutInfo.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
@@ -259,16 +259,10 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBoxInfo2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 51</value>
-  </data>
-  <data name="pictureBoxInfo2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 6, 3, 0</value>
+    <value>3, 42</value>
   </data>
   <data name="pictureBoxInfo2.Size" type="System.Drawing.Size, System.Drawing">
     <value>16, 16</value>
-  </data>
-  <data name="pictureBoxInfo2.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>AutoSize</value>
   </data>
   <data name="pictureBoxInfo2.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -292,19 +286,19 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBoxInfo1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 6</value>
+    <value>3, 3</value>
   </data>
   <data name="pictureBoxInfo1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 6, 3, 3</value>
+    <value>3, 3, 3, 20</value>
   </data>
   <data name="pictureBoxInfo1.Size" type="System.Drawing.Size, System.Drawing">
     <value>16, 16</value>
   </data>
-  <data name="pictureBoxInfo1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>AutoSize</value>
-  </data>
   <data name="pictureBoxInfo1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
+  </data>
+  <data name="pictureBoxInfo1.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="&gt;&gt;pictureBoxInfo1.Name" xml:space="preserve">
     <value>pictureBoxInfo1</value>
@@ -328,13 +322,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>22, 6</value>
+    <value>25, 3</value>
   </data>
   <data name="labelWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 6, 3, 0</value>
+    <value>3, 3, 3, 20</value>
   </data>
   <data name="labelWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>459, 19</value>
+    <value>456, 16</value>
   </data>
   <data name="labelWarning.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -364,13 +358,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>22, 51</value>
+    <value>25, 42</value>
   </data>
   <data name="labelInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 6, 3, 0</value>
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="labelInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>459, 26</value>
+    <value>456, 26</value>
   </data>
   <data name="labelInfo.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -393,20 +387,17 @@
   <data name="labelHostCountWarning.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelHostCountWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
   <data name="labelHostCountWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelHostCountWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>22, 83</value>
+    <value>25, 74</value>
   </data>
   <data name="labelHostCountWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 6, 3, 0</value>
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="labelHostCountWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>459, 107</value>
+    <value>307, 13</value>
   </data>
   <data name="labelHostCountWarning.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -430,13 +421,13 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 125</value>
+    <value>3, 175</value>
   </data>
   <data name="tableLayoutInfo.RowCount" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>484, 190</value>
+    <value>484, 140</value>
   </data>
   <data name="tableLayoutInfo.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -454,7 +445,106 @@
     <value>4</value>
   </data>
   <data name="tableLayoutInfo.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBoxInfo2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="pictureBoxInfo1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelWarning" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInfo" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelHostCountWarning" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,20,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBoxInfo2" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="pictureBoxInfo1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelWarning" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInfo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelHostCountWarning" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,Absolute,20,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>tableLayoutPanelNetworkWarning</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelInconsistentNetwork.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelInconsistentNetwork.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="labelInconsistentNetwork.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelInconsistentNetwork.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 3</value>
+  </data>
+  <data name="labelInconsistentNetwork.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="labelInconsistentNetwork.Size" type="System.Drawing.Size, System.Drawing">
+    <value>383, 38</value>
+  </data>
+  <data name="labelInconsistentNetwork.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelInconsistentNetwork.Text" xml:space="preserve">
+    <value>Inconsistent cluster network. This is normal during creation or deletion of bond.</value>
+  </data>
+  <data name="&gt;&gt;labelInconsistentNetwork.Name" xml:space="preserve">
+    <value>labelInconsistentNetwork</value>
+  </data>
+  <data name="&gt;&gt;labelInconsistentNetwork.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelInconsistentNetwork.Parent" xml:space="preserve">
+    <value>tableLayoutPanelNetworkWarning</value>
+  </data>
+  <data name="&gt;&gt;labelInconsistentNetwork.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>76, 125</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>411, 44</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelNetworkWarning.Name" xml:space="preserve">
+    <value>tableLayoutPanelNetworkWarning</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelNetworkWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelNetworkWarning.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelNetworkWarning.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanelNetworkWarning.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInconsistentNetwork" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -463,7 +553,7 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>490, 318</value>
@@ -484,7 +574,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelTitle" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="CheckBoxEnableClustering" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="labelNetwork" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxNetwork" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutInfo" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelTitle" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="CheckBoxEnableClustering" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="labelNetwork" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxNetwork" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutInfo" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="tableLayoutPanelNetworkWarning" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,50,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION
1) When create/delete bond, inconsistent cluster network may occur. Show
warning in this case.
2) Refactor UI on cluster network edit page.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>