### PR TITLE
Disable automatic VDI Integrity check on export and scare the user if turned on

### DIFF
--- a/XenAdmin/Wizards/ExportWizard/ExportFinishPage.Designer.cs
+++ b/XenAdmin/Wizards/ExportWizard/ExportFinishPage.Designer.cs
@@ -31,34 +31,32 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ExportFinishPage));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.m_checkBoxVerify = new System.Windows.Forms.CheckBox();
             this.m_labelIntro = new XenAdmin.Controls.Common.AutoHeightLabel();
             this.m_dataGridView = new System.Windows.Forms.DataGridView();
             this.Column1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Column2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.warningLabel = new System.Windows.Forms.Label();
+            this.m_checkBoxVerify = new System.Windows.Forms.CheckBox();
+            this.warningPicture = new System.Windows.Forms.PictureBox();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.m_dataGridView)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.warningPicture)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.m_checkBoxVerify, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.m_labelIntro, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.m_dataGridView, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.warningLabel, 2, 4);
+            this.tableLayoutPanel1.Controls.Add(this.m_checkBoxVerify, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.warningPicture, 1, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // m_checkBoxVerify
-            // 
-            resources.ApplyResources(this.m_checkBoxVerify, "m_checkBoxVerify");
-            this.m_checkBoxVerify.Checked = true;
-            this.m_checkBoxVerify.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.m_checkBoxVerify.Name = "m_checkBoxVerify";
-            this.m_checkBoxVerify.UseVisualStyleBackColor = true;
             // 
             // m_labelIntro
             // 
             resources.ApplyResources(this.m_labelIntro, "m_labelIntro");
+            this.tableLayoutPanel1.SetColumnSpan(this.m_labelIntro, 3);
             this.m_labelIntro.Name = "m_labelIntro";
             // 
             // m_dataGridView
@@ -76,6 +74,7 @@
             this.m_dataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Column1,
             this.Column2});
+            this.tableLayoutPanel1.SetColumnSpan(this.m_dataGridView, 3);
             resources.ApplyResources(this.m_dataGridView, "m_dataGridView");
             this.m_dataGridView.MultiSelect = false;
             this.m_dataGridView.Name = "m_dataGridView";
@@ -101,6 +100,25 @@
             this.Column2.Name = "Column2";
             this.Column2.ReadOnly = true;
             // 
+            // warningLabel
+            // 
+            resources.ApplyResources(this.warningLabel, "warningLabel");
+            this.warningLabel.Name = "warningLabel";
+            // 
+            // m_checkBoxVerify
+            // 
+            resources.ApplyResources(this.m_checkBoxVerify, "m_checkBoxVerify");
+            this.m_checkBoxVerify.Name = "m_checkBoxVerify";
+            this.m_checkBoxVerify.UseVisualStyleBackColor = true;
+            this.m_checkBoxVerify.CheckStateChanged += new System.EventHandler(this.m_checkBoxVerify_CheckStateChanged);
+            // 
+            // warningPicture
+            // 
+            resources.ApplyResources(this.warningPicture, "warningPicture");
+            this.warningPicture.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            this.warningPicture.Name = "warningPicture";
+            this.warningPicture.TabStop = false;
+            // 
             // ExportFinishPage
             // 
             resources.ApplyResources(this, "$this");
@@ -110,18 +128,21 @@
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.m_dataGridView)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.warningPicture)).EndInit();
             this.ResumeLayout(false);
 
         }
 
         #endregion
 
-		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.CheckBox m_checkBoxVerify;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
 		private XenAdmin.Controls.Common.AutoHeightLabel m_labelIntro;
 		private System.Windows.Forms.DataGridView m_dataGridView;
 		private System.Windows.Forms.DataGridViewTextBoxColumn Column1;
-		private System.Windows.Forms.DataGridViewTextBoxColumn Column2;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Column2;
+        private System.Windows.Forms.PictureBox warningPicture;
+        private System.Windows.Forms.Label warningLabel;
+        private System.Windows.Forms.CheckBox m_checkBoxVerify;
 
     }
 }

--- a/XenAdmin/Wizards/ExportWizard/ExportFinishPage.cs
+++ b/XenAdmin/Wizards/ExportWizard/ExportFinishPage.cs
@@ -92,5 +92,11 @@ namespace XenAdmin.Wizards.ExportWizard
         public Func<IEnumerable<KeyValuePair<string, string>>> SummaryRetreiver { private get; set; }
 
 		public bool VerifyExport { get { return m_checkBoxVerify.Checked; } }
+
+        private void m_checkBoxVerify_CheckStateChanged(object sender, EventArgs e)
+        {
+            warningLabel.Visible = m_checkBoxVerify.Checked;
+            warningPicture.Visible = m_checkBoxVerify.Checked;
+        }
 	}
 }

--- a/XenAdmin/Wizards/ExportWizard/ExportFinishPage.resx
+++ b/XenAdmin/Wizards/ExportWizard/ExportFinishPage.resx
@@ -112,59 +112,23 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="m_checkBoxVerify.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="m_checkBoxVerify.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="m_checkBoxVerify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="m_checkBoxVerify.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 284</value>
-  </data>
-  <data name="m_checkBoxVerify.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 3, 3, 3</value>
-  </data>
-  <data name="m_checkBoxVerify.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 25</value>
-  </data>
-  <data name="m_checkBoxVerify.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="m_checkBoxVerify.Text" xml:space="preserve">
-    <value>&amp;Verify export on completion</value>
-  </data>
-  <data name="&gt;&gt;m_checkBoxVerify.Name" xml:space="preserve">
-    <value>m_checkBoxVerify</value>
-  </data>
-  <data name="&gt;&gt;m_checkBoxVerify.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;m_checkBoxVerify.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;m_checkBoxVerify.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="m_labelIntro.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="m_labelIntro.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="m_labelIntro.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
@@ -172,7 +136,7 @@
     <value>608, 65</value>
   </data>
   <data name="m_labelIntro.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>0</value>
   </data>
   <data name="m_labelIntro.Text" xml:space="preserve">
     <value>All the necessary information has been collected and the wizard is now ready to export the selected VM(s) using the settings shown below.
@@ -189,9 +153,9 @@ Please review these settings and click Previous if you need to go back and make 
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;m_labelIntro.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
-  <metadata name="Column1.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="Column1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="Column1.HeaderText" xml:space="preserve">
@@ -200,7 +164,7 @@ Please review these settings and click Previous if you need to go back and make 
   <data name="Column1.Width" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <metadata name="Column2.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="Column2.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="Column2.HeaderText" xml:space="preserve">
@@ -213,22 +177,124 @@ Please review these settings and click Previous if you need to go back and make 
     <value>3, 88</value>
   </data>
   <data name="m_dataGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>608, 170</value>
+    <value>608, 176</value>
   </data>
   <data name="m_dataGridView.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;m_dataGridView.Name" xml:space="preserve">
     <value>m_dataGridView</value>
   </data>
   <data name="&gt;&gt;m_dataGridView.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_dataGridView.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;m_dataGridView.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="warningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="warningLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="warningLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>203, 293</value>
+  </data>
+  <data name="warningLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 13</value>
+  </data>
+  <data name="warningLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="warningLabel.Text" xml:space="preserve">
+    <value>Verify export can take up to 5 hours per TB.</value>
+  </data>
+  <data name="warningLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.Name" xml:space="preserve">
+    <value>warningLabel</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="m_checkBoxVerify.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="m_checkBoxVerify.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="m_checkBoxVerify.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="m_checkBoxVerify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="m_checkBoxVerify.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 290</value>
+  </data>
+  <data name="m_checkBoxVerify.Size" type="System.Drawing.Size, System.Drawing">
+    <value>172, 19</value>
+  </data>
+  <data name="m_checkBoxVerify.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="m_checkBoxVerify.Text" xml:space="preserve">
+    <value>&amp;Verify export on completion</value>
+  </data>
+  <data name="m_checkBoxVerify.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;m_checkBoxVerify.Name" xml:space="preserve">
+    <value>m_checkBoxVerify</value>
+  </data>
+  <data name="&gt;&gt;m_checkBoxVerify.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;m_checkBoxVerify.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;m_checkBoxVerify.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="warningPicture.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="warningPicture.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="warningPicture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>181, 291</value>
+  </data>
+  <data name="warningPicture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="warningPicture.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="warningPicture.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;warningPicture.Name" xml:space="preserve">
+    <value>warningPicture</value>
+  </data>
+  <data name="&gt;&gt;warningPicture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningPicture.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;warningPicture.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -249,7 +315,7 @@ Please review these settings and click Previous if you need to go back and make 
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -258,9 +324,9 @@ Please review these settings and click Previous if you need to go back and make 
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="m_checkBoxVerify" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="m_labelIntro" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="m_dataGridView" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,20,Absolute,20" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,20,Percent,100,Absolute,20,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="m_labelIntro" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="m_dataGridView" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="warningLabel" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="m_checkBoxVerify" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="warningPicture" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,20,Percent,100,Absolute,20,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -273,18 +339,18 @@ Please review these settings and click Previous if you need to go back and make 
     <value>Column1</value>
   </data>
   <data name="&gt;&gt;Column1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;Column2.Name" xml:space="preserve">
     <value>Column2</value>
   </data>
   <data name="&gt;&gt;Column2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ExportFinishPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Wizards.GenericPages.ImExPortPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
Set verify on export default to false, added a warning when checkbox is checked (true).

Visual Studio seems to have made some minor changes to files automatically, as I'm new I have no idea if this is an issue or not but I've tested the changes work and I can verify that they do.

CP-Ticket: https://issues.citrite.net/browse/CP-29106