### PR TITLE
CA-304025: XenCenter should not do an immediate toolstack restart if …

### DIFF
--- a/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/RpuUploadAndApplySuppPackPlanAction.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/PlanActions/RpuUploadAndApplySuppPackPlanAction.cs
@@ -258,7 +258,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard.PlanActions
             switch (guidance)
             {
                 case update_after_apply_guidance.restartHost:
-                    return new RestartHostPlanAction(host, host.GetRunningVMs(), true, hostsThatWillRequireReboot);
+                    return new RestartHostPlanAction(host, host.GetRunningVMs(), true, false, hostsThatWillRequireReboot);
                 case update_after_apply_guidance.restartXAPI:
                     return new RestartAgentPlanAction(host);
                 case update_after_apply_guidance.restartHVM:


### PR DESCRIPTION
…a host reboot is pending, but do the host reboot instead

If the update sequence for automated updates contains an update which requires a host reboot and a hotfix with an immediate toolstack restart (after-apply-guidance=restartXAPI and guidance-mandatory=true),
then XenCenter should do an immediate host reboot after applying the hotfix that required the immediate toolstack restart (as doing a toolstack restart when a host reboot is required is potentially risky)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>