### PR TITLE
CA-300384: XC unable to create (GFS2) VDI of virtual-size larger than…

### DIFF
--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
@@ -261,7 +261,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 if (item.Disk.SR.opaque_ref != sr.opaque_ref)
                     continue;
 
-                if (sr.FreeSpace() < totalDiskInitialAllocation[sr.opaque_ref])
+                if (!sr.VdiCreationCanProceed(totalDiskInitialAllocation[sr.opaque_ref]))
                     overcommitedDisk = item.OverCommit = DiskOverCommit.Error;
 
                 if (item.OverCommit != DiskOverCommit.None)
@@ -556,7 +556,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         /// </summary>
         private static bool IsSufficientFreeSpaceAvailableOnSrForVdi(SR sr, VDI disk)
         {
-            return sr != null && !sr.IsFull() && sr.FreeSpace() > Helpers.GetRequiredSpaceToCreateVdiOnSr(sr, disk);
+            return sr != null && sr.VdiCreationCanProceed(Helpers.GetRequiredSpaceToCreateVdiOnSr(sr, disk));
         }
     }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
@@ -263,6 +263,8 @@ namespace XenAdmin.Wizards.NewVMWizard
 
                 if (!sr.VdiCreationCanProceed(totalDiskInitialAllocation[sr.opaque_ref]))
                     overcommitedDisk = item.OverCommit = DiskOverCommit.Error;
+                else if (sr.FreeSpace() < totalDiskInitialAllocation[sr.opaque_ref])
+                    overcommitedDisk = item.OverCommit = DiskOverCommit.Warning;
 
                 if (item.OverCommit != DiskOverCommit.None)
                 {


### PR DESCRIPTION
… available storage when creating new VM.

Calling SR.VdiCreationCanProceed on the total space required of each SR as it takes into account that Thinly Provisioned SRs may overprovision in the same way that the NewDiskDialog does by effectively ignoring the free space limit.
IsSufficientFreeSpaceAvailableOnSrForVdi was not taking into account Thin Provisioning when checking if the virtual disk would fit on the SR and as a consequence would attempt to find another SR to place it on silently; either choosing "Local Storage" or "<no suitable storage>" depending on the size requested relative to the SR sizes.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>