### PR TITLE
CA-172658: Descriptive error message when failing to suspend a VM fro…

### DIFF
--- a/XenAdmin/Commands/SuspendVMCommand.cs
+++ b/XenAdmin/Commands/SuspendVMCommand.cs
@@ -201,9 +201,17 @@ namespace XenAdmin.Commands
             {
                 return Messages.VM_SHUT_DOWN;
             }
-            else if (vm.power_state == vm_power_state.Suspended)
+            if (vm.power_state == vm_power_state.Suspended)
             {
                 return Messages.VM_ALREADY_SUSPENDED;
+            }
+            if (vm.HasGPUPassthrough())
+            {
+                return FriendlyErrorNames.VM_HAS_PCI_ATTACHED;
+            }
+            if (vm.allowed_operations != null && !vm.allowed_operations.Contains(vm_operations.suspend))
+            {
+                return FriendlyErrorNames.VM_LACKS_FEATURE_SUSPEND;
             }
 
             return GetCantExecuteNoToolsOrDriversReasonCore(item) ?? base.GetCantExecuteReasonCore(item);


### PR DESCRIPTION
…m XenCenter.

PCI passthrough from VGPU is checked first and informing the user that the VM lacks the Suspend feature as a fallback.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>