### PR TITLE
CA-301904: Occasional failure to upload status report to CIS

### DIFF
--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolWizard.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolWizard.cs
@@ -134,7 +134,15 @@ namespace XenAdmin.Wizards
                                                                                            Registry.HealthCheckUploadDomainName,// domain name
                                                                                            false); // suppressHistory
                 subActions.Add(uploadAction);
-                action = new MultipleAction(null, Messages.BUGTOOL_SAVING, Messages.BUGTOOL_SAVING, Messages.COMPLETED, subActions,true);
+                action = new MultipleAction(
+                    null,
+                    Messages.BUGTOOL_SAVING,
+                    Messages.BUGTOOL_SAVING,
+                    Messages.COMPLETED,
+                    subActions,
+                    true, // suppressHistory
+                    false, // showSubActionDetails (default value).
+                    true); // stopOnFirstException
             }
             else
             {

--- a/XenModel/Actions/HealthCheck/XenServerHealthCheckUpload.cs
+++ b/XenModel/Actions/HealthCheck/XenServerHealthCheckUpload.cs
@@ -258,7 +258,8 @@ namespace XenServerHealthCheck
             }
             finally
             {
-                source?.Dispose();
+                if (source != null)
+                    source.Dispose();
             }
 
             log.InfoFormat("Succeeded to upload bundle {0}", fileName);

--- a/XenModel/Actions/MultipleAction.cs
+++ b/XenModel/Actions/MultipleAction.cs
@@ -39,7 +39,9 @@ using System.Linq;
 
 namespace XenAdmin.Actions
 {
-    // Run several actions. The outer action is asynchronous, but the subactions are run synchronously within that.
+    /// <summary>
+    /// Run several actions.The outer action is asynchronous, but the subactions are run synchronously within that.
+    /// </summary>
     public class MultipleAction : AsyncAction, IDisposable
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);


### PR DESCRIPTION
The retry mechanism commit is designed to resolve the reported issue.
However I recommend icluding the other commits as one of them cancels the Upload step if the Download/Construction step failed as it would not be able to succeed anyway, resolving a small issue introduced when the code was changed to use MultipleAction in CA-204242 and the other commit is a changing the comment of the MultipleAction to be a summary.