### PR TITLE
Improved the RBAC message on the Patching wizard to provide more info on the…

### DIFF
--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardSelectPool.cs
@@ -100,7 +100,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                         {
                             dlg.ShowDialog(this);
                         }
-                        DeselectMaster(selectedMaster);
+
                         cancel = true;
                         return;
                     }
@@ -135,21 +135,6 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 return false;
             }
             return true;
-        }
-
-        private void DeselectMaster(Host master)
-        {
-            foreach (UpgradeDataGridViewRow row in dataGridView1.Rows)
-            {
-                if (row.Tag is Host && row.Tag == master)
-                {
-                    row.Checked = CheckState.Unchecked;
-                }
-                else if (row.Tag is Pool && ((Pool)(row.Tag)).master.opaque_ref == master.opaque_ref)
-                {
-                    row.Checked = CheckState.Unchecked;
-                }
-            }
         }
 
         public IList<Host> SelectedMasters

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -29345,7 +29345,9 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User {0} does not have sufficient permissions to apply software updates to {1}. Either log in with different user credentials or deselect this server before continuing..
+        ///   Looks up a localized string similar to User {0} does not have sufficient permissions to apply software updates to {1}.
+        ///
+        ///You must reconnect to {1} using an account with Pool Operator permissions before you can apply software updates to it..
         /// </summary>
         public static string RBAC_UPDATES_WIZARD {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10205,7 +10205,9 @@ To configure HA settings, switch to an account with one of the following roles:
     <value>Check complete, you have full access to the features in this wizard.</value>
   </data>
   <data name="RBAC_UPDATES_WIZARD" xml:space="preserve">
-    <value>User {0} does not have sufficient permissions to apply software updates to {1}. Either log in with different user credentials or deselect this server before continuing.</value>
+    <value>User {0} does not have sufficient permissions to apply software updates to {1}.
+
+You must reconnect to {1} using an account with Pool Operator permissions before you can apply software updates to it.</value>
   </data>
   <data name="RBAC_UPGRADE_WIZARD_MESSAGE" xml:space="preserve">
     <value>User {0} does not have sufficient permissions to perform a rolling pool upgrade on {1}. 


### PR DESCRIPTION
… minimum required role. Do not deselect a pool on the RPU wizard if it fails
the RBAC check; let the user decide either to reconnect with more privileges
or deselect it.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>