### PR TITLE
CP-29310 & CP-30765: added support for the new xxHash-based VM imports and exports

### DIFF
--- a/CommandLib/CommandLib.csproj
+++ b/CommandLib/CommandLib.csproj
@@ -46,6 +46,7 @@
     <Compile Include="tar.cs" />
     <Compile Include="thinCLIProtocol.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XXHash.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CommandLib/XXHash.cs
+++ b/CommandLib/XXHash.cs
@@ -1,0 +1,308 @@
+﻿/*MIT License
+
+Copyright (c) 2018 differentrain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+/*
+ * The minimum requirements for YYProject.XXHash are .NET Framework 3.5, and C# 7.0 ,
+ * it means that these code also apply to .NET Core 1.0 or later, Mono 4.6 or later and so on.
+ * If necessary, you can also rewrite these library to .NET Framework 2.0 with just a little work. 
+ * Since all code (XXHash32 and XXHash64) are inside these file independently, 
+ * I don't recommend using compiled library in your project.
+ * Instead, you can just copy the useful parts to your code, this is the benefit of MIT License. P:)
+ * 
+ * If you are using .NET4.5 (or higher) or sibling frameworks,  you can add conditional compilation
+ * symbol "HIGHER_VERSIONS" to optimize static-short-methods.
+ */
+
+using System;
+using System.Security.Cryptography;
+#if HIGHER_VERSIONS
+using System.Runtime.CompilerServices;
+#endif
+
+
+namespace YYProject.XXHash
+{
+    //see details: https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md
+
+    /// <summary>
+    /// Represents the class which provides a implementation of the xxHash64 algorithm.
+    /// </summary>
+    /// <threadsafety static="true" instance="false"/>
+    public sealed class XXHash64 : HashAlgorithm
+    {
+        private const ulong PRIME64_1 = 11400714785074694791UL;
+        private const ulong PRIME64_2 = 14029467366897019727UL;
+        private const ulong PRIME64_3 = 1609587929392839161UL;
+        private const ulong PRIME64_4 = 9650029242287828579UL;
+        private const ulong PRIME64_5 = 2870177450012600261UL;
+
+        private static readonly Func<byte[], int, uint> FuncGetLittleEndianUInt32;
+        private static readonly Func<byte[], int, ulong> FuncGetLittleEndianUInt64;
+        private static readonly Func<ulong, ulong> FuncGetFinalHashUInt64;
+
+        private ulong _Seed64;
+
+        private ulong _ACC64_1;
+        private ulong _ACC64_2;
+        private ulong _ACC64_3;
+        private ulong _ACC64_4;
+        private ulong _Hash64;
+
+        private int _RemainingLength;
+        private long _TotalLength;
+        private int _CurrentIndex;
+        private byte[] _CurrentArray;
+
+        static XXHash64()
+        {
+            if (BitConverter.IsLittleEndian)
+            {
+                FuncGetLittleEndianUInt32 = new Func<byte[], int, uint>((x, i) =>
+                {
+                    return BitConverter.ToUInt32(x, i);
+                });
+                FuncGetLittleEndianUInt64 = new Func<byte[], int, ulong>((x, i) =>
+                {
+                    return BitConverter.ToUInt64(x, i);
+                });
+                FuncGetFinalHashUInt64 = new Func<ulong, ulong>(i => (i & 0x00000000000000FFUL) << 56 | (i & 0x000000000000FF00UL) << 40 | (i & 0x0000000000FF0000UL) << 24 | (i & 0x00000000FF000000UL) << 8 | (i & 0x000000FF00000000UL) >> 8 | (i & 0x0000FF0000000000UL) >> 24 | (i & 0x00FF000000000000UL) >> 40 | (i & 0xFF00000000000000UL) >> 56);
+            }
+            else
+            {
+                FuncGetLittleEndianUInt32 = new Func<byte[], int, uint>((array, i) =>
+                {
+                    return (uint)(array[i++] | (array[i++] << 8) | (array[i++] << 16) | (array[i] << 24));
+                });
+                FuncGetLittleEndianUInt64 = new Func<byte[], int, ulong>((array, i) =>
+                {
+                    return array[i++] | ((ulong)array[i++] << 8) | ((ulong)array[i++] << 16) | ((ulong)array[i++] << 24) | ((ulong)array[i++] << 32) | ((ulong)array[i++] << 40) | ((ulong)array[i++] << 48) | ((ulong)array[i] << 56);
+                });
+                FuncGetFinalHashUInt64 = new Func<ulong, ulong>(i => i);
+            }
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="XXHash64"/> class by default seed(0).
+        /// </summary>
+        /// <returns></returns>
+        public new static XXHash64 Create() => new XXHash64();
+
+        /// <summary>
+        /// Creates an instance of the specified implementation of XXHash64 algorithm.
+        /// <para>This method always throws <see cref="NotSupportedException"/>. </para>
+        /// </summary>
+        /// <param name="algName">The hash algorithm implementation to use.</param>
+        /// <returns>This method always throws <see cref="NotSupportedException"/>. </returns>
+        /// <exception cref="NotSupportedException">This method is not be supported.</exception>
+        public new static XXHash64 Create(string algName) => throw new NotSupportedException("This method is not be supported.");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XXHash64"/> class by default seed(0).
+        /// </summary>
+        public XXHash64() => Initialize(0);
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XXHash64"/> class, and sets the <see cref="Seed"/> to the specified value.
+        /// </summary>
+        /// <param name="seed">Represent the seed to be used for xxHash64 computing.</param>
+        public XXHash64(uint seed) => Initialize(seed);
+
+
+        /// <summary>
+        /// Gets the <see cref="ulong"/> value of the computed hash code.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Computation has not yet completed.</exception>
+        public ulong HashUInt64 => State == 0 ? _Hash64 : throw new InvalidOperationException("Computation has not yet completed.");
+
+        /// <summary>
+        ///  Gets or sets the value of seed used by xxHash64 algorithm.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Computation has not yet completed.</exception>
+        public ulong Seed
+        {
+            get => _Seed64;
+            set
+            {
+                if (value != _Seed64)
+                {
+                    if (State != 0) throw new InvalidOperationException("Computation has not yet completed.");
+                    _Seed64 = value;
+                    Initialize();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes this instance for new hash computing.
+        /// </summary>
+        public override void Initialize()
+        {
+            _ACC64_1 = _Seed64 + PRIME64_1 + PRIME64_2;
+            _ACC64_2 = _Seed64 + PRIME64_2;
+            _ACC64_3 = _Seed64 + 0;
+            _ACC64_4 = _Seed64 - PRIME64_1;
+        }
+
+        /// <summary>
+        /// Routes data written to the object into the hash algorithm for computing the hash.
+        /// </summary>
+        /// <param name="array">The input to compute the hash code for.</param>
+        /// <param name="ibStart">The offset into the byte array from which to begin using data.</param>
+        /// <param name="cbSize">The number of bytes in the byte array to use as data.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (State != 1) State = 1;
+            var size = cbSize - ibStart;
+            _RemainingLength = size & 31;
+            if (cbSize >= 32)
+            {
+                var limit = size - _RemainingLength;
+                do
+                {
+                    _ACC64_1 = Round64(_ACC64_1, FuncGetLittleEndianUInt64(array, ibStart));
+                    ibStart += 8;
+                    _ACC64_2 = Round64(_ACC64_2, FuncGetLittleEndianUInt64(array, ibStart));
+                    ibStart += 8;
+                    _ACC64_3 = Round64(_ACC64_3, FuncGetLittleEndianUInt64(array, ibStart));
+                    ibStart += 8;
+                    _ACC64_4 = Round64(_ACC64_4, FuncGetLittleEndianUInt64(array, ibStart));
+                    ibStart += 8;
+                } while (ibStart < limit);
+            }
+            _TotalLength += cbSize;
+            if (_RemainingLength != 0)
+            {
+                _CurrentArray = array;
+                _CurrentIndex = ibStart;
+            }
+        }
+
+        /// <summary>
+        /// Finalizes the hash computation after the last data is processed by the cryptographic stream object.
+        /// </summary>
+        /// <returns>The computed hash code.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (_TotalLength >= 32)
+            {
+#if HIGHER_VERSIONS
+                _Hash64 = RotateLeft64_1(_ACC64_1) + RotateLeft64_7(_ACC64_2) + RotateLeft64_12(_ACC64_3) + RotateLeft64_18(_ACC64_4);
+#else
+
+                _Hash64 = RotateLeft64(_ACC64_1, 1) + RotateLeft64(_ACC64_2, 7) + RotateLeft64(_ACC64_3, 12) + RotateLeft64(_ACC64_4, 18);
+#endif
+                _Hash64 = MergeRound64(_Hash64, _ACC64_1);
+                _Hash64 = MergeRound64(_Hash64, _ACC64_2);
+                _Hash64 = MergeRound64(_Hash64, _ACC64_3);
+                _Hash64 = MergeRound64(_Hash64, _ACC64_4);
+            }
+            else
+            {
+                _Hash64 = _Seed64 + PRIME64_5;
+            }
+
+            _Hash64 += (ulong)_TotalLength;
+
+            while (_RemainingLength >= 8)
+            {
+#if HIGHER_VERSIONS
+                _Hash64 = RotateLeft64_27(_Hash64 ^ Round64(0, FuncGetLittleEndianUInt64(_CurrentArray, _CurrentIndex))) * PRIME64_1 + PRIME64_4;
+#else
+                _Hash64 = RotateLeft64(_Hash64 ^ Round64(0, FuncGetLittleEndianUInt64(_CurrentArray, _CurrentIndex)), 27) * PRIME64_1 + PRIME64_4;
+#endif
+                _CurrentIndex += 8;
+                _RemainingLength -= 8;
+            }
+
+            while (_RemainingLength >= 4)
+            {
+#if HIGHER_VERSIONS
+                _Hash64 = RotateLeft64_23(_Hash64 ^ (FuncGetLittleEndianUInt32(_CurrentArray, _CurrentIndex) * PRIME64_1)) * PRIME64_2 + PRIME64_3;
+#else
+                _Hash64 = RotateLeft64(_Hash64 ^ (FuncGetLittleEndianUInt32(_CurrentArray, _CurrentIndex) * PRIME64_1), 23) * PRIME64_2 + PRIME64_3;
+#endif
+                _CurrentIndex += 4;
+                _RemainingLength -= 4;
+            }
+
+            while (_RemainingLength-- >= 1)
+            {
+#if HIGHER_VERSIONS
+                _Hash64 = RotateLeft64_11(_Hash64 ^ (_CurrentArray[_CurrentIndex++] * PRIME64_5)) * PRIME64_1;
+#else
+                _Hash64 = RotateLeft64(_Hash64 ^ (_CurrentArray[_CurrentIndex++] * PRIME64_5), 11) * PRIME64_1;
+#endif
+            }
+
+            _Hash64 = (_Hash64 ^ (_Hash64 >> 33)) * PRIME64_2;
+            _Hash64 = (_Hash64 ^ (_Hash64 >> 29)) * PRIME64_3;
+            _Hash64 ^= _Hash64 >> 32;
+
+            _TotalLength = State = 0;
+            return BitConverter.GetBytes(FuncGetFinalHashUInt64(_Hash64));
+        }
+
+#if HIGHER_VERSIONS
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong MergeRound64(ulong input, ulong value) => (input ^ Round64(0, value)) * PRIME64_1 + PRIME64_4;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong Round64(ulong input, ulong value) => RotateLeft64_31(input + (value * PRIME64_2)) * PRIME64_1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_1(ulong value) => (value << 1) | (value >> 63); // _ACC64_1
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_7(ulong value) => (value << 7) | (value >> 57); //  _ACC64_2
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_11(ulong value) => (value << 11) | (value >> 53);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_12(ulong value) => (value << 12) | (value >> 52);// _ACC64_3
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_18(ulong value) => (value << 18) | (value >> 46); // _ACC64_4
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_23(ulong value) => (value << 23) | (value >> 41);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_27(ulong value) => (value << 27) | (value >> 37);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong RotateLeft64_31(ulong value) => (value << 31) | (value >> 33);
+#else
+        private static ulong MergeRound64(ulong input, ulong value) => (input ^ Round64(0, value)) * PRIME64_1 + PRIME64_4;
+
+        private static ulong Round64(ulong input, ulong value) => RotateLeft64(input + (value * PRIME64_2), 31) * PRIME64_1;
+
+        private static ulong RotateLeft64(ulong value, int count) => (value << count) | (value >> (64 - count));
+#endif
+
+
+        private void Initialize(ulong seed)
+        {
+            HashSizeValue = 64;
+            _Seed64 = seed;
+            Initialize();
+        }
+
+
+    }
+
+}
+

--- a/CommandLib/XXHash.cs
+++ b/CommandLib/XXHash.cs
@@ -1,3 +1,38 @@
+/* Copyright (c) Citrix Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * *   Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the
+ *     following disclaimer.
+ * *   Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the
+ *     following disclaimer in the documentation and/or other
+ *     materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Based upon code copyrighted as below.
+ */
+
 ﻿/*MIT License
 
 Copyright (c) 2018 differentrain
@@ -23,11 +58,11 @@ SOFTWARE. */
 /*
  * The minimum requirements for YYProject.XXHash are .NET Framework 3.5, and C# 7.0 ,
  * it means that these code also apply to .NET Core 1.0 or later, Mono 4.6 or later and so on.
- * If necessary, you can also rewrite these library to .NET Framework 2.0 with just a little work. 
- * Since all code (XXHash32 and XXHash64) are inside these file independently, 
+ * If necessary, you can also rewrite these library to .NET Framework 2.0 with just a little work.
+ * Since all code (XXHash32 and XXHash64) are inside these file independently,
  * I don't recommend using compiled library in your project.
  * Instead, you can just copy the useful parts to your code, this is the benefit of MIT License. P:)
- * 
+ *
  * If you are using .NET4.5 (or higher) or sibling frameworks,  you can add conditional compilation
  * symbol "HIGHER_VERSIONS" to optimize static-short-methods.
  */
@@ -305,4 +340,3 @@ namespace YYProject.XXHash
     }
 
 }
-

--- a/XenAdmin/Dialogs/LegalNoticesDialog.resx
+++ b/XenAdmin/Dialogs/LegalNoticesDialog.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -164,7 +164,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Log4Net: Developed by The Apache Software Foundation (http://www.apache.org/) as part of the Apache Logging Services project (http://logging.apache.org/log4net/), and released under the Apache software license.
-To learn more about the Apache software license, please visit http://www.apache.org/licenses/LICENSE-2.0. 
+To learn more about the Apache software license, please visit http://www.apache.org/licenses/LICENSE-2.0.
 
 SharpZipLib: Copyright © 2000-2007 IC#Code (webmaster@icsharpcode.net).
 SharpZipLib is released under the GPL with the Classpath exception.
@@ -177,14 +177,14 @@ NMock: Copyright © 2002, Joe Walnes, Chris Stevenson, Owen Rogers.
 xmldsig-core-schema.xsd: Copyright © 1994-2002 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
 This W3C work (including software, documents, or other related items) is being provided by the copyright holders under the following license. By obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
 Permission to use, copy, modify, and distribute this software and its documentation, with or without modification,  for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications, that you make:
-The full text of this NOTICE in a location viewable to users of the redistributed or derivative work. 
-Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © 2010 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/" 
-Notice of any changes or modifications to the W3C files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.) 
+The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © 2010 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/"
+Notice of any changes or modifications to the W3C files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.)
 THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
 COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
 The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the software without specific, written prior permission. Title to copyright in this software and any associated documentation will at all times remain with copyright holders.
 
-xenc-schema.xsd and xml.xsd: Copyright © 2010 World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University). All Rights Reserved. This work is distributed under the W3C® Software License [1] in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+xenc-schema.xsd and xml.xsd: Copyright © 2010 World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University). All Rights Reserved. This work is distributed under the W3C® Software License [1] in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 Permission to copy, modify, and distribute this software and its documentation, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications:
 The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
@@ -201,7 +201,7 @@ Implementation of certain elements of this standard or proposed standard may be 
 
 Software Licenses that apply to DotNetZip
 This software, the DotNetZip library and tools is provided for your use under several licenses.  One license applies to DotNetZip, and several other licenses apply to work that DotNetZip derives from. To use the software, you must accept the licenses. If you do not accept the licenses, do not use the software.
-The following license, the Microsoft Public License (Ms-PL), applies to the original intellectual property in DotNetZip: 
+The following license, the Microsoft Public License (Ms-PL), applies to the original intellectual property in DotNetZip:
 1. Definitions
 The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law.
 A "contribution" is the original software, or any additions or changes to the software.
@@ -215,23 +215,30 @@ A "contributor" is any person that distributes its contribution under this licen
 (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
 (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
 (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement. 
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
 
 
-The managed ZLIB code included in Ionic.Zlib.dll and Ionic.Zip.dll is derived from the jzlib, which is Copyright (c) 2000,2001,2002,2003 ymnk, JCraft, Inc., and is licensed under the following terms: 
+The managed ZLIB code included in Ionic.Zlib.dll and Ionic.Zip.dll is derived from the jzlib, which is Copyright (c) 2000,2001,2002,2003 ymnk, JCraft, Inc., and is licensed under the following terms:
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 1.	Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 2.	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 3.	The names of the authors may not be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+The xxHash library used in this software has the following MIT license:
+MIT License
+Copyright (c) 2018 differentrain
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The jzlib library, itself, is based on the C-language ZLIB library, v1.1.3.  The following notice and license applies to zlib:
 ZLIB is Copyright (C) 1995-2004 Jean-loup Gailly and Mark Adler
 The ZLIB software is provided 'as-is', without any express or implied warranty.  In no event will the authors be held liable for any damages arising from the use of this software.
 Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
-1.	The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required. 
-2.	Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software. 
+1.	The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2.	Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
 3.	This notice may not be removed or altered from any source distribution.
   Jean-loup Gailly      jloup@gzip.org
   Mark Adler      madler@alumni.caltech.edu
@@ -253,7 +260,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 Blueprint CSS Framework License: Copyright (c) 2007 - 2010 blueprintcss.org
-Permission is hereby granted, free of charge, to any person obtaining a copy of the Blueprint CSS Framework and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Blueprint CSS Framework and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 


### PR DESCRIPTION
Xapi is moving from SHA1 to xxHash for VM imports and exports. These changes allow XenCenter to verify this new format whilst also maintaining backwards compatability. The xxHash code comes from [here ](https://github.com/differentrain/YYProject.XXHash) and is under an MIT license. 

I have manually tested these changes by running all combinations of imports and exports across new and old versions of Xapi. 