### PR TITLE
Filtering out DEBUG XenAPI.Session logs by default to reduce noise wh…

### DIFF
--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -276,5 +276,8 @@
       <level value="INFO"/>
       <appender-ref ref="AuditAppender"/>
     </logger>
+    <logger name="XenAPI.Session">
+      <level value="INFO"/>
+    </logger>
   </log4net>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>


### PR DESCRIPTION
…en generally logging for diagnostic purposes at the DEBUG level.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>