### PR TITLE
CA-299063: Prevent the Network Interfaces from disappearing when the …

### DIFF
--- a/XenAdmin/Controls/NetworkingTab/NetworkList.cs
+++ b/XenAdmin/Controls/NetworkingTab/NetworkList.cs
@@ -272,7 +272,7 @@ namespace XenAdmin.Controls.NetworkingTab
 
             try
             {
-                if (XenObject == null || XenObject.Locked)
+                if (XenObject == null)
                     return;
 
                 if (!XenObject.Connection.CacheIsPopulated)


### PR DESCRIPTION
…VM is Locked due to a Storage Deveice being deleted.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>