### PR TITLE
CA-317856: Ensure that VMs are repatriated after all hotfixes are appl…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -384,13 +384,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                     var restartHostPlanAction = (RestartHostPlanAction)hp.DelayedPlanActions.FirstOrDefault(a => a is RestartHostPlanAction);
                     if (restartHostPlanAction != null)
                     {
-                        if (restartHostPlanAction.SkipRestartHost(host))
-                        {
-                            log.Debug("Did not find patches requiring reboot (live patching succeeded)."
-                                      + " Skipping scheduled restart.");
-                            hp.DelayedPlanActions.RemoveAll(a => a is RestartHostPlanAction);
-                        }
-                        else
+                        if (!restartHostPlanAction.SkipRestartHost(host))
                         {
                             hp.DelayedPlanActions.RemoveAll(a => a is RestartAgentPlanAction);
                         }

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
@@ -100,10 +100,12 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             // Hosts do reenable themselves anyway, so just wait 1 min for that,  
             // occasionally poking it.
             var hostObj = GetResolvedHost();
-            AddProgressStep(string.Format(Messages.UPDATES_WIZARD_EXITING_MAINTENANCE_MODE, hostObj.Name()));
-
-            WaitForHostToBecomeEnabled(session, true);
-
+            if (!hostObj.enabled)
+            {
+                AddProgressStep(string.Format(Messages.UPDATES_WIZARD_EXITING_MAINTENANCE_MODE, hostObj.Name()));
+                WaitForHostToBecomeEnabled(session, true);
+            }
+            
             if (enableOnly || vmrefs.Count == 0)
                 return;
 

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
@@ -99,20 +99,16 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             // CA-17428: Apply hotfixes to a pool of hosts through XenCenter fails.
             // Hosts do reenable themselves anyway, so just wait 1 min for that,  
             // occasionally poking it.
-            var hostObj = GetResolvedHost();
-            if (!hostObj.enabled)
-            {
-                AddProgressStep(string.Format(Messages.UPDATES_WIZARD_EXITING_MAINTENANCE_MODE, hostObj.Name()));
-                WaitForHostToBecomeEnabled(session, true);
-            }
+
+            WaitForHostToBecomeEnabled(session, true);
             
             if (enableOnly || vmrefs.Count == 0)
                 return;
 
             int vmCount = vmrefs.Count;
             int vmNumber = 0;
-            
-            hostObj = GetResolvedHost();
+
+            var hostObj = GetResolvedHost();
             AddProgressStep(string.Format(Messages.PLAN_ACTION_STATUS_REPATRIATING_VMS, hostObj.Name()));
             PBD.CheckPlugPBDsForVMs(Connection, vmrefs, true);
 
@@ -165,6 +161,10 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             int retries = 0;
             while (!Host.get_enabled(session, HostXenRef.opaque_ref))
             {
+                var hostObj = GetResolvedHost();
+                if (retries == 0)
+                    AddProgressStep(string.Format(Messages.UPDATES_WIZARD_EXITING_MAINTENANCE_MODE, hostObj.Name()));
+
                 retries++;
                 var isLastTry = retries > 60;
 
@@ -174,7 +174,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 {
                     if (isLastTry)
                     {
-                        log.Debug(string.Format("Timed out waiting for host {0} to become enabled.", HostXenRef.opaque_ref));
+                        log.DebugFormat("Timed out waiting for host {0} to become enabled.", hostObj.Name());
                         break;
                     }
 
@@ -190,7 +190,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                     if (isLastTry)
                         throw;
 
-                    log.Debug(string.Format("Cannot enable host {0}. Retrying in 5 sec.", HostXenRef.opaque_ref), e);
+                    log.Debug(string.Format("Cannot enable host {0}. Retrying in 5 sec.", hostObj), e);
                 }
             }
         }


### PR DESCRIPTION
…ied and the host has been rebooted.

There is no need to remove the "reboot host" plan actions from the delayed actions list, because the action itself has code to check if a reboot is actually needed.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>