### PR TITLE
CA-271945: Attempting to resolve the pool's connection and searching …

### DIFF
--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
@@ -63,8 +63,12 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 
         public override AsyncAction CreateUnwindChangesAction()
         {
-            Program.MainWindow.CloseActiveWizards(Server.Connection);
-            return new DisableHostAction(Server);
+            var server = Server.Connection.Resolve(new XenRef<Host>(Server.opaque_ref));
+            if (server == null)
+                return null;
+
+            Program.MainWindow.CloseActiveWizards(server.Connection);
+            return new DisableHostAction(server);
         }
 
     }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
@@ -63,11 +63,12 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 
         public override AsyncAction CreateUnwindChangesAction()
         {
+            Program.MainWindow.CloseActiveWizards(Server.Connection);
+
             var server = Server.Connection.Resolve(new XenRef<Host>(Server.opaque_ref));
             if (server == null)
                 return null;
 
-            Program.MainWindow.CloseActiveWizards(server.Connection);
             return new DisableHostAction(server);
         }
 

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/HAEnabledProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/HAEnabledProblem.cs
@@ -58,7 +58,18 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
 
         public override AsyncAction CreateUnwindChangesAction()
         {
-            return new EnableHAAction(Pool, null, HeartbeatSrs, FailuresToTolerate);
+            var pool = Pool.Connection.Resolve(new XenRef<Pool>(Pool.opaque_ref));
+            if (pool == null)
+            {
+                foreach (var xenConnection in ConnectionsManager.XenConnectionsCopy)
+                {
+                    pool = xenConnection.Resolve(new XenRef<Pool>(Pool.opaque_ref));
+                    if (pool != null)
+                        break;
+                }
+            }
+
+            return pool != null ? new EnableHAAction(pool, null, HeartbeatSrs, FailuresToTolerate) : null;
         }
 
         public override string Description

--- a/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
@@ -88,13 +88,14 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
         public override AsyncAction CreateUnwindChangesAction()
         {
-            if (VM.Connection.Resolve(new XenRef<VM>(VM.opaque_ref)) == null) // check if the vm is still in the cache
+            var vm = VM.Connection.Resolve(new XenRef<VM>(VM.opaque_ref));
+            if (vm == null) // check if the vm is still in the cache
                 return null;
 
             return new DelegatedAsyncAction(
                VM.Connection,
                Messages.ACTION_ENABLE_AUTOSTART_ON_VM,
-               string.Format(Messages.ACTION_ENABLING_AUTOSTART_ON_VM, Helpers.GetName(VM)),
+               string.Format(Messages.ACTION_ENABLING_AUTOSTART_ON_VM, Helpers.GetName(vm)),
                null,
                ActionDelegate(true));
         }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
@@ -88,6 +88,9 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
         public override AsyncAction CreateUnwindChangesAction()
         {
+            if (VM.Connection.Resolve(new XenRef<VM>(VM.opaque_ref)) == null) // check if the vm is still in the cache
+                return null;
+
             return new DelegatedAsyncAction(
                VM.Connection,
                Messages.ACTION_ENABLE_AUTOSTART_ON_VM,


### PR DESCRIPTION
…for it in all open connections for the EnableHAAction in case a host has been destroyed or the master changed.
Preventing an Object (host) has been deleted error when attempting to reenable Maintenance Mode on a Host that has been kicked out of the pool when exiting the RPU Wizard.
Returning null to prevent making orphened tasks that will be stuck at 0% completion if it is impossible to fulfill.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>