### PR TITLE
CP-29230: Fix build error in spell check.

### DIFF
--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -844,7 +844,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Legacy Citrix XenServer] Basic Edition.
+        ///   Looks up a localized string similar to [Citrix XenServer] Basic Edition.
         /// </summary>
         public static string Label_host_edition_legacy_basic {
             get {
@@ -916,7 +916,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Legacy Citrix XenServer] Ultimate Edition.
+        ///   Looks up a localized string similar to [Citrix XenServer] Ultimate Edition.
         /// </summary>
         public static string Label_host_edition_legacy_premium {
             get {
@@ -925,7 +925,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Legacy Citrix XenServer] Standard Edition.
+        ///   Looks up a localized string similar to [Citrix XenServer] Standard Edition.
         /// </summary>
         public static string Label_host_edition_legacy_standard {
             get {

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1845,7 +1845,7 @@
     <value>[Citrix] Virtual Apps and Desktops [Citrix] Cloud</value>
   </data>
   <data name="Label-host.edition-legacy-basic" xml:space="preserve">
-    <value>[Legacy Citrix XenServer] Basic Edition</value>
+    <value>[Citrix XenServer] Basic Edition</value>
   </data>
   <data name="Label-host.edition-legacy-desktop" xml:space="preserve">
     <value>XenApp/XenDesktop</value>
@@ -1869,10 +1869,10 @@
     <value>[Legacy XenServer product] Per-Socket</value>
   </data>
   <data name="Label-host.edition-legacy-premium" xml:space="preserve">
-    <value>[Legacy Citrix XenServer] Ultimate Edition</value>
+    <value>[Citrix XenServer] Ultimate Edition</value>
   </data>
   <data name="Label-host.edition-legacy-standard" xml:space="preserve">
-    <value>[Legacy Citrix XenServer] Standard Edition</value>
+    <value>[Citrix XenServer] Standard Edition</value>
   </data>
   <data name="Label-host.edition-legacy-standard-per-socket" xml:space="preserve">
     <value>[Legacy XenServer product] Standard Per-Socket</value>


### PR DESCRIPTION
Fixed wrong branding strings. "[Legacy Citrix XenServer]" didn't exist and didn't pass spell check.

Signed-off-by: Michael Z <michael.zhao@citrix.com>