### PR TITLE
CA-298913 + CA-297215: Fix restartHost and restartXapi bugs after patching

### DIFF
--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -61,6 +61,7 @@ using XenAdmin.Wizards.PatchingWizard;
 using XenAdmin.Plugins;
 using XenCenterLib;
 using System.Linq;
+using XenAdmin.Wizards;
 
 namespace XenAdmin
 {
@@ -2851,12 +2852,21 @@ namespace XenAdmin
             new ImportWizard(SelectionManager.Selection.GetConnectionOfFirstItem(), hostAncestor, param, false).Show();
         }
 
-        internal void InstallUpdate(string path)
+        private void InstallUpdate(string path)
         {
-            var wizard = new PatchingWizard();
-            wizard.Show(this);
-            wizard.NextStep();
-            wizard.AddFile(path);
+            if (WizardHelpers.IsValidFile(path))
+            {
+                var wizard = new PatchingWizard();
+                wizard.Show(this);
+                wizard.NextStep();
+                wizard.AddFile(path);
+            }
+            else
+                using (var popup = new ThreeButtonDialog(new ThreeButtonDialog.Details(
+                    SystemIcons.Error, string.Format(Messages.UPDATES_WIZARD_NOTVALID_EXTENSION, Branding.Update), Messages.UPDATES)))
+                {
+                    popup.ShowDialog();
+                }
         }
 
         #region XenSearch

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -62,6 +62,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         private List<UpdateProgressBackgroundWorker> failedWorkers = new List<UpdateProgressBackgroundWorker>();
 
         private List<PoolPatchMapping> patchMappings = new List<PoolPatchMapping>();
+        protected List<string> hostsThatWillRequireReboot = new List<string>();
         public Dictionary<XenServerPatch, string> AllDownloadedPatches = new Dictionary<XenServerPatch, string>();
 
         public AutomatedUpdatesBasePage()
@@ -332,9 +333,25 @@ namespace XenAdmin.Wizards.PatchingWizard
                         bgw.RunPlanAction(action, ref doWorkEventArgs);
                     }
 
-                    // Step 3: DelayedActions
+                    // Step 3: Rearrange DelayedActions
+                    var restartHostPlanAction = (RestartHostPlanAction)hp.DelayedPlanActions.FirstOrDefault(a => a is RestartHostPlanAction);
+                    if (restartHostPlanAction != null)
+                    {
+                        if (restartHostPlanAction.SkipRestartHost(host))
+                        {
+                            log.Debug("Did not find patches requiring reboot (live patching succeeded)."
+                                      + " Skipping scheduled restart.");
+                            hp.DelayedPlanActions.RemoveAll(a => a is RestartHostPlanAction);
+                        }
+                        else
+                        {
+                            hp.DelayedPlanActions.RemoveAll(a => a is RestartAgentPlanAction);
+                        }
+                    }
+
+                    // Step 4: DelayedActions
                     bgw.ProgressIncrement = bgw.DelayedActionsIncrement(hp);
-                    // running delayed actions, but skipping the ones that should be skipped
+                    // running delayed actions
                     var delayedActions = hp.DelayedPlanActions;
                     var restartActions = delayedActions.Where(a => a is RestartHostPlanAction).ToList();
 
@@ -349,24 +366,11 @@ namespace XenAdmin.Wizards.PatchingWizard
                     foreach (var a in otherActions)
                     {
                         action = a;
-
-                        // any non-restart-alike delayed action needs to be run if:
-                        // - this host is pre-Ely and there isn't any delayed restart plan action, or
-                        // - this host is Ely or above and live patching must have succeeded or there isn't any delayed restart plan action
-                        if (restartActions.Count <= 0 ||
-                            (Helpers.ElyOrGreater(host) && host.Connection.TryResolveWithTimeout(new XenRef<Host>(host.opaque_ref)).updates_requiring_reboot.Count <= 0))
-                        {
-                            bgw.RunPlanAction(action, ref doWorkEventArgs);
-                        }
-                        else
-                        {
-                            //skip running it, but still need to report progress, mainly for the progress bar
-                            bgw.RunPlanAction(action, ref doWorkEventArgs, true);
-                        }
+                        bgw.RunPlanAction(action, ref doWorkEventArgs);
                     }
                 }
 
-                // Step 4: FinalActions (eg. revert pre-checks)
+                // Step 5: FinalActions (eg. revert pre-checks)
                 bgw.ProgressIncrement = bgw.FinalActionsIncrement;
                 foreach (var a in bgw.FinalActions)
                 {
@@ -499,13 +503,10 @@ namespace XenAdmin.Wizards.PatchingWizard
                     uploadedPatches.Add(patch);
                 }
 
-                planActionsPerHost.Add(new PatchPrecheckOnHostPlanAction(host.Connection, patch, host, patchMappings));
+                planActionsPerHost.Add(new PatchPrecheckOnHostPlanAction(host.Connection, patch, host, patchMappings, hostsThatWillRequireReboot));
                 planActionsPerHost.Add(new ApplyXenServerPatchPlanAction(host, patch, patchMappings));
 
-                var action = patch.after_apply_guidance == after_apply_guidance.restartXAPI && delayedActionsPerHost.Any(a => a is RestartHostPlanAction)
-                       ? new RestartHostPlanAction(host, host.GetRunningVMs(), true, true)
-                       : GetAfterApplyGuidanceAction(host, patch.after_apply_guidance);
-
+                var action = GetAfterApplyGuidanceAction(host, patch.after_apply_guidance);
                 if (action != null)
                 {
                     if (patch.GuidanceMandatory)
@@ -545,12 +546,12 @@ namespace XenAdmin.Wizards.PatchingWizard
             return new HostPlan(host, null, planActionsPerHost, delayedActionsPerHost);
         }
 
-        private static PlanAction GetAfterApplyGuidanceAction(Host host, after_apply_guidance guidance)
+        private PlanAction GetAfterApplyGuidanceAction(Host host, after_apply_guidance guidance)
         {
             switch (guidance)
             {
                 case after_apply_guidance.restartHost:
-                    return new RestartHostPlanAction(host, host.GetRunningVMs(), true);
+                    return new RestartHostPlanAction(host, host.GetRunningVMs(), true, hostsThatWillRequireReboot);
                 case after_apply_guidance.restartXAPI:
                     return new RestartAgentPlanAction(host);
                 case after_apply_guidance.restartHVM:

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -93,7 +93,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         public void AddFile(string path)
         {
-            PatchingWizard_SelectPatchPage.AddFile(path);
+            PatchingWizard_SelectPatchPage.FilePath = path;
         }
 
         public void SelectServers(List<Host> selectedServers)

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -44,14 +44,14 @@ using XenAdmin.Alerts;
 using System.Linq;
 using System.Xml;
 using DiscUtils.Iso9660;
-using XenAdmin.Actions;
 
 
 namespace XenAdmin.Wizards.PatchingWizard
 {
     public partial class PatchingWizard_SelectPatchPage : XenTabPage
     {
-        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly log4net.ILog log =
+            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         private bool CheckForUpdatesInProgress;
         public XenServerPatchAlert SelectedUpdateAlert;
@@ -65,7 +65,8 @@ namespace XenAdmin.Wizards.PatchingWizard
             InitializeComponent();
             tableLayoutPanelSpinner.Visible = false;
 
-            labelWithAutomatedUpdates.Visible = automatedUpdatesOptionLabel.Visible = AutomatedUpdatesRadioButton.Visible = false;
+            labelWithAutomatedUpdates.Visible =
+                automatedUpdatesOptionLabel.Visible = AutomatedUpdatesRadioButton.Visible = false;
             downloadUpdateRadioButton.Checked = true;
         }
 
@@ -110,7 +111,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             downloadUpdateRadioButton.Checked = true;
             foreach (PatchGridViewRow row in dataGridViewPatches.Rows)
             {
-                if(row.UpdateAlert.Equals(alert))
+                if (row.UpdateAlert.Equals(alert))
                 {
                     row.Selected = true;
                 }
@@ -119,18 +120,12 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         public override string Text
         {
-            get
-            {
-                return Messages.PATCHINGWIZARD_SELECTPATCHPAGE_TEXT;
-            }
+            get { return Messages.PATCHINGWIZARD_SELECTPATCHPAGE_TEXT; }
         }
 
         public override string PageTitle
         {
-            get
-            {
-                return Messages.PATCHINGWIZARD_SELECTPATCHPAGE_TITLE;
-            }
+            get { return Messages.PATCHINGWIZARD_SELECTPATCHPAGE_TITLE; }
         }
 
         public override string HelpID
@@ -143,13 +138,16 @@ namespace XenAdmin.Wizards.PatchingWizard
             Updates.CheckForUpdatesStarted += CheckForUpdates_CheckForUpdatesStarted;
             Updates.CheckForUpdatesCompleted += CheckForUpdates_CheckForUpdatesCompleted;
             Updates.RestoreDismissedUpdatesStarted += Updates_RestoreDismissedUpdatesStarted;
-         
+
             if (direction == PageLoadedDirection.Forward)
             {
                 //if any connected host is licensed for automated updates
-                bool automatedUpdatesPossible = ConnectionsManager.XenConnectionsCopy.Any(c => c != null && c.Cache.Hosts.Any(h => !Host.RestrictBatchHotfixApply(h)));
-               
-                labelWithAutomatedUpdates.Visible = automatedUpdatesOptionLabel.Visible = AutomatedUpdatesRadioButton.Visible = automatedUpdatesPossible;
+                bool automatedUpdatesPossible =
+                    ConnectionsManager.XenConnectionsCopy.Any(
+                        c => c != null && c.Cache.Hosts.Any(h => !Host.RestrictBatchHotfixApply(h)));
+
+                labelWithAutomatedUpdates.Visible =
+                    automatedUpdatesOptionLabel.Visible = AutomatedUpdatesRadioButton.Visible = automatedUpdatesPossible;
                 labelWithoutAutomatedUpdates.Visible = !automatedUpdatesPossible;
 
                 if (firstLoad)
@@ -170,7 +168,10 @@ namespace XenAdmin.Wizards.PatchingWizard
             firstLoad = false;
         }
 
-        private bool IsInAutomatedUpdatesMode { get { return AutomatedUpdatesRadioButton.Visible && AutomatedUpdatesRadioButton.Checked; } }
+        private bool IsInAutomatedUpdatesMode
+        {
+            get { return AutomatedUpdatesRadioButton.Visible && AutomatedUpdatesRadioButton.Checked; }
+        }
 
         public WizardMode WizardMode
         {
@@ -186,12 +187,13 @@ namespace XenAdmin.Wizards.PatchingWizard
                 if (updateAlert != null && updateAlert.NewServerVersion != null)
                     return WizardMode.NewVersion;
                 return WizardMode.SingleUpdate;
-            } 
+            }
         }
 
         public KeyValuePair<XenServerPatch, string> PatchFromDisk
         {
-            get {
+            get
+            {
                 return selectFromDiskRadioButton.Checked && FileFromDiskAlert != null
                     ? new KeyValuePair<XenServerPatch, string>(FileFromDiskAlert.Patch, SelectedNewPatch)
                     : new KeyValuePair<XenServerPatch, string>(null, null);
@@ -204,12 +206,14 @@ namespace XenAdmin.Wizards.PatchingWizard
             {
                 if (!IsInAutomatedUpdatesMode)
                 {
-                    if (selectFromDiskRadioButton.Checked && !string.IsNullOrEmpty(fileNameTextBox.Text) && Path.GetExtension(fileNameTextBox.Text).ToLowerInvariant().Equals(".zip"))
+                    if (selectFromDiskRadioButton.Checked && !string.IsNullOrEmpty(FilePath) &&
+                        Path.GetExtension(FilePath).ToLowerInvariant().Equals(".zip"))
                     {
                         //check if we are installing update user sees in textbox
-                        if (Path.GetFileNameWithoutExtension(unzippedUpdateFilePath) != Path.GetFileNameWithoutExtension(fileNameTextBox.Text))
+                        if (Path.GetFileNameWithoutExtension(unzippedUpdateFilePath) !=
+                            Path.GetFileNameWithoutExtension(FilePath))
                         {
-                            unzippedUpdateFilePath = ExtractUpdate(fileNameTextBox.Text);
+                            unzippedUpdateFilePath = WizardHelpers.ExtractUpdate(FilePath, this);
                             if (unzippedUpdateFilePath == null)
                                 cancel = true;
 
@@ -219,14 +223,17 @@ namespace XenAdmin.Wizards.PatchingWizard
                     else
                         unzippedUpdateFilePath = null;
 
-                    var fileName = isValidFile(unzippedUpdateFilePath) ? unzippedUpdateFilePath.ToLowerInvariant() : fileNameTextBox.Text.ToLowerInvariant();
+                    var fileName = WizardHelpers.IsValidFile(unzippedUpdateFilePath)
+                        ? unzippedUpdateFilePath.ToLowerInvariant()
+                        : FilePath.ToLowerInvariant();
 
-                    SelectedUpdateAlert = downloadUpdateRadioButton.Checked && dataGridViewPatches.SelectedRows.Count > 0
-                             ? ((PatchGridViewRow)dataGridViewPatches.SelectedRows[0]).UpdateAlert
-                             : null;
+                    SelectedUpdateAlert = downloadUpdateRadioButton.Checked &&
+                                          dataGridViewPatches.SelectedRows.Count > 0
+                        ? ((PatchGridViewRow) dataGridViewPatches.SelectedRows[0]).UpdateAlert
+                        : null;
 
                     bool hasUpdateXml = false;
-                    FileFromDiskAlert = selectFromDiskRadioButton.Checked 
+                    FileFromDiskAlert = selectFromDiskRadioButton.Checked
                         ? GetAlertFromFile(fileName, out hasUpdateXml)
                         : null;
                     FileFromDiskHasUpdateXml = hasUpdateXml;
@@ -234,7 +241,8 @@ namespace XenAdmin.Wizards.PatchingWizard
                     if (downloadUpdateRadioButton.Checked)
                     {
                         var distinctHosts = SelectedUpdateAlert != null ? SelectedUpdateAlert.DistinctHosts : null;
-                        if (distinctHosts != null && distinctHosts.Any(Helpers.ElyOrGreater)) // this is to check whether the Alert represents an ISO update (Ely or greater)
+                        if (distinctHosts != null && distinctHosts.Any(Helpers.ElyOrGreater))
+                            // this is to check whether the Alert represents an ISO update (Ely or greater)
                         {
                             SelectedUpdateType = UpdateType.ISO;
                         }
@@ -245,7 +253,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                     }
                     else
                     {
-                        if (isValidFile(fileName))
+                        if (WizardHelpers.IsValidFile(fileName))
                         {
                             if (fileName.EndsWith("." + Branding.Update))
                                 SelectedUpdateType = UpdateType.NewRetail;
@@ -260,7 +268,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                     {
                         cancel = true;
                         PageLeaveCancelled(string.Format(Messages.UPDATES_WIZARD_CANNOT_DOWNLOAD_PATCH,
-                                                         SelectedExistingPatch.Connection.Name));
+                            SelectedExistingPatch.Connection.Name));
                     }
                     else if (!string.IsNullOrEmpty(SelectedNewPatch) && !File.Exists(SelectedNewPatch))
                     {
@@ -340,8 +348,8 @@ namespace XenAdmin.Wizards.PatchingWizard
             {
                 dlg.ShowDialog(this);
             }
-            
-            ((PatchGridViewRow)dataGridViewPatches.SelectedRows[0]).UpdateDetails();
+
+            ((PatchGridViewRow) dataGridViewPatches.SelectedRows[0]).UpdateDetails();
         }
 
         private void PopulatePatchesBox()
@@ -381,13 +389,14 @@ namespace XenAdmin.Wizards.PatchingWizard
                         if (patchAlert.RequiredXenCenterVersion != null)
                         {
                             row.Enabled = false;
-                            row.SetToolTip(string.Format(Messages.UPDATES_WIZARD_NEWER_XENCENTER_REQUIRED, patchAlert.RequiredXenCenterVersion.Version));
+                            row.SetToolTip(string.Format(Messages.UPDATES_WIZARD_NEWER_XENCENTER_REQUIRED,
+                                patchAlert.RequiredXenCenterVersion.Version));
                         }
                     }
                 }
             }
         }
-        
+
         public override void PageCancelled()
         {
             Updates.RestoreDismissedUpdatesStarted -= Updates_RestoreDismissedUpdatesStarted;
@@ -408,10 +417,10 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
 
             if (downloadUpdateRadioButton.Checked)
-            {                
+            {
                 if (dataGridViewPatches.SelectedRows.Count == 1)
                 {
-                    DataGridViewExRow row = (DataGridViewExRow)dataGridViewPatches.SelectedRows[0];
+                    DataGridViewExRow row = (DataGridViewExRow) dataGridViewPatches.SelectedRows[0];
                     if (row.Enabled)
                     {
                         return true;
@@ -420,7 +429,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
             else if (selectFromDiskRadioButton.Checked)
             {
-                if (isValidFile(fileNameTextBox.Text))
+                if (WizardHelpers.IsValidFile(FilePath))
                     return true;
             }
 
@@ -432,18 +441,6 @@ namespace XenAdmin.Wizards.PatchingWizard
             return !CheckForUpdatesInProgress;
         }
 
-        private string UpdateExtension
-        {
-            get { return "." + Branding.Update; }
-        }
-
-        private bool isValidFile(string fileName)
-        {
-            return !string.IsNullOrEmpty(fileName) && File.Exists(fileName) && (fileName.ToLowerInvariant().EndsWith(UpdateExtension.ToLowerInvariant())
-                || fileName.ToLowerInvariant().EndsWith(".zip") 
-                || fileName.ToLowerInvariant().EndsWith(".iso")); //this iso is supplemental pack iso for XS, not branded
-        }
-
         //list to store unzipped files to be removed later by PatchingWizard
         private List<string> unzippedFiles = new List<string>();
 
@@ -452,55 +449,10 @@ namespace XenAdmin.Wizards.PatchingWizard
             get { return unzippedFiles; }
         }
 
-        private void BrowseButton_Click(object sender, EventArgs e)
+        public string FilePath
         {
-            // Showing this dialog has the (undocumented) side effect of changing the working directory
-            // to that of the file selected. This means a handle to the directory persists, making
-            // it undeletable until the program exits, or the working dir moves on. So, save and
-            // restore the working dir...
-            selectFromDiskRadioButton.Checked = true;
-            String oldDir = "";
-            try
-            {
-                oldDir = Directory.GetCurrentDirectory();
-                using (OpenFileDialog dlg = new OpenFileDialog
-                    {
-                        Multiselect = false,
-                        ShowReadOnly = false,
-                        Filter = string.Format(Messages.PATCHINGWIZARD_SELECTPATCHPAGE_UPDATESEXT, Branding.Update),
-                        FilterIndex = 0,
-                        CheckFileExists = true,
-                        ShowHelp = false,
-                        Title = Messages.PATCHINGWIZARD_SELECTPATCHPAGE_CHOOSE
-                    })
-                {
-                    if (dlg.ShowDialog(this) == DialogResult.OK && dlg.CheckFileExists)
-                        AddFile(dlg.FileName);  
-                }
-                OnPageUpdated(); 
-
-            }
-            finally
-            {
-                Directory.SetCurrentDirectory(oldDir);
-            }
-        }
-
-        public void AddFile(string fileName)
-        {
-            if (isValidFile(fileName))
-            {
-                fileNameTextBox.Text = fileName;
-                selectFromDiskRadioButton.Checked = true;
-            }
-            else
-            {
-                using (var dlg = new ThreeButtonDialog(new ThreeButtonDialog.Details(
-                        SystemIcons.Error, string.Format(Messages.UPDATES_WIZARD_NOTVALID_EXTENSION, Branding.Update), Messages.UPDATES)))
-                {
-                    dlg.ShowDialog(this);
-                }
-            }
+            get { return fileNameTextBox.Text; }
+            set { fileNameTextBox.Text = value; }
         }
 
         public UpdateType SelectedUpdateType { get; set; }
@@ -514,45 +466,22 @@ namespace XenAdmin.Wizards.PatchingWizard
                 if (downloadUpdateRadioButton.Checked)
                 {
                     return SelectedUpdateType == UpdateType.NewRetail || SelectedUpdateType == UpdateType.ISO
-                               ? ((PatchGridViewRow)dataGridViewPatches.SelectedRows[0]).PathPatch
-                               : null;
+                        ? ((PatchGridViewRow) dataGridViewPatches.SelectedRows[0]).PathPatch
+                        : null;
                 }
                 else if (selectFromDiskRadioButton.Checked)
                 {
                     return SelectedUpdateType == UpdateType.NewRetail || SelectedUpdateType == UpdateType.ISO
-                        ? isValidFile(unzippedUpdateFilePath) && Path.GetExtension(fileNameTextBox.Text).ToLowerInvariant().Equals(".zip")
-                        ? unzippedUpdateFilePath : fileNameTextBox.Text : null;
+                        ? WizardHelpers.IsValidFile(unzippedUpdateFilePath) &&
+                          Path.GetExtension(FilePath).ToLowerInvariant().Equals(".zip")
+                            ? unzippedUpdateFilePath
+                            : FilePath
+                        : null;
                 }
-                else 
+                else
                     return null;
             }
         }
-
-        private string ExtractUpdate(string zippedUpdatePath)
-        {
-            var unzipAction = new DownloadAndUnzipXenServerPatchAction(Path.GetFileNameWithoutExtension(zippedUpdatePath), null, zippedUpdatePath, true, Branding.Update, Branding.UpdateIso);
-            using (var dlg = new ActionProgressDialog(unzipAction, ProgressBarStyle.Marquee))
-            {
-                dlg.ShowDialog(Parent);
-            }
-
-            if (string.IsNullOrEmpty(unzipAction.PatchPath))
-            {
-                using (var dlg = new ThreeButtonDialog(new ThreeButtonDialog.Details(
-                    SystemIcons.Error,
-                    string.Format(Messages.UPDATES_WIZARD_NOTVALID_ZIPFILE, Path.GetFileName(zippedUpdatePath)),
-                    Messages.UPDATES)))
-                {
-                    dlg.ShowDialog(this);
-                }
-                return null;
-            }
-            else
-            {
-                return unzipAction.PatchPath;
-            }
-        }
-
 
         #region DataGridView
 
@@ -569,15 +498,15 @@ namespace XenAdmin.Wizards.PatchingWizard
             if (e.RowIndex < 0)
                 // The click is on a column header
                 return;
-            PatchGridViewRow row = (PatchGridViewRow)dataGridViewPatches.Rows[e.RowIndex];
+            PatchGridViewRow row = (PatchGridViewRow) dataGridViewPatches.Rows[e.RowIndex];
             row.toggleExpandedState();
             OnPageUpdated();
         }
 
         private void dataGridViewPatches_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
         {
-            Alert alert1 = ((PatchGridViewRow)dataGridViewPatches.Rows[e.RowIndex1]).UpdateAlert;
-            Alert alert2 = ((PatchGridViewRow)dataGridViewPatches.Rows[e.RowIndex2]).UpdateAlert;
+            Alert alert1 = ((PatchGridViewRow) dataGridViewPatches.Rows[e.RowIndex1]).UpdateAlert;
+            Alert alert2 = ((PatchGridViewRow) dataGridViewPatches.Rows[e.RowIndex2]).UpdateAlert;
 
             if (e.Column.Index == ColumnDate.Index)
             {
@@ -623,7 +552,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             private DataGridViewLinkCell _webPageCell;
 
             public PatchGridViewRow(XenServerPatchAlert alert)
-            {   
+            {
                 _alert = alert;
                 _nameCell = new DataGridViewTextBoxCell();
                 _descriptionCell = new DataGridViewTextBoxCell();
@@ -637,7 +566,8 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 _nameCell.Value = String.Format(alert.Name);
                 _descriptionCell.Value = String.Format(alert.Description);
-                _dateCell.Value = HelpersGUI.DateTimeToString(alert.Timestamp.ToLocalTime(), Messages.DATEFORMAT_DMY, true);
+                _dateCell.Value = HelpersGUI.DateTimeToString(alert.Timestamp.ToLocalTime(), Messages.DATEFORMAT_DMY,
+                    true);
                 _webPageCell.Value = Messages.PATCHING_WIZARD_WEBPAGE_CELL;
             }
 
@@ -649,7 +579,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
 
             public XenServerPatchAlert UpdateAlert
-            { 
+            {
                 get { return _alert; }
             }
 
@@ -691,16 +621,16 @@ namespace XenAdmin.Wizards.PatchingWizard
                     FileInfo fileInfo = new FileInfo(_patchPath);
 
                     string description = expanded
-                                             ? fileInfo.Exists
-                                                   ? String.Format(Messages.PATCH_EXPANDED_DESCRIPTION
-                                                                   , _patchPath, fileInfo.CreationTime,
-                                                                   fileInfo.LastWriteTime, Util.DiskSizeString(fileInfo.Length))
-                                                   : String.Format(Messages.PATCH_NOT_FOUND_EXPANDED_DESCRIPTION,
-                                                                   _patchPath)
-                                             : _patchPath;
+                        ? fileInfo.Exists
+                            ? String.Format(Messages.PATCH_EXPANDED_DESCRIPTION
+                                , _patchPath, fileInfo.CreationTime,
+                                fileInfo.LastWriteTime, Util.DiskSizeString(fileInfo.Length))
+                            : String.Format(Messages.PATCH_NOT_FOUND_EXPANDED_DESCRIPTION,
+                                _patchPath)
+                        : _patchPath;
 
                     UpdateFileDetails(description, fileInfo.Exists ? Messages.NOT_UPLOADED : Messages.PATCH_NOT_FOUND);
-                }         
+                }
             }
 
             public void toggleExpandedState()
@@ -711,7 +641,8 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             public bool Equals(PatchGridViewRow other)
             {
-                if (other.UpdateAlert != null && this.UpdateAlert != null && this.UpdateAlert.uuid == other.UpdateAlert.uuid)
+                if (other.UpdateAlert != null && this.UpdateAlert != null &&
+                    this.UpdateAlert.uuid == other.UpdateAlert.uuid)
                     return true;
                 if (other.PathPatch != null && this.PathPatch != null && this.PathPatch == other.PathPatch)
                     return true;
@@ -726,7 +657,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             public override bool Equals(object obj)
             {
                 if (obj is PatchGridViewRow)
-                    return this.Equals((PatchGridViewRow)obj);
+                    return this.Equals((PatchGridViewRow) obj);
                 return false;
             }
 
@@ -739,7 +670,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                     var cell = c as DataGridViewCell;
                     if (c != null)
-                        ((DataGridViewCell)c).ToolTipText = toolTip;
+                        ((DataGridViewCell) c).ToolTipText = toolTip;
                 }
             }
         }
@@ -751,15 +682,25 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         private void RestoreDismUpdatesButton_Click(object sender, EventArgs e)
         {
-            dataGridViewPatches.Focus(); 
+            dataGridViewPatches.Focus();
             Updates.RestoreDismissedUpdates();
         }
 
         private void RefreshListButton_Click(object sender, EventArgs e)
         {
-            dataGridViewPatches.Focus();        
+            dataGridViewPatches.Focus();
             Updates.CheckForUpdates(true);
         }
+
+        private void BrowseButton_Click(object sender, EventArgs e)
+        {
+            selectFromDiskRadioButton.Checked = true;
+            var suppPack = WizardHelpers.GetSuppPackFromDisk(this);
+            if (!string.IsNullOrEmpty(suppPack))
+                FilePath = suppPack;
+            OnPageUpdated();
+        }
+
         #endregion
 
 

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -503,7 +503,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                         if (Helpers.ElyOrGreater(supplementalPackUploadAction.Connection))
                         {
-                            var newPoolUpdate = (supplementalPackUploadAction).PoolUpdate;
+                            var newPoolUpdate = supplementalPackUploadAction.PoolUpdate;
 
                             if (newPoolUpdate != null)
                             {

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RestartHostPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RestartHostPlanAction.cs
@@ -30,7 +30,6 @@
  */
 
 using System.Collections.Generic;
-using System.Text;
 using XenAdmin.Core;
 using XenAPI;
 
@@ -41,47 +40,40 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
     {
         private readonly List<XenRef<VM>> _vms;
         public bool EnableOnly { get; set; }
-        private readonly bool _restartAgentFallback;
+        private List<string> hostsNeedReboot;
 
-        public RestartHostPlanAction(Host host, List<XenRef<VM>> vms, bool enableOnly = false, bool restartAgentFallback = false)
+        public RestartHostPlanAction(Host host, List<XenRef<VM>> vms, bool enableOnly = false, List<string> hostsThatWillRequireReboot = null)
             : base(host)
         {
             _vms = vms;
             EnableOnly = enableOnly;
-            _restartAgentFallback = restartAgentFallback;
+            hostsNeedReboot = hostsThatWillRequireReboot;
         }
 
         protected override void RunWithSession(ref Session session)
         {
             var hostObj = GetResolvedHost();
+            if (hostObj != null && SkipRestartHost(hostObj))
+                return;
 
-            if (Helpers.ElyOrGreater(hostObj))
-            {
-                log.DebugFormat("Checking host.patches_requiring_reboot now on '{0}'.", hostObj);
-
-                if (hostObj.updates_requiring_reboot.Count > 0)
-                {
-                    log.DebugFormat("Found {0} patches requiring reboot (live patching failed)."
-                                    + "Initiating evacuate-reboot-bringbabiesback process.",
-                        hostObj.updates_requiring_reboot.Count);
-                }
-                else if (_restartAgentFallback)
-                {
-                    log.Debug("Live patching succeeded. Restarting agent.");
-                    RestartAgent(ref session);
-                    return;
-                }
-                else
-                {
-                    log.Debug("Did not find patches requiring reboot (live patching succeeded)."
-                              + " Skipping scheduled restart.");
-                    return;
-                }
-            }
-           
             EvacuateHost(ref session);
             RebootHost(ref session);
             BringBabiesBack(ref session, _vms, EnableOnly);
+
+            if (hostObj != null && hostsNeedReboot != null && hostsNeedReboot.Contains(hostObj.uuid))
+                hostsNeedReboot.Remove(hostObj.uuid);
+        }
+
+        public bool SkipRestartHost(Host host)
+        {
+            if (hostsNeedReboot != null
+                && !hostsNeedReboot.Contains(host.uuid)
+                && Helpers.ElyOrGreater(host)
+                && host.updates_requiring_reboot.Count <= 0)
+            {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/UploadPatchToMasterPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/UploadPatchToMasterPlanAction.cs
@@ -46,20 +46,20 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
         private readonly List<PoolPatchMapping> mappings;
         private Dictionary<XenServerPatch, string> AllDownloadedPatches = new Dictionary<XenServerPatch, string>();
         private KeyValuePair<XenServerPatch, string> patchFromDisk;
-        private AsyncAction inProgressAction = null;
+        private AsyncAction inProgressAction;
 
         public UploadPatchToMasterPlanAction(IXenConnection connection, XenServerPatch patch, List<PoolPatchMapping> mappings, Dictionary<XenServerPatch, string> allDownloadedPatches, KeyValuePair<XenServerPatch, string> patchFromDisk)
             : base(connection)
         {
             this.patch = patch;
             this.mappings = mappings;
-            this.AllDownloadedPatches = allDownloadedPatches;
+            AllDownloadedPatches = allDownloadedPatches;
             this.patchFromDisk = patchFromDisk;
         }
 
         protected override void RunWithSession(ref Session session)
         {
-            var path = AllDownloadedPatches.ContainsKey(patch) 
+            var path = AllDownloadedPatches.ContainsKey(patch)
                 ? AllDownloadedPatches[patch]
                 : patchFromDisk.Key == patch ? patchFromDisk.Value : null;
 

--- a/XenAdmin/Wizards/WizardHelpers.cs
+++ b/XenAdmin/Wizards/WizardHelpers.cs
@@ -1,0 +1,164 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.ComponentModel;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using XenAdmin.Actions;
+using XenAdmin.Dialogs;
+
+
+namespace XenAdmin.Wizards
+{
+    public static class WizardHelpers
+    {
+        public static string GetSuppPackFromDisk(Control control)
+        {
+            string oldDir = string.Empty;
+            try
+            {
+                oldDir = Directory.GetCurrentDirectory();
+                using (var dlg = new OpenFileDialog
+                {
+                    Multiselect = false,
+                    ShowReadOnly = false,
+                    Filter = string.Format(Messages.PATCHINGWIZARD_SELECTPATCHPAGE_UPDATESEXT, Branding.Update),
+                    FilterIndex = 0,
+                    CheckFileExists = true,
+                    CheckPathExists = true,
+                    ShowHelp = false,
+                    Title = Messages.PATCHINGWIZARD_SELECTPATCHPAGE_CHOOSE
+                })
+                {
+                    dlg.FileOk += dlg_FileOk;
+
+                    if (dlg.ShowDialog(control) == DialogResult.OK)
+                        return dlg.FileName;
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(oldDir);
+            }
+
+            return null;
+        }
+
+        private static void dlg_FileOk(object sender, CancelEventArgs e)
+        {
+            var dlg = sender as OpenFileDialog;
+            if (dlg == null)
+                return;
+
+            if (!IsValidFile(dlg.FileName))
+                using (var popup = new ThreeButtonDialog(new ThreeButtonDialog.Details(
+                    SystemIcons.Error, string.Format(Messages.UPDATES_WIZARD_NOTVALID_EXTENSION, Branding.Update), Messages.UPDATES)))
+                {
+                    popup.ShowDialog();
+                    e.Cancel = true;
+                }
+        }       
+
+        public static void ParseSuppPackFile(string path, Control control, ref bool cancel, out string suppPackPath)
+        {
+            string unzippedPath;
+
+            if (Path.GetExtension(path).ToLowerInvariant().Equals(".zip"))
+            {
+                unzippedPath = ExtractUpdate(path, control);
+                if (unzippedPath == null)
+                    cancel = true;
+            }
+            else
+                unzippedPath = null;
+
+            var fileName = IsValidFile(unzippedPath)
+                ? unzippedPath.ToLowerInvariant()
+                : path.ToLowerInvariant();
+
+            if (IsValidFile(fileName))
+            {
+                if (!fileName.EndsWith("." + Branding.Update)
+                    && !fileName.EndsWith("." + Branding.UpdateIso)
+                    && !cancel)
+                {
+                    using (var dlg = new ThreeButtonDialog(new ThreeButtonDialog.Details(
+                        SystemIcons.Error,
+                        string.Format(Messages.UPDATES_WIZARD_NOTVALID_ZIPFILE, Path.GetFileName(fileName)),
+                        Messages.UPDATES)))
+                    {
+                        dlg.ShowDialog(control);
+                    }
+                    cancel = true;
+                }
+                suppPackPath = fileName;
+            }
+            else
+                suppPackPath = string.Empty;
+        }
+
+        public static string ExtractUpdate(string zippedUpdatePath, Control control)
+        {
+            var unzipAction =
+                new DownloadAndUnzipXenServerPatchAction(Path.GetFileNameWithoutExtension(zippedUpdatePath), null,
+                    zippedUpdatePath, true, Branding.Update, Branding.UpdateIso);
+            using (var dlg = new ActionProgressDialog(unzipAction, ProgressBarStyle.Marquee))
+            {
+                dlg.ShowDialog(control);
+            }
+
+            if (string.IsNullOrEmpty(unzipAction.PatchPath))
+            {
+                using (var dlg = new ThreeButtonDialog(new ThreeButtonDialog.Details(
+                    SystemIcons.Error,
+                    string.Format(Messages.UPDATES_WIZARD_NOTVALID_ZIPFILE, Path.GetFileName(zippedUpdatePath)),
+                    Messages.UPDATES)))
+                {
+                    dlg.ShowDialog(control);
+                }
+                return null;
+            }
+            else
+            {
+                return unzipAction.PatchPath;
+            }
+        }
+
+        public static bool IsValidFile(string fileName)
+        {
+            return !string.IsNullOrEmpty(fileName) && File.Exists(fileName)
+                && (fileName.ToLowerInvariant().EndsWith("." + Branding.Update.ToLowerInvariant())
+                || fileName.ToLowerInvariant().EndsWith(".zip")
+                || fileName.ToLowerInvariant().EndsWith(".iso")); //this iso is supplemental pack iso for XS, not branded
+        }
+    }
+}

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -210,7 +210,7 @@
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="Controls\Tags\TagsEditor.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\UpsellPage.cs">
       <SubType>UserControl</SubType>
@@ -452,7 +452,7 @@
       <DependentUpon>DockerDetailsPage.cs</DependentUpon>
     </Compile>
     <Compile Include="TabPages\HomePage.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="TabPages\HomePage.Designer.cs">
       <DependentUpon>HomePage.cs</DependentUpon>
@@ -557,13 +557,13 @@
       <DependentUpon>PerfmonAlertOptionsPage.cs</DependentUpon>
     </Compile>
     <Compile Include="Controls\BlueBorderPanel.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\CustomDataGraph\ArchiveMaintainer.cs">
     </Compile>
     <Compile Include="Controls\CustomDataGraph\DataArchive.cs" />
     <Compile Include="Controls\CustomDataGraph\GraphList.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\CustomDataGraph\GraphList.Designer.cs">
       <DependentUpon>GraphList.cs</DependentUpon>
@@ -577,7 +577,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\DoubleBufferedPanel.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\DoubleBufferedPanel.Designer.cs">
       <DependentUpon>DoubleBufferedPanel.cs</DependentUpon>
@@ -758,6 +758,7 @@
     <Compile Include="Wizards\CrossPoolMigrateWizard\IntraPoolCopyPage.Designer.cs">
       <DependentUpon>IntraPoolCopyPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="Wizards\WizardHelpers.cs" />
     <Compile Include="Wizards\ImportWizard\HardwareCompatibilityFilter.cs" />
     <Compile Include="Wizards\NewSRWizard_Pages\ChooseSrProvisioningPage.cs">
       <SubType>UserControl</SubType>
@@ -929,13 +930,13 @@
       <DependentUpon>DataKey.cs</DependentUpon>
     </Compile>
     <Compile Include="Controls\CustomDataGraph\DataPlot.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\CustomDataGraph\DataPlot.designer.cs">
       <DependentUpon>DataPlot.cs</DependentUpon>
     </Compile>
     <Compile Include="Controls\CustomDataGraph\DataPlotNav.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\CustomDataGraph\DataPlotNav.designer.cs">
       <DependentUpon>DataPlotNav.cs</DependentUpon>
@@ -1033,7 +1034,7 @@
       <DependentUpon>FolderChangeDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="Controls\Folders\FolderEditor.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\Folders\FolderListItem.cs" />
     <Compile Include="Dialogs\NewTagDialog.cs">
@@ -3693,7 +3694,9 @@
     <Compile Include="Wizards\DRWizards\DRFailoverWizardWelcomePage.Designer.cs">
       <DependentUpon>DRFailoverWizardWelcomePage.cs</DependentUpon>
     </Compile>
-    <Compile Include="Controls\DataGridViewEnableableComboBoxCell.cs" />
+    <Compile Include="Controls\DataGridViewEnableableComboBoxCell.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Wizards\GenericPages\DelayLoadingOptionComboBoxItem.cs" />
     <Compile Include="Wizards\GenericPages\LunPerVdiMappingPage.cs">
       <SubType>UserControl</SubType>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -35093,7 +35093,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The selected file does not have a valid extension. Valid extensions are: *.{0} and *.iso.
+        ///   Looks up a localized string similar to The selected file does not have a valid extension. Valid extensions are *.{0}, *.zip and *.iso..
         /// </summary>
         public static string UPDATES_WIZARD_NOTVALID_EXTENSION {
             get {
@@ -35343,6 +35343,15 @@ namespace XenAdmin {
         public static string UPDATES_WIZARD_SKIPPING_UPDATE {
             get {
                 return ResourceManager.GetString("UPDATES_WIZARD_SKIPPING_UPDATE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skipping uploading update {0}. Already uploaded to {1}... .
+        /// </summary>
+        public static string UPDATES_WIZARD_SKIPPING_UPLOAD {
+            get {
+                return ResourceManager.GetString("UPDATES_WIZARD_SKIPPING_UPLOAD", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12089,7 +12089,7 @@ Check your settings and try again.</value>
     <value>Ensure you have upgraded [XenCenter] before upgrading [XenServer].</value>
   </data>
   <data name="UPDATES_WIZARD_NOTVALID_EXTENSION" xml:space="preserve">
-    <value>The selected file does not have a valid extension. Valid extensions are: *.{0} and *.iso</value>
+    <value>The selected file does not have a valid extension. Valid extensions are *.{0}, *.zip and *.iso.</value>
   </data>
   <data name="UPDATES_WIZARD_NOTVALID_ZIPFILE" xml:space="preserve">
     <value>No valid update file found in {0}</value>
@@ -12191,6 +12191,9 @@ Check your settings and try again.</value>
   </data>
   <data name="UPDATES_WIZARD_SKIPPING_UPDATE" xml:space="preserve">
     <value>Skipping update {0}. Already applied on {1}... </value>
+  </data>
+  <data name="UPDATES_WIZARD_SKIPPING_UPLOAD" xml:space="preserve">
+    <value>Skipping uploading update {0}. Already uploaded to {1}... </value>
   </data>
   <data name="UPDATES_WIZARD_SR_TITLE" xml:space="preserve">
     <value>Storage repository '{0}'</value>


### PR DESCRIPTION
With this change, following are working:
1) After applying XS75E003-5 only restart host, no restart toolstack
2) After applying vGPU driver on 7.4, restart host happens

Signed-off-by: Ji Jiang <ji.jiang@citrix.com>