### PR TITLE
CA-294091: Fix two Update wizards co-exist bug

### DIFF
--- a/XenAdmin/IMainWindow.cs
+++ b/XenAdmin/IMainWindow.cs
@@ -53,8 +53,8 @@ namespace XenAdmin
         void RequestRefreshTreeView();
         void ShowPerXenModelObjectWizard(IXenObject obj, Form wizard);
         void ShowPerConnectionWizard(IXenConnection connection, Form wizard);
-        void ShowForm(Type type);
-        void ShowForm(Type type, object[] args);
+        Form ShowForm(Type type);
+        Form ShowForm(Type type, object[] args);
         void CloseActiveWizards(IXenConnection connection);
         void CloseActiveWizards(IXenObject xenObject);
         Collection<IXenConnection> GetXenConnectionsCopy();

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -2393,9 +2393,9 @@ namespace XenAdmin
         /// it is created first and then shown.
         /// </summary>
         /// <param name="type">The type of the form to be shown.</param>
-        public void ShowForm(Type type)
+        public Form ShowForm(Type type)
         {
-            ShowForm(type, null);
+            return ShowForm(type, null);
         }
 
         /// <summary>
@@ -2404,19 +2404,20 @@ namespace XenAdmin
         /// </summary>
         /// <param name="type">The type of the form to be shown.</param>
         /// <param name="args">The arguments to pass to the form's consructor</param>
-        public void ShowForm(Type type, object[] args)
+        public Form ShowForm(Type type, object[] args)
         {
             foreach (Form form in Application.OpenForms)
             {
                 if (form.GetType() == type)
                 {
                     HelpersGUI.BringFormToFront(form);
-                    return;
+                    return form;
                 }
             }
 
             Form newForm = (Form)Activator.CreateInstance(type, args);
             newForm.Show(this);
+            return newForm;
         }
 
         public Form Form

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -1099,8 +1099,9 @@ namespace XenAdmin.TabPages
             if (string.IsNullOrEmpty(patchUri))
                 return;
 
-            var wizard = new PatchingWizard();
-            wizard.Show();
+            PatchingWizard wizard = (PatchingWizard)Program.MainWindow.ShowForm(typeof(PatchingWizard));
+            if (!wizard.IsFirstPage())
+                return;
             wizard.NextStep();
             wizard.AddAlert(patchAlert);
             wizard.NextStep();
@@ -1531,16 +1532,9 @@ namespace XenAdmin.TabPages
 
         private void toolStripButtonUpdate_Click(object sender, EventArgs e)
         {
-            var wizard = new PatchingWizard();
-            wizard.Show();
-            wizard.NextStep();
-
-            var hostlist = new List<Host>();
-            foreach (IXenConnection c in ConnectionsManager.XenConnectionsCopy)
-                hostlist.AddRange(c.Cache.Hosts);
-
-            if (hostlist.Count > 0)
-                wizard.SelectServers(hostlist);
+            PatchingWizard wizard = (PatchingWizard)Program.MainWindow.ShowForm(typeof(PatchingWizard));
+            if (wizard.IsFirstPage())
+                wizard.NextStep();
         }
     }
 }

--- a/XenAdmin/Wizards/XenWizardBase.cs
+++ b/XenAdmin/Wizards/XenWizardBase.cs
@@ -353,6 +353,11 @@ namespace XenAdmin.Wizards
             wizardProgress.PreviousStep();
         }
 
+        public bool IsFirstPage()
+        {
+            return wizardProgress.IsFirstStep;
+        }
+
         protected void RefreshProgress()
         {
             wizardProgress.Refresh();

--- a/XenAdminTests/MainWindowWrapper/MockMainWindow.cs
+++ b/XenAdminTests/MainWindowWrapper/MockMainWindow.cs
@@ -75,14 +75,14 @@ namespace XenAdminTests
 
         }
 
-        public void ShowForm(Type type)
+        public Form ShowForm(Type type)
         {
-            
+            return null;
         }
 
-        public void ShowForm(Type type, object[] args)
+        public Form ShowForm(Type type, object[] args)
         {
-            
+            return null;
         }
 
         public void CloseActiveWizards(IXenConnection connection)


### PR DESCRIPTION
I couldn't find way to go to second page of the Update wizard, when using .showForm() method. But I don't think it's a necessary functionality. Also, IMO, we don't need to pre-select any server in this case. So it does exactly the same thing as clicking from the main menu.

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>