### PR TITLE
CA-300368: Sanitize fields values when loading a xapi xml database in…

### DIFF
--- a/XenModel/ServerDBs/StatusReportXmlDocReader.cs
+++ b/XenModel/ServerDBs/StatusReportXmlDocReader.cs
@@ -45,6 +45,15 @@ namespace XenAdmin.ServerDBs
     /// </summary>
     class StatusReportXmlDocReader
     {
+        private static readonly Dictionary<string, string> escapedCharacters = new Dictionary<string, string>
+        {
+            { "%.", " " },
+            { "%t", "\t" },
+            { "%n", "\n" },
+            { "%r", "\r" },
+            { "%%", "%" }
+        };
+
         /// <summary>
         /// Populates the specified Db with the specified XML document.
         /// </summary>
@@ -130,14 +139,6 @@ namespace XenAdmin.ServerDBs
 
         private string SanitizePropertyValue(string value)
         {
-            var escapedCharacters = new Dictionary<string, string>
-            {
-                { "%.", " " },
-                { "%t", "\t" },
-                { "%n", "\n" },
-                { "%r", "\r" },
-                { "%%", "%" }
-            };
             string newValue = value;
             foreach (var escapedCharacter in escapedCharacters)
             {

--- a/XenModel/ServerDBs/StatusReportXmlDocReader.cs
+++ b/XenModel/ServerDBs/StatusReportXmlDocReader.cs
@@ -80,7 +80,7 @@ namespace XenAdmin.ServerDBs
                             if(string.IsNullOrEmpty(name))
                                 continue;
 
-                            row.Props.Add(name, a.Value);
+                            row.Props.Add(name, SanitizePropertyValue(a.Value));
                         }
                     }
 
@@ -126,6 +126,24 @@ namespace XenAdmin.ServerDBs
                 default:
                     return prop;
             }
+        }
+
+        private string SanitizePropertyValue(string value)
+        {
+            var escapedCharacters = new Dictionary<string, string>
+            {
+                { "%.", " " },
+                { "%t", "\t" },
+                { "%n", "\n" },
+                { "%r", "\r" },
+                { "%%", "%" }
+            };
+            string newValue = value;
+            foreach (var escapedCharacter in escapedCharacters)
+            {
+                newValue = newValue.Replace(escapedCharacter.Key, escapedCharacter.Value);
+            }
+            return newValue;
         }
 
         private static XmlNode GetDatabaseNode(XmlNode doc)


### PR DESCRIPTION
… XenCenter

This fixes the bug where importing a xapi database to xencenter fails with "This server version is incompatible with XenCenter" due to the product brand containing a space character.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>