### PR TITLE
CA-309152: Remote logging is offered in addition to local and not instead of it

### DIFF
--- a/XenAdmin/SettingsPanels/LogDestinationEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/LogDestinationEditPage.Designer.cs
@@ -33,12 +33,11 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.LocalRadioButton = new System.Windows.Forms.RadioButton();
-            this.RemoteRadioButton = new System.Windows.Forms.RadioButton();
             this.ServerLabel = new System.Windows.Forms.Label();
             this.ServerTextBox = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label3 = new System.Windows.Forms.Label();
+            this.checkBoxRemote = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel2.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
@@ -65,21 +64,6 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             // 
-            // LocalRadioButton
-            // 
-            resources.ApplyResources(this.LocalRadioButton, "LocalRadioButton");
-            this.LocalRadioButton.Name = "LocalRadioButton";
-            this.LocalRadioButton.TabStop = true;
-            this.LocalRadioButton.UseVisualStyleBackColor = true;
-            // 
-            // RemoteRadioButton
-            // 
-            resources.ApplyResources(this.RemoteRadioButton, "RemoteRadioButton");
-            this.RemoteRadioButton.Name = "RemoteRadioButton";
-            this.RemoteRadioButton.TabStop = true;
-            this.RemoteRadioButton.UseVisualStyleBackColor = true;
-            this.RemoteRadioButton.CheckedChanged += new System.EventHandler(this.RemoteRadioButton_CheckedChanged);
-            // 
             // ServerLabel
             // 
             resources.ApplyResources(this.ServerLabel, "ServerLabel");
@@ -90,27 +74,36 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.ServerTextBox, "ServerTextBox");
             this.ServerTextBox.Name = "ServerTextBox";
             this.ServerTextBox.TextChanged += new System.EventHandler(this.ServerTextBox_TextChanged);
+            this.ServerTextBox.Enter += new System.EventHandler(this.ServerTextBox_Enter);
             // 
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.label3, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.checkBoxRemote, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.ServerLabel, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.ServerTextBox, 2, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // label3
             // 
             resources.ApplyResources(this.label3, "label3");
+            this.tableLayoutPanel1.SetColumnSpan(this.label3, 3);
             this.label3.Name = "label3";
+            // 
+            // checkBoxRemote
+            // 
+            resources.ApplyResources(this.checkBoxRemote, "checkBoxRemote");
+            this.tableLayoutPanel1.SetColumnSpan(this.checkBoxRemote, 3);
+            this.checkBoxRemote.Name = "checkBoxRemote";
+            this.checkBoxRemote.UseVisualStyleBackColor = true;
+            this.checkBoxRemote.CheckedChanged += new System.EventHandler(this.checkBoxRemote_CheckedChanged);
             // 
             // LogDestinationEditPage
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Controls.Add(this.ServerTextBox);
-            this.Controls.Add(this.ServerLabel);
-            this.Controls.Add(this.RemoteRadioButton);
-            this.Controls.Add(this.LocalRadioButton);
             this.DoubleBuffered = true;
             this.Name = "LogDestinationEditPage";
             this.tableLayoutPanel2.ResumeLayout(false);
@@ -118,7 +111,6 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -128,11 +120,10 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
-        private System.Windows.Forms.RadioButton LocalRadioButton;
-        private System.Windows.Forms.RadioButton RemoteRadioButton;
         private System.Windows.Forms.Label ServerLabel;
         private System.Windows.Forms.TextBox ServerTextBox;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.CheckBox checkBoxRemote;
     }
 }

--- a/XenAdmin/SettingsPanels/LogDestinationEditPage.cs
+++ b/XenAdmin/SettingsPanels/LogDestinationEditPage.cs
@@ -75,8 +75,8 @@ namespace XenAdmin.SettingsPanels
             get
             {
                 return checkBoxRemote.Checked
-                    ? string.Format(Messages.LOCAL_AND_REMOTE, RemoteServer)
-                    : Messages.LOCAL;
+                    ? string.Format(Messages.HOST_LOG_DESTINATION_LOCAL_AND_REMOTE, RemoteServer)
+                    : Messages.HOST_LOG_DESTINATION_LOCAL;
             }
         }
 

--- a/XenAdmin/SettingsPanels/LogDestinationEditPage.resx
+++ b/XenAdmin/SettingsPanels/LogDestinationEditPage.resx
@@ -112,19 +112,19 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 8</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 100</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -132,9 +132,9 @@
     <value>panel1</value>
   </data>
   <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -144,29 +144,11 @@
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 13</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Server system log destination</value>
-  </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -190,10 +172,40 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,Percent,100,Absolute,20" /&gt;&lt;Rows Styles="Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Server system log destination</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="tableLayoutPanel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -220,127 +232,70 @@
     <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls /&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="LocalRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LocalRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 45</value>
-  </data>
-  <data name="LocalRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 17</value>
-  </data>
-  <data name="LocalRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="LocalRadioButton.Text" xml:space="preserve">
-    <value>&amp;Local</value>
-  </data>
-  <data name="&gt;&gt;LocalRadioButton.Name" xml:space="preserve">
-    <value>LocalRadioButton</value>
-  </data>
-  <data name="&gt;&gt;LocalRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LocalRadioButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;LocalRadioButton.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="RemoteRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="RemoteRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 69</value>
-  </data>
-  <data name="RemoteRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 17</value>
-  </data>
-  <data name="RemoteRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="RemoteRadioButton.Text" xml:space="preserve">
-    <value>&amp;Remote</value>
-  </data>
-  <data name="&gt;&gt;RemoteRadioButton.Name" xml:space="preserve">
-    <value>RemoteRadioButton</value>
-  </data>
-  <data name="&gt;&gt;RemoteRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RemoteRadioButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;RemoteRadioButton.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="ServerLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="ServerLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="ServerLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 95</value>
+    <value>23, 89</value>
   </data>
   <data name="ServerLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>41, 13</value>
   </data>
   <data name="ServerLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="ServerLabel.Text" xml:space="preserve">
     <value>Ser&amp;ver:</value>
-  </data>
-  <data name="ServerLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;ServerLabel.Name" xml:space="preserve">
     <value>ServerLabel</value>
   </data>
   <data name="&gt;&gt;ServerLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ServerLabel.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;ServerLabel.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="ServerTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>Left, Right</value>
   </data>
   <data name="ServerTextBox.Font" type="System.Drawing.Font, System.Drawing">
     <value>Verdana, 8.25pt</value>
   </data>
   <data name="ServerTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>74, 92</value>
+    <value>70, 85</value>
   </data>
   <data name="ServerTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 21</value>
+    <value>402, 21</value>
   </data>
   <data name="ServerTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;ServerTextBox.Name" xml:space="preserve">
     <value>ServerTextBox</value>
   </data>
   <data name="&gt;&gt;ServerTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ServerTextBox.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;ServerTextBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -351,20 +306,23 @@
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
+  <data name="label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 20</value>
+  </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>466, 39</value>
+    <value>469, 39</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>By default [XenServer] stores its system logs locally on the server. If you want however you may specify a remote log destination using the settings below.</value>
+    <value>[XenServer] stores its system logs locally on the server. If you want the system logs to be directed to a remote server in addition to being stored locally, you may specify a remote log destination using the settings below.</value>
   </data>
   <data name="&gt;&gt;label3.Name" xml:space="preserve">
     <value>label3</value>
   </data>
   <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label3.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -372,23 +330,56 @@
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="checkBoxRemote.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxRemote.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 62</value>
+  </data>
+  <data name="checkBoxRemote.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 17</value>
+  </data>
+  <data name="checkBoxRemote.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="checkBoxRemote.Text" xml:space="preserve">
+    <value>&amp;Also store the system logs on a remote server</value>
+  </data>
+  <data name="&gt;&gt;checkBoxRemote.Name" xml:space="preserve">
+    <value>checkBoxRemote</value>
+  </data>
+  <data name="&gt;&gt;checkBoxRemote.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxRemote.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;checkBoxRemote.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>472, 39</value>
+    <value>475, 241</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -397,16 +388,16 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50" /&gt;&lt;Rows Styles="Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="checkBoxRemote" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="ServerLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="ServerTextBox" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
-  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>475, 241</value>
@@ -415,6 +406,6 @@
     <value>LogDestinationEditPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1198,7 +1198,13 @@ namespace XenAdmin.TabPages
 
                 s.AddEntry(FriendlyName("host.iscsi_iqn"), host.GetIscsiIqn(),
                     new PropertiesToolStripMenuItem(new IqnPropertiesCommand(Program.MainWindow, xenObject)));
-                s.AddEntry(FriendlyName("host.log_destination"), host.GetSysLogDestination() ?? Messages.HOST_LOG_DESTINATION_LOCAL,
+
+                var sysLog = host.GetSysLogDestination();
+                var sysLogDisplay = string.IsNullOrEmpty(sysLog)
+                    ? Messages.HOST_LOG_DESTINATION_LOCAL
+                    : string.Format(Messages.HOST_LOG_DESTINATION_LOCAL_AND_REMOTE, sysLog);
+
+                s.AddEntry(FriendlyName("host.log_destination"), sysLogDisplay,
                    new PropertiesToolStripMenuItem(new HostEditLogDestinationCommand(Program.MainWindow, xenObject)));
 
                 PrettyTimeSpan uptime = host.Uptime();

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -18117,6 +18117,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Local and Remote ({0}).
+        /// </summary>
+        public static string HOST_LOG_DESTINATION_LOCAL_AND_REMOTE {
+            get {
+                return ResourceManager.GetString("HOST_LOG_DESTINATION_LOCAL_AND_REMOTE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If you are upgrading to [XenServer] [BRANDING_VERSION_8_0] and above, the Control Domain memory on {0} will be increased. 
         ///
         ///This might result in failure to migrate VMs to this server during the RPU or to accommodate after the upgrade all the VMs that are currently residing on this server..
@@ -21034,24 +21043,6 @@ namespace XenAdmin {
         public static string LIVE_PATCHING_FAILED_ONE_HOST {
             get {
                 return ResourceManager.GetString("LIVE_PATCHING_FAILED_ONE_HOST", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Local.
-        /// </summary>
-        public static string LOCAL {
-            get {
-                return ResourceManager.GetString("LOCAL", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Local; Remote ({0}).
-        /// </summary>
-        public static string LOCAL_AND_REMOTE {
-            get {
-                return ResourceManager.GetString("LOCAL_AND_REMOTE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -16058,16 +16058,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must give a valid server name..
-        /// </summary>
-        public static string GENERAL_EDIT_INVALID_HOSTNAME {
-            get {
-                return ResourceManager.GetString("GENERAL_EDIT_INVALID_HOSTNAME", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You must give a valid IQN, e.g. iqn.2007-11.com.example.subdomain:optional-domain-specific-string.
+        ///   Looks up a localized string similar to Please enter a valid IQN, e.g. iqn.2007-11.com.example.subdomain:optional-domain-specific-string.
         /// </summary>
         public static string GENERAL_EDIT_INVALID_IQN {
             get {
@@ -16076,11 +16067,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must give a valid name..
+        ///   Looks up a localized string similar to Please enter a valid name..
         /// </summary>
         public static string GENERAL_EDIT_INVALID_NAME {
             get {
                 return ResourceManager.GetString("GENERAL_EDIT_INVALID_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please enter a valid IP address or server name..
+        /// </summary>
+        public static string GENERAL_EDIT_INVALID_REMOTE {
+            get {
+                return ResourceManager.GetString("GENERAL_EDIT_INVALID_REMOTE", resourceCulture);
             }
         }
         
@@ -21043,6 +21043,15 @@ namespace XenAdmin {
         public static string LOCAL {
             get {
                 return ResourceManager.GetString("LOCAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local; Remote ({0}).
+        /// </summary>
+        public static string LOCAL_AND_REMOTE {
+            get {
+                return ResourceManager.GetString("LOCAL_AND_REMOTE", resourceCulture);
             }
         }
         
@@ -30178,15 +30187,6 @@ namespace XenAdmin {
         public static string REMAINING_VFS {
             get {
                 return ResourceManager.GetString("REMAINING_VFS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Remote ({0}).
-        /// </summary>
-        public static string REMOTE {
-            get {
-                return ResourceManager.GetString("REMOTE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5628,14 +5628,14 @@ Warning: to prevent data loss you must ensure that the LUN is not in use by any 
   <data name="GENERAL_DETAILS_CPU_NUMBER" xml:space="preserve">
     <value>CPU {0}</value>
   </data>
-  <data name="GENERAL_EDIT_INVALID_HOSTNAME" xml:space="preserve">
-    <value>You must give a valid server name.</value>
-  </data>
   <data name="GENERAL_EDIT_INVALID_IQN" xml:space="preserve">
-    <value>You must give a valid IQN, e.g. iqn.2007-11.com.example.subdomain:optional-domain-specific-string</value>
+    <value>Please enter a valid IQN, e.g. iqn.2007-11.com.example.subdomain:optional-domain-specific-string</value>
   </data>
   <data name="GENERAL_EDIT_INVALID_NAME" xml:space="preserve">
-    <value>You must give a valid name.</value>
+    <value>Please enter a valid name.</value>
+  </data>
+  <data name="GENERAL_EDIT_INVALID_REMOTE" xml:space="preserve">
+    <value>Please enter a valid IP address or server name.</value>
   </data>
   <data name="GENERAL_HEADING_BOOT_OPTIONS" xml:space="preserve">
     <value>Boot Options</value>
@@ -7330,6 +7330,9 @@ To complete the patch installation, please put the servers into maintenance mode
   </data>
   <data name="LOCAL" xml:space="preserve">
     <value>Local</value>
+  </data>
+  <data name="LOCAL_AND_REMOTE" xml:space="preserve">
+    <value>Local; Remote ({0})</value>
   </data>
   <data name="LOCAL_SRS" xml:space="preserve">
     <value>Local Storage Repositories</value>
@@ -10494,9 +10497,6 @@ To log out of this server and log in again using a different user account, enter
   </data>
   <data name="REMAINING_VFS" xml:space="preserve">
     <value>Yes ({0} VFs remaining)</value>
-  </data>
-  <data name="REMOTE" xml:space="preserve">
-    <value>Remote ({0})</value>
   </data>
   <data name="REMOTE_SRS" xml:space="preserve">
     <value>Remote Storage Repositories</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -6362,6 +6362,9 @@ Click Configure HA to alter the settings displayed below.</value>
   <data name="HOST_LOG_DESTINATION_LOCAL" xml:space="preserve">
     <value>Local</value>
   </data>
+  <data name="HOST_LOG_DESTINATION_LOCAL_AND_REMOTE" xml:space="preserve">
+    <value>Local and Remote ({0})</value>
+  </data>
   <data name="HOST_MEMORY_POST_UPGRADE_DEFAULT_WARNING_LONG" xml:space="preserve">
     <value>If you are upgrading to [XenServer] [BRANDING_VERSION_8_0] and above, the Control Domain memory on {0} will be increased. 
 
@@ -7327,12 +7330,6 @@ To complete the patch installation, please put the servers into maintenance mode
   </data>
   <data name="LIVE_PATCHING_FAILED_ONE_HOST" xml:space="preserve">
     <value>Live patching failed for server ‘{0}’. To complete the patch installation, please put the server into maintenance mode and reboot it.</value>
-  </data>
-  <data name="LOCAL" xml:space="preserve">
-    <value>Local</value>
-  </data>
-  <data name="LOCAL_AND_REMOTE" xml:space="preserve">
-    <value>Local; Remote ({0})</value>
   </data>
   <data name="LOCAL_SRS" xml:space="preserve">
     <value>Local Storage Repositories</value>


### PR DESCRIPTION
The radiobuttons local-remote gave the impression the two types of logging
were mutually exclusive. Use a checkbox instead to make it obvious that
the logs are directed to a remote server in addition to being stored locally.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>