### PR TITLE
CA-302463: Change the action that applies an update to do an async ca…

### DIFF
--- a/XenModel/Actions/Pool_Patch/ApplyPatchAction.cs
+++ b/XenModel/Actions/Pool_Patch/ApplyPatchAction.cs
@@ -133,9 +133,10 @@ namespace XenAdmin.Actions
             Description = string.Format(Messages.APPLYING_PATCH, patch.Name(), host.Name());
             log.Debug(Description);
 
-            var result = Pool_patch.apply(Session, patchRef, host.opaque_ref);
+            RelatedTask = Pool_patch.async_apply(Session, patchRef, host.opaque_ref);
+            PollToCompletion();
 
-            log.DebugFormat(Messages.APPLY_PATCH_LOG_MESSAGE, patch.Name(), host.Name(), result);
+            log.DebugFormat(Messages.APPLY_PATCH_LOG_MESSAGE, patch.Name(), host.Name(), Result);
             Description = string.Format(Messages.PATCH_APPLIED, patch.Name(), host.Name());
         }
     }

--- a/XenModel/Actions/Pool_update/ApplyUpdateAction.cs
+++ b/XenModel/Actions/Pool_update/ApplyUpdateAction.cs
@@ -69,7 +69,8 @@ namespace XenAdmin.Actions
 
             if (!poolUpdate.AppliedOn(host))
             {
-                Pool_update.apply(Session, poolUpdate.opaque_ref, host.opaque_ref);
+                RelatedTask = Pool_update.async_apply(Session, poolUpdate.opaque_ref, host.opaque_ref);
+                PollToCompletion();
                 Description = string.Format(Messages.PATCH_APPLIED, update.Name(), host.Name());
             }
             else


### PR DESCRIPTION
…ll, so that the calling code notices if the connection has been lost while installing the update

This fixes the bug in the Patching wizard, where the wizard does not show any error and does not notice the disconnection, so it is stuck in the Installing update phase.
The Patching wizard only uses the ApplyUpdateAction class, but I had also changed the ApplyPatchAction class to avoid similar problems in the RPU wizard, where this action is used to install the RPU hotfix during the prechecks.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>