### PR TITLE
CA-302772: A host reboot can result in a requested PercentComplete ex…

### DIFF
--- a/XenModel/Actions/Host/HostAbstractAction.cs
+++ b/XenModel/Actions/Host/HostAbstractAction.cs
@@ -88,7 +88,6 @@ namespace XenAdmin.Actions
                         ? VM.async_clean_shutdown(Session, vm.opaque_ref)
                         : VM.async_hard_shutdown(Session, vm.opaque_ref);
                     PollToCompletion(PercentComplete, PercentComplete + step);
-                    PercentComplete += step;
                     i++;
                 }
             }


### PR DESCRIPTION
…ceeding 100%.

Stepping up the PercentageComplete manually is not required as PollToCompletion is doing this for us already.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>