### PR TITLE
CA-300760: Allow VM intra-pool migration through the wizard, even if …

### DIFF
--- a/XenAdmin/Commands/VMOperationHostCommand.cs
+++ b/XenAdmin/Commands/VMOperationHostCommand.cs
@@ -109,7 +109,7 @@ namespace XenAdmin.Commands
             return vm != null && !_cantBootReasons.ContainsKey(vm);
         }
 
-        private static string GetVmCannotBootOnHostReason(VM vm, Host host, Session session, vm_operations operation)
+        internal static string GetVmCannotBootOnHostReason(VM vm, Host host, Session session, vm_operations operation)
         {
             Host residentHost = vm.Connection.Resolve(vm.resident_on);
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
@@ -62,14 +62,13 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             return sr != null && !sr.HBALunPerVDI() && sr.SupportsStorageMigration();
         }
 
-	    protected override bool IsExtraSpaceNeeded(XenRef<SR> sourceRef, XenRef<SR> targetRef)
+	    protected override bool IsExtraSpaceNeeded(SR sourceSr, SR targetSr)
 	    {
-			// No extra space is needed for Migrate or Move operation on same SR.
-			if (targetRef.Equals(sourceRef) &&
-				((wizardMode == WizardMode.Migrate) || (wizardMode == WizardMode.Move)))
+	        // No extra space is needed for Migrate or Move operation on same SR.
+			if (sourceSr != null && targetSr != null && targetSr.opaque_ref.Equals(sourceSr.opaque_ref) && 
+			    (wizardMode == WizardMode.Migrate || wizardMode == WizardMode.Move))
 				return false;
-			else
-				return true;
+	        return true;
 	    }
 
 		/// <summary>

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateStoragePage.cs
@@ -57,9 +57,16 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             return true;
         }
 
-        protected override bool SrIsSuitable(SR sr)
+        protected override bool SrsAreSuitable(SR sourceSr, SR targetSr)
         {
-            return sr != null && !sr.HBALunPerVDI() && sr.SupportsStorageMigration();
+            if (sourceSr == null || targetSr == null || sourceSr.HBALunPerVDI() || targetSr.HBALunPerVDI())
+                return false;
+
+            // intra-pool move of halted VMs does not require the SRs to support migration because we use VMMoveAction (vdi copy & destroy)
+            if (wizardMode == WizardMode.Move && sourceSr.Connection == targetSr.Connection)
+                return true;
+
+            return sourceSr.SupportsStorageMigration() && targetSr.SupportsStorageMigration();
         }
 
 	    protected override bool IsExtraSpaceNeeded(SR sourceSr, SR targetSr)

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationStorageResource.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationStorageResource.cs
@@ -30,7 +30,6 @@
  */
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using XenAdmin.Wizards.GenericPages;
 using XenAPI;
@@ -67,10 +66,12 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
     public class CrossPoolMigrationStorageResource : IStorageResource
     {
         private readonly VDI vdi;
+        private readonly SR sr;
 
         public CrossPoolMigrationStorageResource(VDI vdi)
         {
             this.vdi = vdi;
+            sr = vdi.Connection.Cache.Resolve(vdi.SR);
         }
 
         public string DiskLabel
@@ -98,10 +99,10 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             get { return Convert.ToUInt64(vdi.physical_utilisation); }
         }
 
-		public XenRef<SR> SR
+		public SR SR
 		{
-			get { return vdi.SR; }
+			get { return sr; }
 		}
-	}
+    }
 }
 

--- a/XenAdmin/Wizards/GenericPages/StorageResource.cs
+++ b/XenAdmin/Wizards/GenericPages/StorageResource.cs
@@ -41,7 +41,7 @@ namespace XenAdmin.Wizards.GenericPages
         bool SRTypeInvalid { get; }
         ulong RequiredDiskCapacity { get; }
         bool CanCalculateDiskCapacity { get; }
-		XenRef<SR> SR { get; }
+		SR SR { get; }
     }
 
     public abstract class StorageResourceContainer : IEnumerable

--- a/XenAdmin/Wizards/ImportWizard/OVFStorageResource.cs
+++ b/XenAdmin/Wizards/ImportWizard/OVFStorageResource.cs
@@ -116,7 +116,7 @@ namespace XenAdmin.Wizards.ImportWizard
             }
         }
 
-		public XenRef<SR> SR
+		public SR SR
 		{
 			get { return null; }
 		}


### PR DESCRIPTION
…the storage migration is not allowed

- if a VM can migrate inside a pool, then we will allow it in the wizard, even if storage migration is not allowed
- If it is a intra-pool migration (without moving the disks), then use the VM migrate action (which does a VM.pool_migrate), not the cross pool migrate action.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>