### PR TITLE
General TabPage layout modifications (includes CA-164372).

### DIFF
--- a/XenAdmin/Controls/PDSection.Designer.cs
+++ b/XenAdmin/Controls/PDSection.Designer.cs
@@ -78,9 +78,9 @@ namespace XenAdmin.Controls
             this.chevron.Image = global::XenAdmin.Properties.Resources.PDChevronUp;
             this.chevron.Name = "chevron";
             this.chevron.TabStop = false;
-            this.chevron.MouseLeave += new System.EventHandler(this.chevron_MouseLeave);
             this.chevron.Click += new System.EventHandler(this.chevron_Click);
             this.chevron.MouseEnter += new System.EventHandler(this.chevron_MouseEnter);
+            this.chevron.MouseLeave += new System.EventHandler(this.chevron_MouseLeave);
             // 
             // contextMenuStrip1
             // 
@@ -97,7 +97,6 @@ namespace XenAdmin.Controls
             // 
             // dataGridViewEx1
             // 
-            resources.ApplyResources(this.dataGridViewEx1, "dataGridViewEx1");
             this.dataGridViewEx1.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
             this.dataGridViewEx1.BackgroundColor = System.Drawing.SystemColors.Window;
             this.dataGridViewEx1.BorderStyle = System.Windows.Forms.BorderStyle.None;
@@ -115,6 +114,7 @@ namespace XenAdmin.Controls
             dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.dataGridViewEx1.DefaultCellStyle = dataGridViewCellStyle3;
+            resources.ApplyResources(this.dataGridViewEx1, "dataGridViewEx1");
             this.dataGridViewEx1.GridColor = System.Drawing.SystemColors.Control;
             this.dataGridViewEx1.HideSelection = true;
             this.dataGridViewEx1.Name = "dataGridViewEx1";
@@ -122,14 +122,14 @@ namespace XenAdmin.Controls
             dataGridViewCellStyle4.Padding = new System.Windows.Forms.Padding(5);
             this.dataGridViewEx1.RowsDefaultCellStyle = dataGridViewCellStyle4;
             this.dataGridViewEx1.ShowCellToolTips = false;
-            this.dataGridViewEx1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.dataGridViewEx1_MouseClick);
-            this.dataGridViewEx1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.dataGridViewEx1_KeyPress);
-            this.dataGridViewEx1.SelectionChanged += new System.EventHandler(this.dataGridViewEx1_SelectionChanged);
             this.dataGridViewEx1.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewEx1_CellContentClick);
+            this.dataGridViewEx1.SelectionChanged += new System.EventHandler(this.dataGridViewEx1_SelectionChanged);
+            this.dataGridViewEx1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.dataGridViewEx1_KeyPress);
+            this.dataGridViewEx1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.dataGridViewEx1_MouseClick);
             // 
             // KeyColumn
             // 
-            this.KeyColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.KeyColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.TopLeft;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             this.KeyColumn.DefaultCellStyle = dataGridViewCellStyle1;
@@ -157,8 +157,8 @@ namespace XenAdmin.Controls
             this.Controls.Add(this.dataGridViewEx1);
             this.Controls.Add(this.panel1);
             this.DoubleBuffered = true;
-            this.Name = "PDSection";
             resources.ApplyResources(this, "$this");
+            this.Name = "PDSection";
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.chevron)).EndInit();
@@ -176,8 +176,8 @@ namespace XenAdmin.Controls
         private System.Windows.Forms.PictureBox chevron;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
         private System.Windows.Forms.DataGridViewTextBoxColumn KeyColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn ValueColumn;
-        private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
     }
 }

--- a/XenAdmin/Controls/PDSection.cs
+++ b/XenAdmin/Controls/PDSection.cs
@@ -492,7 +492,6 @@ namespace XenAdmin.Controls
 
         internal void fixFirstColumnWidth(int width)
         {
-            dataGridViewEx1.Columns[0].AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
             dataGridViewEx1.Columns[0].Width = width;
         }
 

--- a/XenAdmin/Controls/PDSection.resx
+++ b/XenAdmin/Controls/PDSection.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Left</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
   </data>
@@ -148,7 +148,7 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -166,13 +166,13 @@
     <value>2, 24</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
     <value>groupBox1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -202,7 +202,7 @@
     <value>chevron</value>
   </data>
   <data name="&gt;&gt;chevron.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chevron.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -223,13 +223,13 @@
     <value>798, 32</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;panel1.Name" xml:space="preserve">
     <value>panel1</value>
   </data>
   <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -237,7 +237,7 @@
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -253,25 +253,28 @@
     <value>contextMenuStrip1</value>
   </data>
   <data name="&gt;&gt;contextMenuStrip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="dataGridViewEx1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <metadata name="KeyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="KeyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="KeyColumn.HeaderText" xml:space="preserve">
-    <value>Column1</value>
+    <value>Key</value>
+  </data>
+  <data name="KeyColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>150</value>
   </data>
   <data name="KeyColumn.Width" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>150</value>
   </data>
-  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ValueColumn.HeaderText" xml:space="preserve">
-    <value>Column1</value>
+    <value>Value</value>
+  </data>
+  <data name="dataGridViewEx1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="dataGridViewEx1.Location" type="System.Drawing.Point, System.Drawing">
     <value>1, 33</value>
@@ -283,7 +286,7 @@
     <value>798, 116</value>
   </data>
   <data name="dataGridViewEx1.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;dataGridViewEx1.Name" xml:space="preserve">
     <value>dataGridViewEx1</value>
@@ -297,9 +300,12 @@
   <data name="&gt;&gt;dataGridViewEx1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
   </data>
@@ -310,24 +316,24 @@
     <value>copyToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;copyToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;KeyColumn.Name" xml:space="preserve">
     <value>KeyColumn</value>
   </data>
   <data name="&gt;&gt;KeyColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ValueColumn.Name" xml:space="preserve">
     <value>ValueColumn</value>
   </data>
   <data name="&gt;&gt;ValueColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PDSection</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/XenAdmin/TabPages/GeneralTabPage.Designer.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.Designer.cs
@@ -33,9 +33,6 @@ namespace XenAdmin.TabPages
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GeneralTabPage));
             this.buttonProperties = new System.Windows.Forms.Button();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.panel3 = new System.Windows.Forms.Panel();
-            this.buttonPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.buttonViewConsole = new System.Windows.Forms.Button();
             this.buttonViewLog = new System.Windows.Forms.Button();
             this.linkLabelExpand = new System.Windows.Forms.LinkLabel();
@@ -53,8 +50,6 @@ namespace XenAdmin.TabPages
             this.pdSectionMultipathBoot = new XenAdmin.Controls.PDSection();
             this.panelStorageLink = new System.Windows.Forms.Panel();
             this.pdStorageLink = new XenAdmin.Controls.PDSection();
-            this.panelUpdates = new System.Windows.Forms.Panel();
-            this.pdSectionUpdates = new XenAdmin.Controls.PDSection();
             this.panelMemoryAndVCPUs = new System.Windows.Forms.Panel();
             this.pdSectionVCPUs = new XenAdmin.Controls.PDSection();
             this.panelMultipathing = new System.Windows.Forms.Panel();
@@ -67,22 +62,22 @@ namespace XenAdmin.TabPages
             this.pdSectionBootOptions = new XenAdmin.Controls.PDSection();
             this.panelCPU = new System.Windows.Forms.Panel();
             this.pdSectionCPU = new XenAdmin.Controls.PDSection();
-            this.panelLicense = new System.Windows.Forms.Panel();
-            this.pdSectionLicense = new XenAdmin.Controls.PDSection();
-            this.panelVersion = new System.Windows.Forms.Panel();
-            this.pdSectionVersion = new XenAdmin.Controls.PDSection();
             this.panelMemory = new System.Windows.Forms.Panel();
             this.pdSectionMemory = new XenAdmin.Controls.PDSection();
             this.panelManagementInterfaces = new System.Windows.Forms.Panel();
             this.pdSectionManagementInterfaces = new XenAdmin.Controls.PDSection();
+            this.panelUpdates = new System.Windows.Forms.Panel();
+            this.pdSectionUpdates = new XenAdmin.Controls.PDSection();
+            this.panelVersion = new System.Windows.Forms.Panel();
+            this.pdSectionVersion = new XenAdmin.Controls.PDSection();
+            this.panelLicense = new System.Windows.Forms.Panel();
+            this.pdSectionLicense = new XenAdmin.Controls.PDSection();
             this.panelCustomFields = new System.Windows.Forms.Panel();
             this.pdSectionCustomFields = new XenAdmin.Controls.PDSection();
             this.panelGeneral = new System.Windows.Forms.Panel();
             this.pdSectionGeneral = new XenAdmin.Controls.PDSection();
+            this.tableLayoutPanelButtons = new System.Windows.Forms.TableLayoutPanel();
             this.pageContainerPanel.SuspendLayout();
-            this.panel1.SuspendLayout();
-            this.panel3.SuspendLayout();
-            this.buttonPanel.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panelReadCaching.SuspendLayout();
             this.panelDockerInfo.SuspendLayout();
@@ -90,25 +85,26 @@ namespace XenAdmin.TabPages
             this.panelStorageLinkSystemCapabilities.SuspendLayout();
             this.panelMultipathBoot.SuspendLayout();
             this.panelStorageLink.SuspendLayout();
-            this.panelUpdates.SuspendLayout();
             this.panelMemoryAndVCPUs.SuspendLayout();
             this.panelMultipathing.SuspendLayout();
             this.panelStatus.SuspendLayout();
             this.panelHighAvailability.SuspendLayout();
             this.panelBootOptions.SuspendLayout();
             this.panelCPU.SuspendLayout();
-            this.panelLicense.SuspendLayout();
-            this.panelVersion.SuspendLayout();
             this.panelMemory.SuspendLayout();
             this.panelManagementInterfaces.SuspendLayout();
+            this.panelUpdates.SuspendLayout();
+            this.panelVersion.SuspendLayout();
+            this.panelLicense.SuspendLayout();
             this.panelCustomFields.SuspendLayout();
             this.panelGeneral.SuspendLayout();
+            this.tableLayoutPanelButtons.SuspendLayout();
             this.SuspendLayout();
             // 
             // pageContainerPanel
             // 
             this.pageContainerPanel.Controls.Add(this.panel2);
-            this.pageContainerPanel.Controls.Add(this.panel1);
+            this.pageContainerPanel.Controls.Add(this.tableLayoutPanelButtons);
             resources.ApplyResources(this.pageContainerPanel, "pageContainerPanel");
             // 
             // buttonProperties
@@ -117,28 +113,6 @@ namespace XenAdmin.TabPages
             this.buttonProperties.Name = "buttonProperties";
             this.buttonProperties.UseVisualStyleBackColor = true;
             this.buttonProperties.Click += new System.EventHandler(this.EditButton_Click);
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.panel3);
-            resources.ApplyResources(this.panel1, "panel1");
-            this.panel1.Name = "panel1";
-            // 
-            // panel3
-            // 
-            this.panel3.Controls.Add(this.buttonPanel);
-            this.panel3.Controls.Add(this.linkLabelExpand);
-            this.panel3.Controls.Add(this.linkLabelCollapse);
-            resources.ApplyResources(this.panel3, "panel3");
-            this.panel3.Name = "panel3";
-            // 
-            // buttonPanel
-            // 
-            this.buttonPanel.Controls.Add(this.buttonProperties);
-            this.buttonPanel.Controls.Add(this.buttonViewConsole);
-            this.buttonPanel.Controls.Add(this.buttonViewLog);
-            resources.ApplyResources(this.buttonPanel, "buttonPanel");
-            this.buttonPanel.Name = "buttonPanel";
             // 
             // buttonViewConsole
             // 
@@ -177,17 +151,17 @@ namespace XenAdmin.TabPages
             this.panel2.Controls.Add(this.panelStorageLinkSystemCapabilities);
             this.panel2.Controls.Add(this.panelMultipathBoot);
             this.panel2.Controls.Add(this.panelStorageLink);
-            this.panel2.Controls.Add(this.panelUpdates);
             this.panel2.Controls.Add(this.panelMemoryAndVCPUs);
             this.panel2.Controls.Add(this.panelMultipathing);
             this.panel2.Controls.Add(this.panelStatus);
             this.panel2.Controls.Add(this.panelHighAvailability);
             this.panel2.Controls.Add(this.panelBootOptions);
             this.panel2.Controls.Add(this.panelCPU);
-            this.panel2.Controls.Add(this.panelLicense);
-            this.panel2.Controls.Add(this.panelVersion);
             this.panel2.Controls.Add(this.panelMemory);
             this.panel2.Controls.Add(this.panelManagementInterfaces);
+            this.panel2.Controls.Add(this.panelUpdates);
+            this.panel2.Controls.Add(this.panelVersion);
+            this.panel2.Controls.Add(this.panelLicense);
             this.panel2.Controls.Add(this.panelCustomFields);
             this.panel2.Controls.Add(this.panelGeneral);
             this.panel2.Name = "panel2";
@@ -271,20 +245,6 @@ namespace XenAdmin.TabPages
             this.pdStorageLink.Name = "pdStorageLink";
             this.pdStorageLink.ShowCellToolTips = false;
             this.pdStorageLink.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
-            // 
-            // panelUpdates
-            // 
-            resources.ApplyResources(this.panelUpdates, "panelUpdates");
-            this.panelUpdates.Controls.Add(this.pdSectionUpdates);
-            this.panelUpdates.Name = "panelUpdates";
-            // 
-            // pdSectionUpdates
-            // 
-            this.pdSectionUpdates.BackColor = System.Drawing.Color.Gainsboro;
-            resources.ApplyResources(this.pdSectionUpdates, "pdSectionUpdates");
-            this.pdSectionUpdates.Name = "pdSectionUpdates";
-            this.pdSectionUpdates.ShowCellToolTips = false;
-            this.pdSectionUpdates.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
             // 
             // panelMemoryAndVCPUs
             // 
@@ -370,34 +330,6 @@ namespace XenAdmin.TabPages
             this.pdSectionCPU.ShowCellToolTips = false;
             this.pdSectionCPU.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
             // 
-            // panelLicense
-            // 
-            resources.ApplyResources(this.panelLicense, "panelLicense");
-            this.panelLicense.Controls.Add(this.pdSectionLicense);
-            this.panelLicense.Name = "panelLicense";
-            // 
-            // pdSectionLicense
-            // 
-            this.pdSectionLicense.BackColor = System.Drawing.Color.Gainsboro;
-            resources.ApplyResources(this.pdSectionLicense, "pdSectionLicense");
-            this.pdSectionLicense.Name = "pdSectionLicense";
-            this.pdSectionLicense.ShowCellToolTips = false;
-            this.pdSectionLicense.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
-            // 
-            // panelVersion
-            // 
-            resources.ApplyResources(this.panelVersion, "panelVersion");
-            this.panelVersion.Controls.Add(this.pdSectionVersion);
-            this.panelVersion.Name = "panelVersion";
-            // 
-            // pdSectionVersion
-            // 
-            this.pdSectionVersion.BackColor = System.Drawing.Color.Gainsboro;
-            resources.ApplyResources(this.pdSectionVersion, "pdSectionVersion");
-            this.pdSectionVersion.Name = "pdSectionVersion";
-            this.pdSectionVersion.ShowCellToolTips = false;
-            this.pdSectionVersion.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
-            // 
             // panelMemory
             // 
             resources.ApplyResources(this.panelMemory, "panelMemory");
@@ -425,6 +357,48 @@ namespace XenAdmin.TabPages
             this.pdSectionManagementInterfaces.Name = "pdSectionManagementInterfaces";
             this.pdSectionManagementInterfaces.ShowCellToolTips = false;
             this.pdSectionManagementInterfaces.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
+            // 
+            // panelUpdates
+            // 
+            resources.ApplyResources(this.panelUpdates, "panelUpdates");
+            this.panelUpdates.Controls.Add(this.pdSectionUpdates);
+            this.panelUpdates.Name = "panelUpdates";
+            // 
+            // pdSectionUpdates
+            // 
+            this.pdSectionUpdates.BackColor = System.Drawing.Color.Gainsboro;
+            resources.ApplyResources(this.pdSectionUpdates, "pdSectionUpdates");
+            this.pdSectionUpdates.Name = "pdSectionUpdates";
+            this.pdSectionUpdates.ShowCellToolTips = false;
+            this.pdSectionUpdates.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
+            // 
+            // panelVersion
+            // 
+            resources.ApplyResources(this.panelVersion, "panelVersion");
+            this.panelVersion.Controls.Add(this.pdSectionVersion);
+            this.panelVersion.Name = "panelVersion";
+            // 
+            // pdSectionVersion
+            // 
+            this.pdSectionVersion.BackColor = System.Drawing.Color.Gainsboro;
+            resources.ApplyResources(this.pdSectionVersion, "pdSectionVersion");
+            this.pdSectionVersion.Name = "pdSectionVersion";
+            this.pdSectionVersion.ShowCellToolTips = false;
+            this.pdSectionVersion.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
+            // 
+            // panelLicense
+            // 
+            resources.ApplyResources(this.panelLicense, "panelLicense");
+            this.panelLicense.Controls.Add(this.pdSectionLicense);
+            this.panelLicense.Name = "panelLicense";
+            // 
+            // pdSectionLicense
+            // 
+            this.pdSectionLicense.BackColor = System.Drawing.Color.Gainsboro;
+            resources.ApplyResources(this.pdSectionLicense, "pdSectionLicense");
+            this.pdSectionLicense.Name = "pdSectionLicense";
+            this.pdSectionLicense.ShowCellToolTips = false;
+            this.pdSectionLicense.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
             // 
             // panelCustomFields
             // 
@@ -454,6 +428,16 @@ namespace XenAdmin.TabPages
             this.pdSectionGeneral.ShowCellToolTips = false;
             this.pdSectionGeneral.ExpandedChanged += new System.Action<XenAdmin.Controls.PDSection>(this.pdSection_ExpandedChanged);
             // 
+            // tableLayoutPanelButtons
+            // 
+            resources.ApplyResources(this.tableLayoutPanelButtons, "tableLayoutPanelButtons");
+            this.tableLayoutPanelButtons.Controls.Add(this.buttonViewLog, 2, 0);
+            this.tableLayoutPanelButtons.Controls.Add(this.buttonViewConsole, 1, 0);
+            this.tableLayoutPanelButtons.Controls.Add(this.buttonProperties, 0, 0);
+            this.tableLayoutPanelButtons.Controls.Add(this.linkLabelCollapse, 5, 0);
+            this.tableLayoutPanelButtons.Controls.Add(this.linkLabelExpand, 4, 0);
+            this.tableLayoutPanelButtons.Name = "tableLayoutPanelButtons";
+            // 
             // GeneralTabPage
             // 
             resources.ApplyResources(this, "$this");
@@ -461,10 +445,7 @@ namespace XenAdmin.TabPages
             this.DoubleBuffered = true;
             this.Name = "GeneralTabPage";
             this.pageContainerPanel.ResumeLayout(false);
-            this.panel1.ResumeLayout(false);
-            this.panel3.ResumeLayout(false);
-            this.panel3.PerformLayout();
-            this.buttonPanel.ResumeLayout(false);
+            this.pageContainerPanel.PerformLayout();
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
             this.panelReadCaching.ResumeLayout(false);
@@ -473,19 +454,21 @@ namespace XenAdmin.TabPages
             this.panelStorageLinkSystemCapabilities.ResumeLayout(false);
             this.panelMultipathBoot.ResumeLayout(false);
             this.panelStorageLink.ResumeLayout(false);
-            this.panelUpdates.ResumeLayout(false);
             this.panelMemoryAndVCPUs.ResumeLayout(false);
             this.panelMultipathing.ResumeLayout(false);
             this.panelStatus.ResumeLayout(false);
             this.panelHighAvailability.ResumeLayout(false);
             this.panelBootOptions.ResumeLayout(false);
             this.panelCPU.ResumeLayout(false);
-            this.panelLicense.ResumeLayout(false);
-            this.panelVersion.ResumeLayout(false);
             this.panelMemory.ResumeLayout(false);
             this.panelManagementInterfaces.ResumeLayout(false);
+            this.panelUpdates.ResumeLayout(false);
+            this.panelVersion.ResumeLayout(false);
+            this.panelLicense.ResumeLayout(false);
             this.panelCustomFields.ResumeLayout(false);
             this.panelGeneral.ResumeLayout(false);
+            this.tableLayoutPanelButtons.ResumeLayout(false);
+            this.tableLayoutPanelButtons.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -494,7 +477,6 @@ namespace XenAdmin.TabPages
         #endregion
 
         private System.Windows.Forms.Button buttonProperties;
-        private System.Windows.Forms.Panel panel1;
         private XenAdmin.Controls.PanelNoFocusScroll panel2;
         private System.Windows.Forms.Panel panelGeneral;
         private XenAdmin.Controls.PDSection pdSectionGeneral;
@@ -524,7 +506,6 @@ namespace XenAdmin.TabPages
         private XenAdmin.Controls.PDSection pdSectionUpdates;
         private System.Windows.Forms.LinkLabel linkLabelExpand;
         private System.Windows.Forms.LinkLabel linkLabelCollapse;
-        private System.Windows.Forms.Panel panel3;
         private System.Windows.Forms.Panel panelStorageLink;
         private XenAdmin.Controls.PDSection pdStorageLink;
         private System.Windows.Forms.Panel panelMultipathBoot;
@@ -539,6 +520,6 @@ namespace XenAdmin.TabPages
         private Controls.PDSection pdSectionReadCaching;
         private System.Windows.Forms.Button buttonViewConsole;
         private System.Windows.Forms.Button buttonViewLog;
-        private System.Windows.Forms.FlowLayoutPanel buttonPanel;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelButtons;
     }
 }

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -87,8 +87,6 @@ namespace XenAdmin.TabPages
                     if (s == null)
                         continue;
                     sections.Add(s);
-                    s.MaximumSize = new Size(900, 9999999);
-                    s.fixFirstColumnWidth(150);
                     s.contentChangedSelection += s_contentChangedSelection;
                     s.contentReceivedFocus += s_contentReceivedFocus;
                 }
@@ -1747,7 +1745,7 @@ namespace XenAdmin.TabPages
 
             output.Sort(StringUtility.NaturalCompare);
 
-            return String.Join(", ", output.ToArray());
+            return string.Join(Environment.NewLine, output);
         }
 
         private string poolUpdateString(Predicate<Pool_update> predicate)
@@ -1762,7 +1760,7 @@ namespace XenAdmin.TabPages
 
             output.Sort(StringUtility.NaturalCompare);
 
-            return String.Join(", ", output.ToArray());
+            return string.Join(Environment.NewLine, output);
         }
 
         #endregion

--- a/XenAdmin/TabPages/GeneralTabPage.resx
+++ b/XenAdmin/TabPages/GeneralTabPage.resx
@@ -117,10 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="panel2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="panel2.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -128,6 +124,7 @@
   <data name="panelReadCaching.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="panelReadCaching.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
@@ -137,6 +134,9 @@
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pdSectionReadCaching.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
+  </data>
+  <data name="pdSectionReadCaching.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
   </data>
   <data name="pdSectionReadCaching.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
@@ -148,7 +148,7 @@
     <value>Read Caching</value>
   </data>
   <data name="pdSectionReadCaching.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionReadCaching.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -175,10 +175,10 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelReadCaching.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelReadCaching.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>18</value>
   </data>
   <data name="&gt;&gt;panelReadCaching.Name" xml:space="preserve">
     <value>panelReadCaching</value>
@@ -204,6 +204,9 @@
   <data name="pdSectionDockerInfo.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionDockerInfo.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionDockerInfo.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -214,7 +217,7 @@
     <value>Docker Information</value>
   </data>
   <data name="pdSectionDockerInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionDockerInfo.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -241,10 +244,10 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelDockerInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelDockerInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
+    <value>17</value>
   </data>
   <data name="&gt;&gt;panelDockerInfo.Name" xml:space="preserve">
     <value>panelDockerInfo</value>
@@ -270,6 +273,9 @@
   <data name="pdSectionDockerVersion.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionDockerVersion.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionDockerVersion.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -280,7 +286,7 @@
     <value>Docker Version</value>
   </data>
   <data name="pdSectionDockerVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionDockerVersion.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -307,10 +313,10 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelDockerVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelDockerVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+    <value>16</value>
   </data>
   <data name="&gt;&gt;panelDockerVersion.Name" xml:space="preserve">
     <value>panelDockerVersion</value>
@@ -336,6 +342,9 @@
   <data name="pdSectionStorageLinkSystemCapabilities.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionStorageLinkSystemCapabilities.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionStorageLinkSystemCapabilities.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -346,7 +355,7 @@
     <value>Capabilities</value>
   </data>
   <data name="pdSectionStorageLinkSystemCapabilities.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionStorageLinkSystemCapabilities.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -373,10 +382,10 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelStorageLinkSystemCapabilities.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelStorageLinkSystemCapabilities.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;panelStorageLinkSystemCapabilities.Name" xml:space="preserve">
     <value>panelStorageLinkSystemCapabilities</value>
@@ -402,6 +411,9 @@
   <data name="pdSectionMultipathBoot.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionMultipathBoot.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionMultipathBoot.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -412,10 +424,10 @@
     <value>Root Disk Multipathing</value>
   </data>
   <data name="pdSectionMultipathBoot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionMultipathBoot.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;pdSectionMultipathBoot.Name" xml:space="preserve">
     <value>pdSectionMultipathBoot</value>
@@ -439,10 +451,10 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMultipathBoot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelMultipathBoot.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+    <value>14</value>
   </data>
   <data name="&gt;&gt;panelMultipathBoot.Name" xml:space="preserve">
     <value>panelMultipathBoot</value>
@@ -468,6 +480,9 @@
   <data name="pdStorageLink.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdStorageLink.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdStorageLink.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -478,7 +493,7 @@
     <value>StorageLink</value>
   </data>
   <data name="pdStorageLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdStorageLink.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -505,10 +520,10 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelStorageLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelStorageLink.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;panelStorageLink.Name" xml:space="preserve">
     <value>panelStorageLink</value>
@@ -522,72 +537,6 @@
   <data name="&gt;&gt;panelStorageLink.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="panelUpdates.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panelUpdates.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="pdSectionUpdates.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="pdSectionUpdates.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 5</value>
-  </data>
-  <data name="pdSectionUpdates.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 34</value>
-  </data>
-  <data name="pdSectionUpdates.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>1, 1, 1, 1</value>
-  </data>
-  <data name="pdSectionUpdates.SectionTitle" xml:space="preserve">
-    <value>Updates</value>
-  </data>
-  <data name="pdSectionUpdates.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
-  </data>
-  <data name="pdSectionUpdates.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pdSectionUpdates.Name" xml:space="preserve">
-    <value>pdSectionUpdates</value>
-  </data>
-  <data name="&gt;&gt;pdSectionUpdates.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;pdSectionUpdates.Parent" xml:space="preserve">
-    <value>panelUpdates</value>
-  </data>
-  <data name="&gt;&gt;pdSectionUpdates.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panelUpdates.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panelUpdates.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 528</value>
-  </data>
-  <data name="panelUpdates.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 5</value>
-  </data>
-  <data name="panelUpdates.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
-  </data>
-  <data name="panelUpdates.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;panelUpdates.Name" xml:space="preserve">
-    <value>panelUpdates</value>
-  </data>
-  <data name="&gt;&gt;panelUpdates.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelUpdates.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panelUpdates.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="panelMemoryAndVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -600,6 +549,9 @@
   <data name="pdSectionVCPUs.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionVCPUs.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionVCPUs.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -610,7 +562,7 @@
     <value>CPUs</value>
   </data>
   <data name="pdSectionVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionVCPUs.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -631,16 +583,16 @@
     <value>Top</value>
   </data>
   <data name="panelMemoryAndVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 484</value>
+    <value>0, 528</value>
   </data>
   <data name="panelMemoryAndVCPUs.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMemoryAndVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelMemoryAndVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;panelMemoryAndVCPUs.Name" xml:space="preserve">
     <value>panelMemoryAndVCPUs</value>
@@ -652,7 +604,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelMemoryAndVCPUs.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="panelMultipathing.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -666,6 +618,9 @@
   <data name="pdSectionMultipathing.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionMultipathing.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionMultipathing.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -676,7 +631,7 @@
     <value>Multipathing</value>
   </data>
   <data name="pdSectionMultipathing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionMultipathing.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -697,13 +652,13 @@
     <value>Top</value>
   </data>
   <data name="panelMultipathing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 440</value>
+    <value>0, 484</value>
   </data>
   <data name="panelMultipathing.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMultipathing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelMultipathing.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -718,7 +673,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelMultipathing.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="panelStatus.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -732,6 +687,9 @@
   <data name="pdSectionStatus.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionStatus.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionStatus.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -742,7 +700,7 @@
     <value>Status</value>
   </data>
   <data name="pdSectionStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionStatus.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -763,13 +721,13 @@
     <value>Top</value>
   </data>
   <data name="panelStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 396</value>
+    <value>0, 440</value>
   </data>
   <data name="panelStatus.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelStatus.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -784,7 +742,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelStatus.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>8</value>
   </data>
   <data name="panelHighAvailability.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -798,6 +756,9 @@
   <data name="pdSectionHighAvailability.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionHighAvailability.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionHighAvailability.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -808,7 +769,7 @@
     <value>High Availability</value>
   </data>
   <data name="pdSectionHighAvailability.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionHighAvailability.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -829,13 +790,13 @@
     <value>Top</value>
   </data>
   <data name="panelHighAvailability.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 352</value>
+    <value>0, 396</value>
   </data>
   <data name="panelHighAvailability.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelHighAvailability.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelHighAvailability.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -850,7 +811,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelHighAvailability.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="panelBootOptions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -864,6 +825,9 @@
   <data name="pdSectionBootOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionBootOptions.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionBootOptions.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -874,7 +838,7 @@
     <value>Boot Options</value>
   </data>
   <data name="pdSectionBootOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionBootOptions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -895,13 +859,13 @@
     <value>Top</value>
   </data>
   <data name="panelBootOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 308</value>
+    <value>0, 352</value>
   </data>
   <data name="panelBootOptions.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelBootOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelBootOptions.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -916,7 +880,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelBootOptions.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
   </data>
   <data name="panelCPU.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -930,6 +894,9 @@
   <data name="pdSectionCPU.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionCPU.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionCPU.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -940,7 +907,7 @@
     <value>CPUs</value>
   </data>
   <data name="pdSectionCPU.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionCPU.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -961,13 +928,13 @@
     <value>Top</value>
   </data>
   <data name="panelCPU.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 264</value>
+    <value>0, 308</value>
   </data>
   <data name="panelCPU.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelCPU.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelCPU.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -982,139 +949,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelCPU.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="panelLicense.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panelLicense.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="pdSectionLicense.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="pdSectionLicense.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 5</value>
-  </data>
-  <data name="pdSectionLicense.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 34</value>
-  </data>
-  <data name="pdSectionLicense.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>1, 1, 1, 1</value>
-  </data>
-  <data name="pdSectionLicense.SectionTitle" xml:space="preserve">
-    <value>License Details</value>
-  </data>
-  <data name="pdSectionLicense.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
-  </data>
-  <data name="pdSectionLicense.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pdSectionLicense.Name" xml:space="preserve">
-    <value>pdSectionLicense</value>
-  </data>
-  <data name="&gt;&gt;pdSectionLicense.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;pdSectionLicense.Parent" xml:space="preserve">
-    <value>panelLicense</value>
-  </data>
-  <data name="&gt;&gt;pdSectionLicense.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panelLicense.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panelLicense.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 220</value>
-  </data>
-  <data name="panelLicense.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 5</value>
-  </data>
-  <data name="panelLicense.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
-  </data>
-  <data name="panelLicense.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;panelLicense.Name" xml:space="preserve">
-    <value>panelLicense</value>
-  </data>
-  <data name="&gt;&gt;panelLicense.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelLicense.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panelLicense.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="panelVersion.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panelVersion.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="pdSectionVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="pdSectionVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 5</value>
-  </data>
-  <data name="pdSectionVersion.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 34</value>
-  </data>
-  <data name="pdSectionVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>1, 1, 1, 1</value>
-  </data>
-  <data name="pdSectionVersion.SectionTitle" xml:space="preserve">
-    <value>Version Details</value>
-  </data>
-  <data name="pdSectionVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
-  </data>
-  <data name="pdSectionVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pdSectionVersion.Name" xml:space="preserve">
-    <value>pdSectionVersion</value>
-  </data>
-  <data name="&gt;&gt;pdSectionVersion.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;pdSectionVersion.Parent" xml:space="preserve">
-    <value>panelVersion</value>
-  </data>
-  <data name="&gt;&gt;pdSectionVersion.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panelVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panelVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 176</value>
-  </data>
-  <data name="panelVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 5</value>
-  </data>
-  <data name="panelVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
-  </data>
-  <data name="panelVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;panelVersion.Name" xml:space="preserve">
-    <value>panelVersion</value>
-  </data>
-  <data name="&gt;&gt;panelVersion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelVersion.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panelVersion.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>11</value>
   </data>
   <data name="panelMemory.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1128,6 +963,9 @@
   <data name="pdSectionMemory.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionMemory.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionMemory.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -1138,7 +976,7 @@
     <value>Memory</value>
   </data>
   <data name="pdSectionMemory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionMemory.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1159,13 +997,13 @@
     <value>Top</value>
   </data>
   <data name="panelMemory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 132</value>
+    <value>0, 264</value>
   </data>
   <data name="panelMemory.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelMemory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelMemory.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1180,7 +1018,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelMemory.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>12</value>
   </data>
   <data name="panelManagementInterfaces.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1194,6 +1032,9 @@
   <data name="pdSectionManagementInterfaces.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionManagementInterfaces.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionManagementInterfaces.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -1204,7 +1045,7 @@
     <value>Management Interfaces</value>
   </data>
   <data name="pdSectionManagementInterfaces.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionManagementInterfaces.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1225,13 +1066,13 @@
     <value>Top</value>
   </data>
   <data name="panelManagementInterfaces.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 88</value>
+    <value>0, 220</value>
   </data>
   <data name="panelManagementInterfaces.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelManagementInterfaces.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelManagementInterfaces.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1246,6 +1087,213 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelManagementInterfaces.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="panelUpdates.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelUpdates.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionUpdates.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pdSectionUpdates.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionUpdates.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
+  <data name="pdSectionUpdates.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionUpdates.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionUpdates.SectionTitle" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="pdSectionUpdates.Size" type="System.Drawing.Size, System.Drawing">
+    <value>715, 34</value>
+  </data>
+  <data name="pdSectionUpdates.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.Name" xml:space="preserve">
+    <value>pdSectionUpdates</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.Parent" xml:space="preserve">
+    <value>panelUpdates</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelUpdates.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelUpdates.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 176</value>
+  </data>
+  <data name="panelUpdates.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelUpdates.Size" type="System.Drawing.Size, System.Drawing">
+    <value>715, 44</value>
+  </data>
+  <data name="panelUpdates.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.Name" xml:space="preserve">
+    <value>panelUpdates</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="panelVersion.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelVersion.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pdSectionVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionVersion.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
+  <data name="pdSectionVersion.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionVersion.SectionTitle" xml:space="preserve">
+    <value>Version Details</value>
+  </data>
+  <data name="pdSectionVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>715, 34</value>
+  </data>
+  <data name="pdSectionVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionVersion.Name" xml:space="preserve">
+    <value>pdSectionVersion</value>
+  </data>
+  <data name="&gt;&gt;pdSectionVersion.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionVersion.Parent" xml:space="preserve">
+    <value>panelVersion</value>
+  </data>
+  <data name="&gt;&gt;pdSectionVersion.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelVersion.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 132</value>
+  </data>
+  <data name="panelVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>715, 44</value>
+  </data>
+  <data name="panelVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;panelVersion.Name" xml:space="preserve">
+    <value>panelVersion</value>
+  </data>
+  <data name="&gt;&gt;panelVersion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelVersion.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelVersion.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="panelLicense.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelLicense.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionLicense.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pdSectionLicense.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionLicense.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
+  <data name="pdSectionLicense.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionLicense.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionLicense.SectionTitle" xml:space="preserve">
+    <value>License Details</value>
+  </data>
+  <data name="pdSectionLicense.Size" type="System.Drawing.Size, System.Drawing">
+    <value>715, 34</value>
+  </data>
+  <data name="pdSectionLicense.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionLicense.Name" xml:space="preserve">
+    <value>pdSectionLicense</value>
+  </data>
+  <data name="&gt;&gt;pdSectionLicense.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionLicense.Parent" xml:space="preserve">
+    <value>panelLicense</value>
+  </data>
+  <data name="&gt;&gt;pdSectionLicense.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelLicense.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelLicense.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 88</value>
+  </data>
+  <data name="panelLicense.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelLicense.Size" type="System.Drawing.Size, System.Drawing">
+    <value>715, 44</value>
+  </data>
+  <data name="panelLicense.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;panelLicense.Name" xml:space="preserve">
+    <value>panelLicense</value>
+  </data>
+  <data name="&gt;&gt;panelLicense.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelLicense.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelLicense.ZOrder" xml:space="preserve">
     <value>16</value>
   </data>
   <data name="panelCustomFields.AutoSize" type="System.Boolean, mscorlib">
@@ -1260,6 +1308,9 @@
   <data name="pdSectionCustomFields.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionCustomFields.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionCustomFields.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -1270,7 +1321,7 @@
     <value>Custom Fields</value>
   </data>
   <data name="pdSectionCustomFields.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionCustomFields.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1297,7 +1348,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelCustomFields.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelCustomFields.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1326,6 +1377,9 @@
   <data name="pdSectionGeneral.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 5</value>
   </data>
+  <data name="pdSectionGeneral.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 9999999</value>
+  </data>
   <data name="pdSectionGeneral.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 34</value>
   </data>
@@ -1336,7 +1390,7 @@
     <value>General</value>
   </data>
   <data name="pdSectionGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 34</value>
+    <value>715, 34</value>
   </data>
   <data name="pdSectionGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1363,7 +1417,7 @@
     <value>0, 5, 0, 5</value>
   </data>
   <data name="panelGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 44</value>
+    <value>715, 44</value>
   </data>
   <data name="panelGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1380,14 +1434,17 @@
   <data name="&gt;&gt;panelGeneral.ZOrder" xml:space="preserve">
     <value>18</value>
   </data>
+  <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 39</value>
   </data>
   <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 740</value>
+    <value>732, 743</value>
   </data>
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;panel2.Name" xml:space="preserve">
     <value>panel2</value>
@@ -1401,71 +1458,20 @@
   <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="buttonProperties.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 2</value>
+  <data name="tableLayoutPanelButtons.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="buttonProperties.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 2, 0, 0</value>
+  <data name="tableLayoutPanelButtons.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <data name="buttonProperties.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="buttonProperties.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="buttonProperties.Text" xml:space="preserve">
-    <value>P&amp;roperties</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.Name" xml:space="preserve">
-    <value>buttonProperties</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.Parent" xml:space="preserve">
-    <value>buttonPanel</value>
-  </data>
-  <data name="&gt;&gt;buttonProperties.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="buttonViewConsole.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonViewConsole.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 2</value>
-  </data>
-  <data name="buttonViewConsole.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 2, 0, 0</value>
-  </data>
-  <data name="buttonViewConsole.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
-  </data>
-  <data name="buttonViewConsole.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="buttonViewConsole.Text" xml:space="preserve">
-    <value>View &amp;Console</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.Name" xml:space="preserve">
-    <value>buttonViewConsole</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.Parent" xml:space="preserve">
-    <value>buttonPanel</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="tableLayoutPanelButtons.ColumnCount" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="buttonViewLog.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="buttonViewLog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>175, 2</value>
-  </data>
-  <data name="buttonViewLog.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 2, 0, 0</value>
+    <value>180, 3</value>
   </data>
   <data name="buttonViewLog.Size" type="System.Drawing.Size, System.Drawing">
     <value>90, 23</value>
@@ -1483,94 +1489,79 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;buttonViewLog.Parent" xml:space="preserve">
-    <value>buttonPanel</value>
+    <value>tableLayoutPanelButtons</value>
   </data>
   <data name="&gt;&gt;buttonViewLog.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="buttonViewConsole.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="buttonViewConsole.Location" type="System.Drawing.Point, System.Drawing">
+    <value>84, 3</value>
+  </data>
+  <data name="buttonViewConsole.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 23</value>
+  </data>
+  <data name="buttonViewConsole.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="buttonViewConsole.Text" xml:space="preserve">
+    <value>View &amp;Console</value>
+  </data>
+  <data name="&gt;&gt;buttonViewConsole.Name" xml:space="preserve">
+    <value>buttonViewConsole</value>
+  </data>
+  <data name="&gt;&gt;buttonViewConsole.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonViewConsole.Parent" xml:space="preserve">
+    <value>tableLayoutPanelButtons</value>
+  </data>
+  <data name="&gt;&gt;buttonViewConsole.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonProperties.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="buttonProperties.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonProperties.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="buttonProperties.Text" xml:space="preserve">
+    <value>P&amp;roperties</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.Name" xml:space="preserve">
+    <value>buttonProperties</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.Parent" xml:space="preserve">
+    <value>tableLayoutPanelButtons</value>
+  </data>
+  <data name="&gt;&gt;buttonProperties.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="buttonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="buttonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 28</value>
-  </data>
-  <data name="buttonPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.Name" xml:space="preserve">
-    <value>buttonPanel</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="linkLabelExpand.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="linkLabelExpand.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="linkLabelCollapse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
-  </data>
-  <data name="linkLabelExpand.Location" type="System.Drawing.Point, System.Drawing">
-    <value>586, 0</value>
-  </data>
-  <data name="linkLabelExpand.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 2, 0</value>
-  </data>
-  <data name="linkLabelExpand.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>65, 28</value>
-  </data>
-  <data name="linkLabelExpand.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 28</value>
-  </data>
-  <data name="linkLabelExpand.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="linkLabelExpand.Text" xml:space="preserve">
-    <value>Expand all</value>
-  </data>
-  <data name="linkLabelExpand.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="&gt;&gt;linkLabelExpand.Name" xml:space="preserve">
-    <value>linkLabelExpand</value>
-  </data>
-  <data name="&gt;&gt;linkLabelExpand.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;linkLabelExpand.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;linkLabelExpand.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="linkLabelCollapse.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="linkLabelCollapse.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Right</value>
-  </data>
   <data name="linkLabelCollapse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>651, 0</value>
-  </data>
-  <data name="linkLabelCollapse.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>76, 28</value>
+    <value>669, 8</value>
   </data>
   <data name="linkLabelCollapse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 28</value>
+    <value>60, 13</value>
   </data>
   <data name="linkLabelCollapse.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="linkLabelCollapse.Text" xml:space="preserve">
     <value>Collapse all</value>
-  </data>
-  <data name="linkLabelCollapse.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
   </data>
   <data name="&gt;&gt;linkLabelCollapse.Name" xml:space="preserve">
     <value>linkLabelCollapse</value>
@@ -1579,64 +1570,73 @@
     <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;linkLabelCollapse.Parent" xml:space="preserve">
-    <value>panel3</value>
+    <value>tableLayoutPanelButtons</value>
   </data>
   <data name="&gt;&gt;linkLabelCollapse.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
-  <data name="panel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="linkLabelExpand.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
   </data>
-  <data name="panel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+  <data name="linkLabelExpand.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="panel3.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>900, 28</value>
+  <data name="linkLabelExpand.Location" type="System.Drawing.Point, System.Drawing">
+    <value>607, 8</value>
   </data>
-  <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>727, 28</value>
+  <data name="linkLabelExpand.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 13</value>
   </data>
-  <data name="panel3.TabIndex" type="System.Int32, mscorlib">
+  <data name="linkLabelExpand.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="linkLabelExpand.Text" xml:space="preserve">
+    <value>Expand all</value>
+  </data>
+  <data name="&gt;&gt;linkLabelExpand.Name" xml:space="preserve">
+    <value>linkLabelExpand</value>
+  </data>
+  <data name="&gt;&gt;linkLabelExpand.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabelExpand.Parent" xml:space="preserve">
+    <value>tableLayoutPanelButtons</value>
+  </data>
+  <data name="&gt;&gt;linkLabelExpand.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;panel3.Name" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;panel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel3.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;panel3.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="tableLayoutPanelButtons.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tableLayoutPanelButtons.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 10</value>
   </data>
-  <data name="panel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 5, 0</value>
+  <data name="tableLayoutPanelButtons.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>900, 900</value>
   </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tableLayoutPanelButtons.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanelButtons.Size" type="System.Drawing.Size, System.Drawing">
     <value>732, 29</value>
   </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tableLayoutPanelButtons.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
+  <data name="&gt;&gt;tableLayoutPanelButtons.Name" xml:space="preserve">
+    <value>tableLayoutPanelButtons</value>
   </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tableLayoutPanelButtons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tableLayoutPanelButtons.Parent" xml:space="preserve">
     <value>pageContainerPanel</value>
   </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tableLayoutPanelButtons.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="tableLayoutPanelButtons.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="buttonViewLog" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="buttonViewConsole" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonProperties" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelCollapse" Row="0" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelExpand" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 78</value>


### PR DESCRIPTION
- CA-164372: Added line breaks in the pool updates list for readability and to match the corresponding host list.
- Moved the updates, version and licence sections closer together.
- Removed unnecessary panels and placed top buttons on a TableLayoutPanel.
- Moved size hardcoded values from the code to the resource files.