### PR TITLE
 CA-289948: allow VDI of a stopped VM to be moved on unlicensed pools

### DIFF
--- a/XenAdmin/Commands/MigrateVirtualDiskCommand.cs
+++ b/XenAdmin/Commands/MigrateVirtualDiskCommand.cs
@@ -74,7 +74,7 @@ namespace XenAdmin.Commands
             }
             else
             {
-                new MoveVirtualDiskDialog(selection.FirstAsXenObject.Connection, null, vdis).Show(Program.MainWindow);
+                new MigrateVirtualDiskDialog(selection.FirstAsXenObject.Connection, vdis).Show(Program.MainWindow);
             }
         }
 

--- a/XenAdmin/Commands/MoveVirtualDiskCommand.cs
+++ b/XenAdmin/Commands/MoveVirtualDiskCommand.cs
@@ -64,7 +64,7 @@ namespace XenAdmin.Commands
         protected override void ExecuteCore(SelectedItemCollection selection)
         {
             var vdis = selection.AsXenObjects<VDI>();
-            new MoveVirtualDiskDialog(selection.GetConnectionOfFirstItem(), vdis, null).Show(Program.MainWindow);
+            new MoveVirtualDiskDialog(selection.GetConnectionOfFirstItem(), vdis).Show(Program.MainWindow);
         }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)

--- a/XenAdmin/Commands/MoveVirtualDiskCommand.cs
+++ b/XenAdmin/Commands/MoveVirtualDiskCommand.cs
@@ -76,11 +76,12 @@ namespace XenAdmin.Commands
         {
             if (vdi == null || vdi.is_a_snapshot || vdi.Locked || vdi.IsHaType() || vdi.cbt_enabled)
                 return false;
-            if (vdi.VBDs.Count != 0)
-                return false;
 
             SR sr = vdi.Connection.Resolve(vdi.SR);
             if (sr == null || sr.HBALunPerVDI())
+                return false;
+
+            if (vdi.GetVMs().Any(vm => vm.power_state != vm_power_state.Halted))
                 return false;
 
             return true;
@@ -102,8 +103,6 @@ namespace XenAdmin.Commands
                 return Messages.CANNOT_MOVE_CBT_ENABLED_VDI;
             if (vdi.IsMetadataForDR())
                 return Messages.CANNOT_MOVE_DR_VD;
-            if (vdi.VBDs.Count != 0)
-                return Messages.CANNOT_MOVE_VDI_WITH_VBDS;
 
             SR sr = vdi.Connection.Resolve(vdi.SR);
             if (sr == null)

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.Designer.cs
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.Designer.cs
@@ -29,7 +29,6 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MoveVirtualDiskDialog));
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.toolTipContainer2 = new XenAdmin.Controls.ToolTipContainer();
             this.buttonMove = new System.Windows.Forms.Button();
@@ -40,11 +39,6 @@
             this.toolTipContainer2.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // tableLayoutPanel1
-            // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // label1
             // 
@@ -73,7 +67,7 @@
             this.srPicker1.Name = "srPicker1";
             this.srPicker1.ItemSelectionNull += new System.Action(this.srPicker1_ItemSelectionNull);
             this.srPicker1.ItemSelectionNotNull += new System.Action(this.srPicker1_ItemSelectionNotNull);
-            this.srPicker1.DoubleClickOnRow += new System.EventHandler(this.SRPicker_DoubleClickOnRow);
+            this.srPicker1.DoubleClickOnRow += new System.EventHandler(this.srPicker1_DoubleClickOnRow);
             // 
             // tableLayoutPanel2
             // 
@@ -116,7 +110,6 @@
 
         #endregion
 
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label label1;
         private XenAdmin.Controls.ToolTipContainer toolTipContainer2;
         private System.Windows.Forms.Button buttonMove;

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
@@ -38,6 +38,7 @@ using XenAdmin.Network;
 using XenAPI;
 using XenAdmin.Actions;
 using XenAdmin.Commands;
+using XenAdmin.Core;
 
 namespace XenAdmin.Dialogs
 {
@@ -159,11 +160,12 @@ namespace XenAdmin.Dialogs
             get { return "VDIMigrateDialog"; }
         }
 
-        internal static Command MoveMigrateCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selection)
+        internal static Command MoveMigrateCommand(IMainWindow mainWindow, SelectedItemCollection selection)
         {
             var cmd = new MigrateVirtualDiskCommand(mainWindow, selection);
+            var con = selection.GetConnectionOfFirstItem();
 
-            if (cmd.CanExecute())
+            if (cmd.CanExecute() && !Helpers.FeatureForbidden(con, Host.RestrictCrossPoolMigrate))
                 return cmd;
 
             return new MoveVirtualDiskCommand(mainWindow, selection);

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
@@ -32,22 +32,20 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using XenAdmin.Controls;
-using XenAdmin.Network;
-using XenAPI;
 using XenAdmin.Actions;
+using XenAdmin.Network;
 using XenAdmin.Commands;
+using XenAdmin.Controls;
 using XenAdmin.Core;
+using XenAPI;
 
 namespace XenAdmin.Dialogs
 {
     public partial class MoveVirtualDiskDialog : XenDialogBase
     {
-        private const int BATCH_SIZE = 3;
-        
-        private readonly List<VDI> _vdisToMove;
-        private readonly List<VDI> _vdisToMigrate;
+        protected const int BATCH_SIZE = 3;
+
+        protected readonly List<VDI> _vdis= new List<VDI>();
 
         /// <summary>
         /// Designer support only. Do not use.
@@ -57,39 +55,36 @@ namespace XenAdmin.Dialogs
             InitializeComponent();
         }
 
-        public MoveVirtualDiskDialog(IXenConnection connection, List<VDI> vdisToMove, List<VDI> vdisToMigrate)
+        public MoveVirtualDiskDialog(IXenConnection connection, List<VDI> vdis)
             : base(connection)
         {
             InitializeComponent();
+            _vdis = vdis ?? new List<VDI>();
+        }
 
-            //set those so we don't have to bother with null checks further down
-            _vdisToMove = vdisToMove ?? new List<VDI>();
-            _vdisToMigrate = vdisToMigrate ?? new List<VDI>();
-
-            if (_vdisToMove.Count > 0)
-            {
-                srPicker1.Usage = SrPicker.SRPickerType.MoveOrCopy;
-                srPicker1.SetExistingVDIs(_vdisToMove.ToArray());
-                srPicker1.DiskSize = _vdisToMove.Sum(d => d.physical_utilisation);
-            }
-            else if (_vdisToMigrate.Count > 0)
-            {
-                srPicker1.Usage = SrPicker.SRPickerType.Migrate;
-                srPicker1.SetExistingVDIs(_vdisToMigrate.ToArray());
-                srPicker1.DiskSize = _vdisToMigrate.Sum(d => d.physical_utilisation);
-            }
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
             
+            srPicker1.Usage = SrPickerType;
+            srPicker1.SetExistingVDIs(_vdis.ToArray());
+            srPicker1.DiskSize = _vdis.Sum(d => d.physical_utilisation);
             srPicker1.SrHint.Visible = false;
             srPicker1.Connection = connection;
             srPicker1.srListBox.Invalidate();
             srPicker1.selectDefaultSROrAny();
         }
 
-        private SR SelectedSR
+        protected SR SelectedSR
         {
             get { return srPicker1.SR; }
         }
-        
+
+        protected virtual SrPicker.SRPickerType SrPickerType
+        {
+            get { return SrPicker.SRPickerType.MoveOrCopy; }
+        }
+
         private void srPicker1_ItemSelectionNull()
         {
             updateButtons();
@@ -100,7 +95,7 @@ namespace XenAdmin.Dialogs
             updateButtons();
         }
 
-        void SRPicker_DoubleClickOnRow(object sender, EventArgs e)
+        private void srPicker1_DoubleClickOnRow(object sender, EventArgs e)
         {
             if (buttonMove.Enabled)
                 buttonMove.PerformClick();
@@ -122,32 +117,17 @@ namespace XenAdmin.Dialogs
             Close();
         }
 
-        private void CreateAndRunParallelActions()
+        protected virtual void CreateAndRunParallelActions()
         {
-            if (_vdisToMigrate.Count == 1)
+            if (_vdis.Count == 1)
             {
-                new MigrateVirtualDiskAction(connection, _vdisToMigrate[0], SelectedSR).RunAsync();
+                new MoveVirtualDiskAction(connection, _vdis[0], SelectedSR).RunAsync();
             }
-            else if (_vdisToMigrate.Count > 1)
+            else if (_vdis.Count > 1)
             {
-                string title = string.Format(Messages.ACTION_MIGRATING_X_VDIS, _vdisToMigrate.Count, SelectedSR.name_label);
+                string title = string.Format(Messages.ACTION_MOVING_X_VDIS, _vdis.Count, SelectedSR.name_label);
 
-                var batch = from VDI vdi in _vdisToMigrate
-                    select (AsyncAction)new MigrateVirtualDiskAction(connection, vdi, SelectedSR);
-
-                new ParallelAction(connection, title, Messages.ACTION_MIGRATING_X_VDIS_STARTED,
-                    Messages.ACTION_MIGRATING_X_VDIS_COMPLETED, batch.ToList(), BATCH_SIZE).RunAsync();
-            }
-
-            if (_vdisToMove.Count == 1)
-            {
-                new MoveVirtualDiskAction(connection, _vdisToMove[0], SelectedSR).RunAsync();
-            }
-            else if (_vdisToMove.Count > 1)
-            {
-                string title = string.Format(Messages.ACTION_MOVING_X_VDIS, _vdisToMove.Count, SelectedSR.name_label);
-
-                var batch = from VDI vdi in _vdisToMove
+                var batch = from VDI vdi in _vdis
                     select (AsyncAction)new MoveVirtualDiskAction(connection, vdi, SelectedSR);
 
                 new ParallelAction(connection, title, Messages.ACTION_MOVING_X_VDIS_STARTED,
@@ -169,6 +149,38 @@ namespace XenAdmin.Dialogs
                 return cmd;
 
             return new MoveVirtualDiskCommand(mainWindow, selection);
+        }
+    }
+
+
+    public class MigrateVirtualDiskDialog : MoveVirtualDiskDialog
+    {
+        public MigrateVirtualDiskDialog(IXenConnection connection, List<VDI> vdis)
+            : base(connection, vdis)
+        {
+        }
+
+        protected override SrPicker.SRPickerType SrPickerType
+        {
+            get { return SrPicker.SRPickerType.Migrate; }
+        }
+
+        protected override void CreateAndRunParallelActions()
+        {
+            if (_vdis.Count == 1)
+            {
+                new MigrateVirtualDiskAction(connection, _vdis[0], SelectedSR).RunAsync();
+            }
+            else if (_vdis.Count > 1)
+            {
+                string title = string.Format(Messages.ACTION_MIGRATING_X_VDIS, _vdis.Count, SelectedSR.name_label);
+
+                var batch = from VDI vdi in _vdis
+                    select (AsyncAction)new MigrateVirtualDiskAction(connection, vdi, SelectedSR);
+
+                new ParallelAction(connection, title, Messages.ACTION_MIGRATING_X_VDIS_STARTED,
+                    Messages.ACTION_MIGRATING_X_VDIS_COMPLETED, batch.ToList(), BATCH_SIZE).RunAsync();
+            }
         }
     }
 }

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.resx
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.resx
@@ -117,45 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 100</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls /&gt;&lt;Columns Styles="Absolute,20" /&gt;&lt;Rows Styles="Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -217,7 +187,7 @@
     <value>75, 25</value>
   </data>
   <data name="buttonMove.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="buttonMove.Text" xml:space="preserve">
     <value>&amp;Move</value>
@@ -244,7 +214,7 @@
     <value>75, 25</value>
   </data>
   <data name="toolTipContainer2.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;toolTipContainer2.Name" xml:space="preserve">
     <value>toolTipContainer2</value>
@@ -263,9 +233,6 @@
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
   </data>
   <data name="buttonCancel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -289,7 +256,7 @@
     <value>75, 25</value>
   </data>
   <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>3</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -328,7 +295,7 @@
     <value>507, 25</value>
   </data>
   <data name="labelBlurb.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="labelBlurb.Text" xml:space="preserve">
     <value>Select the storage repository that you would like to move the virtual disk to:</value>
@@ -361,7 +328,7 @@
     <value>513, 246</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
     <value>tableLayoutPanel2</value>

--- a/XenAdmin/TabPages/PhysicalStoragePage.Designer.cs
+++ b/XenAdmin/TabPages/PhysicalStoragePage.Designer.cs
@@ -39,33 +39,31 @@ namespace XenAdmin.TabPages
             this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.labelNetworkheadings = new System.Windows.Forms.Label();
             this.TitleLabel = new System.Windows.Forms.Label();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.dataGridViewSr = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
-            this.columnImage = new System.Windows.Forms.DataGridViewImageColumn();
-            this.columnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.columnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.columnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.columnShared = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.columnUsage = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.columnSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnVirtAlloc = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnUsage = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnShared = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnImage = new System.Windows.Forms.DataGridViewImageColumn();
+            this.dataGridViewSr = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.newSRButton = new XenAdmin.Commands.CommandButton();
             this.trimButtonContainer = new XenAdmin.Controls.ToolTipContainer();
             this.trimButton = new XenAdmin.Commands.CommandButton();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.buttonProperties = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.pageContainerPanel.SuspendLayout();
-            this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSr)).BeginInit();
             this.flowLayoutPanel1.SuspendLayout();
             this.trimButtonContainer.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // pageContainerPanel
             // 
-            this.pageContainerPanel.Controls.Add(this.panel1);
-            this.pageContainerPanel.Controls.Add(this.labelNetworkheadings);
+            this.pageContainerPanel.Controls.Add(this.tableLayoutPanel1);
             resources.ApplyResources(this.pageContainerPanel, "pageContainerPanel");
             // 
             // contextMenuStrip
@@ -85,15 +83,58 @@ namespace XenAdmin.TabPages
             this.TitleLabel.ForeColor = System.Drawing.Color.White;
             this.TitleLabel.Name = "TitleLabel";
             // 
-            // panel1
+            // columnVirtAlloc
             // 
-            resources.ApplyResources(this.panel1, "panel1");
-            this.panel1.Controls.Add(this.dataGridViewSr);
-            this.panel1.Controls.Add(this.flowLayoutPanel1);
-            this.panel1.Name = "panel1";
+            this.columnVirtAlloc.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.columnVirtAlloc, "columnVirtAlloc");
+            this.columnVirtAlloc.Name = "columnVirtAlloc";
+            // 
+            // columnSize
+            // 
+            this.columnSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.columnSize, "columnSize");
+            this.columnSize.Name = "columnSize";
+            // 
+            // columnUsage
+            // 
+            this.columnUsage.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.columnUsage, "columnUsage");
+            this.columnUsage.Name = "columnUsage";
+            // 
+            // columnShared
+            // 
+            this.columnShared.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.columnShared, "columnShared");
+            this.columnShared.Name = "columnShared";
+            // 
+            // columnType
+            // 
+            this.columnType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.columnType, "columnType");
+            this.columnType.Name = "columnType";
+            // 
+            // columnDescription
+            // 
+            this.columnDescription.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            resources.ApplyResources(this.columnDescription, "columnDescription");
+            this.columnDescription.Name = "columnDescription";
+            // 
+            // columnName
+            // 
+            this.columnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            resources.ApplyResources(this.columnName, "columnName");
+            this.columnName.Name = "columnName";
+            // 
+            // columnImage
+            // 
+            this.columnImage.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.columnImage, "columnImage");
+            this.columnImage.Name = "columnImage";
+            this.columnImage.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             // 
             // dataGridViewSr
             // 
+            resources.ApplyResources(this.dataGridViewSr, "dataGridViewSr");
             this.dataGridViewSr.BackgroundColor = System.Drawing.SystemColors.Window;
             this.dataGridViewSr.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             this.dataGridViewSr.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
@@ -106,67 +147,16 @@ namespace XenAdmin.TabPages
             this.columnUsage,
             this.columnSize,
             this.columnVirtAlloc});
-            resources.ApplyResources(this.dataGridViewSr, "dataGridViewSr");
             this.dataGridViewSr.MultiSelect = true;
             this.dataGridViewSr.Name = "dataGridViewSr";
             this.dataGridViewSr.SelectionChanged += new System.EventHandler(this.dataGridViewSrs_SelectedIndexChanged);
             this.dataGridViewSr.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridViewSr_SortCompare);
             this.dataGridViewSr.MouseUp += new System.Windows.Forms.MouseEventHandler(this.dataGridViewSr_MouseUp);
             // 
-            // columnImage
-            // 
-            this.columnImage.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.columnImage, "columnImage");
-            this.columnImage.Name = "columnImage";
-            this.columnImage.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            // 
-            // columnName
-            // 
-            this.columnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            resources.ApplyResources(this.columnName, "columnName");
-            this.columnName.Name = "columnName";
-            // 
-            // columnDescription
-            // 
-            this.columnDescription.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            resources.ApplyResources(this.columnDescription, "columnDescription");
-            this.columnDescription.Name = "columnDescription";
-            // 
-            // columnType
-            // 
-            this.columnType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.columnType, "columnType");
-            this.columnType.Name = "columnType";
-            // 
-            // columnShared
-            // 
-            this.columnShared.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.columnShared, "columnShared");
-            this.columnShared.Name = "columnShared";
-            // 
-            // columnUsage
-            // 
-            this.columnUsage.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.columnUsage, "columnUsage");
-            this.columnUsage.Name = "columnUsage";
-            // 
-            // columnSize
-            // 
-            this.columnSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.columnSize, "columnSize");
-            this.columnSize.Name = "columnSize";
-            // 
-            // columnVirtAlloc
-            // 
-            this.columnVirtAlloc.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.columnVirtAlloc, "columnVirtAlloc");
-            this.columnVirtAlloc.Name = "columnVirtAlloc";
-            // 
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.Controls.Add(this.newSRButton);
             this.flowLayoutPanel1.Controls.Add(this.trimButtonContainer);
-            this.flowLayoutPanel1.Controls.Add(this.groupBox1);
             this.flowLayoutPanel1.Controls.Add(this.buttonProperties);
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
@@ -191,18 +181,20 @@ namespace XenAdmin.TabPages
             this.trimButton.Name = "trimButton";
             this.trimButton.UseVisualStyleBackColor = true;
             // 
-            // groupBox1
-            // 
-            resources.ApplyResources(this.groupBox1, "groupBox1");
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.TabStop = false;
-            // 
             // buttonProperties
             // 
             resources.ApplyResources(this.buttonProperties, "buttonProperties");
             this.buttonProperties.Name = "buttonProperties";
             this.buttonProperties.UseVisualStyleBackColor = true;
             this.buttonProperties.Click += new System.EventHandler(this.buttonProperties_Click);
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.labelNetworkheadings, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.dataGridViewSr, 0, 1);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // PhysicalStoragePage
             // 
@@ -213,11 +205,11 @@ namespace XenAdmin.TabPages
             this.Name = "PhysicalStoragePage";
             this.Controls.SetChildIndex(this.pageContainerPanel, 0);
             this.pageContainerPanel.ResumeLayout(false);
-            this.pageContainerPanel.PerformLayout();
-            this.panel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSr)).EndInit();
             this.flowLayoutPanel1.ResumeLayout(false);
             this.trimButtonContainer.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -225,17 +217,16 @@ namespace XenAdmin.TabPages
 
         #endregion
 
-        private System.Windows.Forms.Label TitleLabel;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
+        private System.Windows.Forms.Label TitleLabel;
         private System.Windows.Forms.Label labelNetworkheadings;
-        private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Button buttonProperties;
-        private System.Windows.Forms.GroupBox groupBox1;
-        private XenAdmin.Commands.CommandButton newSRButton;
-        private XenAdmin.Commands.CommandButton trimButton;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private Commands.CommandButton newSRButton;
+        private Commands.CommandButton trimButton;
         private Controls.ToolTipContainer trimButtonContainer;
+
         private Controls.DataGridViewEx.DataGridViewEx dataGridViewSr;
+        private System.Windows.Forms.Button buttonProperties;
         private System.Windows.Forms.DataGridViewImageColumn columnImage;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnName;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnDescription;
@@ -244,5 +235,6 @@ namespace XenAdmin.TabPages
         private System.Windows.Forms.DataGridViewTextBoxColumn columnUsage;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnSize;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnVirtAlloc;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }
 }

--- a/XenAdmin/TabPages/PhysicalStoragePage.resx
+++ b/XenAdmin/TabPages/PhysicalStoragePage.resx
@@ -117,8 +117,184 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelNetworkheadings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="labelNetworkheadings.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 11.25pt</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="labelNetworkheadings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelNetworkheadings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="labelNetworkheadings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 20</value>
+  </data>
+  <data name="labelNetworkheadings.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelNetworkheadings.Text" xml:space="preserve">
+    <value>Storage</value>
+  </data>
+  <data name="&gt;&gt;labelNetworkheadings.Name" xml:space="preserve">
+    <value>labelNetworkheadings</value>
+  </data>
+  <data name="&gt;&gt;labelNetworkheadings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelNetworkheadings.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelNetworkheadings.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="newSRButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="newSRButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="newSRButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 23</value>
+  </data>
+  <data name="newSRButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="newSRButton.Text" xml:space="preserve">
+    <value>&amp;New SR...</value>
+  </data>
+  <data name="&gt;&gt;newSRButton.Name" xml:space="preserve">
+    <value>newSRButton</value>
+  </data>
+  <data name="&gt;&gt;newSRButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;newSRButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;newSRButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="trimButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="trimButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="trimButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="trimButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="trimButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>140, 23</value>
+  </data>
+  <data name="trimButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="trimButton.Text" xml:space="preserve">
+    <value>Re&amp;claim freed space</value>
+  </data>
+  <data name="&gt;&gt;trimButton.Name" xml:space="preserve">
+    <value>trimButton</value>
+  </data>
+  <data name="&gt;&gt;trimButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;trimButton.Parent" xml:space="preserve">
+    <value>trimButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;trimButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="trimButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>111, 3</value>
+  </data>
+  <data name="trimButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>140, 23</value>
+  </data>
+  <data name="trimButtonContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.Name" xml:space="preserve">
+    <value>trimButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;trimButtonContainer.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonProperties.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="buttonProperties.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="buttonProperties.Location" type="System.Drawing.Point, System.Drawing">
+    <value>257, 3</value>
+  </data>
+  <data name="buttonProperties.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 23</value>
+  </data>
+  <data name="buttonProperties.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonProperties.Text" xml:space="preserve">
+    <value>P&amp;roperties</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.Name" xml:space="preserve">
+    <value>buttonProperties</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 267</value>
+  </data>
+  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>900, 83</value>
+  </data>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="dataGridViewSr.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
   <metadata name="columnImage.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -127,7 +303,6 @@
   <data name="columnImage.HeaderText" xml:space="preserve">
     <value />
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="columnImage.Width" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
@@ -209,18 +384,17 @@
   <data name="columnVirtAlloc.Width" type="System.Int32, mscorlib">
     <value>120</value>
   </data>
-  <data name="dataGridViewSr.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="dataGridViewSr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 23</value>
+  </data>
+  <data name="dataGridViewSr.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 12</value>
   </data>
   <data name="dataGridViewSr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 259</value>
+    <value>894, 232</value>
   </data>
   <data name="dataGridViewSr.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;dataGridViewSr.Name" xml:space="preserve">
     <value>dataGridViewSr</value>
@@ -229,247 +403,46 @@
     <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewSr.Parent" xml:space="preserve">
-    <value>panel1</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;dataGridViewSr.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
-  <data name="newSRButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 5</value>
-  </data>
-  <data name="newSRButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="newSRButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="newSRButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="newSRButton.Text" xml:space="preserve">
-    <value>&amp;New SR...</value>
-  </data>
-  <data name="&gt;&gt;newSRButton.Name" xml:space="preserve">
-    <value>newSRButton</value>
-  </data>
-  <data name="&gt;&gt;newSRButton.Type" xml:space="preserve">
-    <value>XenAdmin.Commands.CommandButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;newSRButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;newSRButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="trimButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="trimButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 10</value>
   </data>
-  <data name="trimButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="trimButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 23</value>
-  </data>
-  <data name="trimButton.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="trimButton.Text" xml:space="preserve">
-    <value>Re&amp;claim freed space</value>
-  </data>
-  <data name="&gt;&gt;trimButton.Name" xml:space="preserve">
-    <value>trimButton</value>
-  </data>
-  <data name="&gt;&gt;trimButton.Type" xml:space="preserve">
-    <value>XenAdmin.Commands.CommandButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;trimButton.Parent" xml:space="preserve">
-    <value>trimButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;trimButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="trimButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 5</value>
-  </data>
-  <data name="trimButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 0</value>
-  </data>
-  <data name="trimButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 23</value>
-  </data>
-  <data name="trimButtonContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;trimButtonContainer.Name" xml:space="preserve">
-    <value>trimButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;trimButtonContainer.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;trimButtonContainer.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;trimButtonContainer.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>234, 5</value>
-  </data>
-  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>2, 20</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="groupBox1.Text" xml:space="preserve">
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>900, 350</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="buttonProperties.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="buttonProperties.Location" type="System.Drawing.Point, System.Drawing">
-    <value>242, 5</value>
-  </data>
-  <data name="buttonProperties.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="buttonProperties.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="buttonProperties.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="buttonProperties.Text" xml:space="preserve">
-    <value>P&amp;roperties</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.Name" xml:space="preserve">
-    <value>buttonProperties</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 259</value>
-  </data>
-  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 34</value>
-  </data>
-  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 35</value>
-  </data>
-  <data name="panel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>900, 400</value>
-  </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>897, 293</value>
-  </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>pageContainerPanel</value>
   </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="labelNetworkheadings.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelNetworkheadings.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 11.25pt</value>
-  </data>
-  <data name="labelNetworkheadings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelNetworkheadings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 10</value>
-  </data>
-  <data name="labelNetworkheadings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="labelNetworkheadings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 2</value>
-  </data>
-  <data name="labelNetworkheadings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 22</value>
-  </data>
-  <data name="labelNetworkheadings.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="labelNetworkheadings.Text" xml:space="preserve">
-    <value>Storage</value>
-  </data>
-  <data name="&gt;&gt;labelNetworkheadings.Name" xml:space="preserve">
-    <value>labelNetworkheadings</value>
-  </data>
-  <data name="&gt;&gt;labelNetworkheadings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelNetworkheadings.Parent" xml:space="preserve">
-    <value>pageContainerPanel</value>
-  </data>
-  <data name="&gt;&gt;labelNetworkheadings.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelNetworkheadings" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="flowLayoutPanel1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="dataGridViewSr" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,75,Percent,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 78</value>
   </data>
   <data name="pageContainerPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>920, 344</value>
+    <value>920, 370</value>
   </data>
   <data name="pageContainerPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -534,6 +507,9 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>38</value>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
@@ -541,42 +517,12 @@
     <value>Segoe UI, 8.25pt</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>920, 422</value>
+    <value>920, 448</value>
   </data>
-  <data name="&gt;&gt;columnImage.Name" xml:space="preserve">
-    <value>columnImage</value>
+  <data name="&gt;&gt;columnVirtAlloc.Name" xml:space="preserve">
+    <value>columnVirtAlloc</value>
   </data>
-  <data name="&gt;&gt;columnImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;columnName.Name" xml:space="preserve">
-    <value>columnName</value>
-  </data>
-  <data name="&gt;&gt;columnName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;columnDescription.Name" xml:space="preserve">
-    <value>columnDescription</value>
-  </data>
-  <data name="&gt;&gt;columnDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;columnType.Name" xml:space="preserve">
-    <value>columnType</value>
-  </data>
-  <data name="&gt;&gt;columnType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;columnShared.Name" xml:space="preserve">
-    <value>columnShared</value>
-  </data>
-  <data name="&gt;&gt;columnShared.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;columnUsage.Name" xml:space="preserve">
-    <value>columnUsage</value>
-  </data>
-  <data name="&gt;&gt;columnUsage.Type" xml:space="preserve">
+  <data name="&gt;&gt;columnVirtAlloc.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;columnSize.Name" xml:space="preserve">
@@ -585,11 +531,41 @@
   <data name="&gt;&gt;columnSize.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;columnVirtAlloc.Name" xml:space="preserve">
-    <value>columnVirtAlloc</value>
+  <data name="&gt;&gt;columnUsage.Name" xml:space="preserve">
+    <value>columnUsage</value>
   </data>
-  <data name="&gt;&gt;columnVirtAlloc.Type" xml:space="preserve">
+  <data name="&gt;&gt;columnUsage.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnShared.Name" xml:space="preserve">
+    <value>columnShared</value>
+  </data>
+  <data name="&gt;&gt;columnShared.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnType.Name" xml:space="preserve">
+    <value>columnType</value>
+  </data>
+  <data name="&gt;&gt;columnType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnDescription.Name" xml:space="preserve">
+    <value>columnDescription</value>
+  </data>
+  <data name="&gt;&gt;columnDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnName.Name" xml:space="preserve">
+    <value>columnName</value>
+  </data>
+  <data name="&gt;&gt;columnName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnImage.Name" xml:space="preserve">
+    <value>columnImage</value>
+  </data>
+  <data name="&gt;&gt;columnImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PhysicalStoragePage</value>

--- a/XenAdmin/TabPages/SrStoragePage.Designer.cs
+++ b/XenAdmin/TabPages/SrStoragePage.Designer.cs
@@ -40,13 +40,13 @@ namespace XenAdmin.TabPages
             this.toolTipContainerMove = new XenAdmin.Controls.ToolTipContainer();
             this.buttonMove = new System.Windows.Forms.Button();
             this.dataGridViewVDIs = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnVolume = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnDesc = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnVM = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnCBT = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.pageContainerPanel.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
             this.RemoveButtonContainer.SuspendLayout();
@@ -161,9 +161,9 @@ namespace XenAdmin.TabPages
             // 
             this.flowLayoutPanel1.Controls.Add(this.toolTipContainerRescan);
             this.flowLayoutPanel1.Controls.Add(this.addVirtualDiskButton);
-            this.flowLayoutPanel1.Controls.Add(this.EditButtonContainer);
             this.flowLayoutPanel1.Controls.Add(this.toolTipContainerMove);
             this.flowLayoutPanel1.Controls.Add(this.RemoveButtonContainer);
+            this.flowLayoutPanel1.Controls.Add(this.EditButtonContainer);
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             // 
@@ -215,14 +215,6 @@ namespace XenAdmin.TabPages
             this.dataGridViewVDIs.KeyUp += new System.Windows.Forms.KeyEventHandler(this.dataGridViewVDIs_KeyUp);
             this.dataGridViewVDIs.MouseUp += new System.Windows.Forms.MouseEventHandler(this.dataGridViewVDIs_MouseUp);
             // 
-            // tableLayoutPanel1
-            // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.dataGridViewVDIs, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
             // ColumnName
             // 
             this.ColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
@@ -264,6 +256,14 @@ namespace XenAdmin.TabPages
             resources.ApplyResources(this.ColumnCBT, "ColumnCBT");
             this.ColumnCBT.Name = "ColumnCBT";
             this.ColumnCBT.ReadOnly = true;
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.dataGridViewVDIs, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // SrStoragePage
             // 

--- a/XenAdmin/TabPages/SrStoragePage.resx
+++ b/XenAdmin/TabPages/SrStoragePage.resx
@@ -201,6 +201,108 @@
   <data name="&gt;&gt;addVirtualDiskButton.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="buttonMove.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="buttonMove.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="buttonMove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="buttonMove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 23</value>
+  </data>
+  <data name="buttonMove.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="buttonMove.Text" xml:space="preserve">
+    <value>Mov&amp;e...</value>
+  </data>
+  <data name="&gt;&gt;buttonMove.Name" xml:space="preserve">
+    <value>buttonMove</value>
+  </data>
+  <data name="&gt;&gt;buttonMove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonMove.Parent" xml:space="preserve">
+    <value>toolTipContainerMove</value>
+  </data>
+  <data name="&gt;&gt;buttonMove.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="toolTipContainerMove.Location" type="System.Drawing.Point, System.Drawing">
+    <value>219, 3</value>
+  </data>
+  <data name="toolTipContainerMove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 23</value>
+  </data>
+  <data name="toolTipContainerMove.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.Name" xml:space="preserve">
+    <value>toolTipContainerMove</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;toolTipContainerMove.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="RemoveButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="RemoveButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="RemoveButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="RemoveButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 23</value>
+  </data>
+  <data name="RemoveButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="RemoveButton.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
+  </data>
+  <data name="&gt;&gt;RemoveButton.Name" xml:space="preserve">
+    <value>RemoveButton</value>
+  </data>
+  <data name="&gt;&gt;RemoveButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RemoveButton.Parent" xml:space="preserve">
+    <value>RemoveButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;RemoveButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="RemoveButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>327, 3</value>
+  </data>
+  <data name="RemoveButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 23</value>
+  </data>
+  <data name="RemoveButtonContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.Name" xml:space="preserve">
+    <value>RemoveButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;RemoveButtonContainer.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="EditButtonContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
   </data>
@@ -238,13 +340,13 @@
     <value>1</value>
   </data>
   <data name="EditButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>219, 3</value>
+    <value>435, 3</value>
   </data>
   <data name="EditButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 23</value>
   </data>
   <data name="EditButtonContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;EditButtonContainer.Name" xml:space="preserve">
     <value>EditButtonContainer</value>
@@ -256,118 +358,19 @@
     <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;EditButtonContainer.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="buttonMove.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="buttonMove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="buttonMove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="buttonMove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="buttonMove.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="buttonMove.Text" xml:space="preserve">
-    <value>Mov&amp;e...</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.Name" xml:space="preserve">
-    <value>buttonMove</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.Parent" xml:space="preserve">
-    <value>toolTipContainerMove</value>
-  </data>
-  <data name="&gt;&gt;buttonMove.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="toolTipContainerMove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>327, 3</value>
-  </data>
-  <data name="toolTipContainerMove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="toolTipContainerMove.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Name" xml:space="preserve">
-    <value>toolTipContainerMove</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;toolTipContainerMove.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="RemoveButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="RemoveButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="RemoveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="RemoveButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="RemoveButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="RemoveButton.Text" xml:space="preserve">
-    <value>&amp;Delete</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Name" xml:space="preserve">
-    <value>RemoveButton</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.Parent" xml:space="preserve">
-    <value>RemoveButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;RemoveButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="RemoveButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>435, 3</value>
-  </data>
-  <data name="RemoveButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 23</value>
-  </data>
-  <data name="RemoveButtonContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Name" xml:space="preserve">
-    <value>RemoveButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;RemoveButtonContainer.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
   <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 272</value>
+    <value>0, 269</value>
+  </data>
+  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>894, 77</value>
+    <value>900, 83</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -434,6 +437,9 @@
   </metadata>
   <data name="ColumnCBT.HeaderText" xml:space="preserve">
     <value>Changed Block Tracking</value>
+  </data>
+  <data name="ColumnCBT.Width" type="System.Int32, mscorlib">
+    <value>155</value>
   </data>
   <data name="dataGridViewVDIs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/XenAdmin/TabPages/VMStoragePage.Designer.cs
+++ b/XenAdmin/TabPages/VMStoragePage.Designer.cs
@@ -41,10 +41,10 @@ namespace XenAdmin.TabPages
             this.DeactivateButton = new System.Windows.Forms.Button();
             this.MoveButtonContainer = new XenAdmin.Controls.ToolTipContainer();
             this.MoveButton = new System.Windows.Forms.Button();
-            this.DeleteButtonContainer = new XenAdmin.Controls.ToolTipContainer();
-            this.DeleteButton = new System.Windows.Forms.Button();
             this.DetachButtonContainer = new XenAdmin.Controls.ToolTipContainer();
             this.DetachButton = new System.Windows.Forms.Button();
+            this.DeleteButtonContainer = new XenAdmin.Controls.ToolTipContainer();
+            this.DeleteButton = new System.Windows.Forms.Button();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItemAdd = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemAttach = new System.Windows.Forms.ToolStripMenuItem();
@@ -56,6 +56,16 @@ namespace XenAdmin.TabPages
             this.toolStripMenuItemProperties = new System.Windows.Forms.ToolStripMenuItem();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.dataGridViewStorage = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
+            this.ColumnDevicePosition = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnDesc = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnSR = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnSRVolume = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnReadOnly = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnPriority = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnActive = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnDevicePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.multipleDvdIsoList1 = new XenAdmin.Controls.MultipleDvdIsoList();
             this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -67,22 +77,12 @@ namespace XenAdmin.TabPages
             this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnDevicePosition = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnDesc = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnSR = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnSRVolume = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnReadOnly = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnPriority = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnActive = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnDevicePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.pageContainerPanel.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.DeactivateButtonContainer.SuspendLayout();
             this.MoveButtonContainer.SuspendLayout();
-            this.DeleteButtonContainer.SuspendLayout();
             this.DetachButtonContainer.SuspendLayout();
+            this.DeleteButtonContainer.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewStorage)).BeginInit();
@@ -120,9 +120,9 @@ namespace XenAdmin.TabPages
             this.flowLayoutPanel1.Controls.Add(this.AttachButton);
             this.flowLayoutPanel1.Controls.Add(this.DeactivateButtonContainer);
             this.flowLayoutPanel1.Controls.Add(this.MoveButtonContainer);
-            this.flowLayoutPanel1.Controls.Add(this.EditButton);
-            this.flowLayoutPanel1.Controls.Add(this.DeleteButtonContainer);
             this.flowLayoutPanel1.Controls.Add(this.DetachButtonContainer);
+            this.flowLayoutPanel1.Controls.Add(this.DeleteButtonContainer);
+            this.flowLayoutPanel1.Controls.Add(this.EditButton);
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             // 
@@ -152,19 +152,6 @@ namespace XenAdmin.TabPages
             this.MoveButton.UseVisualStyleBackColor = true;
             this.MoveButton.Click += new System.EventHandler(this.MoveButton_Click);
             // 
-            // DeleteButtonContainer
-            // 
-            this.DeleteButtonContainer.Controls.Add(this.DeleteButton);
-            resources.ApplyResources(this.DeleteButtonContainer, "DeleteButtonContainer");
-            this.DeleteButtonContainer.Name = "DeleteButtonContainer";
-            // 
-            // DeleteButton
-            // 
-            resources.ApplyResources(this.DeleteButton, "DeleteButton");
-            this.DeleteButton.Name = "DeleteButton";
-            this.DeleteButton.UseVisualStyleBackColor = true;
-            this.DeleteButton.Click += new System.EventHandler(this.DeleteDriveButton_Click);
-            // 
             // DetachButtonContainer
             // 
             this.DetachButtonContainer.Controls.Add(this.DetachButton);
@@ -177,6 +164,19 @@ namespace XenAdmin.TabPages
             this.DetachButton.Name = "DetachButton";
             this.DetachButton.UseVisualStyleBackColor = true;
             this.DetachButton.Click += new System.EventHandler(this.DetachButton_Click);
+            // 
+            // DeleteButtonContainer
+            // 
+            this.DeleteButtonContainer.Controls.Add(this.DeleteButton);
+            resources.ApplyResources(this.DeleteButtonContainer, "DeleteButtonContainer");
+            this.DeleteButtonContainer.Name = "DeleteButtonContainer";
+            // 
+            // DeleteButton
+            // 
+            resources.ApplyResources(this.DeleteButton, "DeleteButton");
+            this.DeleteButton.Name = "DeleteButton";
+            this.DeleteButton.UseVisualStyleBackColor = true;
+            this.DeleteButton.Click += new System.EventHandler(this.DeleteDriveButton_Click);
             // 
             // contextMenuStrip1
             // 
@@ -276,6 +276,76 @@ namespace XenAdmin.TabPages
             this.dataGridViewStorage.KeyUp += new System.Windows.Forms.KeyEventHandler(this.dataGridViewStorage_KeyUp);
             this.dataGridViewStorage.MouseUp += new System.Windows.Forms.MouseEventHandler(this.dataGridViewStorage_MouseUp);
             // 
+            // ColumnDevicePosition
+            // 
+            this.ColumnDevicePosition.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.ColumnDevicePosition, "ColumnDevicePosition");
+            this.ColumnDevicePosition.Name = "ColumnDevicePosition";
+            this.ColumnDevicePosition.ReadOnly = true;
+            // 
+            // ColumnName
+            // 
+            this.ColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            resources.ApplyResources(this.ColumnName, "ColumnName");
+            this.ColumnName.Name = "ColumnName";
+            this.ColumnName.ReadOnly = true;
+            // 
+            // ColumnDesc
+            // 
+            this.ColumnDesc.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            resources.ApplyResources(this.ColumnDesc, "ColumnDesc");
+            this.ColumnDesc.Name = "ColumnDesc";
+            this.ColumnDesc.ReadOnly = true;
+            // 
+            // ColumnSR
+            // 
+            this.ColumnSR.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            resources.ApplyResources(this.ColumnSR, "ColumnSR");
+            this.ColumnSR.Name = "ColumnSR";
+            this.ColumnSR.ReadOnly = true;
+            // 
+            // ColumnSRVolume
+            // 
+            this.ColumnSRVolume.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            resources.ApplyResources(this.ColumnSRVolume, "ColumnSRVolume");
+            this.ColumnSRVolume.Name = "ColumnSRVolume";
+            this.ColumnSRVolume.ReadOnly = true;
+            // 
+            // ColumnSize
+            // 
+            this.ColumnSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.ColumnSize, "ColumnSize");
+            this.ColumnSize.Name = "ColumnSize";
+            this.ColumnSize.ReadOnly = true;
+            // 
+            // ColumnReadOnly
+            // 
+            this.ColumnReadOnly.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.ColumnReadOnly, "ColumnReadOnly");
+            this.ColumnReadOnly.Name = "ColumnReadOnly";
+            this.ColumnReadOnly.ReadOnly = true;
+            // 
+            // ColumnPriority
+            // 
+            this.ColumnPriority.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.ColumnPriority, "ColumnPriority");
+            this.ColumnPriority.Name = "ColumnPriority";
+            this.ColumnPriority.ReadOnly = true;
+            // 
+            // ColumnActive
+            // 
+            this.ColumnActive.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.ColumnActive, "ColumnActive");
+            this.ColumnActive.Name = "ColumnActive";
+            this.ColumnActive.ReadOnly = true;
+            // 
+            // ColumnDevicePath
+            // 
+            this.ColumnDevicePath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.ColumnDevicePath, "ColumnDevicePath");
+            this.ColumnDevicePath.Name = "ColumnDevicePath";
+            this.ColumnDevicePath.ReadOnly = true;
+            // 
             // multipleDvdIsoList1
             // 
             resources.ApplyResources(this.multipleDvdIsoList1, "multipleDvdIsoList1");
@@ -355,76 +425,6 @@ namespace XenAdmin.TabPages
             this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
             this.dataGridViewTextBoxColumn10.ReadOnly = true;
             // 
-            // ColumnDevicePosition
-            // 
-            this.ColumnDevicePosition.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.ColumnDevicePosition, "ColumnDevicePosition");
-            this.ColumnDevicePosition.Name = "ColumnDevicePosition";
-            this.ColumnDevicePosition.ReadOnly = true;
-            // 
-            // ColumnName
-            // 
-            this.ColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            resources.ApplyResources(this.ColumnName, "ColumnName");
-            this.ColumnName.Name = "ColumnName";
-            this.ColumnName.ReadOnly = true;
-            // 
-            // ColumnDesc
-            // 
-            this.ColumnDesc.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            resources.ApplyResources(this.ColumnDesc, "ColumnDesc");
-            this.ColumnDesc.Name = "ColumnDesc";
-            this.ColumnDesc.ReadOnly = true;
-            // 
-            // ColumnSR
-            // 
-            this.ColumnSR.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            resources.ApplyResources(this.ColumnSR, "ColumnSR");
-            this.ColumnSR.Name = "ColumnSR";
-            this.ColumnSR.ReadOnly = true;
-            // 
-            // ColumnSRVolume
-            // 
-            this.ColumnSRVolume.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            resources.ApplyResources(this.ColumnSRVolume, "ColumnSRVolume");
-            this.ColumnSRVolume.Name = "ColumnSRVolume";
-            this.ColumnSRVolume.ReadOnly = true;
-            // 
-            // ColumnSize
-            // 
-            this.ColumnSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.ColumnSize, "ColumnSize");
-            this.ColumnSize.Name = "ColumnSize";
-            this.ColumnSize.ReadOnly = true;
-            // 
-            // ColumnReadOnly
-            // 
-            this.ColumnReadOnly.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.ColumnReadOnly, "ColumnReadOnly");
-            this.ColumnReadOnly.Name = "ColumnReadOnly";
-            this.ColumnReadOnly.ReadOnly = true;
-            // 
-            // ColumnPriority
-            // 
-            this.ColumnPriority.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.ColumnPriority, "ColumnPriority");
-            this.ColumnPriority.Name = "ColumnPriority";
-            this.ColumnPriority.ReadOnly = true;
-            // 
-            // ColumnActive
-            // 
-            this.ColumnActive.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.ColumnActive, "ColumnActive");
-            this.ColumnActive.Name = "ColumnActive";
-            this.ColumnActive.ReadOnly = true;
-            // 
-            // ColumnDevicePath
-            // 
-            this.ColumnDevicePath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.ColumnDevicePath, "ColumnDevicePath");
-            this.ColumnDevicePath.Name = "ColumnDevicePath";
-            this.ColumnDevicePath.ReadOnly = true;
-            // 
             // VMStoragePage
             // 
             resources.ApplyResources(this, "$this");
@@ -437,8 +437,8 @@ namespace XenAdmin.TabPages
             this.flowLayoutPanel1.ResumeLayout(false);
             this.DeactivateButtonContainer.ResumeLayout(false);
             this.MoveButtonContainer.ResumeLayout(false);
-            this.DeleteButtonContainer.ResumeLayout(false);
             this.DetachButtonContainer.ResumeLayout(false);
+            this.DeleteButtonContainer.ResumeLayout(false);
             this.contextMenuStrip1.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewStorage)).EndInit();

--- a/XenAdmin/TabPages/VMStoragePage.cs
+++ b/XenAdmin/TabPages/VMStoragePage.cs
@@ -365,7 +365,7 @@ namespace XenAdmin.TabPages
             }
 
             // Move button
-            Command moveCmd = MoveVirtualDiskDialog.MoveMigrateCommand(Program.MainWindow, selectedVDIs);
+            Command moveCmd = MoveVirtualDiskDialog.MoveMigrateCommand(Program.MainWindow, new SelectedItemCollection(selectedVDIs));
             if (moveCmd.CanExecute())
             {
                 MoveButton.Enabled = true;
@@ -404,11 +404,10 @@ namespace XenAdmin.TabPages
             List<VBDRow> rows = SelectedVBDRows;
             if (rows == null)
                 return;
-            List<SelectedItem> l = new List<SelectedItem>();
-            foreach (VBDRow r in rows)
-                l.Add(new SelectedItem(r.VDI));
 
-            Command cmd = MoveVirtualDiskDialog.MoveMigrateCommand(Program.MainWindow, l);
+            var vdis = (from VBDRow r in rows select new SelectedItem(r.VDI)).ToList();
+
+            var cmd = MoveVirtualDiskDialog.MoveMigrateCommand(Program.MainWindow, new SelectedItemCollection(vdis));
             if (cmd.CanExecute())
                 cmd.Execute();
         }

--- a/XenAdmin/TabPages/VMStoragePage.resx
+++ b/XenAdmin/TabPages/VMStoragePage.resx
@@ -127,10 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="AddButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 2</value>
-  </data>
-  <data name="AddButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
+    <value>3, 3</value>
   </data>
   <data name="AddButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 23</value>
@@ -157,10 +154,7 @@
     <value>NoControl</value>
   </data>
   <data name="AttachButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>102, 2</value>
-  </data>
-  <data name="AttachButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
+    <value>105, 3</value>
   </data>
   <data name="AttachButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 23</value>
@@ -217,10 +211,7 @@
     <value>1</value>
   </data>
   <data name="DeactivateButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>202, 2</value>
-  </data>
-  <data name="DeactivateButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
+    <value>207, 3</value>
   </data>
   <data name="DeactivateButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 23</value>
@@ -274,10 +265,7 @@
     <value>1</value>
   </data>
   <data name="MoveButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 2</value>
-  </data>
-  <data name="MoveButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
+    <value>309, 3</value>
   </data>
   <data name="MoveButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 23</value>
@@ -297,37 +285,58 @@
   <data name="&gt;&gt;MoveButtonContainer.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="EditButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
+  <data name="DetachButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="EditButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="DetachButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="EditButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>402, 2</value>
+  <data name="DetachButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
   </data>
-  <data name="EditButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
+  <data name="DetachButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
-  <data name="EditButton.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="DetachButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 23</value>
   </data>
-  <data name="EditButton.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="DetachButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="EditButton.Text" xml:space="preserve">
-    <value>P&amp;roperties</value>
+  <data name="DetachButton.Text" xml:space="preserve">
+    <value>D&amp;etach</value>
   </data>
-  <data name="&gt;&gt;EditButton.Name" xml:space="preserve">
-    <value>EditButton</value>
+  <data name="&gt;&gt;DetachButton.Name" xml:space="preserve">
+    <value>DetachButton</value>
   </data>
-  <data name="&gt;&gt;EditButton.Type" xml:space="preserve">
+  <data name="&gt;&gt;DetachButton.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;EditButton.Parent" xml:space="preserve">
+  <data name="&gt;&gt;DetachButton.Parent" xml:space="preserve">
+    <value>DetachButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;DetachButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="DetachButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>411, 3</value>
+  </data>
+  <data name="DetachButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 23</value>
+  </data>
+  <data name="DetachButtonContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;DetachButtonContainer.Name" xml:space="preserve">
+    <value>DetachButtonContainer</value>
+  </data>
+  <data name="&gt;&gt;DetachButtonContainer.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;DetachButtonContainer.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;EditButton.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;DetachButtonContainer.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
   <data name="DeleteButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -364,10 +373,7 @@
     <value>1</value>
   </data>
   <data name="DeleteButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>502, 2</value>
-  </data>
-  <data name="DeleteButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
+    <value>513, 3</value>
   </data>
   <data name="DeleteButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 23</value>
@@ -387,74 +393,47 @@
   <data name="&gt;&gt;DeleteButtonContainer.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="DetachButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="EditButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
-  <data name="DetachButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="EditButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="DetachButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+  <data name="EditButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>615, 3</value>
   </data>
-  <data name="DetachButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="DetachButton.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="EditButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 23</value>
   </data>
-  <data name="DetachButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="DetachButton.Text" xml:space="preserve">
-    <value>D&amp;etach</value>
-  </data>
-  <data name="&gt;&gt;DetachButton.Name" xml:space="preserve">
-    <value>DetachButton</value>
-  </data>
-  <data name="&gt;&gt;DetachButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DetachButton.Parent" xml:space="preserve">
-    <value>DetachButtonContainer</value>
-  </data>
-  <data name="&gt;&gt;DetachButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="DetachButtonContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>602, 2</value>
-  </data>
-  <data name="DetachButtonContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="DetachButtonContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 23</value>
-  </data>
-  <data name="DetachButtonContainer.TabIndex" type="System.Int32, mscorlib">
+  <data name="EditButton.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;DetachButtonContainer.Name" xml:space="preserve">
-    <value>DetachButtonContainer</value>
+  <data name="EditButton.Text" xml:space="preserve">
+    <value>P&amp;roperties</value>
   </data>
-  <data name="&gt;&gt;DetachButtonContainer.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;EditButton.Name" xml:space="preserve">
+    <value>EditButton</value>
   </data>
-  <data name="&gt;&gt;DetachButtonContainer.Parent" xml:space="preserve">
+  <data name="&gt;&gt;EditButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;EditButton.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;DetachButtonContainer.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;EditButton.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
   <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 252</value>
+    <value>0, 250</value>
   </data>
   <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>796, 64</value>
+    <value>800, 68</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -567,20 +546,23 @@
   <data name="ColumnDevicePath.HeaderText" xml:space="preserve">
     <value>Device Path</value>
   </data>
+  <data name="ColumnDevicePath.Width" type="System.Int32, mscorlib">
+    <value>91</value>
+  </data>
   <data name="dataGridViewStorage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="dataGridViewStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 50</value>
+    <value>3, 51</value>
   </data>
   <data name="dataGridViewStorage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 10</value>
+    <value>3, 3, 3, 12</value>
   </data>
   <data name="dataGridViewStorage.MaximumSize" type="System.Drawing.Size, System.Drawing">
     <value>900, 0</value>
   </data>
   <data name="dataGridViewStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>796, 190</value>
+    <value>794, 187</value>
   </data>
   <data name="dataGridViewStorage.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -640,7 +622,7 @@
     <value>800, 318</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -662,6 +644,9 @@
   </data>
   <data name="pageContainerPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>820, 338</value>
+  </data>
+  <data name="pageContainerPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="&gt;&gt;pageContainerPanel.Name" xml:space="preserve">
     <value>pageContainerPanel</value>

--- a/XenAdminTests/DialogTests/MoveVirtualDiskDialogTests.cs
+++ b/XenAdminTests/DialogTests/MoveVirtualDiskDialogTests.cs
@@ -44,7 +44,7 @@ namespace XenAdminTests.DialogTests.boston.MoveVirtualDiskDialogTests
         protected override MoveVirtualDiskDialog NewDialog()
         {
             var vdi = GetAnyVDI();
-            return new MoveVirtualDiskDialog(vdi.Connection, new List<VDI> {vdi}, null);
+            return new MoveVirtualDiskDialog(vdi.Connection, new List<VDI> {vdi});
         }
 
         protected override void RunAfter()

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -6794,15 +6794,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must detach this virtual disk before it can be moved..
-        /// </summary>
-        public static string CANNOT_MOVE_VDI_WITH_VBDS {
-            get {
-                return ResourceManager.GetString("CANNOT_MOVE_VDI_WITH_VBDS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot parse required parameter &apos;{1}&apos; on XML node &apos;{0}&apos;.
         /// </summary>
         public static string CANNOT_PARSE_NODE_PARAM {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2464,9 +2464,6 @@ Deleting this bond will disrupt traffic through the secondary interface on the b
   <data name="CANNOT_MOVE_VDI_IS_SNAPSHOT" xml:space="preserve">
     <value>Snapshot disks cannot be moved</value>
   </data>
-  <data name="CANNOT_MOVE_VDI_WITH_VBDS" xml:space="preserve">
-    <value>You must detach this virtual disk before it can be moved.</value>
-  </data>
   <data name="CANNOT_PARSE_NODE_PARAM" xml:space="preserve">
     <value>Cannot parse required parameter '{1}' on XML node '{0}'</value>
   </data>

--- a/XenOvfTransport/Import.cs
+++ b/XenOvfTransport/Import.cs
@@ -553,7 +553,6 @@ namespace XenOvfTransport
             string sourcefile = filename;
             string encryptfilename = null;
             string uncompressedfilename = null;
-            string destinationPath = Properties.Settings.Default.xenISOMount;
             string StartPath = Directory.GetCurrentDirectory();
             Directory.SetCurrentDirectory(pathToOvf);
             Stream dataStream = null;
@@ -701,8 +700,7 @@ namespace XenOvfTransport
             try
             {
                 #region SEE IF TARGET SR HAS ENOUGH SPACE
-                if (useTransport == TransferType.UploadRawVDI ||
-                    useTransport == TransferType.iSCSI)
+                if (useTransport == TransferType.UploadRawVDI || useTransport == TransferType.iSCSI)
                 {
                     long freespace;
                     string contenttype = string.Empty;
@@ -785,11 +783,24 @@ namespace XenOvfTransport
                 {
                     wimDisk = null;
                 }
-                if (File.Exists(encryptfilename)) { File.Delete(encryptfilename); }
-                if (File.Exists(uncompressedfilename)) { File.Delete(uncompressedfilename); }
+
+                try
+                {
+                    if (File.Exists(encryptfilename))
+                        File.Delete(encryptfilename);
+
+                    if (File.Exists(uncompressedfilename))
+                        File.Delete(uncompressedfilename);
+                }
+                catch
+                {
+                    //ignore errors
+                }
+
+                Directory.SetCurrentDirectory(StartPath);
             }
 
-            Directory.SetCurrentDirectory(StartPath);
+
             log.DebugFormat("OVF.Import.ImportFile leave: created {0} VDIs", vdiRef.Count);
             return vdiRef;
         }


### PR DESCRIPTION
This was reopened on XSO-838: The original commit 9a7fcde66e7abf4170baae38aefe8f0cf1a87232 fixed VDI move starting from a selected VM, but not when starting from a selected VDI. This PR removes the upsell dialog in the latter case and also extends the original behaviour allowing the VDI to be moved even if there are attached VBDs.
Alongside this change I did some refactoring, minor layout improvements on the storage tabs, and fixed disk import issue randomly discovered while testing.