### PR TITLE
CA-302791: Rewrote the ChangeFolder dialog to fix usability issues.

### DIFF
--- a/XenAdmin/Commands/NewFolderCommand.cs
+++ b/XenAdmin/Commands/NewFolderCommand.cs
@@ -82,23 +82,35 @@ namespace XenAdmin.Commands
             // (although we will also sudo a Read Only command when the FolderAction is run).
             if (folder == null || folder.IsRootFolder || folder.Connection == null || CrossConnectionCommand.IsReadOnly(folder.Connection))
             {
-                NameAndConnectionPrompt dialog = new NameAndConnectionPrompt();
-                dialog.Text = Messages.NEW_FOLDER_DIALOG_TITLE;
-                dialog.OKText = Messages.CREATE_MNEMONIC_R;
-                dialog.HelpID = "NewFolderDialog";
-                if (dialog.ShowDialog(ownerWindow) != DialogResult.OK)
-                    return;
-                name = dialog.PromptedName;
-                connection = dialog.Connection;
+                using (var dialog = new NameAndConnectionPrompt
+                {
+                    Text = Messages.NEW_FOLDER_DIALOG_TITLE,
+                    OKText = Messages.CREATE_MNEMONIC_R,
+                    HelpID = "NewFolderDialog"
+                })
+                {
+                    if (dialog.ShowDialog(ownerWindow) != DialogResult.OK)
+                        return;
+                    name = dialog.PromptedName;
+                    connection = dialog.Connection;
+                }
             }
             else
             {
-                name = InputPromptDialog.Prompt(ownerWindow, Messages.NEW_FOLDER_NAME, Messages.NEW_FOLDER_DIALOG_TITLE, "NewFolderDialog");
+                using (var dialog = new InputPromptDialog {
+                    Text = Messages.NEW_FOLDER_DIALOG_TITLE,
+                    PromptText = Messages.NEW_FOLDER_NAME,
+                    OkButtonText = Messages.NEW_FOLDER_BUTTON,
+                    HelpID = "NewFolderDialog"
+                })
+                {
+                    if (dialog.ShowDialog(ownerWindow) != DialogResult.OK)
+                        return;
+                    name = dialog.InputText;
+                }
                 connection = folder.Connection;
             }
 
-            if (name == null)
-                return;  // Happens if InputPromptDialog was cancelled
 
             List<string> newPaths = new List<string>();
             foreach (string s in name.Split(';'))

--- a/XenAdmin/Commands/NewTemplateFromSnapshotCommand.cs
+++ b/XenAdmin/Commands/NewTemplateFromSnapshotCommand.cs
@@ -32,11 +32,11 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Windows.Forms;
 using XenAPI;
 using XenAdmin.Actions;
 using XenAdmin.Core;
 using XenAdmin.Dialogs;
-using System.Collections.ObjectModel;
 using XenAdmin.Actions.VMActions;
 
 
@@ -74,14 +74,21 @@ namespace XenAdmin.Commands
 
             // Generate a unique suggested name for the new template
             string defaultName = Helpers.MakeUniqueName(String.Format(Messages.TEMPLATE_FROM_SNAPSHOT_DEFAULT_NAME, snapshot.Name()), takenNames);
-            string newName = InputPromptDialog.Prompt(Parent, Messages.NEW_TEMPLATE_PROMPT, Messages.SAVE_AS_TEMPLATE, defaultName, "VMSnapshotPage");
 
-            if (newName != null) // is null if user cancelled
+            using (var dialog = new InputPromptDialog {
+                Text = Messages.SAVE_AS_TEMPLATE,
+                PromptText = Messages.NEW_TEMPLATE_PROMPT,
+                InputText = defaultName,
+                HelpID = "VMSnapshotPage"
+            })
             {
-                // TODO: work out what the new description should be
-                var action = new VMCloneAction(snapshot, newName, "");
-                action.Completed += action_Completed;
-                action.RunAsync();
+                if (dialog.ShowDialog(Parent) == DialogResult.OK)
+                {
+                    // TODO: work out what the new description should be
+                    var action = new VMCloneAction(snapshot, dialog.InputText, "");
+                    action.Completed += action_Completed;
+                    action.RunAsync();
+                }
             }
         }
 

--- a/XenAdmin/Controls/Folders/FolderEditor.cs
+++ b/XenAdmin/Controls/Folders/FolderEditor.cs
@@ -57,7 +57,7 @@ namespace XenAdmin.Controls
             get { return _folderListItem.Path; }
         }
 
-        private void folderListItem_PathChanged(object sender, EventArgs e)
+        private void folderListItem_PathChanged()
         {
             RefreshBuffer();
             Refresh();

--- a/XenAdmin/Controls/Folders/FolderListItem.cs
+++ b/XenAdmin/Controls/Folders/FolderListItem.cs
@@ -45,7 +45,7 @@ namespace XenAdmin.Controls
 {
     public class FolderListItem
     {
-        public event EventHandler PathChanged;
+        public event Action PathChanged;
 
         private const int INNER_PADDING = 9;
         private const int RIGHT_PADDING = 20;
@@ -328,20 +328,26 @@ namespace XenAdmin.Controls
 
         private void LaunchFolderChangeDlg()
         {
-            FolderChangeDialog dialog = new FolderChangeDialog(path);
-         
-            if (dialog.ShowDialog(Program.MainWindow) == DialogResult.OK)
-            {
-                Folder _selectedFolder = dialog.CurrentFolder;
-                path = (_selectedFolder == null ? "" : Folders.AppendPath(_selectedFolder.Path, _selectedFolder.ToString()));
-                OnPathChanged();
-            }
+            using (var dialog = new FolderChangeDialog(path))
+                if (dialog.ShowDialog(Program.MainWindow) == DialogResult.OK)
+                {
+                    if (!dialog.FolderChanged)
+                        return;
+
+                    Folder selectedFolder = dialog.CurrentFolder;
+
+                    path = selectedFolder == null
+                        ? string.Empty
+                        : Folders.AppendPath(selectedFolder.Path, selectedFolder.ToString());
+
+                    OnPathChanged();
+                }
         }
 
         private void OnPathChanged()
         {
             if (PathChanged != null)
-                PathChanged(null, null);
+                PathChanged();
         }
 
         private class FLIControl

--- a/XenAdmin/Controls/TreeViews/FolderChangeDialogTreeView.cs
+++ b/XenAdmin/Controls/TreeViews/FolderChangeDialogTreeView.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 using System.Windows.Forms;
 
@@ -39,12 +40,16 @@ namespace XenAdmin.Controls
     internal class FolderChangeDialogTreeView : VirtualTreeView
     {
         public bool expandOnDoubleClick = true;
-        private bool blockExpansion = false;
+        private bool blockExpansion;
 
         protected override void OnMouseDown(MouseEventArgs e)
         {
             if (e.Clicks > 1)
                 blockExpansion = true;
+
+            var hitTesInfo = HitTest(e.X, e.Y);
+            if (hitTesInfo.Node == null)
+                SelectedNode = null;
 
             base.OnMouseDown(e);
         }

--- a/XenAdmin/Controls/TreeViews/MultiSelectTreeView.cs
+++ b/XenAdmin/Controls/TreeViews/MultiSelectTreeView.cs
@@ -80,6 +80,8 @@ namespace XenAdmin.Controls
         public event TreeViewEventHandler AfterDeselect;
         public event TreeViewEventHandler BeforeDeselect;
         public event EventHandler SelectionsChanged;
+        public new event EventHandler<MultiSelectTreeViewCancelEventArgs> BeforeSelect;
+        public new event EventHandler<MultiSelectTreeViewItemDragEventArgs> ItemDrag;
 
         public MultiSelectTreeView()
         {
@@ -264,8 +266,6 @@ namespace XenAdmin.Controls
             }
         }
 
-        public new event EventHandler<MultiSelectTreeViewCancelEventArgs> BeforeSelect;
-
         protected sealed override void OnItemDrag(ItemDragEventArgs e)
         {
             OnItemDrag(new MultiSelectTreeViewItemDragEventArgs(MouseButtons.Left, SelectedNodes));
@@ -280,8 +280,6 @@ namespace XenAdmin.Controls
                 handler(this, e);
             }
         }
-
-        public new event EventHandler<MultiSelectTreeViewItemDragEventArgs> ItemDrag;
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
@@ -325,29 +323,37 @@ namespace XenAdmin.Controls
                     break;
 
                 case Keys.Left:
-                    if (_mostRecentSelectedNode.IsExpanded)
-                        _mostRecentSelectedNode.Collapse();
-                    else
-                        endNode = _mostRecentSelectedNode.Parent;
+                    if (_mostRecentSelectedNode != null)
+                    {
+                        if (_mostRecentSelectedNode.IsExpanded)
+                            _mostRecentSelectedNode.Collapse();
+                        else
+                            endNode = _mostRecentSelectedNode.Parent;
+                    }
                     break;
 
                 case Keys.Up:
-                    endNode = _mostRecentSelectedNode.PrevVisibleNode;
+                    if (_mostRecentSelectedNode != null)
+                        endNode = _mostRecentSelectedNode.PrevVisibleNode;
                     break;
 
                 case Keys.Right:
-                    if (_mostRecentSelectedNode.IsExpanded)
+                    if (_mostRecentSelectedNode != null)
                     {
-                        endNode = _mostRecentSelectedNode.NextVisibleNode;
-                        if (endNode != null && !endNode.Parent.Equals(_mostRecentSelectedNode))
-                            endNode = null;
+                        if (_mostRecentSelectedNode.IsExpanded)
+                        {
+                            endNode = _mostRecentSelectedNode.NextVisibleNode;
+                            if (endNode != null && !endNode.Parent.Equals(_mostRecentSelectedNode))
+                                endNode = null;
+                        }
+                        else
+                            _mostRecentSelectedNode.Expand();
                     }
-                    else
-                        _mostRecentSelectedNode.Expand();
                     break;
 
                 case Keys.Down:
-                    endNode = _mostRecentSelectedNode.NextVisibleNode;
+                    if (_mostRecentSelectedNode != null)
+                        endNode = _mostRecentSelectedNode.NextVisibleNode;
                     break;
 
                 default:
@@ -387,7 +393,7 @@ namespace XenAdmin.Controls
                 }
                 if (tnMostRecentSelectedNode != null)
                 {
-                    if (((e.KeyData & Keys.Control) != 0) || ((e.KeyData & Keys.Shift) != 0))
+                    if ((e.KeyData & Keys.Control) != 0 || (e.KeyData & Keys.Shift) != 0)
                     {
                         SuspendLayout();
                         int prevScrollPos = HScrollPos;
@@ -1085,6 +1091,7 @@ namespace XenAdmin.Controls
             return si.nPos;
         }
 
+        [DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Hidden)]
         public int HScrollPos
         {
             get
@@ -1097,6 +1104,7 @@ namespace XenAdmin.Controls
             }
         }
 
+        [DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Hidden)]
         public int VScrollPos
         {
             get

--- a/XenAdmin/Dialogs/FolderChangeDialog.Designer.cs
+++ b/XenAdmin/Dialogs/FolderChangeDialog.Designer.cs
@@ -1,5 +1,3 @@
-using XenAdmin.Controls;
-using System;
 namespace XenAdmin.Dialogs
 {
     partial class FolderChangeDialog
@@ -30,54 +28,79 @@ namespace XenAdmin.Dialogs
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FolderChangeDialog));
             this.cancelButton = new System.Windows.Forms.Button();
             this.okButton = new System.Windows.Forms.Button();
-            this.treeView = new XenAdmin.Controls.FolderChangeDialogTreeView();
+            this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolStripMenuItemNew = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.radioButtonNone = new System.Windows.Forms.RadioButton();
             this.radioButtonChoose = new System.Windows.Forms.RadioButton();
             this.newButton = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.treeView = new XenAdmin.Controls.FolderChangeDialogTreeView();
+            this.buttonDelete = new System.Windows.Forms.Button();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.contextMenuStrip.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
             // 
             // cancelButton
             // 
-            resources.ApplyResources(this.cancelButton, "cancelButton");
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            resources.ApplyResources(this.cancelButton, "cancelButton");
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.UseVisualStyleBackColor = true;
-            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
             // 
             // okButton
             // 
             resources.ApplyResources(this.okButton, "okButton");
+            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.okButton.Name = "okButton";
             this.okButton.UseVisualStyleBackColor = true;
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
             // 
-            // treeView
+            // contextMenuStrip
             // 
-            resources.ApplyResources(this.treeView, "treeView");
-            this.treeView.HideSelection = false;
-            this.treeView.Name = "treeView";
-            this.treeView.ShowLines = false;
-            this.treeView.NodeMouseDoubleClick += new EventHandler<VirtualTreeNodeMouseClickEventArgs>(this.treeView_NodeMouseDoubleClick);
-            this.treeView.AfterSelect += new EventHandler<VirtualTreeViewEventArgs>(this.treeView_AfterSelect);
-            this.treeView.NodeMouseClick += new EventHandler<VirtualTreeNodeMouseClickEventArgs>(this.treeView_NodeMouseClick);
+            this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemNew,
+            this.toolStripMenuItemDelete});
+            this.contextMenuStrip.Name = "contextMenuStrip";
+            resources.ApplyResources(this.contextMenuStrip, "contextMenuStrip");
+            // 
+            // toolStripMenuItemNew
+            // 
+            this.toolStripMenuItemNew.Image = global::XenAdmin.Properties.Resources._000_Folder_open_h32bit_16;
+            this.toolStripMenuItemNew.Name = "toolStripMenuItemNew";
+            resources.ApplyResources(this.toolStripMenuItemNew, "toolStripMenuItemNew");
+            this.toolStripMenuItemNew.Click += new System.EventHandler(this.toolStripMenuItemNew_Click);
+            // 
+            // toolStripMenuItemDelete
+            // 
+            this.toolStripMenuItemDelete.Name = "toolStripMenuItemDelete";
+            resources.ApplyResources(this.toolStripMenuItemDelete, "toolStripMenuItemDelete");
+            this.toolStripMenuItemDelete.Click += new System.EventHandler(this.toolStripMenuItemDelete_Click);
             // 
             // radioButtonNone
             // 
             resources.ApplyResources(this.radioButtonNone, "radioButtonNone");
+            this.tableLayoutPanel1.SetColumnSpan(this.radioButtonNone, 3);
             this.radioButtonNone.Name = "radioButtonNone";
             this.radioButtonNone.TabStop = true;
             this.radioButtonNone.UseVisualStyleBackColor = true;
-            this.radioButtonNone.Click += new System.EventHandler(this.radioButtonNone_Click);
+            this.radioButtonNone.CheckedChanged += new System.EventHandler(this.radioButtonNone_CheckedChanged);
+            this.radioButtonNone.TabStopChanged += new System.EventHandler(this.radioButtonNone_TabStopChanged);
             // 
             // radioButtonChoose
             // 
             resources.ApplyResources(this.radioButtonChoose, "radioButtonChoose");
+            this.tableLayoutPanel1.SetColumnSpan(this.radioButtonChoose, 3);
             this.radioButtonChoose.Name = "radioButtonChoose";
+            this.radioButtonChoose.TabStop = true;
             this.radioButtonChoose.UseVisualStyleBackColor = true;
-            this.radioButtonChoose.Click += new System.EventHandler(this.radioButtonChoose_Click);
+            this.radioButtonChoose.CheckedChanged += new System.EventHandler(this.radioButtonChoose_CheckedChanged);
+            this.radioButtonChoose.TabStopChanged += new System.EventHandler(this.radioButtonChoose_TabStopChanged);
             // 
             // newButton
             // 
@@ -86,22 +109,58 @@ namespace XenAdmin.Dialogs
             this.newButton.UseVisualStyleBackColor = true;
             this.newButton.Click += new System.EventHandler(this.newButton_Click);
             // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.radioButtonNone, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.radioButtonChoose, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.treeView, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.newButton, 2, 2);
+            this.tableLayoutPanel1.Controls.Add(this.buttonDelete, 2, 3);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 4);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // treeView
+            // 
+            resources.ApplyResources(this.treeView, "treeView");
+            this.treeView.ContextMenuStrip = this.contextMenuStrip;
+            this.treeView.HideSelection = false;
+            this.treeView.Name = "treeView";
+            this.tableLayoutPanel1.SetRowSpan(this.treeView, 2);
+            this.treeView.ShowLines = false;
+            this.treeView.NodeMouseDoubleClick += new System.EventHandler<XenAdmin.Controls.VirtualTreeNodeMouseClickEventArgs>(this.treeView_NodeMouseDoubleClick);
+            this.treeView.SelectionsChanged += new System.EventHandler(this.treeView_SelectionsChanged);
+            this.treeView.Enter += new System.EventHandler(this.treeView_Enter);
+            // 
+            // buttonDelete
+            // 
+            resources.ApplyResources(this.buttonDelete, "buttonDelete");
+            this.buttonDelete.Name = "buttonDelete";
+            this.buttonDelete.UseVisualStyleBackColor = true;
+            this.buttonDelete.Click += new System.EventHandler(this.buttonDelete_Click);
+            // 
+            // tableLayoutPanel2
+            // 
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutPanel2, 3);
+            this.tableLayoutPanel2.Controls.Add(this.okButton, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.cancelButton, 1, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            // 
             // FolderChangeDialog
             // 
             this.AcceptButton = this.okButton;
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.cancelButton;
-            this.Controls.Add(this.newButton);
-            this.Controls.Add(this.radioButtonChoose);
-            this.Controls.Add(this.radioButtonNone);
-            this.Controls.Add(this.treeView);
-            this.Controls.Add(this.cancelButton);
-            this.Controls.Add(this.okButton);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.Name = "FolderChangeDialog";
+            this.contextMenuStrip.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -109,9 +168,15 @@ namespace XenAdmin.Dialogs
 
         private System.Windows.Forms.Button cancelButton;
         private System.Windows.Forms.Button okButton;
-        private XenAdmin.Controls.FolderChangeDialogTreeView treeView;
         private System.Windows.Forms.RadioButton radioButtonNone;
         private System.Windows.Forms.RadioButton radioButtonChoose;
         private System.Windows.Forms.Button newButton;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemNew;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private Controls.FolderChangeDialogTreeView treeView;
+        private System.Windows.Forms.Button buttonDelete;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemDelete;
     }
 }

--- a/XenAdmin/Dialogs/FolderChangeDialog.Designer.cs
+++ b/XenAdmin/Dialogs/FolderChangeDialog.Designer.cs
@@ -34,14 +34,16 @@ namespace XenAdmin.Dialogs
             this.okButton = new System.Windows.Forms.Button();
             this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItemNew = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemRename = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.radioButtonNone = new System.Windows.Forms.RadioButton();
             this.radioButtonChoose = new System.Windows.Forms.RadioButton();
-            this.newButton = new System.Windows.Forms.Button();
+            this.buttonNew = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.treeView = new XenAdmin.Controls.FolderChangeDialogTreeView();
-            this.buttonDelete = new System.Windows.Forms.Button();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.buttonDelete = new System.Windows.Forms.Button();
+            this.buttonRename = new System.Windows.Forms.Button();
             this.contextMenuStrip.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -65,6 +67,7 @@ namespace XenAdmin.Dialogs
             // 
             this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItemNew,
+            this.toolStripMenuItemRename,
             this.toolStripMenuItemDelete});
             this.contextMenuStrip.Name = "contextMenuStrip";
             resources.ApplyResources(this.contextMenuStrip, "contextMenuStrip");
@@ -75,6 +78,12 @@ namespace XenAdmin.Dialogs
             this.toolStripMenuItemNew.Name = "toolStripMenuItemNew";
             resources.ApplyResources(this.toolStripMenuItemNew, "toolStripMenuItemNew");
             this.toolStripMenuItemNew.Click += new System.EventHandler(this.toolStripMenuItemNew_Click);
+            // 
+            // toolStripMenuItemRename
+            // 
+            this.toolStripMenuItemRename.Name = "toolStripMenuItemRename";
+            resources.ApplyResources(this.toolStripMenuItemRename, "toolStripMenuItemRename");
+            this.toolStripMenuItemRename.Click += new System.EventHandler(this.toolStripMenuItemRename_Click);
             // 
             // toolStripMenuItemDelete
             // 
@@ -102,12 +111,12 @@ namespace XenAdmin.Dialogs
             this.radioButtonChoose.CheckedChanged += new System.EventHandler(this.radioButtonChoose_CheckedChanged);
             this.radioButtonChoose.TabStopChanged += new System.EventHandler(this.radioButtonChoose_TabStopChanged);
             // 
-            // newButton
+            // buttonNew
             // 
-            resources.ApplyResources(this.newButton, "newButton");
-            this.newButton.Name = "newButton";
-            this.newButton.UseVisualStyleBackColor = true;
-            this.newButton.Click += new System.EventHandler(this.newButton_Click);
+            resources.ApplyResources(this.buttonNew, "buttonNew");
+            this.buttonNew.Name = "buttonNew";
+            this.buttonNew.UseVisualStyleBackColor = true;
+            this.buttonNew.Click += new System.EventHandler(this.buttonNew_Click);
             // 
             // tableLayoutPanel1
             // 
@@ -115,29 +124,24 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel1.Controls.Add(this.radioButtonNone, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.radioButtonChoose, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.treeView, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.newButton, 2, 2);
-            this.tableLayoutPanel1.Controls.Add(this.buttonDelete, 2, 3);
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.buttonNew, 2, 2);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.buttonDelete, 2, 4);
+            this.tableLayoutPanel1.Controls.Add(this.buttonRename, 2, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // treeView
             // 
-            resources.ApplyResources(this.treeView, "treeView");
             this.treeView.ContextMenuStrip = this.contextMenuStrip;
+            resources.ApplyResources(this.treeView, "treeView");
             this.treeView.HideSelection = false;
             this.treeView.Name = "treeView";
-            this.tableLayoutPanel1.SetRowSpan(this.treeView, 2);
+            this.tableLayoutPanel1.SetRowSpan(this.treeView, 3);
             this.treeView.ShowLines = false;
             this.treeView.NodeMouseDoubleClick += new System.EventHandler<XenAdmin.Controls.VirtualTreeNodeMouseClickEventArgs>(this.treeView_NodeMouseDoubleClick);
             this.treeView.SelectionsChanged += new System.EventHandler(this.treeView_SelectionsChanged);
             this.treeView.Enter += new System.EventHandler(this.treeView_Enter);
-            // 
-            // buttonDelete
-            // 
-            resources.ApplyResources(this.buttonDelete, "buttonDelete");
-            this.buttonDelete.Name = "buttonDelete";
-            this.buttonDelete.UseVisualStyleBackColor = true;
-            this.buttonDelete.Click += new System.EventHandler(this.buttonDelete_Click);
+            this.treeView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.treeView_KeyDown);
             // 
             // tableLayoutPanel2
             // 
@@ -146,6 +150,20 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel2.Controls.Add(this.okButton, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.cancelButton, 1, 0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            // 
+            // buttonDelete
+            // 
+            resources.ApplyResources(this.buttonDelete, "buttonDelete");
+            this.buttonDelete.Name = "buttonDelete";
+            this.buttonDelete.UseVisualStyleBackColor = true;
+            this.buttonDelete.Click += new System.EventHandler(this.buttonDelete_Click);
+            // 
+            // buttonRename
+            // 
+            resources.ApplyResources(this.buttonRename, "buttonRename");
+            this.buttonRename.Name = "buttonRename";
+            this.buttonRename.UseVisualStyleBackColor = true;
+            this.buttonRename.Click += new System.EventHandler(this.buttonRename_Click);
             // 
             // FolderChangeDialog
             // 
@@ -170,7 +188,7 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.Button okButton;
         private System.Windows.Forms.RadioButton radioButtonNone;
         private System.Windows.Forms.RadioButton radioButtonChoose;
-        private System.Windows.Forms.Button newButton;
+        private System.Windows.Forms.Button buttonNew;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemNew;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
@@ -178,5 +196,7 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.Button buttonDelete;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemDelete;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemRename;
+        private System.Windows.Forms.Button buttonRename;
     }
 }

--- a/XenAdmin/Dialogs/FolderChangeDialog.resx
+++ b/XenAdmin/Dialogs/FolderChangeDialog.resx
@@ -112,28 +112,28 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cancelButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cancelButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>352, 364</value>
+    <value>337, 3</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>1</value>
   </data>
   <data name="cancelButton.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -142,157 +142,304 @@
     <value>cancelButton</value>
   </data>
   <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+    <value>Top, Right</value>
+  </data>
+  <data name="okButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="okButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>271, 364</value>
+    <value>256, 3</value>
   </data>
   <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
   <data name="okButton.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>0</value>
   </data>
   <data name="okButton.Text" xml:space="preserve">
-    <value>&amp;Move</value>
+    <value>OK</value>
   </data>
   <data name="&gt;&gt;okButton.Name" xml:space="preserve">
     <value>okButton</value>
   </data>
   <data name="&gt;&gt;okButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;okButton.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>0</value>
   </data>
-  <data name="treeView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="toolStripMenuItemNew.Size" type="System.Drawing.Size, System.Drawing">
+    <value>140, 22</value>
   </data>
-  <data name="treeView.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 62</value>
+  <data name="toolStripMenuItemNew.Text" xml:space="preserve">
+    <value>&amp;New Folder..</value>
   </data>
-  <data name="treeView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>415, 288</value>
+  <data name="toolStripMenuItemDelete.Size" type="System.Drawing.Size, System.Drawing">
+    <value>140, 22</value>
   </data>
-  <data name="treeView.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="toolStripMenuItemDelete.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
   </data>
-  <data name="&gt;&gt;treeView.Name" xml:space="preserve">
-    <value>treeView</value>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>141, 48</value>
   </data>
-  <data name="&gt;&gt;treeView.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.TreeViewWithNodes, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
   </data>
-  <data name="&gt;&gt;treeView.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;treeView.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="radioButtonNone.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="radioButtonNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
-  </data>
-  <data name="radioButtonNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 19</value>
-  </data>
-  <data name="radioButtonNone.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="radioButtonNone.Text" xml:space="preserve">
-    <value>N&amp;ot in any folder</value>
-  </data>
-  <data name="&gt;&gt;radioButtonNone.Name" xml:space="preserve">
-    <value>radioButtonNone</value>
-  </data>
-  <data name="&gt;&gt;radioButtonNone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioButtonNone.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;radioButtonNone.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
   <data name="radioButtonChoose.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="radioButtonChoose.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
   <data name="radioButtonChoose.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 37</value>
+    <value>3, 28</value>
   </data>
   <data name="radioButtonChoose.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 19</value>
+    <value>195, 19</value>
   </data>
   <data name="radioButtonChoose.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="radioButtonChoose.Text" xml:space="preserve">
-    <value>&amp;In this folder:</value>
+    <value>Place this resource &amp;in this folder:</value>
   </data>
   <data name="&gt;&gt;radioButtonChoose.Name" xml:space="preserve">
     <value>radioButtonChoose</value>
   </data>
   <data name="&gt;&gt;radioButtonChoose.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;radioButtonChoose.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;radioButtonChoose.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="newButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
+  <data name="treeView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="treeView.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="treeView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 53</value>
+  </data>
+  <data name="treeView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>308, 277</value>
+  </data>
+  <data name="treeView.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;treeView.Name" xml:space="preserve">
+    <value>treeView</value>
+  </data>
+  <data name="&gt;&gt;treeView.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.FolderChangeDialogTreeView, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;treeView.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;treeView.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="newButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="newButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="newButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 364</value>
+    <value>337, 53</value>
   </data>
   <data name="newButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 23</value>
+    <value>75, 23</value>
   </data>
   <data name="newButton.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="newButton.Text" xml:space="preserve">
-    <value>&amp;New Folder...</value>
+    <value>&amp;New...</value>
   </data>
   <data name="&gt;&gt;newButton.Name" xml:space="preserve">
     <value>newButton</value>
   </data>
   <data name="&gt;&gt;newButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;newButton.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;newButton.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="buttonDelete.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonDelete.Location" type="System.Drawing.Point, System.Drawing">
+    <value>337, 82</value>
+  </data>
+  <data name="buttonDelete.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonDelete.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="buttonDelete.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.Name" xml:space="preserve">
+    <value>buttonDelete</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 333</value>
+  </data>
+  <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>415, 29</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="okButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cancelButton" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>415, 362</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radioButtonNone" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="radioButtonChoose" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treeView" Row="2" RowSpan="2" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="newButton" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="buttonDelete" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel2" Row="4" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="radioButtonNone.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="radioButtonNone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="radioButtonNone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 19</value>
+  </data>
+  <data name="radioButtonNone.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="radioButtonNone.Text" xml:space="preserve">
+    <value>Do n&amp;ot place this resource in any folder</value>
+  </data>
+  <data name="&gt;&gt;radioButtonNone.Name" xml:space="preserve">
+    <value>radioButtonNone</value>
+  </data>
+  <data name="&gt;&gt;radioButtonNone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonNone.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;radioButtonNone.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>439, 399</value>
+    <value>439, 386</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -303,8 +450,23 @@
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>445, 425</value>
   </data>
+  <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>12, 12, 12, 12</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Change Folder</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemNew.Name" xml:space="preserve">
+    <value>toolStripMenuItemNew</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemNew.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemDelete.Name" xml:space="preserve">
+    <value>toolStripMenuItemDelete</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemDelete.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>FolderChangeDialog</value>

--- a/XenAdmin/Dialogs/FolderChangeDialog.resx
+++ b/XenAdmin/Dialogs/FolderChangeDialog.resx
@@ -192,6 +192,12 @@
   <data name="toolStripMenuItemNew.Text" xml:space="preserve">
     <value>&amp;New Folder..</value>
   </data>
+  <data name="toolStripMenuItemRename.Size" type="System.Drawing.Size, System.Drawing">
+    <value>140, 22</value>
+  </data>
+  <data name="toolStripMenuItemRename.Text" xml:space="preserve">
+    <value>&amp;Rename...</value>
+  </data>
   <data name="toolStripMenuItemDelete.Size" type="System.Drawing.Size, System.Drawing">
     <value>140, 22</value>
   </data>
@@ -199,7 +205,7 @@
     <value>&amp;Delete</value>
   </data>
   <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>141, 48</value>
+    <value>141, 70</value>
   </data>
   <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
     <value>contextMenuStrip</value>
@@ -243,8 +249,8 @@
   <data name="&gt;&gt;radioButtonChoose.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="treeView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+  <data name="treeView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="treeView.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -270,62 +276,35 @@
   <data name="&gt;&gt;treeView.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="newButton.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="buttonNew.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <data name="newButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="buttonNew.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="newButton.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="buttonNew.Location" type="System.Drawing.Point, System.Drawing">
     <value>337, 53</value>
   </data>
-  <data name="newButton.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="buttonNew.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
-  <data name="newButton.TabIndex" type="System.Int32, mscorlib">
+  <data name="buttonNew.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="newButton.Text" xml:space="preserve">
+  <data name="buttonNew.Text" xml:space="preserve">
     <value>&amp;New...</value>
   </data>
-  <data name="&gt;&gt;newButton.Name" xml:space="preserve">
-    <value>newButton</value>
+  <data name="&gt;&gt;buttonNew.Name" xml:space="preserve">
+    <value>buttonNew</value>
   </data>
-  <data name="&gt;&gt;newButton.Type" xml:space="preserve">
+  <data name="&gt;&gt;buttonNew.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;newButton.Parent" xml:space="preserve">
+  <data name="&gt;&gt;buttonNew.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;newButton.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;buttonNew.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="buttonDelete.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="buttonDelete.Location" type="System.Drawing.Point, System.Drawing">
-    <value>337, 82</value>
-  </data>
-  <data name="buttonDelete.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="buttonDelete.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="buttonDelete.Text" xml:space="preserve">
-    <value>&amp;Delete</value>
-  </data>
-  <data name="&gt;&gt;buttonDelete.Name" xml:space="preserve">
-    <value>buttonDelete</value>
-  </data>
-  <data name="&gt;&gt;buttonDelete.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonDelete.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;buttonDelete.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -367,10 +346,64 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="okButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cancelButton" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="buttonDelete.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonDelete.Location" type="System.Drawing.Point, System.Drawing">
+    <value>337, 111</value>
+  </data>
+  <data name="buttonDelete.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonDelete.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="buttonDelete.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.Name" xml:space="preserve">
+    <value>buttonDelete</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonDelete.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="buttonRename.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonRename.Location" type="System.Drawing.Point, System.Drawing">
+    <value>337, 82</value>
+  </data>
+  <data name="buttonRename.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonRename.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="buttonRename.Text" xml:space="preserve">
+    <value>&amp;Rename...</value>
+  </data>
+  <data name="&gt;&gt;buttonRename.Name" xml:space="preserve">
+    <value>buttonRename</value>
+  </data>
+  <data name="&gt;&gt;buttonRename.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRename.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonRename.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -382,7 +415,7 @@
     <value>12, 12</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>415, 362</value>
@@ -403,7 +436,7 @@
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radioButtonNone" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="radioButtonChoose" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treeView" Row="2" RowSpan="2" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="newButton" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="buttonDelete" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel2" Row="4" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radioButtonNone" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="radioButtonChoose" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treeView" Row="2" RowSpan="3" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonNew" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel2" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="buttonDelete" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="buttonRename" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="radioButtonNone.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -460,6 +493,12 @@
     <value>toolStripMenuItemNew</value>
   </data>
   <data name="&gt;&gt;toolStripMenuItemNew.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemRename.Name" xml:space="preserve">
+    <value>toolStripMenuItemRename</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemRename.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripMenuItemDelete.Name" xml:space="preserve">

--- a/XenAdmin/Dialogs/InputPromptDialog.Designer.cs
+++ b/XenAdmin/Dialogs/InputPromptDialog.Designer.cs
@@ -48,18 +48,17 @@ namespace XenAdmin.Dialogs
             // 
             // button1
             // 
+            this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
             resources.ApplyResources(this.button1, "button1");
             this.button1.Name = "button1";
             this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
             // button2
             // 
-            this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             resources.ApplyResources(this.button2, "button2");
+            this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.button2.Name = "button2";
             this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button2_Click);
             // 
             // InputPromptDialog
             // 
@@ -79,9 +78,9 @@ namespace XenAdmin.Dialogs
 
         #endregion
 
-        public System.Windows.Forms.Label promptLabel;
-        public System.Windows.Forms.TextBox textBox1;
-        public System.Windows.Forms.Button button1;
-        public System.Windows.Forms.Button button2;
+        private System.Windows.Forms.Label promptLabel;
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
     }
 }

--- a/XenAdmin/Dialogs/InputPromptDialog.cs
+++ b/XenAdmin/Dialogs/InputPromptDialog.cs
@@ -30,92 +30,54 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
-using System.Windows.Forms;
 
 namespace XenAdmin.Dialogs
 {
     public partial class InputPromptDialog : XenDialogBase
     {
-        // Do not use this constructor: use InputPromptDialog.Prompt(..) instead
         public InputPromptDialog()
         {
             InitializeComponent();
-            textBox1_TextChanged(null, null);
+            EnableButtons();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="owner"></param>
-        /// <param name="message"></param>
-        /// <param name="title"></param>
-        /// <param name="helpID"></param>
-        /// <returns>null if the user cancelled, otherwise the string they gave.</returns>
-        public static String Prompt(IWin32Window owner, String message, String title, String helpID)
+        public string OkButtonText
         {
-            return Prompt(owner, message, title, "", helpID);
+            set { button1.Text = value; }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="owner"></param>
-        /// <param name="message"></param>
-        /// <param name="title"></param>
-        /// <param name="defaultInput"></param>
-        /// <param name="helpID"></param>
-        /// <returns>null if the user cancelled, otherwise the string they gave.</returns>
-        public static String Prompt(IWin32Window owner, String message, String title, String defaultInput, String helpID)
+        public string PromptText
         {
-            InputPromptDialog messageBox = new InputPromptDialog();
-
-            messageBox.Text = title;
-            messageBox.promptLabel.Text = message;
-            messageBox.textBox1.Text = defaultInput;
-            messageBox.HelpID = helpID;
-
-            if (messageBox.ShowDialog(owner) == DialogResult.Cancel)
-                return null;
-
-            return messageBox.textBox1.Text;
+            set { promptLabel.Text = value; }
         }
 
-        private void button2_Click(object sender, EventArgs e)
+        public string InputText
         {
-            DialogResult = DialogResult.Cancel;
-            Close();
+            get { return textBox1.Text.Trim();}
+            set { textBox1.Text = value; }
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private string helpID;
+        public string HelpID
         {
-            DialogResult = DialogResult.OK;
-            Close();
+            set { helpID = value; }
         }
+
+        internal override string HelpName
+        {
+            get { return helpID ?? base.HelpName; }
+        }
+
+
+        private void EnableButtons()
+        {
+            button1.Enabled = !string.IsNullOrEmpty(InputText);
+        }
+
 
         private void textBox1_TextChanged(object sender, EventArgs e)
         {
-            button1.Enabled = !String.IsNullOrEmpty(textBox1.Text.Trim());
-        }
-
-        private string helpID = null;
-        public string HelpID
-        {
-            set
-            {
-                helpID = value;
-            }
-        }
-        internal override string HelpName
-        {
-            get
-            {
-                return helpID ?? base.HelpName;
-            }
+            EnableButtons();
         }
     }
 }

--- a/XenAdmin/Dialogs/InputPromptDialog.resx
+++ b/XenAdmin/Dialogs/InputPromptDialog.resx
@@ -112,33 +112,36 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="promptLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="promptLabel.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8pt</value>
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="promptLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 9</value>
+    <value>13, 10</value>
   </data>
   <data name="promptLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 13</value>
+    <value>26, 15</value>
   </data>
   <data name="promptLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
+  </data>
+  <data name="promptLabel.Text" xml:space="preserve">
+    <value>text</value>
   </data>
   <data name="&gt;&gt;promptLabel.Name" xml:space="preserve">
     <value>promptLabel</value>
   </data>
   <data name="&gt;&gt;promptLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;promptLabel.Parent" xml:space="preserve">
     <value>$this</value>
@@ -147,13 +150,13 @@
     <value>3</value>
   </data>
   <data name="textBox1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8pt</value>
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 25</value>
+    <value>13, 33</value>
   </data>
   <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>353, 20</value>
+    <value>385, 23</value>
   </data>
   <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -162,7 +165,7 @@
     <value>textBox1</value>
   </data>
   <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;textBox1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -171,10 +174,10 @@
     <value>2</value>
   </data>
   <data name="button1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8pt</value>
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>209, 52</value>
+    <value>242, 67</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -183,13 +186,13 @@
     <value>2</value>
   </data>
   <data name="button1.Text" xml:space="preserve">
-    <value>C&amp;reate</value>
+    <value>OK</value>
   </data>
   <data name="&gt;&gt;button1.Name" xml:space="preserve">
     <value>button1</value>
   </data>
   <data name="&gt;&gt;button1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;button1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -197,11 +200,15 @@
   <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="button2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
   <data name="button2.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8pt</value>
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="button2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 52</value>
+    <value>323, 67</value>
   </data>
   <data name="button2.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -216,7 +223,7 @@
     <value>button2</value>
   </data>
   <data name="&gt;&gt;button2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;button2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -224,19 +231,21 @@
   <data name="&gt;&gt;button2.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>377, 85</value>
+    <value>411, 103</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 10, 10, 10</value>
+  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -168,7 +168,7 @@
     <Compile Include="Controls\ComboBoxes\EnableableComboBoxEditingControl.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="Controls\FolderChangeDialogTreeView.cs">
+    <Compile Include="Controls\TreeViews\FolderChangeDialogTreeView.cs">
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\ListViewEx.cs">

--- a/XenAdminTests/DialogTests/DialogsWithDefaultConstructor.cs
+++ b/XenAdminTests/DialogTests/DialogsWithDefaultConstructor.cs
@@ -70,8 +70,8 @@ namespace XenAdminTests.DialogTests.state1_xml.DialogsWithDefaultConstructor
         protected override void RunBeforeShow()
         {
             dialog.Text = "Foo";
-            dialog.promptLabel.Text = "Bar";
-            dialog.textBox1.Text = "stuff";
+            dialog.PromptText = "Bar";
+            dialog.InputText = "stuff";
             dialog.HelpID = "NewFolderDialog";
         }
     }

--- a/XenAdminTests/DialogTests/OtherDialogs.cs
+++ b/XenAdminTests/DialogTests/OtherDialogs.cs
@@ -78,7 +78,7 @@ namespace XenAdminTests.DialogTests.state1_xml.OtherDialogs
     {
         protected override FolderChangeDialog NewDialog()
         {
-            return new FolderChangeDialog("");
+            return new FolderChangeDialog();
         }
     }
 
@@ -87,7 +87,7 @@ namespace XenAdminTests.DialogTests.state1_xml.OtherDialogs
     {
         protected override FolderChangeDialog NewDialog()
         {
-            return new FolderChangeDialog(GetAnyFolder().Name());
+            return new FolderChangeDialog(GetAnyFolder().opaque_ref);
         }
     }
 

--- a/XenAdminTests/MainWindowWrapper/InputPromptDialogWrapper.cs
+++ b/XenAdminTests/MainWindowWrapper/InputPromptDialogWrapper.cs
@@ -51,18 +51,12 @@ namespace XenAdminTests
 
         public TextBox NameTextBox
         {
-            get
-            {
-                return Item.textBox1;
-            }
+            get { return TestUtils.GetTextBox(Item, "textBox1"); }
         }
 
         public Button OKButton
         {
-            get
-            {
-                return Item.button1;
-            }
+            get { return TestUtils.GetButton(Item, "button1"); }
         }
     }
 }

--- a/XenModel/Actions/Folders/FolderAction.cs
+++ b/XenModel/Actions/Folders/FolderAction.cs
@@ -372,6 +372,11 @@ namespace XenAdmin.Actions
                 AppliesTo.Add(path);
         }
 
+        public string[] NewPaths
+        {
+            get { return paths; }
+        }
+
         protected override void Run()
         {
             CanCancel = true;
@@ -384,7 +389,7 @@ namespace XenAdmin.Actions
             Description = paths.Length == 1 ? Messages.CREATED_NEW_FOLDER : Messages.CREATED_NEW_FOLDERS;
         }
 
-        internal static string GetTitle(params string[] paths)
+        private static string GetTitle(params string[] paths)
         {
             return paths.Length == 1
                 ? string.Format(Messages.CREATE_NEW_FOLDER, paths[0])

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -23891,6 +23891,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &amp;Create.
+        /// </summary>
+        public static string NEW_FOLDER_BUTTON {
+            get {
+                return ResourceManager.GetString("NEW_FOLDER_BUTTON", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New Folder.
         /// </summary>
         public static string NEW_FOLDER_DIALOG_TITLE {
@@ -30286,6 +30295,15 @@ namespace XenAdmin {
         public static string RENAME_FOLDER {
             get {
                 return ResourceManager.GetString("RENAME_FOLDER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename Folder.
+        /// </summary>
+        public static string RENAME_FOLDER_TITLE {
+            get {
+                return ResourceManager.GetString("RENAME_FOLDER_TITLE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8952,6 +8952,9 @@ Once the VM has restarted click the Install [Citrix VM Tools] menu item once aga
   <data name="NEW_FOLDER" xml:space="preserve">
     <value>&amp;New Folder...</value>
   </data>
+  <data name="NEW_FOLDER_BUTTON" xml:space="preserve">
+    <value>&amp;Create</value>
+  </data>
   <data name="NEW_FOLDER_DIALOG_TITLE" xml:space="preserve">
     <value>New Folder</value>
   </data>
@@ -10533,6 +10536,9 @@ Click Server Status Report to open the Compile Server Status Report Wizard or cl
   </data>
   <data name="RENAME_FOLDER" xml:space="preserve">
     <value>&amp;Rename Folder...</value>
+  </data>
+  <data name="RENAME_FOLDER_TITLE" xml:space="preserve">
+    <value>Rename Folder</value>
   </data>
   <data name="RENAME_TAG" xml:space="preserve">
     <value>Rename tag '{0}'</value>


### PR DESCRIPTION
- Corrected folder selection; reduced clicks required to select folders;
  improved text; added delete button.
- Moved FolderChangeDialogTreeView to the same folder as the other TreeViews;
- Added missing null checks to the MutliSelectTreeView and hid properties
  HScrollPos and VScrollPos from VS's designer (the former was initialised
  to zero every time the designer was updated, causing the treeview images
  to disappear).