### PR TITLE
CP-29230: Change License names (Enterprise to Premium, Free to Express)

### DIFF
--- a/XenAdmin/Dialogs/AssignLicenseDialog.cs
+++ b/XenAdmin/Dialogs/AssignLicenseDialog.cs
@@ -55,7 +55,7 @@ namespace XenAdmin.Dialogs
             InitializeComponent();
             licenseServerNameTextBox.TextChanged += licenseServerPortTextBox_TextChanged;
             licenseServerPortTextBox.TextChanged += licenseServerNameTextBox_TextChanged;
-            SetOptionsForClearwaterAndNewer();
+            LoadLicenseOptions();
             UpdateButtonEnablement();
 
             // if all the hosts have the same license server details then populate the textboxes.
@@ -99,25 +99,39 @@ namespace XenAdmin.Dialogs
             return hosts;
         }
 
-
-        /// <summary>
-        /// Not all license types apply for post-clearwater hosts. Hide them to declutter the UI
-        /// </summary>
-        private void SetOptionsForClearwaterAndNewer()
+        private void LoadLicenseOptions()
         {
-            if (xos.TrueForAll(x => Helpers.CreedenceOrGreater(x.Connection)))
+            if (xos.TrueForAll(x => Helpers.NaplesOrGreater(x.Connection)))
             {
                 perSocketRadioButton.Visible = false;
                 xenDesktopEnterpriseRadioButton.Visible = false;
                 enterprisePerSocketRadioButton.Checked = true;
-                enterprisePerSocketRadioButton.Text = String.Format(Messages.ENTERPRISE_PERSOCKET_LICENSES_X_REQUIRED,
-                                                          xos.Sum(x => x.Connection.Cache.Hosts.Sum(h => h.CpuSockets())));
-                standardPerSocketRadioButton.Text = String.Format(Messages.STANDARD_PERSOCKET_LICENSES_X_REQUIRED,
-                                                          xos.Sum(x => x.Connection.Cache.Hosts.Sum(h => h.CpuSockets())));
-
+                enterprisePerSocketRadioButton.Text = String.Format(Messages.LICENSE_EDITION_ENTERPRISE_PERSOCKET, 
+                    xos.Sum(x => x.Connection.Cache.Hosts.Sum(h => h.CpuSockets()))); 
+                enterprisePerUserRadioButton.Text = Messages.LICENSE_EDITION_ENTERPRISE_PERUSER;
+                desktopPlusRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP_PLUS;
+                desktopRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP;
+                desktopCloudRadioButton.Visible = true;
+                desktopCloudRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP_CLOUD;
+                standardPerSocketRadioButton.Text = String.Format(Messages.LICENSE_EDITION_STANDARD_PERSOCKET,
+                    xos.Sum(x => x.Connection.Cache.Hosts.Sum(h => h.CpuSockets())));
+            }
+            else if (xos.TrueForAll(x => Helpers.CreedenceOrGreater(x.Connection)))
+            {
+                perSocketRadioButton.Visible = false;
+                xenDesktopEnterpriseRadioButton.Visible = false;
+                enterprisePerSocketRadioButton.Checked = true;
+                enterprisePerSocketRadioButton.Text = String.Format(Messages.LICENSE_EDITION_ENTERPRISE_PERSOCKET_LEGACY, 
+                    xos.Sum(x => x.Connection.Cache.Hosts.Sum(h => h.CpuSockets())));
+                enterprisePerUserRadioButton.Text = Messages.LICENSE_EDITION_ENTERPRISE_PERUSER_LEGACY;
+                desktopPlusRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP_PLUS_LEGACY;
+                desktopRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP_LEGACY;
                 desktopCloudRadioButton.Visible = xos.TrueForAll(x => Helpers.JuraOrGreater(x.Connection));
-            } 
-            else 
+                desktopCloudRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP_CLOUD_LEGACY;
+                standardPerSocketRadioButton.Text = String.Format(Messages.LICENSE_EDITION_STANDARD_PERSOCKET_LEGACY,
+                    xos.Sum(x => x.Connection.Cache.Hosts.Sum(h => h.CpuSockets())));
+            }
+            else
             {
                 enterprisePerSocketRadioButton.Visible = false;
                 enterprisePerUserRadioButton.Visible = false;
@@ -126,8 +140,9 @@ namespace XenAdmin.Dialogs
                 desktopRadioButton.Visible = false;
                 desktopCloudRadioButton.Visible = false;
                 perSocketRadioButton.Checked = true;
-                perSocketRadioButton.Text = String.Format(Messages.PERSOCKET_LICENSES_X_REQUIRED,
-                                                          xos.Sum(x => x.Connection.Cache.Hosts.Sum(h=>h.CpuSockets())));
+                perSocketRadioButton.Text = String.Format(Messages.LICENSE_EDITION_PERSOCKET_LEGACY,
+                    xos.Sum(x => x.Connection.Cache.Hosts.Sum(h => h.CpuSockets())));
+                xenDesktopEnterpriseRadioButton.Text = Messages.LICENSE_EDITION_XENDESKTOP_LEGACY;
             }
         }
 

--- a/XenAdmin/Dialogs/AssignLicenseDialog.resx
+++ b/XenAdmin/Dialogs/AssignLicenseDialog.resx
@@ -418,13 +418,10 @@
     <value>7, 3</value>
   </data>
   <data name="perSocketRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="perSocketRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="perSocketRadioButton.Text" xml:space="preserve">
-    <value>[XenServer product] Per-&amp;Socket</value>
   </data>
   <data name="&gt;&gt;perSocketRadioButton.Name" xml:space="preserve">
     <value>perSocketRadioButton</value>
@@ -448,16 +445,13 @@
     <value>NoControl</value>
   </data>
   <data name="xenDesktopEnterpriseRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 28</value>
+    <value>7, 22</value>
   </data>
   <data name="xenDesktopEnterpriseRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>274, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="xenDesktopEnterpriseRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="xenDesktopEnterpriseRadioButton.Text" xml:space="preserve">
-    <value>[XenServer product] for [Citrix] Virtual &amp;Desktops</value>
   </data>
   <data name="&gt;&gt;xenDesktopEnterpriseRadioButton.Name" xml:space="preserve">
     <value>xenDesktopEnterpriseRadioButton</value>
@@ -481,16 +475,13 @@
     <value>NoControl</value>
   </data>
   <data name="enterprisePerSocketRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 53</value>
+    <value>7, 41</value>
   </data>
   <data name="enterprisePerSocketRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>242, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="enterprisePerSocketRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="enterprisePerSocketRadioButton.Text" xml:space="preserve">
-    <value>[XenServer product] P&amp;remium Per-Socket</value>
   </data>
   <data name="&gt;&gt;enterprisePerSocketRadioButton.Name" xml:space="preserve">
     <value>enterprisePerSocketRadioButton</value>
@@ -514,16 +505,13 @@
     <value>NoControl</value>
   </data>
   <data name="enterprisePerUserRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 78</value>
+    <value>7, 60</value>
   </data>
   <data name="enterprisePerUserRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>230, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="enterprisePerUserRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="enterprisePerUserRadioButton.Text" xml:space="preserve">
-    <value>[XenServer product] Pr&amp;emium Per-User</value>
   </data>
   <data name="enterprisePerUserRadioButton.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -550,16 +538,13 @@
     <value>NoControl</value>
   </data>
   <data name="desktopPlusRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 103</value>
+    <value>7, 79</value>
   </data>
   <data name="desktopPlusRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="desktopPlusRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
-  </data>
-  <data name="desktopPlusRadioButton.Text" xml:space="preserve">
-    <value>[Citrix] Virtual Apps and Desktops &amp;Premium</value>
   </data>
   <data name="&gt;&gt;desktopPlusRadioButton.Name" xml:space="preserve">
     <value>desktopPlusRadioButton</value>
@@ -583,16 +568,13 @@
     <value>NoControl</value>
   </data>
   <data name="desktopRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 128</value>
+    <value>7, 98</value>
   </data>
   <data name="desktopRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>201, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="desktopRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="desktopRadioButton.Text" xml:space="preserve">
-    <value>[Citrix] Virtual &amp;Apps and Desktops</value>
   </data>
   <data name="&gt;&gt;desktopRadioButton.Name" xml:space="preserve">
     <value>desktopRadioButton</value>
@@ -616,16 +598,13 @@
     <value>NoControl</value>
   </data>
   <data name="desktopCloudRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 153</value>
+    <value>7, 117</value>
   </data>
   <data name="desktopCloudRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>274, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="desktopCloudRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
-  </data>
-  <data name="desktopCloudRadioButton.Text" xml:space="preserve">
-    <value>[Citrix] Virtual Apps and Desktops [Citrix] &amp;Cloud</value>
   </data>
   <data name="desktopCloudRadioButton.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -652,16 +631,13 @@
     <value>NoControl</value>
   </data>
   <data name="standardPerSocketRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 178</value>
+    <value>7, 136</value>
   </data>
   <data name="standardPerSocketRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>240, 19</value>
+    <value>14, 13</value>
   </data>
   <data name="standardPerSocketRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
-  </data>
-  <data name="standardPerSocketRadioButton.Text" xml:space="preserve">
-    <value>[XenServer product] &amp;Standard Per-Socket</value>
   </data>
   <data name="&gt;&gt;standardPerSocketRadioButton.Name" xml:space="preserve">
     <value>standardPerSocketRadioButton</value>
@@ -691,7 +667,7 @@
     <value>4, 0, 4, 4</value>
   </data>
   <data name="editionLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>519, 204</value>
+    <value>519, 156</value>
   </data>
   <data name="editionLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -718,7 +694,7 @@
     <value>11, 92</value>
   </data>
   <data name="editionsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>525, 226</value>
+    <value>525, 178</value>
   </data>
   <data name="editionsGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -751,7 +727,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonsLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>350, 329</value>
+    <value>350, 281</value>
   </data>
   <data name="buttonsLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 8, 3, 3</value>

--- a/XenAdmin/Dialogs/AssignLicenseDialog.resx
+++ b/XenAdmin/Dialogs/AssignLicenseDialog.resx
@@ -484,13 +484,13 @@
     <value>7, 53</value>
   </data>
   <data name="enterprisePerSocketRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>245, 19</value>
+    <value>242, 19</value>
   </data>
   <data name="enterprisePerSocketRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="enterprisePerSocketRadioButton.Text" xml:space="preserve">
-    <value>[XenServer product] E&amp;nterprise Per-Socket</value>
+    <value>[XenServer product] P&amp;remium Per-Socket</value>
   </data>
   <data name="&gt;&gt;enterprisePerSocketRadioButton.Name" xml:space="preserve">
     <value>enterprisePerSocketRadioButton</value>
@@ -517,13 +517,13 @@
     <value>7, 78</value>
   </data>
   <data name="enterprisePerUserRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>233, 19</value>
+    <value>230, 19</value>
   </data>
   <data name="enterprisePerUserRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="enterprisePerUserRadioButton.Text" xml:space="preserve">
-    <value>[XenServer product] &amp;Enterprise Per-User</value>
+    <value>[XenServer product] Pr&amp;emium Per-User</value>
   </data>
   <data name="enterprisePerUserRadioButton.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -553,13 +553,13 @@
     <value>7, 103</value>
   </data>
   <data name="desktopPlusRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 19</value>
+    <value>253, 19</value>
   </data>
   <data name="desktopPlusRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="desktopPlusRadioButton.Text" xml:space="preserve">
-    <value>[Citrix] Virtual Apps/Desktops &amp;Platinum</value>
+    <value>[Citrix] Virtual Apps and Desktops &amp;Premium</value>
   </data>
   <data name="&gt;&gt;desktopPlusRadioButton.Name" xml:space="preserve">
     <value>desktopPlusRadioButton</value>
@@ -586,13 +586,13 @@
     <value>7, 128</value>
   </data>
   <data name="desktopRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 19</value>
+    <value>201, 19</value>
   </data>
   <data name="desktopRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
   <data name="desktopRadioButton.Text" xml:space="preserve">
-    <value>[Citrix] Virtual &amp;Apps/Desktops</value>
+    <value>[Citrix] Virtual &amp;Apps and Desktops</value>
   </data>
   <data name="&gt;&gt;desktopRadioButton.Name" xml:space="preserve">
     <value>desktopRadioButton</value>
@@ -619,13 +619,13 @@
     <value>7, 153</value>
   </data>
   <data name="desktopCloudRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 19</value>
+    <value>274, 19</value>
   </data>
   <data name="desktopCloudRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="desktopCloudRadioButton.Text" xml:space="preserve">
-    <value>[Citrix] Virtual Apps/Desktops [Citrix] &amp;Cloud</value>
+    <value>[Citrix] Virtual Apps and Desktops [Citrix] &amp;Cloud</value>
   </data>
   <data name="desktopCloudRadioButton.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/XenModel/Actions/Host/ApplyLicenseEditionAction.cs
+++ b/XenModel/Actions/Host/ApplyLicenseEditionAction.cs
@@ -184,7 +184,7 @@ namespace XenAdmin.Actions
 
                     if(xo is Host && host != null)
                     {
-                        Host.apply_edition(host.Connection.Session, host.opaque_ref, Host.GetEditionText(_edition), false);
+                        Host.apply_edition(host.Connection.Session, host.opaque_ref, host.GetEditionText(_edition), false);
 
                         // PR-1102: populate the list of updated hosts
                         updatedHosts.Add(host, previousLicenseData);
@@ -192,8 +192,7 @@ namespace XenAdmin.Actions
 
                     if (xo is Pool)
                     {
-                        Pool.apply_edition(xo.Connection.Session, pool.opaque_ref, Host.GetEditionText(_edition));
-
+                        Pool.apply_edition(xo.Connection.Session, pool.opaque_ref, xo.Connection.Cache.Hosts.First().GetEditionText(_edition));
                         xo.Connection.Cache.Hosts.ToList().ForEach(h => updatedHosts.Add(h, previousLicenseData));
                     }
 
@@ -228,7 +227,7 @@ namespace XenAdmin.Actions
             // PR-1102: Send licensing data to the activation server
             if (updatedHosts.Count > 0)
             {
-                LicensingHelper.SendLicenseEditionData(updatedHosts, Host.GetEditionText(_edition));
+                LicensingHelper.SendLicenseEditionData(updatedHosts, updatedHosts.Keys.First().GetEditionText(_edition));
             }
 
             if (LicenseFailures.Count > 0)

--- a/XenModel/Actions/Host/LicensingHelper.cs
+++ b/XenModel/Actions/Host/LicensingHelper.cs
@@ -75,7 +75,7 @@ namespace XenAdmin.Actions.HostActions
         public static void SendActivationData(Dictionary<XenAPI.Host, LicenseDataStruct> hosts)
         {
             // Supply the state information required by the task.
-            SendLicenseDataHelper sendLicenseDataHelper = new SendLicenseDataHelper(hosts, "activation", XenAPI.Host.GetEditionText(XenAPI.Host.Edition.Free), true);
+            SendLicenseDataHelper sendLicenseDataHelper = new SendLicenseDataHelper(hosts, "activation", hosts.Keys.First().GetEditionText(XenAPI.Host.Edition.Free), true);
 
             // start a separate thread
             Thread thread = new Thread(new ThreadStart(sendLicenseDataHelper.ThreadProc));

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -817,7 +817,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer product] Premium Per-Socket.
+        ///   Looks up a localized string similar to [Legacy XenServer product] Premium Per-Socket.
         /// </summary>
         public static string Label_host_edition_enterprise_per_socket {
             get {
@@ -826,7 +826,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer product] Premium Per-User.
+        ///   Looks up a localized string similar to [Legacy XenServer product] Premium Per-User.
         /// </summary>
         public static string Label_host_edition_enterprise_per_user {
             get {
@@ -835,11 +835,119 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer product].
+        ///   Looks up a localized string similar to [XenServer product] Express.
         /// </summary>
-        public static string Label_host_edition_free {
+        public static string Label_host_edition_express {
             get {
-                return ResourceManager.GetString("Label-host.edition-free", resourceCulture);
+                return ResourceManager.GetString("Label-host.edition-express", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy Citrix XenServer] Basic Edition.
+        /// </summary>
+        public static string Label_host_edition_legacy_basic {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-basic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XenApp/XenDesktop.
+        /// </summary>
+        public static string Label_host_edition_legacy_desktop {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-desktop", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XenApp/XenDesktop [Citrix] Cloud.
+        /// </summary>
+        public static string Label_host_edition_legacy_desktop_cloud {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-desktop-cloud", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XenApp/XenDesktop Platinum.
+        /// </summary>
+        public static string Label_host_edition_legacy_desktop_plus {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-desktop-plus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] Enterprise Per-Socket.
+        /// </summary>
+        public static string Label_host_edition_legacy_enterprise_per_socket {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-enterprise-per-socket", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] Enterprise Per-User.
+        /// </summary>
+        public static string Label_host_edition_legacy_enterprise_per_user {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-enterprise-per-user", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product].
+        /// </summary>
+        public static string Label_host_edition_legacy_free {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-free", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] Per-Socket.
+        /// </summary>
+        public static string Label_host_edition_legacy_per_socket {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-per-socket", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy Citrix XenServer] Ultimate Edition.
+        /// </summary>
+        public static string Label_host_edition_legacy_premium {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-premium", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy Citrix XenServer] Standard Edition.
+        /// </summary>
+        public static string Label_host_edition_legacy_standard {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-standard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] Standard Per-Socket.
+        /// </summary>
+        public static string Label_host_edition_legacy_standard_per_socket {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-standard-per-socket", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] for XenDesktop.
+        /// </summary>
+        public static string Label_host_edition_legacy_xendesktop {
+            get {
+                return ResourceManager.GetString("Label-host.edition-legacy-xendesktop", resourceCulture);
             }
         }
         
@@ -858,6 +966,24 @@ namespace XenAdmin {
         public static string Label_host_edition_premium {
             get {
                 return ResourceManager.GetString("Label-host.edition-premium", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [XenServer product] Premium Per-Socket.
+        /// </summary>
+        public static string Label_host_edition_premium_per_socket {
+            get {
+                return ResourceManager.GetString("Label-host.edition-premium-per-socket", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [XenServer product] Premium Per-User.
+        /// </summary>
+        public static string Label_host_edition_premium_per_user {
+            get {
+                return ResourceManager.GetString("Label-host.edition-premium-per-user", resourceCulture);
             }
         }
         
@@ -3672,7 +3798,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The license on server &apos;{0}&apos; has expired or been changed, and no longer supports [XenServer product] Premium features..
+        ///   Looks up a localized string similar to The license on server &apos;{0}&apos; has expired or been changed, pooling is no longer supported..
         /// </summary>
         public static string Message_body_license_does_not_support_pooling {
             get {

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -115,7 +115,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Retrieve the user information stored as binary objects on [XenServer]..
+        ///   Looks up a localized string similar to Retrieve the user information stored as binary objects on the server..
         /// </summary>
         public static string Description_host_system_status_blobs {
             get {
@@ -142,7 +142,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tests for connectivity between [XenServer] and the internet.
+        ///   Looks up a localized string similar to Tests for connectivity between the server and the internet.
         /// </summary>
         public static string Description_host_system_status_conntest {
             get {
@@ -493,7 +493,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The database which stores the state of the [XenServer].
+        ///   Looks up a localized string similar to The database which stores the state of the server.
         /// </summary>
         public static string Description_host_system_status_xenserver_databases {
             get {
@@ -511,7 +511,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Log files generated during the installation of the [XenServer].
+        ///   Looks up a localized string similar to Log files generated during the installation of the server.
         /// </summary>
         public static string Description_host_system_status_xenserver_install {
             get {
@@ -520,7 +520,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Log files concerning the [XenServer]&apos;s activity.
+        ///   Looks up a localized string similar to Log files concerning the server&apos;s activity.
         /// </summary>
         public static string Description_host_system_status_xenserver_logs {
             get {
@@ -790,7 +790,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Citrix] Virtual Apps/Desktops.
+        ///   Looks up a localized string similar to [Citrix] Virtual Apps and Desktops.
         /// </summary>
         public static string Label_host_edition_desktop {
             get {
@@ -799,7 +799,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Citrix] Virtual Apps/Desktops [Citrix] Cloud.
+        ///   Looks up a localized string similar to [Citrix] Virtual Apps and Desktops [Citrix] Cloud.
         /// </summary>
         public static string Label_host_edition_desktop_cloud {
             get {
@@ -808,7 +808,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Citrix] Virtual Apps/Desktops Platinum.
+        ///   Looks up a localized string similar to [Citrix] Virtual Apps and Desktops Premium.
         /// </summary>
         public static string Label_host_edition_desktop_plus {
             get {
@@ -817,7 +817,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer product] Enterprise Per-Socket.
+        ///   Looks up a localized string similar to [XenServer product] Premium Per-Socket.
         /// </summary>
         public static string Label_host_edition_enterprise_per_socket {
             get {
@@ -826,7 +826,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer product] Enterprise Per-User.
+        ///   Looks up a localized string similar to [XenServer product] Premium Per-User.
         /// </summary>
         public static string Label_host_edition_enterprise_per_user {
             get {
@@ -1015,7 +1015,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] build number.
+        ///   Looks up a localized string similar to Build number.
         /// </summary>
         public static string Label_host_software_version_build_number {
             get {
@@ -1024,7 +1024,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] build date.
+        ///   Looks up a localized string similar to Build date.
         /// </summary>
         public static string Label_host_software_version_date {
             get {
@@ -1033,7 +1033,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] version.
+        ///   Looks up a localized string similar to Version.
         /// </summary>
         public static string Label_host_software_version_product_version {
             get {
@@ -3618,7 +3618,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] on server &apos;{0}&apos; is taking too long to respond and may fence..
+        ///   Looks up a localized string similar to Server &apos;{0}&apos; is taking too long to respond and may fence..
         /// </summary>
         public static string Message_body_ha_xapi_healthcheck_approaching_timeout {
             get {
@@ -3672,7 +3672,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The license on server &apos;{0}&apos; has expired or been changed, and no longer supports [XenServer product] Enterprise features..
+        ///   Looks up a localized string similar to The license on server &apos;{0}&apos; has expired or been changed, and no longer supports [XenServer product] Premium features..
         /// </summary>
         public static string Message_body_license_does_not_support_pooling {
             get {
@@ -3969,7 +3969,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The [XenServer] license you are using does not allow you to use the Scheduled Snapshots feature..
+        ///   Looks up a localized string similar to The server license you are using does not allow you to use the Scheduled Snapshots feature..
         /// </summary>
         public static string Message_body_vmss_license_error {
             get {
@@ -4392,7 +4392,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] healthcheck approaching timeout.
+        ///   Looks up a localized string similar to Server healthcheck approaching timeout.
         /// </summary>
         public static string Message_name_ha_xapi_healthcheck_approaching_timeout {
             get {
@@ -4437,7 +4437,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] statistics synchronization failed.
+        ///   Looks up a localized string similar to Server statistics synchronization failed.
         /// </summary>
         public static string Message_name_host_sync_data_failed {
             get {
@@ -4869,11 +4869,11 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pool Admins have full access to all [XenServer] features and settings. They can access the [XenServer] console and manage the roles of other users.
+        ///   Looks up a localized string similar to Pool Admins have full access to all features and settings. They can access the server console and manage the roles of other users.
         /// 
         ///- No restrictions
         ///- Role and user management
-        ///- Access to [XenServer] console.
+        ///- Access to server console.
         /// </summary>
         public static string Role_pool_admin_Description {
             get {
@@ -4933,7 +4933,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to VM Admins can manage VMs and Templates and can access the storage necessary to complete these tasks. This role relies on [XenServer] to choose where to run each VM, and on templates to provide values for dynamic memory control (DMC) and Home Server settings.
+        ///   Looks up a localized string similar to VM Admins can manage VMs and Templates and can access the storage necessary to complete these tasks. This role relies on the server to choose where to run each VM, and on templates to provide values for dynamic memory control (DMC) and Home Server settings.
         /// 
         ///- Manage VMs and Templates
         ///- No access to dynamic memory control features

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -543,8 +543,8 @@
   <data name="Label-host.edition" xml:space="preserve">
     <value>License</value>
   </data>
-  <data name="Label-host.edition-free" xml:space="preserve">
-    <value>[XenServer product]</value>
+  <data name="Label-host.edition-express" xml:space="preserve">
+    <value>[XenServer product] Express</value>
   </data>
   <data name="Label-host.enabled" xml:space="preserve">
     <value>Enabled</value>
@@ -1029,7 +1029,7 @@
     <value>There was a temporary failure synchronizing performance statistics across the pool, probably because one or more servers were offline.  Another synchronization attempt will be made later.</value>
   </data>
   <data name="Message.body-license_does_not_support_pooling" xml:space="preserve">
-    <value>The license on server '{0}' has expired or been changed, and no longer supports [XenServer product] Premium features.</value>
+    <value>The license on server '{0}' has expired or been changed, pooling is no longer supported.</value>
   </data>
   <data name="Message.body-license_expired" xml:space="preserve">
     <value>The license for {0} has expired.</value>
@@ -1610,10 +1610,10 @@
   <data name="Message.name-license_server_version_obsolete" xml:space="preserve">
     <value>The license server is an out-of-date version.</value>
   </data>
-  <data name="Label-host.edition-enterprise-per-socket" xml:space="preserve">
+  <data name="Label-host.edition-premium-per-socket" xml:space="preserve">
     <value>[XenServer product] Premium Per-Socket</value>
   </data>
-  <data name="Label-host.edition-enterprise-per-user" xml:space="preserve">
+  <data name="Label-host.edition-premium-per-user" xml:space="preserve">
     <value>[XenServer product] Premium Per-User</value>
   </data>
   <data name="Label-host.edition-standard-per-socket" xml:space="preserve">
@@ -1843,5 +1843,47 @@
   </data>
   <data name="Label-host.edition-desktop-cloud" xml:space="preserve">
     <value>[Citrix] Virtual Apps and Desktops [Citrix] Cloud</value>
+  </data>
+  <data name="Label-host.edition-legacy-basic" xml:space="preserve">
+    <value>[Legacy Citrix XenServer] Basic Edition</value>
+  </data>
+  <data name="Label-host.edition-legacy-desktop" xml:space="preserve">
+    <value>XenApp/XenDesktop</value>
+  </data>
+  <data name="Label-host.edition-legacy-desktop-cloud" xml:space="preserve">
+    <value>XenApp/XenDesktop [Citrix] Cloud</value>
+  </data>
+  <data name="Label-host.edition-legacy-desktop-plus" xml:space="preserve">
+    <value>XenApp/XenDesktop Platinum</value>
+  </data>
+  <data name="Label-host.edition-legacy-enterprise-per-socket" xml:space="preserve">
+    <value>[Legacy XenServer product] Enterprise Per-Socket</value>
+  </data>
+  <data name="Label-host.edition-legacy-enterprise-per-user" xml:space="preserve">
+    <value>[Legacy XenServer product] Enterprise Per-User</value>
+  </data>
+  <data name="Label-host.edition-legacy-free" xml:space="preserve">
+    <value>[Legacy XenServer product]</value>
+  </data>
+  <data name="Label-host.edition-legacy-per-socket" xml:space="preserve">
+    <value>[Legacy XenServer product] Per-Socket</value>
+  </data>
+  <data name="Label-host.edition-legacy-premium" xml:space="preserve">
+    <value>[Legacy Citrix XenServer] Ultimate Edition</value>
+  </data>
+  <data name="Label-host.edition-legacy-standard" xml:space="preserve">
+    <value>[Legacy Citrix XenServer] Standard Edition</value>
+  </data>
+  <data name="Label-host.edition-legacy-standard-per-socket" xml:space="preserve">
+    <value>[Legacy XenServer product] Standard Per-Socket</value>
+  </data>
+  <data name="Label-host.edition-legacy-xendesktop" xml:space="preserve">
+    <value>[Legacy XenServer product] for XenDesktop</value>
+  </data>
+  <data name="Label-host.edition-enterprise-per-socket" xml:space="preserve">
+    <value>[Legacy XenServer product] Premium Per-Socket</value>
+  </data>
+  <data name="Label-host.edition-enterprise-per-user" xml:space="preserve">
+    <value>[Legacy XenServer product] Premium Per-User</value>
   </data>
 </root>

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1029,7 +1029,7 @@
     <value>There was a temporary failure synchronizing performance statistics across the pool, probably because one or more servers were offline.  Another synchronization attempt will be made later.</value>
   </data>
   <data name="Message.body-license_does_not_support_pooling" xml:space="preserve">
-    <value>The license on server '{0}' has expired or been changed, and no longer supports [XenServer product] Enterprise features.</value>
+    <value>The license on server '{0}' has expired or been changed, and no longer supports [XenServer product] Premium features.</value>
   </data>
   <data name="Message.body-license_expired" xml:space="preserve">
     <value>The license for {0} has expired.</value>
@@ -1611,10 +1611,10 @@
     <value>The license server is an out-of-date version.</value>
   </data>
   <data name="Label-host.edition-enterprise-per-socket" xml:space="preserve">
-    <value>[XenServer product] Enterprise Per-Socket</value>
+    <value>[XenServer product] Premium Per-Socket</value>
   </data>
   <data name="Label-host.edition-enterprise-per-user" xml:space="preserve">
-    <value>[XenServer product] Enterprise Per-User</value>
+    <value>[XenServer product] Premium Per-User</value>
   </data>
   <data name="Label-host.edition-standard-per-socket" xml:space="preserve">
     <value>[XenServer product] Standard Per-Socket</value>
@@ -1641,7 +1641,7 @@
     <value>[Citrix] Virtual Apps and Desktops</value>
   </data>
   <data name="Label-host.edition-desktop-plus" xml:space="preserve">
-    <value>[Citrix] Virtual Apps and Desktops Platinum</value>
+    <value>[Citrix] Virtual Apps and Desktops Premium</value>
   </data>
   <data name="Label-Supplemental_packs.installed" xml:space="preserve">
     <value>Installed supplemental packs</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -13902,15 +13902,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] P&amp;remium Per-Socket ({0} required).
-        /// </summary>
-        public static string ENTERPRISE_PERSOCKET_LICENSES_X_REQUIRED {
-            get {
-                return ResourceManager.GetString("ENTERPRISE_PERSOCKET_LICENSES_X_REQUIRED", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Members.
         /// </summary>
         public static string EQUALLOGICS_MEMBERS {
@@ -20071,6 +20062,150 @@ namespace XenAdmin {
         public static string LICENSE_ACTIVATED {
             get {
                 return ResourceManager.GetString("LICENSE_ACTIVATED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Citrix] Virtual &amp;Apps and Desktops.
+        /// </summary>
+        public static string LICENSE_EDITION_DESKTOP {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_DESKTOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Citrix] Virtual Apps and Desktops [Citrix] &amp;Cloud.
+        /// </summary>
+        public static string LICENSE_EDITION_DESKTOP_CLOUD {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_DESKTOP_CLOUD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XenApp/XenDesktop [Citrix] &amp;Cloud.
+        /// </summary>
+        public static string LICENSE_EDITION_DESKTOP_CLOUD_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_DESKTOP_CLOUD_LEGACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XenApp/Xen&amp;Desktop.
+        /// </summary>
+        public static string LICENSE_EDITION_DESKTOP_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_DESKTOP_LEGACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Citrix] Virtual Apps and Desktops &amp;Premium.
+        /// </summary>
+        public static string LICENSE_EDITION_DESKTOP_PLUS {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_DESKTOP_PLUS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XenApp/XenDesktop &amp;Platinum.
+        /// </summary>
+        public static string LICENSE_EDITION_DESKTOP_PLUS_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_DESKTOP_PLUS_LEGACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [XenServer product] P&amp;remium Per-Socket ({0} required).
+        /// </summary>
+        public static string LICENSE_EDITION_ENTERPRISE_PERSOCKET {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_ENTERPRISE_PERSOCKET", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] E&amp;nterprise Per-Socket ({0} required).
+        /// </summary>
+        public static string LICENSE_EDITION_ENTERPRISE_PERSOCKET_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_ENTERPRISE_PERSOCKET_LEGACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [XenServer product] Pr&amp;emium Per-User.
+        /// </summary>
+        public static string LICENSE_EDITION_ENTERPRISE_PERUSER {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_ENTERPRISE_PERUSER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] &amp;Enterprise Per-User.
+        /// </summary>
+        public static string LICENSE_EDITION_ENTERPRISE_PERUSER_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_ENTERPRISE_PERUSER_LEGACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [XenServer product] Per-&amp;Socket ({0} required).
+        /// </summary>
+        public static string LICENSE_EDITION_PERSOCKET {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_PERSOCKET", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] Per-&amp;Socket ({0} required).
+        /// </summary>
+        public static string LICENSE_EDITION_PERSOCKET_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_PERSOCKET_LEGACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [XenServer product] &amp;Standard Per-Socket ({0} required).
+        /// </summary>
+        public static string LICENSE_EDITION_STANDARD_PERSOCKET {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_STANDARD_PERSOCKET", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] &amp;Standard Per-Socket ({0} required).
+        /// </summary>
+        public static string LICENSE_EDITION_STANDARD_PERSOCKET_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_STANDARD_PERSOCKET_LEGACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [XenServer product] for [Citrix] Virtual &amp;Desktops.
+        /// </summary>
+        public static string LICENSE_EDITION_XENDESKTOP {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_XENDESKTOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Legacy XenServer product] for &amp;XenDesktop.
+        /// </summary>
+        public static string LICENSE_EDITION_XENDESKTOP_LEGACY {
+            get {
+                return ResourceManager.GetString("LICENSE_EDITION_XENDESKTOP_LEGACY", resourceCulture);
             }
         }
         
@@ -27894,15 +28029,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Citrix XenServer] Per-&amp;Socket ({0} required).
-        /// </summary>
-        public static string PERSOCKET_LICENSES_X_REQUIRED {
-            get {
-                return ResourceManager.GetString("PERSOCKET_LICENSES_X_REQUIRED", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Physical device.
         /// </summary>
         public static string PHYSICAL_DEVICE {
@@ -32427,15 +32553,6 @@ namespace XenAdmin {
         public static string SRWIZARD_STORAGE_NAME {
             get {
                 return ResourceManager.GetString("SRWIZARD_STORAGE_NAME", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to [XenServer product] &amp;Standard Per-Socket ({0} required).
-        /// </summary>
-        public static string STANDARD_PERSOCKET_LICENSES_X_REQUIRED {
-            get {
-                return ResourceManager.GetString("STANDARD_PERSOCKET_LICENSES_X_REQUIRED", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8184,7 +8184,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find [XenServer] running on {0}..
+        ///   Looks up a localized string similar to Could not find server running on {0}..
         /// </summary>
         public static string CONNECT_NO_XAPI_FAILURE {
             get {
@@ -13902,7 +13902,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] &amp;Enterprise Per-Socket ({0} required).
+        ///   Looks up a localized string similar to [XenServer] P&amp;remium Per-Socket ({0} required).
         /// </summary>
         public static string ENTERPRISE_PERSOCKET_LICENSES_X_REQUIRED {
             get {
@@ -14397,7 +14397,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] is still booting..
+        ///   Looks up a localized string similar to Server is still booting..
         /// </summary>
         public static string ERROR_HOST_STILL_BOOTING {
             get {
@@ -14451,7 +14451,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find [XenServer] on &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Could not find a server on &apos;{0}&apos;..
         /// </summary>
         public static string ERROR_NO_XENSERVER {
             get {
@@ -14705,7 +14705,7 @@ namespace XenAdmin {
         /// <summary>
         ///   Looks up a localized string similar to An existing {0} SR was found on the selected LUN. Click Reattach to use the existing SR, or click Format to destroy any data present on the disk and create a new {1} SR.
         ///
-        ///Warning: to prevent data loss you must ensure that the LUN is not in use by any other system, including [XenServer] hosts that are not connected to [XenCenter]..
+        ///Warning: to prevent data loss you must ensure that the LUN is not in use by any other system, including servers that are not connected to [XenCenter]..
         /// </summary>
         public static string EXISTING_SR_FOUND_ON_LUN {
             get {
@@ -20291,7 +20291,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Servers must be selected one at a time when activating free [XenServer]..
+        ///   Looks up a localized string similar to Servers must be selected one at a time when activating Express [XenServer]..
         /// </summary>
         public static string LICENSE_NO_MULTISELECT_ACTIVATE {
             get {
@@ -20400,7 +20400,7 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to Eligible for support 
-        ///[Citrix] Virtual Apps/Desktops [Citrix] Cloud features enabled.
+        ///[Citrix] Virtual Apps and Desktops [Citrix] Cloud features enabled.
         /// </summary>
         public static string LICENSE_SUPPORT_AND_DESKTOP_CLOUD_FEATURES_ENABLED {
             get {
@@ -20410,7 +20410,7 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to Eligible for support 
-        ///[Citrix] Virtual Apps/Desktops features enabled.
+        ///[Citrix] Virtual Apps and Desktops features enabled.
         /// </summary>
         public static string LICENSE_SUPPORT_AND_DESKTOP_FEATURES_ENABLED {
             get {
@@ -20420,7 +20420,7 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to Eligible for support 
-        ///[Citrix] Virtual Apps/Desktops Platinum features enabled.
+        ///[Citrix] Virtual Apps and Desktops Premium features enabled.
         /// </summary>
         public static string LICENSE_SUPPORT_AND_DESKTOP_PLUS_FEATURES_ENABLED {
             get {
@@ -20430,7 +20430,7 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to Eligible for support 
-        ///Enterprise features enabled.
+        ///Premium features enabled.
         /// </summary>
         public static string LICENSE_SUPPORT_AND_ENTERPRISE_FEATURES_ENABLED {
             get {
@@ -20459,7 +20459,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Activation keys can only be applied to one Free [XenServer] product at a time..
+        ///   Looks up a localized string similar to Activation keys can only be applied to one Express [XenServer] product at a time..
         /// </summary>
         public static string LICENSE_TOO_MANY_SERVERS_SELECTED_CAPTION {
             get {
@@ -20540,7 +20540,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more managed servers have expired. Either assign [XenServer] licenses, or activate Free [XenServer] products..
+        ///   Looks up a localized string similar to One or more managed servers have expired. Either assign [XenServer] licenses, or activate Express [XenServer] products..
         /// </summary>
         public static string LICENSING_DIALOG_EXPIRED_TEXT {
             get {
@@ -20549,7 +20549,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more managed servers will expire soon. Either assign [XenServer] licenses, or activate Free [XenServer] products..
+        ///   Looks up a localized string similar to One or more managed servers will expire soon. Either assign [XenServer] licenses, or activate Express [XenServer] products..
         /// </summary>
         public static string LICENSING_DIALOG_EXPIRING_SOON_TEXT {
             get {
@@ -25795,7 +25795,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This pool is only licensed for [Citrix] Virtual Apps/Desktops workloads.
+        ///   Looks up a localized string similar to This pool is only licensed for [Citrix] Virtual Apps and Desktops workloads.
         /// </summary>
         public static string NEWVMWIZARD_XENAPP_XENDESKTOP_INFO_MESSAGE_POOL {
             get {
@@ -25804,7 +25804,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server is only licensed for [Citrix] Virtual Apps/Desktops workloads.
+        ///   Looks up a localized string similar to This server is only licensed for [Citrix] Virtual Apps and Desktops workloads.
         /// </summary>
         public static string NEWVMWIZARD_XENAPP_XENDESKTOP_INFO_MESSAGE_SERVER {
             get {
@@ -26002,7 +26002,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] cannot create any more disks for this VM.
+        ///   Looks up a localized string similar to Server cannot create any more disks for this VM.
         /// </summary>
         public static string NO_MORE_USERDEVICES {
             get {
@@ -26038,7 +26038,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No [XenServer] session information is available, cannot continue..
+        ///   Looks up a localized string similar to No server session information is available, cannot continue..
         /// </summary>
         public static string NO_SESSION_INFO {
             get {
@@ -28841,7 +28841,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The use of StorageLink SRs was removed in [XenServer]. Remove StorageLink SRs before upgrading..
+        ///   Looks up a localized string similar to The use of StorageLink SRs was removed in server. Remove StorageLink SRs before upgrading..
         /// </summary>
         public static string PROBLEM_UNSUPPORTED_STORAGELINK_SR {
             get {
@@ -31958,7 +31958,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Check the proxy settings and that [XenServer] is configured correctly on &apos;{0}&apos; and try again..
+        ///   Looks up a localized string similar to Check the proxy settings and that server is configured correctly on &apos;{0}&apos; and try again..
         /// </summary>
         public static string SOLUTION_CHECK_XENSERVER_WITH_PROXY {
             get {
@@ -35454,7 +35454,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Active Directory.  Active Directory allows you to configure [XenServer] access control by adding named user accounts..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Active Directory.  Active Directory allows you to configure [XenServer] access control by adding named user accounts..
         /// </summary>
         public static string UPSELL_BLURB_AD {
             get {
@@ -35463,7 +35463,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Alerting and Reporting capabilities. Email based performance and error alerting will proactively notify administrators of error conditions or performance problems before they affect critical services..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Alerting and Reporting capabilities. Email based performance and error alerting will proactively notify administrators of error conditions or performance problems before they affect critical services..
         /// </summary>
         public static string UPSELL_BLURB_ALERTS {
             get {
@@ -35472,7 +35472,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable VM live migration. This feature enables you to migrate running VMs on shared or local storage between servers in the same pool or across pools with no VM downtime. .
+        ///   Looks up a localized string similar to Upgrade your server license to enable VM live migration. This feature enables you to migrate running VMs on shared or local storage between servers in the same pool or across pools with no VM downtime. .
         /// </summary>
         public static string UPSELL_BLURB_CPM {
             get {
@@ -35481,7 +35481,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Heterogeneous Pools. Heterogeneous Pools allows hosts with different CPUs to form a resource pool, and allows virtual machines to migrate between them..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Heterogeneous Pools. Heterogeneous Pools allows hosts with different CPUs to form a resource pool, and allows virtual machines to migrate between them..
         /// </summary>
         public static string UPSELL_BLURB_CPUMASKING {
             get {
@@ -35490,7 +35490,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Dynamic Memory Control.  Dynamic Memory Control allows [XenServer] to adjust the memory of live virtual machines, and respond dynamically to changing demands on the host server..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Dynamic Memory Control.  Dynamic Memory Control allows server to adjust the memory of live virtual machines, and respond dynamically to changing demands on the server..
         /// </summary>
         public static string UPSELL_BLURB_DMC {
             get {
@@ -35499,7 +35499,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Disaster Recovery. The Disaster Recovery feature allows you to recover your critical VMs and vApps at your DR site in the event of a disaster at your primary production site..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Disaster Recovery. The Disaster Recovery feature allows you to recover your critical VMs and vApps at your DR site in the event of a disaster at your primary production site..
         /// </summary>
         public static string UPSELL_BLURB_DR {
             get {
@@ -35508,7 +35508,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable StorageLink™ Technology. StorageLink allows [XenServer] to leverage all the power of your existing storage hardware and offload storage operations automatically. This allows for high performance and space efficient storage provisioning, cloning, and snapshot capabilities to be handled in hardware using your storage hardware&apos;s native features..
+        ///   Looks up a localized string similar to Upgrade your server license to enable StorageLink™ Technology. StorageLink allows server to leverage all the power of your existing storage hardware and offload storage operations automatically. This allows for high performance and space efficient storage provisioning, cloning, and snapshot capabilities to be handled in hardware using your storage hardware&apos;s native features..
         /// </summary>
         public static string UPSELL_BLURB_ENHANCEDSR {
             get {
@@ -35517,7 +35517,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable GPU pass-through. The GPU pass-through feature allows you to assign a dedicated graphics processing unit to a VM for higher graphics performance..
+        ///   Looks up a localized string similar to Upgrade your server license to enable GPU pass-through. The GPU pass-through feature allows you to assign a dedicated graphics processing unit to a VM for higher graphics performance..
         /// </summary>
         public static string UPSELL_BLURB_GPU {
             get {
@@ -35526,7 +35526,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable High Availability. High Availability allows virtual machines to be automatically restarted in the event of an underlying hardware failure or individual VM failure. If the server fails the VMs will be intelligently restarted on other virtualized servers in the resource pool..
+        ///   Looks up a localized string similar to Upgrade your server license to enable High Availability. High Availability allows virtual machines to be automatically restarted in the event of an underlying hardware failure or individual VM failure. If the server fails the VMs will be intelligently restarted on other virtualized servers in the resource pool..
         /// </summary>
         public static string UPSELL_BLURB_HA {
             get {
@@ -35535,7 +35535,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Performance Reporting capabilities. Performance Reporting provides guidance on overall environment performance trends and enables you to accurately plan capacity as business needs change..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Performance Reporting capabilities. Performance Reporting provides guidance on overall environment performance trends and enables you to accurately plan capacity as business needs change..
         /// </summary>
         public static string UPSELL_BLURB_PERFORMANCE {
             get {
@@ -35544,7 +35544,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Role Based Access Control. Using the RBAC feature, you will be able to control access to vital components in your [XenServer] resource pools, with full audit logging capabilities and seamless integration with your current Active Directory setup..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Role Based Access Control. Using the RBAC feature, you will be able to control access to vital components in your [XenServer] resource pools, with full audit logging capabilities and seamless integration with your current Active Directory setup..
         /// </summary>
         public static string UPSELL_BLURB_RBAC {
             get {
@@ -35564,7 +35564,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable vApps. The vApps feature allows you to place your VMs into groups, allowing them to be started or stopped as a unit, and also allowing them to be easily recovered at your DR site in the event of a disaster at your primary production site..
+        ///   Looks up a localized string similar to Upgrade your server license to enable vApps. The vApps feature allows you to place your VMs into groups, allowing them to be started or stopped as a unit, and also allowing them to be easily recovered at your DR site in the event of a disaster at your primary production site..
         /// </summary>
         public static string UPSELL_BLURB_VM_APPLIANCES {
             get {
@@ -35573,7 +35573,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable VM Scheduled Snapshots. VM Scheduled Snapshots allows you to create automatic snapshots for your critical VMs..
+        ///   Looks up a localized string similar to Upgrade your server license to enable VM Scheduled Snapshots. VM Scheduled Snapshots allows you to create automatic snapshots for your critical VMs..
         /// </summary>
         public static string UPSELL_BLURB_VMSS {
             get {
@@ -35582,7 +35582,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade your [XenServer] license to enable Dynamic Workload Balancing. Dynamic Workload Balancing continually profiles your virtual machines’ and [XenServer] hosts’ performance and will intelligently rebalance and optimally place new workloads to ensure the best use of physical server resources in your resource pool..
+        ///   Looks up a localized string similar to Upgrade your server license to enable Dynamic Workload Balancing. Dynamic Workload Balancing continually profiles your virtual machines’ and servers&apos; performance and will intelligently rebalance and optimally place new workloads to ensure the best use of physical server resources in your resource pool..
         /// </summary>
         public static string UPSELL_BLURB_WLB {
             get {
@@ -37211,7 +37211,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] can send you email notifications when alerts associated with snapshot schedule jobs are raised, such as when a VM snapshot is created or when a snapshot operation fails..
+        ///   Looks up a localized string similar to Server can send you email notifications when alerts associated with snapshot schedule jobs are raised, such as when a VM snapshot is created or when a snapshot operation fails..
         /// </summary>
         public static string VMSS_EMAIL_PAGE_TEXT {
             get {
@@ -38002,7 +38002,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occurred when WLB tried to establish a session with [XenServer]..
+        ///   Looks up a localized string similar to An error occurred when WLB tried to establish a session with server..
         /// </summary>
         public static string WLB_ERROR_4001 {
             get {
@@ -38011,7 +38011,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB could not log into [XenServer]. It could be due to invalid credentials..
+        ///   Looks up a localized string similar to WLB could not log into server. It could be due to invalid credentials..
         /// </summary>
         public static string WLB_ERROR_4002 {
             get {
@@ -38020,7 +38020,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB cannot connect to [XenServer]. It could be the [XenServer] being offline or an incorrect TCP/IP address..
+        ///   Looks up a localized string similar to WLB cannot connect to server. It could be the server being offline or an incorrect TCP/IP address..
         /// </summary>
         public static string WLB_ERROR_4003 {
             get {
@@ -38029,7 +38029,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB received a null argument from [XenServer], which is not allowed..
+        ///   Looks up a localized string similar to WLB received a null argument from server, which is not allowed..
         /// </summary>
         public static string WLB_ERROR_4004 {
             get {
@@ -38047,7 +38047,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB received an invalid argument from [XenServer]..
+        ///   Looks up a localized string similar to WLB received an invalid argument from server..
         /// </summary>
         public static string WLB_ERROR_4007 {
             get {
@@ -38056,7 +38056,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB data collection service cannot retrieve [XenServer] data..
+        ///   Looks up a localized string similar to WLB data collection service cannot retrieve server data..
         /// </summary>
         public static string WLB_ERROR_4008 {
             get {
@@ -38074,7 +38074,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB received an invalid operation from [XenServer]..
+        ///   Looks up a localized string similar to WLB received an invalid operation from server..
         /// </summary>
         public static string WLB_ERROR_4010 {
             get {
@@ -38083,7 +38083,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB received an out of range argument from [XenServer]..
+        ///   Looks up a localized string similar to WLB received an out of range argument from server..
         /// </summary>
         public static string WLB_ERROR_4011 {
             get {
@@ -38173,7 +38173,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WLB could not connect to [XenServer] because the supplied credentials were invalid..
+        ///   Looks up a localized string similar to WLB could not connect to server because the supplied credentials were invalid..
         /// </summary>
         public static string WLB_ERROR_4021 {
             get {
@@ -38200,7 +38200,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] cannot connect to the WLB Server with the supplied WLB Server credentials..
+        ///   Looks up a localized string similar to Server cannot connect to the WLB Server with the supplied WLB Server credentials..
         /// </summary>
         public static string WLB_ERROR_5 {
             get {
@@ -38209,7 +38209,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The user WLB uses to connect to [XenServer] either doesn&apos;t have sufficient privileges or doesn&apos;t have access to [XenServer]. Please re-initialize WLB with an valid user..
+        ///   Looks up a localized string similar to The user WLB uses to connect to server either doesn&apos;t have sufficient privileges or doesn&apos;t have access to server. Please re-initialize WLB with an valid user..
         /// </summary>
         public static string WLB_ERROR_6 {
             get {
@@ -38728,7 +38728,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The stored [XenServer] credentials are no longer valid.  Please update the connection settings for Workload Balancing..
+        ///   Looks up a localized string similar to The stored server credentials are no longer valid.  Please update the connection settings for Workload Balancing..
         /// </summary>
         public static string WLB_RECONFIGURE_CREDS {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -4895,7 +4895,7 @@ Would you like to eject these ISOs before continuing?</value>
     <value>ends with</value>
   </data>
   <data name="ENTERPRISE_PERSOCKET_LICENSES_X_REQUIRED" xml:space="preserve">
-    <value>[XenServer] &amp;Enterprise Per-Socket ({0} required)</value>
+    <value>[XenServer] P&amp;remium Per-Socket ({0} required)</value>
   </data>
   <data name="ENTER_MAINTENANCE_MODE" xml:space="preserve">
     <value>Enter &amp;Maintenance Mode...</value>
@@ -7071,7 +7071,7 @@ Size: {3}</value>
     <value>The license for a host cannot be changed when HA is on</value>
   </data>
   <data name="LICENSE_NO_MULTISELECT_ACTIVATE" xml:space="preserve">
-    <value>Servers must be selected one at a time when activating free [XenServer].</value>
+    <value>Servers must be selected one at a time when activating Express [XenServer].</value>
   </data>
   <data name="LICENSE_NO_MULTISELECT_LICENSE" xml:space="preserve">
     <value>Servers must be selected one at a time when licensing servers which have a version lower than [BRANDING_VERSION_5_6].</value>
@@ -7113,11 +7113,11 @@ Size: {3}</value>
   </data>
   <data name="LICENSE_SUPPORT_AND_DESKTOP_PLUS_FEATURES_ENABLED" xml:space="preserve">
     <value>Eligible for support 
-[Citrix] Virtual Apps and Desktops Platinum features enabled</value>
+[Citrix] Virtual Apps and Desktops Premium features enabled</value>
   </data>
   <data name="LICENSE_SUPPORT_AND_ENTERPRISE_FEATURES_ENABLED" xml:space="preserve">
     <value>Eligible for support 
-Enterprise features enabled</value>
+Premium features enabled</value>
   </data>
   <data name="LICENSE_SUPPORT_AND_PREMIUM_FEATURES_ENABLED" xml:space="preserve">
     <value>Eligible for support 
@@ -7128,7 +7128,7 @@ Premium features enabled</value>
 Standard features only</value>
   </data>
   <data name="LICENSE_TOO_MANY_SERVERS_SELECTED_CAPTION" xml:space="preserve">
-    <value>Activation keys can only be applied to one Free [XenServer] product at a time.</value>
+    <value>Activation keys can only be applied to one Express [XenServer] product at a time.</value>
   </data>
   <data name="LICENSE_UNLICENSED" xml:space="preserve">
     <value>Unlicensed</value>
@@ -7155,10 +7155,10 @@ Standard features only</value>
     <value>Your license has expired</value>
   </data>
   <data name="LICENSING_DIALOG_EXPIRED_TEXT" xml:space="preserve">
-    <value>One or more managed servers have expired. Either assign [XenServer] licenses, or activate Free [XenServer] products.</value>
+    <value>One or more managed servers have expired. Either assign [XenServer] licenses, or activate Express [XenServer] products.</value>
   </data>
   <data name="LICENSING_DIALOG_EXPIRING_SOON_TEXT" xml:space="preserve">
-    <value>One or more managed servers will expire soon. Either assign [XenServer] licenses, or activate Free [XenServer] products.</value>
+    <value>One or more managed servers will expire soon. Either assign [XenServer] licenses, or activate Express [XenServer] products.</value>
   </data>
   <data name="LINK_STATUS" xml:space="preserve">
     <value>Link Status</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -4894,9 +4894,6 @@ Would you like to eject these ISOs before continuing?</value>
   <data name="ENDS_WITH" xml:space="preserve">
     <value>ends with</value>
   </data>
-  <data name="ENTERPRISE_PERSOCKET_LICENSES_X_REQUIRED" xml:space="preserve">
-    <value>[XenServer] P&amp;remium Per-Socket ({0} required)</value>
-  </data>
   <data name="ENTER_MAINTENANCE_MODE" xml:space="preserve">
     <value>Enter &amp;Maintenance Mode...</value>
   </data>
@@ -6993,6 +6990,54 @@ Size: {3}</value>
   </data>
   <data name="LICENSE_ACTIVATED" xml:space="preserve">
     <value>Activated</value>
+  </data>
+  <data name="LICENSE_EDITION_DESKTOP" xml:space="preserve">
+    <value>[Citrix] Virtual &amp;Apps and Desktops</value>
+  </data>
+  <data name="LICENSE_EDITION_DESKTOP_CLOUD" xml:space="preserve">
+    <value>[Citrix] Virtual Apps and Desktops [Citrix] &amp;Cloud</value>
+  </data>
+  <data name="LICENSE_EDITION_DESKTOP_CLOUD_LEGACY" xml:space="preserve">
+    <value>XenApp/XenDesktop [Citrix] &amp;Cloud</value>
+  </data>
+  <data name="LICENSE_EDITION_DESKTOP_LEGACY" xml:space="preserve">
+    <value>XenApp/Xen&amp;Desktop</value>
+  </data>
+  <data name="LICENSE_EDITION_DESKTOP_PLUS" xml:space="preserve">
+    <value>[Citrix] Virtual Apps and Desktops &amp;Premium</value>
+  </data>
+  <data name="LICENSE_EDITION_DESKTOP_PLUS_LEGACY" xml:space="preserve">
+    <value>XenApp/XenDesktop &amp;Platinum</value>
+  </data>
+  <data name="LICENSE_EDITION_ENTERPRISE_PERSOCKET" xml:space="preserve">
+    <value>[XenServer product] P&amp;remium Per-Socket ({0} required)</value>
+  </data>
+  <data name="LICENSE_EDITION_ENTERPRISE_PERSOCKET_LEGACY" xml:space="preserve">
+    <value>[Legacy XenServer product] E&amp;nterprise Per-Socket ({0} required)</value>
+  </data>
+  <data name="LICENSE_EDITION_ENTERPRISE_PERUSER" xml:space="preserve">
+    <value>[XenServer product] Pr&amp;emium Per-User</value>
+  </data>
+  <data name="LICENSE_EDITION_ENTERPRISE_PERUSER_LEGACY" xml:space="preserve">
+    <value>[Legacy XenServer product] &amp;Enterprise Per-User</value>
+  </data>
+  <data name="LICENSE_EDITION_PERSOCKET" xml:space="preserve">
+    <value>[XenServer product] Per-&amp;Socket ({0} required)</value>
+  </data>
+  <data name="LICENSE_EDITION_PERSOCKET_LEGACY" xml:space="preserve">
+    <value>[Legacy XenServer product] Per-&amp;Socket ({0} required)</value>
+  </data>
+  <data name="LICENSE_EDITION_STANDARD_PERSOCKET" xml:space="preserve">
+    <value>[XenServer product] &amp;Standard Per-Socket ({0} required)</value>
+  </data>
+  <data name="LICENSE_EDITION_STANDARD_PERSOCKET_LEGACY" xml:space="preserve">
+    <value>[Legacy XenServer product] &amp;Standard Per-Socket ({0} required)</value>
+  </data>
+  <data name="LICENSE_EDITION_XENDESKTOP" xml:space="preserve">
+    <value>[XenServer product] for [Citrix] Virtual &amp;Desktops</value>
+  </data>
+  <data name="LICENSE_EDITION_XENDESKTOP_LEGACY" xml:space="preserve">
+    <value>[Legacy XenServer product] for &amp;XenDesktop</value>
   </data>
   <data name="LICENSE_ERROR_1" xml:space="preserve">
     <value>The licensing action for {0} failed.</value>
@@ -9701,9 +9746,6 @@ File not found</value>
   <data name="PERMISSION_DENIED" xml:space="preserve">
     <value>Permission Denied</value>
   </data>
-  <data name="PERSOCKET_LICENSES_X_REQUIRED" xml:space="preserve">
-    <value>[Citrix XenServer] Per-&amp;Socket ({0} required)</value>
-  </data>
   <data name="PHYSICAL_DEVICE" xml:space="preserve">
     <value>Physical device</value>
   </data>
@@ -11246,9 +11288,6 @@ The upper limit: SR size / {2}</value>
   </data>
   <data name="SR_X_ON_Y" xml:space="preserve">
     <value>SR {0} on {1}</value>
-  </data>
-  <data name="STANDARD_PERSOCKET_LICENSES_X_REQUIRED" xml:space="preserve">
-    <value>[XenServer product] &amp;Standard Per-Socket ({0} required)</value>
   </data>
   <data name="STARTED" xml:space="preserve">
     <value>Started</value>

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -312,8 +312,7 @@ namespace XenAdmin.Core
                 return true;
 
             string platform_version = HostPlatformVersion(host);
-            return
-                platform_version != null && productVersionCompare(platform_version, "1.8.90") >= 0;
+            return platform_version != null && productVersionCompare(platform_version, "1.8.90") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -330,8 +329,7 @@ namespace XenAdmin.Core
                 return true;
 
             string platform_version = HostPlatformVersion(host);
-            return
-                platform_version != null && productVersionCompare(platform_version, "2.0.0") >= 0;
+            return platform_version != null && productVersionCompare(platform_version, "2.0.0") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -348,8 +346,7 @@ namespace XenAdmin.Core
                 return true;
 
             string platform_version = HostPlatformVersion(host);
-            return
-                platform_version != null && productVersionCompare(platform_version, "2.1.1") >= 0;
+            return platform_version != null && productVersionCompare(platform_version, "2.1.1") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -366,8 +363,7 @@ namespace XenAdmin.Core
                 return true;
 
             string platform_version = HostPlatformVersion(host);
-            return
-                platform_version != null && productVersionCompare(platform_version, "2.2.50") >= 0;
+            return platform_version != null && productVersionCompare(platform_version, "2.2.50") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -384,8 +380,7 @@ namespace XenAdmin.Core
                 return true;
 
             string platform_version = HostPlatformVersion(host);
-            return
-                platform_version != null && productVersionCompare(platform_version, "2.3.50") >= 0;
+            return platform_version != null && productVersionCompare(platform_version, "2.3.50") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -402,8 +397,7 @@ namespace XenAdmin.Core
                 return true;
 
             string platform_version = HostPlatformVersion(host);
-            return
-                platform_version != null && productVersionCompare(platform_version, "2.4.50") >= 0;
+            return platform_version != null && productVersionCompare(platform_version, "2.4.50") >= 0;
         }
 
         /// <param name="conn">May be null, in which case true is returned.</param>
@@ -463,8 +457,7 @@ namespace XenAdmin.Core
                 return true;
 
             string platform_version = HostPlatformVersion(host);
-            return
-                platform_version != null && productVersionCompare(platform_version, "1.6.900") >= 0;
+            return platform_version != null && productVersionCompare(platform_version, "1.6.900") >= 0;
         }
 
         /// <summary>
@@ -475,6 +468,23 @@ namespace XenAdmin.Core
         public static bool ClearwaterSp1OrGreater(IXenConnection conn)
         {
             return conn == null || conn.Session == null || conn.Session.APIVersion >= API_Version.API_2_1;
+        }
+
+        /// <param name="conn">May be null, in which case true is returned.</param>
+        public static bool NaplesOrGreater(IXenConnection conn)
+        {
+            return conn == null || NaplesOrGreater(Helpers.GetMaster(conn));
+        }
+
+        /// Naples is ver. 3.0.0
+        /// <param name="host">May be null, in which case true is returned.</param>
+        public static bool NaplesOrGreater(Host host)
+        {
+            if (host == null)
+                return true;
+
+            string platform_version = HostPlatformVersion(host);
+            return platform_version != null && productVersionCompare(platform_version, "2.9.50") >= 0;
         }
 
         // CP-3435: Disable Check for Updates in Common Criteria Certification project
@@ -879,7 +889,8 @@ namespace XenAdmin.Core
 			if (string.IsNullOrEmpty(host.edition))
 				return Messages.UNKNOWN;
 
-            string name = PropertyManager.GetFriendlyName("Label-host.edition-" + host.edition);
+            string legacy = NaplesOrGreater(host) ? "" : "legacy-";
+            string name = PropertyManager.GetFriendlyName("Label-host.edition-" + legacy + host.edition);
             return name ?? Messages.UNKNOWN;
         }
 

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -78,8 +78,10 @@ namespace XenAPI
                 case "per-socket":
                     return Edition.PerSocket;
                 case "enterprise-per-socket":
+                case "premium-per-socket":
                     return Edition.EnterprisePerSocket;
                 case "enterprise-per-user":
+                case "premium-per-user":
                     return Edition.EnterprisePerUser;
                 case "standard-per-socket":
                     return Edition.StandardPerSocket;
@@ -118,19 +120,18 @@ namespace XenAPI
             return false;
         }
 
-        public static string GetEditionText(Edition edition)
+        public string GetEditionText(Edition edition)
         {
             switch (edition)
             {
-
                 case Edition.XenDesktop:
                     return "xendesktop";
                 case Edition.PerSocket:
                     return "per-socket";
                 case Edition.EnterprisePerSocket:
-                    return "enterprise-per-socket";
+                    return Helpers.NaplesOrGreater(this) ? "premium-per-socket" : "enterprise-per-socket";
                 case Edition.EnterprisePerUser:
-                    return "enterprise-per-user";
+                    return Helpers.NaplesOrGreater(this) ? "premium-per-user" : "enterprise-per-user";
                 case Edition.StandardPerSocket:
                     return "standard-per-socket";
                 case Edition.Desktop:
@@ -144,7 +145,7 @@ namespace XenAPI
                 case Edition.Standard:
                     return "standard";
                 default:
-                    return "free";
+                    return Helpers.NaplesOrGreater(this) ? "express" : "free";
             }
         }
 
@@ -286,7 +287,7 @@ namespace XenAPI
 
         public virtual bool IsFreeLicense()
         {
-            return edition == "free";
+            return edition == "free" || edition == "express";
         }
 
         public virtual bool IsFreeLicenseOrExpired()


### PR DESCRIPTION
Modify the names in AssignLicenseDialog, FriendlyNames.resx and Messages.resx.

Note, FriendlyNames.Designer.cs and Messages.Designer.cs also include some modification from "[XenServer]" to "server". They were introduced in a preceding commit, but I forgot to commit the *.Designer.cs files.