### PR TITLE
CA-286882: Shutting down large number of VMs causes XenCenter to hang

### DIFF
--- a/XenAdmin/Commands/ForceVMRebootCommand.cs
+++ b/XenAdmin/Commands/ForceVMRebootCommand.cs
@@ -72,7 +72,7 @@ namespace XenAdmin.Commands
         protected override void Execute(List<VM> vms)
         {
             CancelAllTasks(vms);
-            RunAction(vms, Messages.ACTION_VM_REBOOTING, Messages.ACTION_VM_REBOOTING, Messages.ACTION_VM_REBOOTED, null);
+            RunAction(vms, Messages.ACTION_VMS_REBOOTING_TITLE, Messages.ACTION_VMS_REBOOTING_TITLE, Messages.ACTION_VM_REBOOTED, null);
         }
 
 

--- a/XenAdmin/Commands/ForceVMShutDownCommand.cs
+++ b/XenAdmin/Commands/ForceVMShutDownCommand.cs
@@ -71,7 +71,7 @@ namespace XenAdmin.Commands
         protected override void Execute(List<VM> vms)
         {
             CancelAllTasks(vms);
-            RunAction(vms, Messages.ACTION_VM_SHUTTING_DOWN, Messages.ACTION_VM_SHUTTING_DOWN, Messages.ACTION_VM_SHUT_DOWN, null);
+            RunAction(vms, Messages.ACTION_VMS_SHUTTING_DOWN_TITLE, Messages.ACTION_VMS_SHUTTING_DOWN_TITLE, Messages.ACTION_VM_SHUT_DOWN, null);
         }
 
         protected override bool CanExecute(VM vm)

--- a/XenAdmin/Commands/RebootVMCommand.cs
+++ b/XenAdmin/Commands/RebootVMCommand.cs
@@ -87,7 +87,7 @@ namespace XenAdmin.Commands
 
         protected override void Execute(List<VM> vms)
         {
-            RunAction(vms, Messages.ACTION_VM_REBOOTING, Messages.ACTION_VM_REBOOTING, Messages.ACTION_VM_REBOOTED, null);
+            RunAction(vms, Messages.ACTION_VMS_REBOOTING_TITLE, Messages.ACTION_VMS_REBOOTING_TITLE, Messages.ACTION_VM_REBOOTED, null);
         }
 
         private static bool EnabledTargetExists(Host host, IXenConnection connection)

--- a/XenAdmin/Commands/ResumeVMCommand.cs
+++ b/XenAdmin/Commands/ResumeVMCommand.cs
@@ -75,7 +75,7 @@ namespace XenAdmin.Commands
 
         protected override void Execute(List<VM> vms)
         {
-            RunAction(vms, Messages.ACTION_VM_RESUMING, Messages.ACTION_VM_RESUMING, Messages.ACTION_VM_RESUMED, null);
+            RunAction(vms, Messages.ACTION_VMS_RESUMING_ON_TITLE, Messages.ACTION_VMS_RESUMING_ON_TITLE, Messages.ACTION_VM_RESUMED, null);
         }
 
         protected override bool CanExecute(VM vm)

--- a/XenAdmin/Commands/ShutDownVMCommand.cs
+++ b/XenAdmin/Commands/ShutDownVMCommand.cs
@@ -76,7 +76,7 @@ namespace XenAdmin.Commands
 
         protected override void Execute(List<VM> vms)
         {
-            RunAction(vms, Messages.ACTION_VM_SHUTTING_DOWN, Messages.ACTION_VM_SHUTTING_DOWN, Messages.ACTION_VM_SHUT_DOWN, null);
+            RunAction(vms, Messages.ACTION_VMS_SHUTTING_DOWN_TITLE, Messages.ACTION_VMS_SHUTTING_DOWN_TITLE, Messages.ACTION_VM_SHUT_DOWN, null);
         }
 
         public override string MenuText

--- a/XenAdmin/Commands/StartVMCommand.cs
+++ b/XenAdmin/Commands/StartVMCommand.cs
@@ -115,7 +115,7 @@ namespace XenAdmin.Commands
                 if (d == DialogResult.Ignore)
                     brokenCDs = null;
             }
-            RunAction(vms, Messages.ACTION_VM_STARTING, Messages.ACTION_VM_STARTING, Messages.ACTION_VM_STARTED, brokenCDs);
+            RunAction(vms, Messages.ACTION_VMS_STARTING_ON_TITLE, Messages.ACTION_VMS_STARTING_ON_TITLE, Messages.ACTION_VM_STARTED, brokenCDs);
         }
 
         protected override bool CanExecute(VM vm)

--- a/XenAdmin/Commands/SuspendVMCommand.cs
+++ b/XenAdmin/Commands/SuspendVMCommand.cs
@@ -80,7 +80,7 @@ namespace XenAdmin.Commands
 
         protected override void Execute(List<VM> vms)
         {
-            RunAction(vms, Messages.ACTION_VM_SUSPENDING, Messages.ACTION_VM_SUSPENDING, Messages.ACTION_VM_SUSPENDED, null);
+            RunAction(vms, Messages.ACTION_VMS_SUSPENDING_TITLE, Messages.ACTION_VMS_SUSPENDING_TITLE, Messages.ACTION_VM_SUSPENDED, null);
         }
 
         public override string MenuText

--- a/XenAdmin/Commands/VMOperationCommand.cs
+++ b/XenAdmin/Commands/VMOperationCommand.cs
@@ -118,7 +118,7 @@ namespace XenAdmin.Commands
             AssertOperationAllowsExecution();
 
             string title = Messages.ACTION_VMS_RESUMING_ON_TITLE;
-            string startDescription = Messages.ACTION_VM_RESUMING;
+            string startDescription = Messages.ACTION_VMS_RESUMING_ON_TITLE;
             string endDescription = Messages.ACTION_VM_RESUMED;
 
             List<AsyncAction> actions = new List<AsyncAction>();
@@ -126,7 +126,7 @@ namespace XenAdmin.Commands
             {
                 
                 title = Messages.ACTION_VMS_MIGRATING_TITLE;
-                startDescription = Messages.ACTION_VM_MIGRATING;
+                startDescription = Messages.ACTION_VMS_MIGRATING_TITLE;
                 endDescription = Messages.ACTION_VM_MIGRATED;
                 foreach (VM vm in selection.AsXenObjects<VM>(CanExecute))
                 {
@@ -138,7 +138,7 @@ namespace XenAdmin.Commands
             else if (_operation == vm_operations.start_on)
             {
                 title = Messages.ACTION_VMS_STARTING_ON_TITLE;
-                startDescription = Messages.ACTION_VM_STARTING;
+                startDescription = Messages.ACTION_VMS_STARTING_ON_TITLE;
                 endDescription = Messages.ACTION_VM_STARTED;
                 foreach (VM vm in selection.AsXenObjects<VM>(CanExecute))
                 {
@@ -149,7 +149,7 @@ namespace XenAdmin.Commands
             else if (_operation == vm_operations.resume_on)
             {
                 title = Messages.ACTION_VMS_RESUMING_ON_TITLE;
-                startDescription = Messages.ACTION_VM_RESUMING;
+                startDescription = Messages.ACTION_VMS_RESUMING_ON_TITLE;
                 endDescription = Messages.ACTION_VM_RESUMED;
                 foreach (VM vm in selection.AsXenObjects<VM>(CanExecute))
                 {

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -3031,18 +3031,24 @@ namespace XenAdmin
             switch (submodeItem.SubMode)
             {
                 case NotificationsSubMode.Alerts:
+                    if (updatesPage.Visible)
+                        updatesPage.HidePage();
+                    if (eventsPage.Visible)
+                        eventsPage.HidePage();
                     alertPage.ShowPage();
-                    updatesPage.HidePage();
-                    eventsPage.HidePage();
                     break;
                 case NotificationsSubMode.Updates:
-                    alertPage.HidePage();
+                    if (alertPage.Visible)
+                        alertPage.HidePage();
+                    if (eventsPage.Visible)
+                        eventsPage.HidePage();
                     updatesPage.ShowPage();
-                    eventsPage.HidePage();
                     break;
                 case NotificationsSubMode.Events:
-                    alertPage.HidePage();
-                    updatesPage.HidePage();
+                    if (alertPage.Visible)
+                        alertPage.HidePage();
+                    if (updatesPage.Visible)
+                        updatesPage.HidePage();
                     eventsPage.ShowPage();
                     break;
             } 

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -3028,21 +3028,26 @@ namespace XenAdmin
 
         private void navigationPane_NotificationsSubModeChanged(NotificationsSubModeItem submodeItem)
         {
-            alertPage.Visible = submodeItem.SubMode == NotificationsSubMode.Alerts;
-            updatesPage.Visible = submodeItem.SubMode == NotificationsSubMode.Updates;
-            eventsPage.Visible = submodeItem.SubMode == NotificationsSubMode.Events;
-            TheTabControl.Visible = false;
-
-            if (alertPage.Visible)
-                alertPage.RefreshAlertList();
-
-            if (updatesPage.Visible)
-                updatesPage.RefreshUpdateList();
-
-            if (eventsPage.Visible)
+            switch (submodeItem.SubMode)
             {
-                eventsPage.RefreshDisplayedEvents();
-            }
+                case NotificationsSubMode.Alerts:
+                    alertPage.ShowPage();
+                    updatesPage.HidePage();
+                    eventsPage.HidePage();
+                    break;
+                case NotificationsSubMode.Updates:
+                    alertPage.HidePage();
+                    updatesPage.ShowPage();
+                    eventsPage.HidePage();
+                    break;
+                case NotificationsSubMode.Events:
+                    alertPage.HidePage();
+                    updatesPage.HidePage();
+                    eventsPage.ShowPage();
+                    break;
+            } 
+
+            TheTabControl.Visible = false;
 
             loggedInLabel1.Connection = null;
             TitleLabel.Text = submodeItem.Text;
@@ -3060,7 +3065,12 @@ namespace XenAdmin
             {
                 bool tabControlWasVisible = TheTabControl.Visible;
                 TheTabControl.Visible = true;
-                alertPage.Visible = updatesPage.Visible = eventsPage.Visible = false;
+                if (alertPage.Visible)
+                    alertPage.HidePage();
+                if (updatesPage.Visible)
+                    updatesPage.HidePage();
+                if (eventsPage.Visible)
+                    eventsPage.HidePage();
 
                 // force an update of the selected tab when switching back from Notification view, 
                 // as some tabs ignore the update events when not visible (e.g. Snapshots, HA)

--- a/XenAdmin/TabPages/AlertSummaryPage.Designer.cs
+++ b/XenAdmin/TabPages/AlertSummaryPage.Designer.cs
@@ -15,7 +15,7 @@ namespace XenAdmin.TabPages
         {
             if (disposing)
             {
-                XenAdmin.Alerts.Alert.DeregisterAlertCollectionChanged(m_alertCollectionChangedWithInvoke);
+                DeregisterEventHandlers();
 
                 if (components != null)
                     components.Dispose();

--- a/XenAdmin/TabPages/AlertSummaryPage.cs
+++ b/XenAdmin/TabPages/AlertSummaryPage.cs
@@ -49,7 +49,7 @@ using System.IO;
 
 namespace XenAdmin.TabPages
 {
-    public partial class AlertSummaryPage : UserControl
+    public partial class AlertSummaryPage : NotificationsBasePage
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -69,18 +69,29 @@ namespace XenAdmin.TabPages
             UpdateActionEnablement();
 
             m_alertCollectionChangedWithInvoke = Program.ProgramInvokeHandler(AlertsCollectionChanged);
-            Alert.RegisterAlertCollectionChanged(m_alertCollectionChangedWithInvoke);
 
             toolStripSplitButtonDismiss.DefaultItem = tsmiDismissAll;
             toolStripSplitButtonDismiss.Text = tsmiDismissAll.Text;
         }
 
-        public void RefreshAlertList()
+        #region NotificationPage overrides
+        protected override void RefreshPage()
         {
             toolStripDropDownButtonServerFilter.InitializeHostList();
             toolStripDropDownButtonServerFilter.BuildFilterList();
             Rebuild();
         }
+
+        protected override void RegisterEventHandlers()
+        {
+            Alert.RegisterAlertCollectionChanged(m_alertCollectionChangedWithInvoke);
+        }
+
+        protected override void DeregisterEventHandlers()
+        {
+            Alert.DeregisterAlertCollectionChanged(m_alertCollectionChangedWithInvoke);
+        }
+        #endregion
         
         private void SetFilterLabel()
         {

--- a/XenAdmin/TabPages/HistoryPage.Designer.cs
+++ b/XenAdmin/TabPages/HistoryPage.Designer.cs
@@ -13,7 +13,7 @@ namespace XenAdmin.TabPages
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            ConnectionsManager.History.CollectionChanged -= History_CollectionChanged;
+            DeregisterEventHandlers();
             XenAdmin.Actions.ActionBase.NewAction -= Action_NewAction;
 
             if (disposing && (components != null))

--- a/XenAdmin/TabPages/HistoryPage.cs
+++ b/XenAdmin/TabPages/HistoryPage.cs
@@ -34,7 +34,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 using XenAdmin.Actions;
@@ -46,7 +45,7 @@ using XenAPI;
 
 namespace XenAdmin.TabPages
 {
-    public partial class HistoryPage : UserControl
+    public partial class HistoryPage : NotificationsBasePage
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -63,16 +62,30 @@ namespace XenAdmin.TabPages
             toolStripSplitButtonDismiss.DefaultItem = tsmiDismissAll;
             toolStripSplitButtonDismiss.Text = tsmiDismissAll.Text;
             UpdateButtons();
-            ConnectionsManager.History.CollectionChanged += History_CollectionChanged;
+            
             ActionBase.NewAction += Action_NewAction;
         }
 
-        public void RefreshDisplayedEvents()
+        #region NotificationPage overrides
+        protected override void RefreshPage()
         {
             toolStripDdbFilterLocation.InitializeHostList();
             toolStripDdbFilterLocation.BuildFilterList();
             BuildRowList();
         }
+
+        protected override void RegisterEventHandlers()
+        {
+            ConnectionsManager.History.CollectionChanged += History_CollectionChanged;
+        }
+
+        protected override void DeregisterEventHandlers()
+        {
+            ConnectionsManager.History.CollectionChanged -= History_CollectionChanged;
+            foreach (var action in ConnectionsManager.History)
+                DeregisterActionEvents(action);
+        }
+        #endregion
 
         private void Action_NewAction(ActionBase action)
         {
@@ -260,16 +273,20 @@ namespace XenAdmin.TabPages
 
         private void RegisterActionEvents(ActionBase action)
         {
-            action.Changed -= action_Changed;
-            action.Completed -= action_Changed;
+            DeregisterActionEvents(action);
             action.Changed += action_Changed;
             action.Completed += action_Changed;
         }
 
-        private void RemoveActionRow(ActionBase action)
+        private void DeregisterActionEvents(ActionBase action)
         {
             action.Changed -= action_Changed;
             action.Completed -= action_Changed;
+        }
+
+        private void RemoveActionRow(ActionBase action)
+        {
+            DeregisterActionEvents(action);
 
             var row = FindRowFromAction(action);
             if (row != null)

--- a/XenAdmin/TabPages/ManageUpdatesPage.Designer.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.Designer.cs
@@ -15,10 +15,7 @@
         {
             if (disposing)
             {
-                XenAdmin.Core.Updates.DeregisterCollectionChanged(m_updateCollectionChangedWithInvoke);
-                XenAdmin.Core.Updates.RestoreDismissedUpdatesStarted -= Updates_RestoreDismissedUpdatesStarted;
-                XenAdmin.Core.Updates.CheckForUpdatesStarted -= CheckForUpdates_CheckForUpdatesStarted;
-                XenAdmin.Core.Updates.CheckForUpdatesCompleted -= CheckForUpdates_CheckForUpdatesCompleted;
+                DeregisterEventHandlers();
 
                 if (components != null)
                     components.Dispose();

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -54,7 +54,7 @@ using Timer = System.Windows.Forms.Timer;
 
 namespace XenAdmin.TabPages
 {
-    public partial class ManageUpdatesPage : UserControl
+    public partial class ManageUpdatesPage : NotificationsBasePage
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         
@@ -78,21 +78,35 @@ namespace XenAdmin.TabPages
             UpdateButtonEnablement();
             informationLabel.Click += informationLabel_Click;
             m_updateCollectionChangedWithInvoke = Program.ProgramInvokeHandler(UpdatesCollectionChanged);
-            Updates.RegisterCollectionChanged(m_updateCollectionChangedWithInvoke);
-            Updates.RestoreDismissedUpdatesStarted += Updates_RestoreDismissedUpdatesStarted;
-            Updates.CheckForUpdatesStarted += CheckForUpdates_CheckForUpdatesStarted;
-            Updates.CheckForUpdatesCompleted += CheckForUpdates_CheckForUpdatesCompleted;
             toolStripSplitButtonDismiss.DefaultItem = dismissAllToolStripMenuItem;
             toolStripSplitButtonDismiss.Text = dismissAllToolStripMenuItem.Text;
             toolStripButtonUpdate.Visible = false;
         }
 
-        public void RefreshUpdateList()
+        #region NotificationPage overrides
+        protected override void RefreshPage()
         {
             toolStripDropDownButtonServerFilter.InitializeHostList();
             toolStripDropDownButtonServerFilter.BuildFilterList();
-            Rebuild();
+            Rebuild(); 
         }
+
+        protected override void RegisterEventHandlers()
+        {
+            Updates.RegisterCollectionChanged(m_updateCollectionChangedWithInvoke);
+            Updates.RestoreDismissedUpdatesStarted += Updates_RestoreDismissedUpdatesStarted;
+            Updates.CheckForUpdatesStarted += CheckForUpdates_CheckForUpdatesStarted;
+            Updates.CheckForUpdatesCompleted += CheckForUpdates_CheckForUpdatesCompleted;
+        }
+
+        protected override void DeregisterEventHandlers()
+        {
+            Updates.DeregisterCollectionChanged(m_updateCollectionChangedWithInvoke);
+            Updates.RestoreDismissedUpdatesStarted -= Updates_RestoreDismissedUpdatesStarted;
+            Updates.CheckForUpdatesStarted -= CheckForUpdates_CheckForUpdatesStarted;
+            Updates.CheckForUpdatesCompleted -= CheckForUpdates_CheckForUpdatesCompleted;
+        }
+        #endregion
 
         private void UpdatesCollectionChanged(object sender, CollectionChangeEventArgs e)
         {

--- a/XenAdmin/TabPages/NotificationsBasePage.cs
+++ b/XenAdmin/TabPages/NotificationsBasePage.cs
@@ -1,0 +1,60 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Windows.Forms;
+
+namespace XenAdmin.TabPages
+{
+    public class NotificationsBasePage: UserControl
+    {
+        protected virtual void RefreshPage()
+        { }
+
+        protected virtual void RegisterEventHandlers()
+        { }
+
+        protected virtual void DeregisterEventHandlers()
+        { }
+
+        public void ShowPage()
+        {
+            Visible = true;
+            RefreshPage();
+            RegisterEventHandlers();
+        }
+
+        public void HidePage()
+        {
+            Visible = false;
+            DeregisterEventHandlers();
+        }
+    }
+}

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -451,6 +451,9 @@
     <Compile Include="TabPages\HomePage.Designer.cs">
       <DependentUpon>HomePage.cs</DependentUpon>
     </Compile>
+    <Compile Include="TabPages\NotificationsBasePage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="TabPages\PvsPage.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -3445,6 +3445,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rebooting VMs.
+        /// </summary>
+        public static string ACTION_VMS_REBOOTING_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_VMS_REBOOTING_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Resuming VMs.
         /// </summary>
         public static string ACTION_VMS_RESUMING_ON_TITLE {
@@ -3468,6 +3477,15 @@ namespace XenAdmin {
         public static string ACTION_VMS_STARTING_ON_TITLE {
             get {
                 return ResourceManager.GetString("ACTION_VMS_STARTING_ON_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Suspending VMs.
+        /// </summary>
+        public static string ACTION_VMS_SUSPENDING_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_VMS_SUSPENDING_TITLE", resourceCulture);
             }
         }
         
@@ -33299,24 +33317,6 @@ namespace XenAdmin {
         public static string SUSPEND_VMS {
             get {
                 return ResourceManager.GetString("SUSPEND_VMS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Suspended specified VMs.
-        /// </summary>
-        public static string SUSPENDED_SPECIFIED_VMS {
-            get {
-                return ResourceManager.GetString("SUSPENDED_SPECIFIED_VMS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Suspending specified VMs.
-        /// </summary>
-        public static string SUSPENDING_SPECIFIED_VMS {
-            get {
-                return ResourceManager.GetString("SUSPENDING_SPECIFIED_VMS", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1107,6 +1107,9 @@
   <data name="ACTION_VMS_MIGRATING_TITLE" xml:space="preserve">
     <value>Migrating VMs</value>
   </data>
+  <data name="ACTION_VMS_REBOOTING_TITLE" xml:space="preserve">
+    <value>Rebooting VMs</value>
+  </data>
   <data name="ACTION_VMS_RESUMING_ON_TITLE" xml:space="preserve">
     <value>Resuming VMs</value>
   </data>
@@ -1115,6 +1118,9 @@
   </data>
   <data name="ACTION_VMS_STARTING_ON_TITLE" xml:space="preserve">
     <value>Starting VMs</value>
+  </data>
+  <data name="ACTION_VMS_SUSPENDING_TITLE" xml:space="preserve">
+    <value>Suspending VMs</value>
   </data>
   <data name="ACTION_VM_COPIED" xml:space="preserve">
     <value>Copied</value>
@@ -11530,12 +11536,6 @@ Refer to the "[XenServer product] Administrator's Guide" for instructions on how
   </data>
   <data name="SUSPEND" xml:space="preserve">
     <value>Suspend</value>
-  </data>
-  <data name="SUSPENDED_SPECIFIED_VMS" xml:space="preserve">
-    <value>Suspended specified VMs</value>
-  </data>
-  <data name="SUSPENDING_SPECIFIED_VMS" xml:space="preserve">
-    <value>Suspending specified VMs</value>
   </data>
   <data name="SUSPENDING_VM_OUT_OF" xml:space="preserve">
     <value>Suspending VM {0} out of {1}</value>


### PR DESCRIPTION
Created a new base class for the Notifications pages (Alerts, Updates, Events). This can be used in the future to host more of the common code between these pages. For now, it implements a common mechanism for showing/hiding the page and ensures that the event handlers are deregistered when the page is hidden (i.e. when the user switches to a different view) and registered again when the page becomes visible

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>