### PR TITLE
CP-30597: Update the RPU hotfixes

### DIFF
--- a/Branding/branding.sh
+++ b/Branding/branding.sh
@@ -44,7 +44,7 @@ OUTPUT_DIR=${ROOT}/output
 
 cd ${REPO}/Branding/Hotfixes
 
-for hfx in RPU001 RPU002 RPU003
+for hfx in RPU003
 do
   if [ -d "${hfx}" ]; then
     latest=$(ls ${hfx} | /usr/bin/sort -n | tail -n 1)
@@ -53,21 +53,12 @@ do
   fi
 done
 
-for hfx in RPU004
+for hfx in RPU004 RPU005
 do
   if [ -d "${hfx}" ]; then
     latest=$(ls ${hfx} | /usr/bin/sort -n | tail -n 1)
     echo "INFO: Latest version of ${hfx} hotfix is $latest"
     cp ${hfx}/$latest/${hfx}.iso ${hfx}.iso
-  fi
-done
-
-for hfx in RPU001
-do
-  if [ -d "${hfx}" ]; then
-    latest=$(ls ${hfx} | /usr/bin/sort -n | tail -n 1)
-    echo "INFO: Latest version of ${hfx} hotfix is $latest"
-    cp ${hfx}/$latest/${hfx}-src-pkgs.tar ${hfx}-src-pkgs.tar && rm -f ${hfx}-src-pkgs.tar.gz && gzip ${hfx}-src-pkgs.tar
   fi
 done
 

--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -153,13 +153,9 @@
                             </ProgId>
                         </Component>
                         <Component Id="UpdateFiles" Guid="[BRANDING_XSUPDATE_FILE_GUID]">
-                            <?if "$(env.Branding)"="XenCenter"?>
-							<File Id="hotfixClearwater" Source="..\Branding\Hotfixes\RPU001.xsupdate" />
-                            <File Id="hotfixClearwaterSource" Source="..\Branding\Hotfixes\RPU001-src-pkgs.tar.gz" />
-							<?endif?>
-                            <File Id="hotfixCreedence" Source="..\Branding\Hotfixes\RPU002.[xsupdate]" />
                             <File Id="hotfixDundee" Source="..\Branding\Hotfixes\RPU003.[xsupdate]" />
                             <File Id="hotfixEly" Source="..\Branding\Hotfixes\RPU004.iso" />
+                            <File Id="hotfixLima" Source="..\Branding\Hotfixes\RPU005.iso" />
                         </Component>
                         <?if "$(env.Branding)"="XenCenter"?>
 						<!-- TestResources -->

--- a/XenAdmin/Diagnostics/Hotfixing/HotfixFactory.cs
+++ b/XenAdmin/Diagnostics/Hotfixing/HotfixFactory.cs
@@ -40,23 +40,32 @@ namespace XenAdmin.Diagnostics.Hotfixing
         public enum HotfixableServerVersion
         {
             Dundee,
-            ElyKolkata
+            ElyKolkata,
+            Lima
         }
 
         private readonly Hotfix dundeeHotfix = new SingleHotfix
         {
             Filename = "RPU003",
-            UUID = "f6014211-7611-47ac-ac4c-e66bb1692c35"
+            UUID = "149be566-421d-4661-bfca-e70970f86a36"
         };
 
         private readonly Hotfix elyKolkataHotfix = new SingleHotfix
         {
             Filename = "RPU004",
-            UUID = "ddd68553-2bf8-411d-99bc-ed4a95265840"
+            UUID = "072bf802-c54d-4e0d-b110-f0647ea86e32"
+        };
+
+        private readonly Hotfix limaHotfix = new SingleHotfix
+        {
+            Filename = "RPU005",
+            UUID = "660e3036-a090-44b5-a06b-10b3bd929855"
         };
 
         public Hotfix Hotfix(Host host)
         {
+            if (Helpers.LimaOrGreater(host) && !Helpers.NaplesOrGreater(host))
+                return Hotfix(HotfixableServerVersion.Lima);
             if (Helpers.ElyOrGreater(host) && !Helpers.LimaOrGreater(host))
                 return Hotfix(HotfixableServerVersion.ElyKolkata);
             if (Helpers.DundeeOrGreater(host) && !Helpers.ElyOrGreater(host))
@@ -66,6 +75,8 @@ namespace XenAdmin.Diagnostics.Hotfixing
 
         public Hotfix Hotfix(HotfixableServerVersion version)
         {
+            if (version == HotfixableServerVersion.Lima)
+                return limaHotfix;
             if (version == HotfixableServerVersion.ElyKolkata)
                 return elyKolkataHotfix;
             if (version == HotfixableServerVersion.Dundee)

--- a/XenAdminTests/UnitTests/Diagnostics/HotFixFactoryTests.cs
+++ b/XenAdminTests/UnitTests/Diagnostics/HotFixFactoryTests.cs
@@ -59,7 +59,7 @@ namespace XenAdminTests.UnitTests.Diagnostics
             string[] enumNames = Enum.GetNames(typeof (HotfixFactory.HotfixableServerVersion));
             Array.Sort(enumNames);
 
-            string[] expectedNames = {"Clearwater", "Creedence", "Dundee", "ElyKolkata"};
+            string[] expectedNames = {"Dundee", "ElyKolkata", "Lima"};
             Array.Sort(expectedNames);
 
             CollectionAssert.AreEqual(expectedNames, enumNames, "Expected contents of HotfixableServerVersion enum");
@@ -68,13 +68,17 @@ namespace XenAdminTests.UnitTests.Diagnostics
         [Test]
         public void UUIDLookedUpFromEnum()
         {
-            Assert.AreEqual("f6014211-7611-47ac-ac4c-e66bb1692c35",
+            Assert.AreEqual("149be566-421d-4661-bfca-e70970f86a36",
                             factory.Hotfix(HotfixFactory.HotfixableServerVersion.Dundee).UUID,
                             "Dundee UUID lookup from enum");
 
-            Assert.AreEqual("ddd68553-2bf8-411d-99bc-ed4a95265840",
+            Assert.AreEqual("072bf802-c54d-4e0d-b110-f0647ea86e32",
                             factory.Hotfix(HotfixFactory.HotfixableServerVersion.ElyKolkata).UUID,
-                            "Ely-Jura UUID lookup from enum");
+                            "Ely - Kolkata UUID lookup from enum");
+
+            Assert.AreEqual("660e3036-a090-44b5-a06b-10b3bd929855",
+                            factory.Hotfix(HotfixFactory.HotfixableServerVersion.Lima).UUID,
+                            "Lima UUID lookup from enum");
         }
 
         [Test]
@@ -86,11 +90,15 @@ namespace XenAdminTests.UnitTests.Diagnostics
 
             Assert.AreEqual("RPU004",
                             factory.Hotfix(HotfixFactory.HotfixableServerVersion.ElyKolkata).Filename,
-                            "Ely-Jura Filename lookup from enum");
+                            "Ely - Kolkata Filename lookup from enum");
+
+            Assert.AreEqual("RPU005",
+                            factory.Hotfix(HotfixFactory.HotfixableServerVersion.Lima).Filename,
+                            "Lima Filename lookup from enum");
         }
 
         [Test]
-        [TestCase("2.6.50", Description = "Lima")]
+        [TestCase("2.9.50", Description = "Naples")]
         [TestCase("9999.9999.9999", Description = "Future")]
         public void TestPlatformVersionNumbersLatestReleaseGiveNulls(string platformVersion)
         {
@@ -100,15 +108,14 @@ namespace XenAdminTests.UnitTests.Diagnostics
         }
 
         [Test]
-        [TestCase("2.7.0", Description = "Lima", Result = false)]
+        [TestCase("3.0.0", Description = "Naples", Result = false)]
+        [TestCase("2.7.0", Description = "Lima", Result = true)]
         [TestCase("2.6.0", Description = "Kolkata", Result = true)]
         [TestCase("2.5.0", Description = "Jura", Result = true)]
         [TestCase("2.4.0", Description = "Inverness", Result = true)]
         [TestCase("2.3.0", Description = "Falcon", Result = true)]
         [TestCase("2.1.1", Description = "Ely", Result = true)]
         [TestCase("2.0.0", Description = "Dundee", Result = true)]
-        [TestCase("1.9.0", Description = "Creedence", Result = true)]
-        [TestCase("1.8.0", Description = "Clearwater", Result = true)]
         [TestCase("9999.9999.9999", Description = "Future", Result = false)]
         public bool TestIsHotfixRequiredBasedOnPlatformVersion(string version)
         {


### PR DESCRIPTION
- Removed RPU001 and RPU002, as 6.x versions are not supported in XenCenter anymore
- Replaced RPU003 and RPU004 with new versions
- Added RPU005 for Lima

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>