### PR TITLE
CA-271967: Dismiss button is flat after dismissing first of a list of…

### DIFF
--- a/XenAdmin/Controls/DataGridViewDropDownSplitButtonCell.cs
+++ b/XenAdmin/Controls/DataGridViewDropDownSplitButtonCell.cs
@@ -237,6 +237,15 @@ namespace XenAdmin.Controls
             DataGridView.InvalidateCell(this);
         }
 
+        protected override void OnMouseMove(DataGridViewCellMouseEventArgs e)
+        {
+            if (active || e.Button != MouseButtons.None)
+                return;
+
+            active = true;
+            DataGridView.InvalidateCell(this);
+        }
+
         protected override void OnMouseDown(DataGridViewCellMouseEventArgs e)
         {
             var cell = DataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex];


### PR DESCRIPTION
… events.

Handling OnMouseMove which fires more repeatedly than OnMouseEnter and OnMouseLeave with an early return to preserve CPU efficiency.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>