### PR TITLE
CA-298954: Match server branding and version.

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -10534,7 +10534,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default install of [XenServer].
+        ///   Looks up a localized string similar to Default install of {0}.
         /// </summary>
         public static string DEFAULT_INSTALL_OF_XENSERVER {
             get {
@@ -32301,7 +32301,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] build number.
+        ///   Looks up a localized string similar to Build number.
         /// </summary>
         public static string SOFTWARE_VERSION_BUILD_NUMBER {
             get {
@@ -32310,7 +32310,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] build date.
+        ///   Looks up a localized string similar to Build date.
         /// </summary>
         public static string SOFTWARE_VERSION_DATE {
             get {
@@ -32319,7 +32319,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [XenServer] version.
+        ///   Looks up a localized string similar to Version.
         /// </summary>
         public static string SOFTWARE_VERSION_PRODUCT_VERSION {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3771,7 +3771,7 @@ For optimal performance and reliability during VM migration, ensure that the net
     <value>Default</value>
   </data>
   <data name="DEFAULT_INSTALL_OF_XENSERVER" xml:space="preserve">
-    <value>Default install of [XenServer]</value>
+    <value>Default install of {0}</value>
   </data>
   <data name="DEFAULT_SEARCH" xml:space="preserve">
     <value>Default Search</value>
@@ -11208,13 +11208,13 @@ Do you want to connect to the pool master '{1}'?</value>
     <value>What type of snapshot do you want to use for scheduled snapshots?</value>
   </data>
   <data name="SOFTWARE_VERSION_BUILD_NUMBER" xml:space="preserve">
-    <value>[XenServer] build number</value>
+    <value>Build number</value>
   </data>
   <data name="SOFTWARE_VERSION_DATE" xml:space="preserve">
-    <value>[XenServer] build date</value>
+    <value>Build date</value>
   </data>
   <data name="SOFTWARE_VERSION_PRODUCT_VERSION" xml:space="preserve">
-    <value>[XenServer] version</value>
+    <value>Version</value>
   </data>
   <data name="SOLUTION_AUTHENTICATION" xml:space="preserve">
     <value>Try again using a correct user name and password.</value>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -178,7 +178,7 @@ namespace XenAPI
         public override string Description()
         {
             if (name_description == "Default install of XenServer" || name_description == "Default install") // i18n: CA-30372, CA-207273
-                return Messages.DEFAULT_INSTALL_OF_XENSERVER;
+                return string.Format(Messages.DEFAULT_INSTALL_OF_XENSERVER, software_version.ContainsKey("product_brand") ? software_version["product_brand"] : Messages.XENSERVER);
             else if (name_description == null)
                 return "";
             else


### PR DESCRIPTION
This PR contains:
1. Remove branding from Build data, Build number and Version in general tab page.
2. Show different branding in Name field of general tab page according to server version. 

Signed-off-by: Michael Z <michael.zhao@citrix.com>