### PR TITLE
CA-293857: When uploading and introducing an update, delete the VDI i…

### DIFF
--- a/XenModel/XenAPI-Extensions/Failure.cs
+++ b/XenModel/XenAPI-Extensions/Failure.cs
@@ -92,6 +92,7 @@ namespace XenAPI
         public const string OTHER_OPERATION_IN_PROGRESS = "OTHER_OPERATION_IN_PROGRESS";
         public const string PATCH_ALREADY_APPLIED = "PATCH_ALREADY_APPLIED";
         public const string UPDATE_ALREADY_APPLIED = "UPDATE_ALREADY_APPLIED";
+        public const string UPDATE_ALREADY_EXISTS = "UPDATE_ALREADY_EXISTS";
 
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 


### PR DESCRIPTION
…f the update introduce fails (regardless of the error).

Also add a sleep to try and avoid getting a VDI_IN_USE exception when deleting the VDI after the upload failed or has been cancelled by the user

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>