### PR TITLE
CA-310765: Reset the lostConnection flag, so that a retry of this act…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootPlanAction.cs
@@ -97,6 +97,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
         {
             bool master = GetResolvedHost().IsMaster();
 
+            lostConnection = false;
             _cancelled = false;
             double metric = metricDelegate(session, HostXenRef.opaque_ref);
 


### PR DESCRIPTION
…ion runs correctly.

Thsi fixes the bug where XenCenter shows connection failure in the RPU when retrying an upgrade

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>