### PR TITLE
CA-310250: Improvements to the guest UEFI UI

### DIFF
--- a/XenAdmin/Wizards/ImportWizard/ImportBootOptionPage.resx
+++ b/XenAdmin/Wizards/ImportWizard/ImportBootOptionPage.resx
@@ -217,7 +217,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="lblIntro" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="bootModesControl1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,20,AutoSize,0,Absolute,20,Absolute,20,Absolute,20,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="lblIntro" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="bootModesControl1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,20,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -275,7 +275,7 @@ namespace XenAdmin.Wizards.ImportWizard
                 m_pageOptions.Connection = TargetConnection;
                 m_pageTvmIp.Connection = TargetConnection;
 			    RemovePage(m_pageBootOptions);
-                if (m_typeOfImport == ImportType.Vhd && Helpers.NaplesOrGreater(TargetConnection))
+                if (m_typeOfImport == ImportType.Vhd && BootModesControl.ShowBootModeOptions(TargetConnection))
 			    {
 			        AddAfterPage(m_pageNetwork, m_pageBootOptions);
 			        m_pageBootOptions.Connection = TargetConnection;

--- a/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_InstallationMedia.cs
@@ -90,7 +90,9 @@ namespace XenAdmin.Wizards.NewVMWizard
             PvBootBox.Visible = !IsSelectedTemplateHVM;
             PvBootTextBox.Text = m_template.PV_args;
 
-            bootModesControl1.Visible = Helpers.NaplesOrGreater(SelectedTemplate.Connection) && IsSelectedTemplateHVM;
+            bootModesControl1.Visible = IsSelectedTemplateHVM &&
+                                        BootModesControl.ShowBootModeOptions(SelectedTemplate.Connection);
+            ;
             bootModesControl1.TemplateVM = m_template;
 
             if (!ShowInstallationMedia)
@@ -159,7 +161,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             UpdateEnablement();
         }
 
-        public Actions.VMActions.BootMode SelectedBootMode { get { return IsSelectedTemplateHVM ? bootModesControl1.SelectedOption : BootMode.NOT_AVAILABLE; } }
+        public BootMode SelectedBootMode { get { return IsSelectedTemplateHVM ? bootModesControl1.SelectedOption : BootMode.NOT_AVAILABLE; } }
 
         private bool IsBootFromNetworkCustomTemplate(bool userTemplate)
         {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -16726,11 +16726,29 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UEFI boot mode is experimental, and is currently not suitable for production use..
+        ///   Looks up a localized string similar to &amp;UEFI Boot (experimental).
+        /// </summary>
+        public static string GUEFI_BOOT_MODE_EXPERIMENTAL_LABEL {
+            get {
+                return ResourceManager.GetString("GUEFI_BOOT_MODE_EXPERIMENTAL_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Guest UEFI boot is an experimental feature. You can create UEFI-enabled VMs on hosts that are in a production environment. However, UEFI-enabled VMs must not be used for production purposes. You may have to re-create the VMs when you upgrade the host to a newer version of [XenServer]..
         /// </summary>
         public static string GUEFI_BOOT_MODE_EXPERIMENTAL_WARNING {
             get {
                 return ResourceManager.GetString("GUEFI_BOOT_MODE_EXPERIMENTAL_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &amp;UEFI Boot.
+        /// </summary>
+        public static string GUEFI_BOOT_MODE_LABEL {
+            get {
+                return ResourceManager.GetString("GUEFI_BOOT_MODE_LABEL", resourceCulture);
             }
         }
         
@@ -16744,7 +16762,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UEFI and UEFI secure boot modes are experimental, and are currently not suitable for production use..
+        ///   Looks up a localized string similar to Guest UEFI boot and guest UEFI secure boot are experimental features. You can create UEFI-enabled VMs on hosts that are in a production environment. However, UEFI-enabled VMs must not be used for production purposes. You may have to re-create the VMs when you upgrade the host to a newer version of [XenServer]..
         /// </summary>
         public static string GUEFI_BOOT_MODES_EXPERIMENTAL_WARNING {
             get {
@@ -16762,7 +16780,25 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UEFI secure boot mode is experimental, and is currently not suitable for production use..
+        ///   Looks up a localized string similar to UEFI &amp;Secure Boot (experimental).
+        /// </summary>
+        public static string GUEFI_SECURE_BOOT_MODE_EXPERIMENTAL_LABEL {
+            get {
+                return ResourceManager.GetString("GUEFI_SECURE_BOOT_MODE_EXPERIMENTAL_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UEFI &amp;Secure Boot.
+        /// </summary>
+        public static string GUEFI_SECURE_BOOT_MODE_LABEL {
+            get {
+                return ResourceManager.GetString("GUEFI_SECURE_BOOT_MODE_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Guest UEFI secure boot is an experimental feature. You can create VMs configured to use the UEFI secure boot mode on hosts that are in a production environment. However, these VMs must not be used for production purposes. You may have to re-create the VMs when you upgrade the host to a newer version of [XenServer]..
         /// </summary>
         public static string GUEFI_SECUREBOOT_MODE_EXPERIMENTAL_WARNING {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5853,22 +5853,34 @@ Note: Any custom color selections will remain unchanged</value>
     <value>Group Roles</value>
   </data>
   <data name="GUEFI_BOOT_MODES_EXPERIMENTAL_WARNING" xml:space="preserve">
-    <value>The UEFI and UEFI secure boot modes are experimental, and are currently not suitable for production use.</value>
+    <value>Guest UEFI boot and guest UEFI secure boot are experimental features. You can create UEFI-enabled VMs on hosts that are in a production environment. However, UEFI-enabled VMs must not be used for production purposes. You may have to re-create the VMs when you upgrade the host to a newer version of [XenServer].</value>
   </data>
   <data name="GUEFI_BOOT_MODES_UNSUPPORTED_WARNING" xml:space="preserve">
     <value>The UEFI and UEFI secure boot modes are not supported with the selected template.</value>
   </data>
+  <data name="GUEFI_BOOT_MODE_EXPERIMENTAL_LABEL" xml:space="preserve">
+    <value>&amp;UEFI Boot (experimental)</value>
+  </data>
   <data name="GUEFI_BOOT_MODE_EXPERIMENTAL_WARNING" xml:space="preserve">
-    <value>The UEFI boot mode is experimental, and is currently not suitable for production use.</value>
+    <value>Guest UEFI boot is an experimental feature. You can create UEFI-enabled VMs on hosts that are in a production environment. However, UEFI-enabled VMs must not be used for production purposes. You may have to re-create the VMs when you upgrade the host to a newer version of [XenServer].</value>
+  </data>
+  <data name="GUEFI_BOOT_MODE_LABEL" xml:space="preserve">
+    <value>&amp;UEFI Boot</value>
   </data>
   <data name="GUEFI_BOOT_MODE_UNSUPPORTED_WARNING" xml:space="preserve">
     <value>The UEFI boot mode is not supported with the selected template.</value>
   </data>
   <data name="GUEFI_SECUREBOOT_MODE_EXPERIMENTAL_WARNING" xml:space="preserve">
-    <value>The UEFI secure boot mode is experimental, and is currently not suitable for production use.</value>
+    <value>Guest UEFI secure boot is an experimental feature. You can create VMs configured to use the UEFI secure boot mode on hosts that are in a production environment. However, these VMs must not be used for production purposes. You may have to re-create the VMs when you upgrade the host to a newer version of [XenServer].</value>
   </data>
   <data name="GUEFI_SECUREBOOT_MODE_UNSUPPORTED_WARNING" xml:space="preserve">
     <value>The UEFI secure boot mode is not supported with the selected template.</value>
+  </data>
+  <data name="GUEFI_SECURE_BOOT_MODE_EXPERIMENTAL_LABEL" xml:space="preserve">
+    <value>UEFI &amp;Secure Boot (experimental)</value>
+  </data>
+  <data name="GUEFI_SECURE_BOOT_MODE_LABEL" xml:space="preserve">
+    <value>UEFI &amp;Secure Boot</value>
   </data>
   <data name="GUI_OUT_OF_DATE" xml:space="preserve">
     <value>This version of [XenCenter] is out of date and cannot connect to {0}.


### PR DESCRIPTION
-  hide the boot mode control if there is only one option (BIOS boot);
- add text "(experimental)" to the experimental options (in the radio button text);
- if an option is disabled, then hide the experimantal warning, as there is already a note saying why it is disabled;
- more detailed experimental warning.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>