### PR TITLE
XOP-953: Cannot change dom0 memory via XenCenter (XC 7.5 RTM on XS 7.…

### DIFF
--- a/XenAdmin/Dialogs/ControlDomainMemoryDialog.cs
+++ b/XenAdmin/Dialogs/ControlDomainMemoryDialog.cs
@@ -80,8 +80,7 @@ namespace XenAdmin.Dialogs
 
             // Since updates come in dribs and drabs, avoid error if new max and min arrive
             // out of sync and maximum < minimum.
-            if (vm.memory_dynamic_max >= vm.memory_dynamic_min &&
-                vm.memory_static_max >= vm.memory_static_min)
+            if (vm.memory_dynamic_max >= vm.memory_dynamic_min)
             {
                 double min = vm.memory_static_min;
                 double max = Math.Min(vm.memory_dynamic_min + host.memory_available_calc(), MAXIMUM_DOM0_MEMORY_GB * Util.BINARY_GIGA);

--- a/XenModel/Actions/Host/ChangeControlDomainMemoryAction.cs
+++ b/XenModel/Actions/Host/ChangeControlDomainMemoryAction.cs
@@ -61,10 +61,9 @@ namespace XenAdmin.Actions
             {
                 XenAPI.VM.set_memory(Session, vm.opaque_ref, memory);
             }
-            catch (Exception e)
+            catch (Failure f)
             {
-                var f = e as Failure;
-                if (f != null && f.ErrorDescription[0] == Failure.MEMORY_CONSTRAINT_VIOLATION
+                if (f.ErrorDescription[0] == Failure.MEMORY_CONSTRAINT_VIOLATION
                     && memory < vm.memory_static_min)
                 {
                     throw new Failure(string.Format(Messages.ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW,

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -88,7 +88,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The memory {0} has to be at least the value of the static minimum ({1}).
+        ///   Looks up a localized string similar to The memory specified ({0}) was too low. It has to be at least the value of the static minimum ({1}).
         /// </summary>
         public static string ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -88,7 +88,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The memory {0} has to be at least the value of the Static minimum ({1}).
+        ///   Looks up a localized string similar to The memory {0} has to be at least the value of the static minimum ({1}).
         /// </summary>
         public static string ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -88,6 +88,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The memory {0} has to be at least the value of the Static minimum ({1}).
+        /// </summary>
+        public static string ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW {
+            get {
+                return ResourceManager.GetString("ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change disk size.
         /// </summary>
         public static string ACTION_CHANGE_DISK_SIZE {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -130,7 +130,7 @@
     <value>Changing control domain memory settings on '{0}'</value>
   </data>
   <data name="ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW" xml:space="preserve">
-    <value>The memory {0} has to be at least the value of the Static minimum ({1})</value>
+    <value>The memory {0} has to be at least the value of the static minimum ({1})</value>
   </data>
   <data name="ACTION_CHANGE_DISK_SIZE" xml:space="preserve">
     <value>Change disk size</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -130,7 +130,7 @@
     <value>Changing control domain memory settings on '{0}'</value>
   </data>
   <data name="ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW" xml:space="preserve">
-    <value>The memory {0} has to be at least the value of the static minimum ({1})</value>
+    <value>The memory specified ({0}) was too low. It has to be at least the value of the static minimum ({1})</value>
   </data>
   <data name="ACTION_CHANGE_DISK_SIZE" xml:space="preserve">
     <value>Change disk size</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -129,6 +129,9 @@
   <data name="ACTION_CHANGE_CONTROL_DOMAIN_MEMORY" xml:space="preserve">
     <value>Changing control domain memory settings on '{0}'</value>
   </data>
+  <data name="ACTION_CHANGE_CONTROL_DOMAIN_MEMORY_VALUE_TOO_LOW" xml:space="preserve">
+    <value>The memory {0} has to be at least the value of the Static minimum ({1})</value>
+  </data>
   <data name="ACTION_CHANGE_DISK_SIZE" xml:space="preserve">
     <value>Change disk size</value>
   </data>

--- a/XenModel/XenAPI-Extensions/Failure.cs
+++ b/XenModel/XenAPI-Extensions/Failure.cs
@@ -93,6 +93,7 @@ namespace XenAPI
         public const string PATCH_ALREADY_APPLIED = "PATCH_ALREADY_APPLIED";
         public const string UPDATE_ALREADY_APPLIED = "UPDATE_ALREADY_APPLIED";
         public const string UPDATE_ALREADY_EXISTS = "UPDATE_ALREADY_EXISTS";
+        public const string MEMORY_CONSTRAINT_VIOLATION = "MEMORY_CONSTRAINT_VIOLATION";
 
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 


### PR DESCRIPTION
…5 RTM).

Allowing the user to proceed (not set the value and min/max to 0.0GB) even if the memory static min and max is in the wrong order.
Adding further detail to the error message in case an out of bounds value is sent to the API which could potentially happen due to the range widening that occurs if the min/max would invalidate the existing value.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>