### PR TITLE
CA-304786: Fix the error where the Patching wizard cannot display ava…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectPatchPage.cs
@@ -302,7 +302,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             try
             {
-                using (var isoStream = File.Open(fileName, FileMode.Open))
+                using (var isoStream = File.OpenRead(fileName))
                 {
                     var cd = new CDReader(isoStream, true);
                     if (cd.Exists("Update.xml"))


### PR DESCRIPTION
…ilable hosts when patch ISO is used by another process

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>