### PR TITLE
CA-309844: Fix meddling actions

### DIFF
--- a/XenAdmin/Actions/GUIActions/MeddlingAction.cs
+++ b/XenAdmin/Actions/GUIActions/MeddlingAction.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using XenAPI;
 using XenAdmin.Core;
@@ -46,20 +47,46 @@ namespace XenAdmin.Actions.GUIActions
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
+        private static readonly string XapiExportTaskPrefix = "Export of VM: ";
+        private static readonly string XapiImportTaskName = "VM import";
+
+        private static readonly List<vm_operations> RecognisedVmOperations = new List<vm_operations>
+        {
+            vm_operations.clean_reboot,
+            vm_operations.clean_shutdown,
+            vm_operations.clone,
+            vm_operations.hard_reboot,
+            vm_operations.hard_shutdown,
+            vm_operations.migrate_send,
+            vm_operations.pool_migrate,
+            vm_operations.resume,
+            vm_operations.resume_on,
+            vm_operations.start,
+            vm_operations.start_on,
+            vm_operations.suspend,
+            vm_operations.checkpoint,
+            vm_operations.snapshot,
+            vm_operations.export,
+            vm_operations.import
+        };
+
+        private vm_operations vmOperation;
         public MeddlingAction(Task task)
-            : base(task.Title(), task.Description(), false, false)
+            : base(task.Name(), task.Description(), false, false)
         {
             RelatedTask = new XenRef<Task>(task.opaque_ref);
 
-            this.Host = task.Connection.Resolve(task.resident_on);
+            Host = task.Connection.Resolve(task.resident_on);
 
-            if (this.Host == null)
-                this.Host = Helpers.GetMaster(task.Connection);
+            if (Host == null)
+                Host = Helpers.GetMaster(task.Connection);
 
             Started = (task.created + task.Connection.ServerTimeOffset).ToLocalTime();
             SetAppliesToData(task);
-            VM = VMFromAppliesTo(task);
             Connection = task.Connection;
+            VM = GetVm(task);
+            vmOperation = GetVmOperation(task);
+            UpdateActionTitleAndDescription(task);
             Update(task, false);
         }
 
@@ -130,7 +157,6 @@ namespace XenAdmin.Actions.GUIActions
             if (applies_to != null)
             {
                 AppliesTo.AddRange(applies_to);
-                Description = task.Name();
             }
             else
             {
@@ -142,17 +168,148 @@ namespace XenAdmin.Actions.GUIActions
             }
         }
 
-        private VM VMFromAppliesTo(Task task)
+        private VM GetVm(Task task)
         {
+            // try to find the VM in AppliesTo
             foreach (string r in AppliesTo)
             {
                 VM vm = task.Connection.Resolve(new XenRef<VM>(r));
                 if (vm != null)
                     return vm;
             }
-            return null;
+
+            // try to find a VM in the cache which has this task in its current_operations
+            return task.Connection.Cache.VMs.FirstOrDefault(vm => vm.current_operations.Keys.Contains(task.opaque_ref));
         }
 
+        private static vm_operations GetVmOperation(Task task)
+        {
+            string nl = task.name_label.Replace("Async.", "");
+            if (nl.StartsWith("VM."))
+            {
+                nl = nl.Replace("VM.", "");
+                if (Enum.TryParse(nl, out vm_operations vmOperation) && RecognisedVmOperations.Contains(vmOperation))
+                {
+                    return vmOperation;
+                }
+            }
+            else
+            {
+                // other tasks, e.g. export, import
+                if (task.name_label == XapiImportTaskName)
+                    return vm_operations.import;
+                if (task.name_label.StartsWith(XapiExportTaskPrefix))
+                    return vm_operations.export;
+            }
+
+            return vm_operations.unknown;
+        }
+
+        private void UpdateActionTitleAndDescription(Task task)
+        {
+            Host host1 = null;
+            Host host2 = null;
+            var appliesTo = task.AppliesTo();
+            if (appliesTo != null)
+            {
+                foreach (string r in appliesTo)
+                {
+                    var host = Connection.Resolve(new XenRef<Host>(r));
+                    if (host == null)
+                        continue;
+                    if (host1 == null)
+                        host1 = host;
+                    else
+                        host2 = host;
+                }
+            }
+            else
+            {
+                host1 = task.Connection.Resolve(task.resident_on) ?? Helpers.GetMaster(task.Connection);
+            }
+
+            List<string> names = new List<string>();
+
+            if (VM != null)
+                names.Add(VM.name_label);
+            if (host1 != null)
+                names.Add(host1.name_label);
+            if (host2 != null)
+                names.Add(host2.name_label);
+
+            string titleFormat;
+            switch (vmOperation)
+            {
+                case vm_operations.clean_reboot:
+                case vm_operations.hard_reboot:
+                    titleFormat = names.Count > 1 ? Messages.ACTION_VM_REBOOTING_ON_TITLE : Messages.ACTION_VM_REBOOTING_TITLE;
+                    Description = Messages.ACTION_VM_REBOOTING;
+                    break;
+                case vm_operations.clean_shutdown:
+                case vm_operations.hard_shutdown:
+                    titleFormat = names.Count > 1 ? Messages.ACTION_VM_SHUTTING_DOWN_ON_TITLE : Messages.ACTION_VM_SHUTTING_DOWN_TITLE;
+                    Description = Messages.ACTION_VM_SHUTTING_DOWN;
+                    break;
+                case vm_operations.clone:
+                    titleFormat = Messages.ACTION_VM_COPYING_TITLE_MEDDLING;
+                    Description = Messages.ACTION_VM_COPYING;
+                    break;
+                case vm_operations.migrate_send:
+                case vm_operations.pool_migrate:
+                    titleFormat = names.Count > 2 ? Messages.ACTION_VM_MIGRATING_RESIDENT : Messages.ACTION_VM_MIGRATING_TITLE;
+                    Description = Messages.ACTION_VM_MIGRATING;
+                    break;
+                case vm_operations.resume:
+                case vm_operations.resume_on:
+                    titleFormat = names.Count > 1 ? Messages.ACTION_VM_RESUMING_ON_TITLE : Messages.ACTION_VM_RESUMING_TITLE;
+                    Description = Messages.ACTION_VM_RESUMING;
+                    break;
+                case vm_operations.start:
+                case vm_operations.start_on:
+                    titleFormat = names.Count > 1 ? Messages.ACTION_VM_STARTING_ON_TITLE : Messages.ACTION_VM_STARTING_TITLE;
+                    Description = Messages.ACTION_VM_STARTING;
+                    break;
+                case vm_operations.suspend:
+                    titleFormat =Messages.ACTION_VM_SUSPENDING_TITLE;
+                    Description = Messages.ACTION_VM_SUSPENDING;
+                    break;
+                case vm_operations.checkpoint:
+                case vm_operations.snapshot:
+                    titleFormat = Messages.ACTION_VM_SNAPSHOT_TITLE;
+                    Description = Messages.SNAPSHOTTING;
+                    break;
+                case vm_operations.export:
+                    titleFormat = Messages.ACTION_EXPORT_TASK_NAME;
+                    Description = Messages.ACTION_EXPORT_DESCRIPTION_IN_PROGRESS;
+                    break;
+                case vm_operations.import:
+                    titleFormat = VM == null ? Messages.IMPORTING : names.Count > 1 
+                        ? Messages.ACTION_IMPORT_VM_TO_HOST_TITLE 
+                        : Messages.ACTION_IMPORT_VM_TITLE;
+                    Description = Messages.IMPORTING;
+                    break;
+                default:
+                    titleFormat = task.name_label;
+                    Description = task.name_description;
+                    break;
+            }
+
+            try
+            {
+                Title = string.Format(titleFormat, names.ToArray());
+            }
+            catch (Exception e)
+            {
+                log.Error(e.Message);
+                Title = Description ?? task.name_label;
+            }
+        }
+
+
+        public static bool IsTaskUnwanted(Task task)
+        {
+            return GetVmOperation(task) == vm_operations.unknown;
+        }
         private void DestroyUnwantedOperations(Task task)
         {
             string[] err = task.error_info;

--- a/XenAdmin/Actions/GUIActions/MeddlingActionTaskSpecifications.cs
+++ b/XenAdmin/Actions/GUIActions/MeddlingActionTaskSpecifications.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Actions.GUIActions
         {
             return task.XenCenterUUID() == Program.XenCenterUUID ||
                    task.Connection.Resolve(task.subtask_of) != null ||
-                   task.IsHidden();
+                   MeddlingAction.IsTaskUnwanted(task);
         }
     }
 

--- a/XenModel/Actions/VM/VMRebootAction.cs
+++ b/XenModel/Actions/VM/VMRebootAction.cs
@@ -40,7 +40,7 @@ namespace XenAdmin.Actions.VMActions
     {
 
         public VMRebootAction(VM vm)
-            : base(vm.Connection, string.Format(Messages.ACTION_VM_REBOOTING_TITLE, vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
+            : base(vm.Connection, string.Format(Messages.ACTION_VM_REBOOTING_ON_TITLE, vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
         {
             this.Description = Messages.ACTION_PREPARING;
             this.VM = vm;

--- a/XenModel/Actions/VM/VMShutdownAction.cs
+++ b/XenModel/Actions/VM/VMShutdownAction.cs
@@ -50,7 +50,7 @@ namespace XenAdmin.Actions.VMActions
     public class VMCleanShutdown : VMShutdownAction
     {
         public VMCleanShutdown(VM vm)
-            : base(vm, string.Format(Messages.ACTION_VM_SHUTTING_DOWN_TITLE, vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
+            : base(vm, string.Format(Messages.ACTION_VM_SHUTTING_DOWN_ON_TITLE, vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
         {
         }
 
@@ -67,7 +67,7 @@ namespace XenAdmin.Actions.VMActions
     public class VMHardShutdown : VMShutdownAction
     {
         public VMHardShutdown(VM vm)
-            : base(vm, string.Format(Messages.ACTION_VM_SHUTTING_DOWN_TITLE, vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
+            : base(vm, string.Format(Messages.ACTION_VM_SHUTTING_DOWN_ON_TITLE, vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
         {
         }
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -1492,6 +1492,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Importing VM &apos;{0}&apos;.
+        /// </summary>
+        public static string ACTION_IMPORT_VM_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_IMPORT_VM_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Importing VM &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        public static string ACTION_IMPORT_VM_TO_HOST_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_IMPORT_VM_TO_HOST_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Scanning for IQNs on iSCSI filer {0}.
         /// </summary>
         public static string ACTION_ISCSI_IQN_SCANNING {
@@ -3166,6 +3184,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Migrating VM &apos;{0}&apos;.
+        /// </summary>
+        public static string ACTION_VM_MIGRATING_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_VM_MIGRATING_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Moving VM to new storage....
         /// </summary>
         public static string ACTION_VM_MOVING {
@@ -3203,6 +3230,15 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to Rebooting VM &apos;{0}&apos; on &apos;{1}&apos;.
+        /// </summary>
+        public static string ACTION_VM_REBOOTING_ON_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_VM_REBOOTING_ON_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rebooting VM &apos;{0}&apos;.
         /// </summary>
         public static string ACTION_VM_REBOOTING_TITLE {
             get {
@@ -3293,6 +3329,15 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to Shutting down VM &apos;{0}&apos; on &apos;{1}&apos;.
+        /// </summary>
+        public static string ACTION_VM_SHUTTING_DOWN_ON_TITLE {
+            get {
+                return ResourceManager.GetString("ACTION_VM_SHUTTING_DOWN_ON_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shutting down VM &apos;{0}&apos;.
         /// </summary>
         public static string ACTION_VM_SHUTTING_DOWN_TITLE {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -594,6 +594,12 @@
   <data name="ACTION_HOST_START_TITLE" xml:space="preserve">
     <value>Powering on server '{0}'</value>
   </data>
+  <data name="ACTION_IMPORT_VM_TITLE" xml:space="preserve">
+    <value>Importing VM '{0}'</value>
+  </data>
+  <data name="ACTION_IMPORT_VM_TO_HOST_TITLE" xml:space="preserve">
+    <value>Importing VM '{0}' to '{1}'</value>
+  </data>
   <data name="ACTION_ISCSI_IQN_SCANNING" xml:space="preserve">
     <value>Scanning for IQNs on iSCSI filer {0}</value>
   </data>
@@ -1173,6 +1179,9 @@
   <data name="ACTION_VM_MIGRATING_RESIDENT" xml:space="preserve">
     <value>Migrating VM '{0}' from '{1}' to '{2}'</value>
   </data>
+  <data name="ACTION_VM_MIGRATING_TITLE" xml:space="preserve">
+    <value>Migrating VM '{0}'</value>
+  </data>
   <data name="ACTION_VM_MOVING" xml:space="preserve">
     <value>Moving VM to new storage...</value>
   </data>
@@ -1185,8 +1194,11 @@
   <data name="ACTION_VM_REBOOTING" xml:space="preserve">
     <value>Rebooting VM</value>
   </data>
-  <data name="ACTION_VM_REBOOTING_TITLE" xml:space="preserve">
+  <data name="ACTION_VM_REBOOTING_ON_TITLE" xml:space="preserve">
     <value>Rebooting VM '{0}' on '{1}'</value>
+  </data>
+  <data name="ACTION_VM_REBOOTING_TITLE" xml:space="preserve">
+    <value>Rebooting VM '{0}'</value>
   </data>
   <data name="ACTION_VM_RESUMED" xml:space="preserve">
     <value>Resumed</value>
@@ -1212,8 +1224,11 @@
   <data name="ACTION_VM_SHUTTING_DOWN" xml:space="preserve">
     <value>Shutting down VM</value>
   </data>
-  <data name="ACTION_VM_SHUTTING_DOWN_TITLE" xml:space="preserve">
+  <data name="ACTION_VM_SHUTTING_DOWN_ON_TITLE" xml:space="preserve">
     <value>Shutting down VM '{0}' on '{1}'</value>
+  </data>
+  <data name="ACTION_VM_SHUTTING_DOWN_TITLE" xml:space="preserve">
+    <value>Shutting down VM '{0}'</value>
   </data>
   <data name="ACTION_VM_SHUT_DOWN" xml:space="preserve">
     <value>Shut down</value>


### PR DESCRIPTION
- Refactored MeddlingAction and Task classes: moved the logic for building a MeddlingAction outside the Task class and switched to using the vm_operations enum to identify which tasks are suitable for MeddlingAction

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>