### PR TITLE
CA-301501: Update the progress bar for the action uploading a server status report.

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -2725,6 +2725,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Uploading report to [Citrix] Insight Services ({0} of {1}).
+        /// </summary>
+        public static string ACTION_UPLOAD_SERVER_STATUS_REPORT_PERCENTAGE {
+            get {
+                return ResourceManager.GetString("ACTION_UPLOAD_SERVER_STATUS_REPORT_PERCENTAGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Uploading report to [Citrix] Insight Services.
         /// </summary>
         public static string ACTION_UPLOAD_SERVER_STATUS_REPORT_PROGRESS {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1008,6 +1008,9 @@
   <data name="ACTION_UPLOAD_SERVER_STATUS_REPORT_FAILED" xml:space="preserve">
     <value>Failed to upload the status report.</value>
   </data>
+  <data name="ACTION_UPLOAD_SERVER_STATUS_REPORT_PERCENTAGE" xml:space="preserve">
+    <value>Uploading report to [Citrix] Insight Services ({0} of {1})</value>
+  </data>
   <data name="ACTION_UPLOAD_SERVER_STATUS_REPORT_PROGRESS" xml:space="preserve">
     <value>Uploading report to [Citrix] Insight Services</value>
   </data>

--- a/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
+++ b/XenServerHealthCheck/XenServerHealthCheckBundleUpload.cs
@@ -247,20 +247,23 @@ namespace XenServerHealthCheck
             // Upload the zip file to CIS uploading server.
             string upload_url = Registry.HealthCheckUploadDomainName;
             log.InfoFormat("Upload report to {0}", upload_url);
-            XenServerHealthCheckUpload upload = new XenServerHealthCheckUpload(uploadToken, VERBOSITY_LEVEL, upload_url, connection);
+            string upload_uuid;
 
-            string upload_uuid = "";
-            try
+            using (var upload = new XenServerHealthCheckUpload(uploadToken, VERBOSITY_LEVEL, upload_url, connection))
             {
-                upload_uuid = upload.UploadZip(bundleToUpload, null, cancel);
-            }
-            catch (Exception e)
-            {
-                if (session != null)
-                    session.logout();
-                session = null;
-                log.Error(e, e);
-                return "";
+
+                try
+                {
+                    upload_uuid = upload.UploadZip(bundleToUpload, null, cancel);
+                }
+                catch (Exception e)
+                {
+                    if (session != null)
+                        session.logout();
+                    session = null;
+                    log.Error(e, e);
+                    return "";
+                }
             }
 
             if (File.Exists(bundleToUpload))


### PR DESCRIPTION
Also, call the XenServerHealthCheckUpload in a using block; use the FileInfo.Open
method to open the zip file for upload.