### PR TITLE
CA-305383: Correct Helper.AreEqual2 which considered identical (but n…

### DIFF
--- a/XenAdminTests/XenAdminTests.csproj
+++ b/XenAdminTests/XenAdminTests.csproj
@@ -373,6 +373,7 @@
     <Compile Include="WizardTests\RollingUpgradeWizardTest.cs" />
     <Compile Include="XenModelTests\ActionTestBase.cs" />
     <Compile Include="XenModelTests\AddressTests.cs" />
+    <Compile Include="XenModelTests\AreEqual2Tests.cs" />
     <Compile Include="XenModelTests\DestroyPolicyActionTests.cs" />
     <Compile Include="XenModelTests\DestroyVMTests.cs" />
     <Compile Include="UnitTests\UnitTestHelper\MockObjectBuilders\MockActionFactory.cs" />

--- a/XenAdminTests/XenModelTests/AreEqual2Tests.cs
+++ b/XenAdminTests/XenModelTests/AreEqual2Tests.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using XenAPI;
+
+namespace XenAdminTests.XenModelTests
+{
+    [TestFixture, Category(TestCategories.Unit)]
+    public class AreEqual2Tests
+    {
+        [Test]
+        public void Separate_null()
+        {
+            Assert.That(Helper.AreEqual2((List<string>)null, (List<string>)null), Is.True);
+        }
+
+        [Test]
+        public void Same_null()
+        {
+            List<string> given = null;
+            Assert.That(Helper.AreEqual2(given, given), Is.True);
+        }
+
+        [Test]
+        public void Separate_same_dictionary()
+        {
+            Assert.That(
+                Helper.AreEqual2(
+                    new Dictionary<string, string> {
+                        { "test", "a"},
+                        { "other", "b"}
+                    },
+                    new Dictionary<string, string> {
+                        { "test", "a" },
+                        { "other", "b" }
+                    }),
+                Is.True);
+        }
+
+        [Test]
+        public void Separate_not_same_list()
+        {
+            Assert.That(
+                Helper.AreEqual2(
+                    new List<string> {
+                        "test",
+                        "other"
+                    },
+                    new List<string> {
+                        "something",
+                        "else"
+                    }),
+                Is.False);
+        }
+
+        [Test]
+        public void Same_list()
+        {
+            var given = new List<string> {
+                "test",
+                "other"
+            };
+            Assert.That(Helper.AreEqual2(given, given), Is.True);
+        }
+
+        [Test]
+        public void Separate_same_list()
+        {
+            Assert.That(
+                Helper.AreEqual2(
+                    new List<string> {
+                        "test",
+                        "other"
+                    },
+                    new List<string> {
+                        "test",
+                        "other"
+                    }),
+            Is.True);
+        }
+
+        [Test]
+        public void Separate_not_same_dictionary()
+        {
+            Assert.That(
+                Helper.AreEqual2(
+                    new Dictionary<string, string> {
+                        { "test", "a"},
+                        { "other", "b"}
+                    },
+                    new Dictionary<string, string> {
+                        { "something", "c" },
+                        { "else", "d" }
+                    }),
+                Is.False);
+        }
+
+        [Test]
+        public void Same_dictionary()
+        {
+            var given = new Dictionary<string, string> {
+                { "test", "a"},
+                { "other", "b"}
+            };
+            Assert.That(Helper.AreEqual2(given, given), Is.True);
+        }
+    }
+}

--- a/XenModel/XenAPI/Helper.cs
+++ b/XenModel/XenAPI/Helper.cs
@@ -66,9 +66,9 @@ namespace XenAPI
                 return true;
             if (o1 == null || o2 == null)
                 return o1 == null && IsEmptyCollection(o2) || o2 == null && IsEmptyCollection(o1);
-            if (typeof(T) is IDictionary)
+            if (o1 is IDictionary)
                 return AreDictEqual((IDictionary)o1, (IDictionary)o2);
-            if (typeof(T) is System.Collections.ICollection)
+            if (o1 is ICollection)
                 return AreCollectionsEqual((ICollection)o1, (ICollection)o2);
             return o1.Equals(o2);
         }


### PR DESCRIPTION
…ot reference equal) generic lists or dictionaries as being different.

PropertiesDialog was saving unchanged Snapshot Schedule information back to the server unnecessarily. Noticed while working on CA-301907.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>