### PR TITLE
CA-293854: Patching wizard updates list loses selection and resizes c…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.Designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.Designer.cs
@@ -208,7 +208,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             this.dataGridViewPatches.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
             this.dataGridViewPatches.BackgroundColor = System.Drawing.SystemColors.Window;
             this.dataGridViewPatches.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
-            this.dataGridViewPatches.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewPatches.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.dataGridViewPatches.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ColumnUpdate,
             this.ColumnDescription,

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.Designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.Designer.cs
@@ -239,14 +239,13 @@ namespace XenAdmin.Wizards.PatchingWizard
             this.dataGridViewPatches.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.dataGridViewPatches.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewPatches_CellContentClick);
             this.dataGridViewPatches.CellMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridViewPatches_CellMouseClick);
-            this.dataGridViewPatches.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridViewPatches_ColumnHeaderMouseClick);
             this.dataGridViewPatches.SelectionChanged += new System.EventHandler(this.dataGridViewPatches_SelectionChanged);
             this.dataGridViewPatches.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridViewPatches_SortCompare);
             this.dataGridViewPatches.Enter += new System.EventHandler(this.dataGridViewPatches_Enter);
             // 
             // ColumnUpdate
             // 
-            this.ColumnUpdate.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            this.ColumnUpdate.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.ColumnUpdate.DefaultCellStyle = dataGridViewCellStyle1;

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -587,12 +587,6 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
         }
 
-        private void dataGridViewPatches_ColumnHeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)
-        {
-            if (dataGridViewPatches.Columns[e.ColumnIndex].SortMode == DataGridViewColumnSortMode.Automatic)
-                PopulatePatchesBox();
-        }
-
         private void dataGridViewPatches_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
             // The click is on a column header

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -581,8 +581,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             if (e.Column.Index == ColumnDate.Index)
             {
-                int sortResult = DateTime.Compare(alert1.Timestamp, alert2.Timestamp);
-                e.SortResult = (dataGridViewPatches.SortOrder == SortOrder.Descending) ? sortResult *= -1 : sortResult;
+                e.SortResult = DateTime.Compare(alert1.Timestamp, alert2.Timestamp);
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
…olumns when resorted

Remove the redundant code
Change the AutoSize mode from DisplayedCells to AllCells.

Signed-off-by: Tim Liu <tim.liu@citrix.com>