### PR TITLE
CA-297088: Fixed issue where XenCenter froze if a new server was added…

### DIFF
--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -533,7 +533,7 @@ namespace XenAdmin.Wizards.GenericPages
 
 		private void CollectionChanged(object sender, CollectionChangeEventArgs e)
 		{
-			Program.Invoke(this, PopulateComboBox);
+			Program.BeginInvoke(this, PopulateComboBox);
 		}
 
 		private void xenConnection_CachePopulated(object sender, EventArgs e)


### PR DESCRIPTION
… while we were on the select host page of the Import and Migration Wizards.