### PR TITLE
CA-303201: Added null check for the update on host corresponding to the selected update.

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -553,11 +553,14 @@ namespace XenAdmin.Wizards.PatchingWizard
                 var serverChecks = new List<Check>();
                 foreach (Host host in SelectedServers)
                 {
-                    List<Pool_update> updates = new List<Pool_update>(host.Connection.Cache.Pool_updates);
-                    Pool_update poolUpdateFromHost = updates.Find(otherPatch => string.Equals(otherPatch.uuid, update.uuid, StringComparison.OrdinalIgnoreCase));
+                    var updates = new List<Pool_update>(host.Connection.Cache.Pool_updates);
+                    var poolUpdateFromHost = updates.Find(p => string.Equals(p.uuid, update.uuid, StringComparison.OrdinalIgnoreCase));
+
                     SR uploadSr = null;
-                    if (SrUploadedUpdates != null && SrUploadedUpdates.ContainsKey(poolUpdateFromHost) && SrUploadedUpdates[poolUpdateFromHost].ContainsKey(host))
+                    if (SrUploadedUpdates != null && poolUpdateFromHost != null &&
+                        SrUploadedUpdates.ContainsKey(poolUpdateFromHost) && SrUploadedUpdates[poolUpdateFromHost].ContainsKey(host))
                         uploadSr = SrUploadedUpdates[poolUpdateFromHost][host];
+
                     serverChecks.Add(new PatchPrecheckCheck(host, poolUpdateFromHost, LivePatchCodesByHost, uploadSr));
                 }
                 groups.Add(new CheckGroup(Messages.CHECKING_SERVER_SIDE_STATUS, serverChecks));

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class FriendlyNames {
@@ -385,6 +385,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Measured boot logs.
+        /// </summary>
+        public static string Description_host_system_status_tboot {
+            get {
+                return ResourceManager.GetString("Description-host.system_status-tboot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [XenServer] licensing daemon logs.
         /// </summary>
         public static string Description_host_system_status_v6d {
@@ -561,6 +570,15 @@ namespace XenAdmin {
         public static string Description_host_system_status_xha_liveset {
             get {
                 return ResourceManager.GetString("Description-host.system_status-xha-liveset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Container management logs.
+        /// </summary>
+        public static string Description_host_system_status_xscontainer {
+            get {
+                return ResourceManager.GetString("Description-host.system_status-xscontainer", resourceCulture);
             }
         }
         
@@ -1452,6 +1470,15 @@ namespace XenAdmin {
         public static string Label_host_system_status_tapdisk_logs {
             get {
                 return ResourceManager.GetString("Label-host.system_status-tapdisk-logs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Measured boot logs.
+        /// </summary>
+        public static string Label_host_system_status_tboot {
+            get {
+                return ResourceManager.GetString("Label-host.system_status-tboot", resourceCulture);
             }
         }
         

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1760,6 +1760,15 @@
   <data name="Label-host.system_status-xscontainer" xml:space="preserve">
     <value>Container management logs</value>
   </data>
+  <data name="Description-host.system_status-xscontainer" xml:space="preserve">
+    <value>Container management logs</value>
+  </data>
+  <data name="Label-host.system_status-tboot" xml:space="preserve">
+    <value>Measured boot logs</value>
+  </data>
+  <data name="Description-host.system_status-tboot" xml:space="preserve">
+    <value>Measured boot logs</value>
+  </data>
   <data name="Description-host.system_status-conntest" xml:space="preserve">
     <value>Tests for connectivity between the server and the internet</value>
   </data>


### PR DESCRIPTION
If, for example, the host was disconnected, poolUpdateFromHost was null,
which was causing a silent exception resulting to an empty precheck list
shown on the page.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>