### PR TITLE
CA-300759: When there is a GFS2 SR in the pool, VMs on local storage …

### DIFF
--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
@@ -59,7 +59,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
 
         protected override bool SrIsSuitable(SR sr)
         {
-            return sr != null && !sr.HBALunPerVDI();
+            return sr != null && !sr.HBALunPerVDI() && sr.SupportsStorageMigration();
         }
 
 	    protected override bool IsExtraSpaceNeeded(XenRef<SR> sourceRef, XenRef<SR> targetRef)

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -80,7 +80,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
 
                 foreach (Host host in targets)
                 {
-                    var targetSrs = host.Connection.Cache.SRs.Where(sr => sr.SupportsVdiCreate()).ToList();
+                    var targetSrs = host.Connection.Cache.SRs.Where(sr => sr.SupportsStorageMigration()).ToList();
                     var targetNetwork = GetANetwork(host);
 
                     foreach (VM vm in preSelectedVMs)

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -459,7 +459,6 @@ namespace XenAPI
         /// <summary>
         /// Whether the underlying SR backend supports VDI_CREATE. Will return true even if the SR is full.
         /// </summary>
-        /// <param name="connection"></param>
         /// <returns></returns>
         public virtual bool SupportsVdiCreate()
         {
@@ -474,6 +473,20 @@ namespace XenAPI
 
             SM sm = SM.GetByType(Connection, type);
             return sm != null && -1 != Array.IndexOf(sm.capabilities, "VDI_CREATE");
+        }
+        
+        /// <summary>
+        /// Whether the underlying SR backend supports storage migration. Will return true even if the SR is full.
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool SupportsStorageMigration()
+        {
+            // ISO and Memory SRs should not support migration
+            if (content_type == SR.Content_Type_ISO || GetSRType(false) == SR.SRTypes.tmpfs)
+                return false;
+
+            SM sm = SM.GetByType(Connection, type);
+            return sm != null && Array.IndexOf(sm.capabilities, "VDI_MIRROR") != -1 && Array.IndexOf(sm.capabilities, "VDI_SNAPSHOT") != -1;
         }
 
         public static List<SRInfo> ParseSRList(List<Probe_result> probeExtResult)


### PR DESCRIPTION
…should still be allowed to be migrated to the local storage of another host.

When XenCenter checks if a VM can be storage-migrated (including in the same pool), it only checks if migration is possible to one SR (the first SR from the SR list  that supports vdi creation), which could be a GFS2 SR, where migration is not supported. With this fix, we will only consider the SRs which support migration (instead of vdi creation).

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>