### PR TITLE
CP-29440: Prevent connections to XenServer >= 7.2 in Havana.

### DIFF
--- a/XenModel/XenAPI/ApiVersion.cs
+++ b/XenModel/XenAPI/ApiVersion.cs
@@ -59,7 +59,7 @@ namespace XenAPI
         API_2_9 = 20, //XenServer 7.4 (jura)
         API_2_10 = 21, //XenServer 7.5 (kolkata)
         API_2_11 = 22, //Unreleased (lima)
-        LATEST = 22,
+        LATEST = 17,
         UNKNOWN = 99
     }
 


### PR DESCRIPTION
Signed-off-by: Aaron Robson <aaron.robson@citrix.com>