### PR TITLE
CA-237915: When one attempts logging oneself out, warn them if there are outstanding actions.

### DIFF
--- a/XenAdmin/TabPages/HistoryPage.cs
+++ b/XenAdmin/TabPages/HistoryPage.cs
@@ -92,7 +92,7 @@ namespace XenAdmin.TabPages
             if (action == null)
                 return;
 
-            Program.BeginInvoke(Program.MainWindow,
+            Program.Invoke(Program.MainWindow,
                            () =>
                            {
                                int count = ConnectionsManager.History.Count;

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -33640,6 +33640,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Interface {0}: Network = {1}.
+        /// </summary>
+        public static string TEMPLATE_INFO_VIF {
+            get {
+                return ResourceManager.GetString("TEMPLATE_INFO_VIF", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must install the Linux pack to use this template.
         /// </summary>
         public static string TEMPLATE_LINUX_PACK_NEEDED {
@@ -33658,20 +33667,11 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Terminating sessions....
+        ///   Looks up a localized string similar to Terminating session for user &apos;{0}&apos;.
         /// </summary>
-        public static string TERMINATING_SESSIONS {
+        public static string TERMINATING_USER_SESSION {
             get {
-                return ResourceManager.GetString("TERMINATING_SESSIONS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Interface {0}: Network = {1}.
-        /// </summary>
-        public static string TERMPLATE_INFO_VIF {
-            get {
-                return ResourceManager.GetString("TERMPLATE_INFO_VIF", resourceCulture);
+                return ResourceManager.GetString("TERMINATING_USER_SESSION", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -11658,17 +11658,17 @@ Refer to the "[XenServer product] Administrator's Guide" for instructions on how
   <data name="TEMPLATE_INFO_VCPUS" xml:space="preserve">
     <value>vCPUs: {0}</value>
   </data>
+  <data name="TEMPLATE_INFO_VIF" xml:space="preserve">
+    <value>Interface {0}: Network = {1}</value>
+  </data>
   <data name="TEMPLATE_LINUX_PACK_NEEDED" xml:space="preserve">
     <value>You must install the Linux pack to use this template</value>
   </data>
   <data name="TEMPLATE_NO_DESCRIPTION" xml:space="preserve">
     <value>&lt;no description&gt;</value>
   </data>
-  <data name="TERMINATING_SESSIONS" xml:space="preserve">
-    <value>Terminating sessions...</value>
-  </data>
-  <data name="TERMPLATE_INFO_VIF" xml:space="preserve">
-    <value>Interface {0}: Network = {1}</value>
+  <data name="TERMINATING_USER_SESSION" xml:space="preserve">
+    <value>Terminating session for user '{0}'</value>
   </data>
   <data name="TEST_ARCHIVE_LOCATION" xml:space="preserve">
     <value>Test archive target location</value>


### PR DESCRIPTION
For this purpose, call the DisconnectCommand instead of session.logout_subject_identifier.
Also:
- Add the new actions to the History synchronously on the main thread,
otherwise the warning dialog may not detect in time the new actions.
- Although the local root account is currently first in the list, checking whether
the first item is selected is a fragile way of establishing whether the local
root account is selected. Check the row's IsLocalRootRow property as in the
rest of the file.
- Added username detail to the logout action; fixed typo in message key.
- Some minor refactoring to make the code more efficient.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>