### PR TITLE
CA-309758: Optimisations to the way we assert if Vms can be migrated …

### DIFF
--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateDestinationPage.cs
@@ -134,8 +134,8 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
             var filters = new List<ReasoningFilter>
             {
                 new ResidentHostIsSameAsSelectionFilter(xenItem, selectedVMs),
-                new CrossPoolMigrateCanMigrateFilter(xenItem, selectedVMs, wizardMode, migrateFilterCache),
-                new WlbEnabledFilter(xenItem, selectedVMs)
+                new WlbEnabledFilter(xenItem, selectedVMs),
+                new CrossPoolMigrateCanMigrateFilter(xenItem, selectedVMs, wizardMode, migrateFilterCache)
             };
             return new DelayLoadingOptionComboBoxItem(xenItem, filters);
         }
@@ -151,8 +151,8 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                     vmList.Add(selectedVMs.Find(vm => vm.opaque_ref == opaqueRef));
 
                 filters.Add(new ResidentHostIsSameAsSelectionFilter(selectedItem.Item, vmList));
-                filters.Add(new CrossPoolMigrateCanMigrateFilter(selectedItem.Item, vmList, wizardMode, migrateFilterCache));
                 filters.Add(new WlbEnabledFilter(selectedItem.Item, vmList));
+                filters.Add(new CrossPoolMigrateCanMigrateFilter(selectedItem.Item, vmList, wizardMode, migrateFilterCache));
             } 
 
             return filters;

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/WlbEnabledFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/WlbEnabledFilter.cs
@@ -50,21 +50,18 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
             this.preSelectedVMs = preSelectedVMs;
         }
 
-        public override bool FailureFound
+        public override bool FailureFoundFor(IXenObject itemToFilterOn)
         {
-            get
-            {
-                bool targetWlb = false;
+            bool targetWlb = false;
 
-                if(ItemToFilterOn != null)
-                    targetWlb = Helpers.CrossPoolMigrationRestrictedWithWlb(ItemToFilterOn.Connection);
+            if(itemToFilterOn != null)
+                targetWlb = Helpers.CrossPoolMigrationRestrictedWithWlb(itemToFilterOn.Connection);
 
-                bool sourceWlb = preSelectedVMs.Any(vm => Helpers.CrossPoolMigrationRestrictedWithWlb(vm.Connection));
+            bool sourceWlb = preSelectedVMs.Any(vm => Helpers.CrossPoolMigrationRestrictedWithWlb(vm.Connection));
 
-                reason = targetWlb ? Messages.CPM_WLB_ENABLED_ON_HOST_FAILURE_REASON : Messages.CPM_WLB_ENABLED_ON_VM_FAILURE_REASON;
+            reason = targetWlb ? Messages.CPM_WLB_ENABLED_ON_HOST_FAILURE_REASON : Messages.CPM_WLB_ENABLED_ON_VM_FAILURE_REASON;
 
-                return targetWlb || sourceWlb;
-            }
+            return targetWlb || sourceWlb;
         }
 
         private string reason = Messages.UNKNOWN;

--- a/XenAdmin/Wizards/GenericPages/DelayLoadingOptionComboBoxItem.cs
+++ b/XenAdmin/Wizards/GenericPages/DelayLoadingOptionComboBoxItem.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Windows.Forms;
 using XenAdmin.Controls;
 using XenAPI;
 
@@ -48,6 +49,7 @@ namespace XenAdmin.Wizards.GenericPages
         /// Event raised when the reason is updated
         /// </summary>
         public event Action<DelayLoadingOptionComboBoxItem> ReasonUpdated;
+        public Object ParentComboBox;
         private string failureReason;
         private IXenObject xenObject;
         private const int DEFAULT_RETRIES = 10;

--- a/XenAdmin/Wizards/GenericPages/ReasoningFilter.cs
+++ b/XenAdmin/Wizards/GenericPages/ReasoningFilter.cs
@@ -41,21 +41,19 @@ namespace XenAdmin.Wizards.GenericPages
             if (!(itemToFilterOn is Host) && !(itemToFilterOn is Pool))
                 throw new ArgumentException("Target should be host or pool");
 
-            ItemToFilterOn = itemToFilterOn;
+            baseItemToFilterOn = itemToFilterOn;
         }
 
         /// <summary>
         /// Base item that should be used to filter on
         /// </summary>
-        protected IXenObject ItemToFilterOn { get; set; }
-        public abstract bool FailureFound { get; }
+        private IXenObject baseItemToFilterOn { get; set; }
+        //public abstract bool FailureFound { get; }
         public abstract string Reason { get; }
 
-        public bool FailureFoundFor(IXenObject xenObject)
-        {
-            ItemToFilterOn = xenObject;
-            return FailureFound;
-        }
+        public abstract bool FailureFoundFor(IXenObject xenObject);
+
+        public bool FailureFound => FailureFoundFor(baseItemToFilterOn);
 
         public virtual void Cancel() { }
     } 

--- a/XenAdmin/Wizards/ImportWizard/HardwareCompatibilityFilter.cs
+++ b/XenAdmin/Wizards/ImportWizard/HardwareCompatibilityFilter.cs
@@ -47,37 +47,34 @@ namespace XenAdmin.Wizards.ImportWizard.Filters
         {
             _hardwarePlatformSettings = hardwarePlatformSettings;
 
-            if (ItemToFilterOn is Host host)
+            if (itemAddedToComboBox is Host host)
                 _hosts.Add(host);
 
-            if (ItemToFilterOn is Pool pool)
+            if (itemAddedToComboBox is Pool pool)
                 _hosts.AddRange(pool.Connection.Cache.Hosts);
         }
     
-        public override bool FailureFound
+        public override bool FailureFoundFor(IXenObject itemToFilterOn)
         {
-            get
+            foreach (var setting in _hardwarePlatformSettings)
             {
-                foreach (var setting in _hardwarePlatformSettings)
+                long hardwarePlatformVersion;
+                if (!long.TryParse(setting.Value.Value, out hardwarePlatformVersion))
+                    continue;
+
+                if (_hosts.Count > 0)
                 {
-                    long hardwarePlatformVersion;
-                    if (!long.TryParse(setting.Value.Value, out hardwarePlatformVersion))
-                        continue;
-
-                    if (_hosts.Count > 0)
-                    {
-                        if (_hosts.Any(h => !h.virtual_hardware_platform_versions.Contains(hardwarePlatformVersion)))
-                            return true;
-                    }
-                    else
-                    {
-                        if (hardwarePlatformVersion > 0)
-                            return true;
-                    }
+                    if (_hosts.Any(h => !h.virtual_hardware_platform_versions.Contains(hardwarePlatformVersion)))
+                        return true;
                 }
-
-                return false;
+                else
+                {
+                    if (hardwarePlatformVersion > 0)
+                        return true;
+                }
             }
+
+            return false;
         }
 
         public override string Reason => Messages.CPM_FAILURE_REASON_HARDWARE_PLATFORM;


### PR DESCRIPTION
…to a destination pool in the Cross Pool Migrate wizard

- When asserting if a VM can be migrated to a pool we don't have to check all the hosts in the pool at this point, we can enable the pool when we find the first host where migration is possible; we will check the rest of the hosts only if that pool is selected.
- If the destination pool is older than the source, then we don't need to do any server calls because we know that migration to an older host is not allowed.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>