### PR TITLE
Show bios strings as a new panel in the hosts general tab

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.Designer.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.Designer.cs
@@ -77,6 +77,8 @@ namespace XenAdmin.TabPages
             this.panelGeneral = new System.Windows.Forms.Panel();
             this.pdSectionGeneral = new XenAdmin.Controls.PDSection();
             this.tableLayoutPanelButtons = new System.Windows.Forms.TableLayoutPanel();
+            this.panelBios = new System.Windows.Forms.Panel();
+            this.pdSectionBios = new XenAdmin.Controls.PDSection();
             this.pageContainerPanel.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panelReadCaching.SuspendLayout();
@@ -99,6 +101,7 @@ namespace XenAdmin.TabPages
             this.panelCustomFields.SuspendLayout();
             this.panelGeneral.SuspendLayout();
             this.tableLayoutPanelButtons.SuspendLayout();
+            this.panelBios.SuspendLayout();
             this.SuspendLayout();
             // 
             // pageContainerPanel
@@ -162,6 +165,8 @@ namespace XenAdmin.TabPages
             this.panel2.Controls.Add(this.panelUpdates);
             this.panel2.Controls.Add(this.panelVersion);
             this.panel2.Controls.Add(this.panelLicense);
+
+            this.panel2.Controls.Add(this.panelBios);
             this.panel2.Controls.Add(this.panelCustomFields);
             this.panel2.Controls.Add(this.panelGeneral);
             this.panel2.Name = "panel2";
@@ -438,6 +443,19 @@ namespace XenAdmin.TabPages
             this.tableLayoutPanelButtons.Controls.Add(this.linkLabelExpand, 4, 0);
             this.tableLayoutPanelButtons.Name = "tableLayoutPanelButtons";
             // 
+            // panelBios
+            // 
+            resources.ApplyResources(this.panelBios, "panelBios");
+            this.panelBios.Controls.Add(this.pdSectionBios);
+            this.panelBios.Name = "panelBios";
+            // 
+            // pdSectionBios
+            // 
+            this.pdSectionBios.BackColor = System.Drawing.Color.Gainsboro;
+            resources.ApplyResources(this.pdSectionBios, "pdSectionBios");
+            this.pdSectionBios.Name = "pdSectionBios";
+            this.pdSectionBios.ShowCellToolTips = false;
+            // 
             // GeneralTabPage
             // 
             resources.ApplyResources(this, "$this");
@@ -469,6 +487,7 @@ namespace XenAdmin.TabPages
             this.panelGeneral.ResumeLayout(false);
             this.tableLayoutPanelButtons.ResumeLayout(false);
             this.tableLayoutPanelButtons.PerformLayout();
+            this.panelBios.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -521,5 +540,7 @@ namespace XenAdmin.TabPages
         private System.Windows.Forms.Button buttonViewConsole;
         private System.Windows.Forms.Button buttonViewLog;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelButtons;
+        private System.Windows.Forms.Panel panelBios;
+        private Controls.PDSection pdSectionBios;
     }
 }

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -501,6 +501,7 @@ namespace XenAdmin.TabPages
             {
                 generateGeneralBox();
                 generateCustomFieldsBox();
+                generateBiosBox();
                 generateInterfaceBox();
                 generateMemoryBox();
                 generateVersionBox();
@@ -601,6 +602,23 @@ namespace XenAdmin.TabPages
                             string.Format(Messages.PROPERTY_ON_OBJECT, pif.GetManagementPurpose().Ellipsise(30), Helpers.GetName(Host)),
                             pif.FriendlyIPAddress(),
                             editValue);
+                }
+            }
+        }
+
+        private void generateBiosBox()
+        {
+            PDSection s = pdSectionBios;
+
+            Host host = xenObject as Host;
+            if (host != null)
+            {
+                if (host.bios_strings != null)
+                {
+                    foreach (var entry in host.bios_strings)
+                    {
+                        s.AddEntry(entry.Key, entry.Value);
+                    }
                 }
             }
         }

--- a/XenAdmin/TabPages/GeneralTabPage.resx
+++ b/XenAdmin/TabPages/GeneralTabPage.resx
@@ -169,7 +169,7 @@
     <value>Top</value>
   </data>
   <data name="panelReadCaching.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 792</value>
+    <value>0, 836</value>
   </data>
   <data name="panelReadCaching.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -238,7 +238,7 @@
     <value>Top</value>
   </data>
   <data name="panelDockerInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 748</value>
+    <value>0, 792</value>
   </data>
   <data name="panelDockerInfo.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -307,7 +307,7 @@
     <value>Top</value>
   </data>
   <data name="panelDockerVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 704</value>
+    <value>0, 748</value>
   </data>
   <data name="panelDockerVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -376,7 +376,7 @@
     <value>Top</value>
   </data>
   <data name="panelStorageLinkSystemCapabilities.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 660</value>
+    <value>0, 704</value>
   </data>
   <data name="panelStorageLinkSystemCapabilities.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -445,7 +445,7 @@
     <value>Top</value>
   </data>
   <data name="panelMultipathBoot.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 616</value>
+    <value>0, 660</value>
   </data>
   <data name="panelMultipathBoot.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -514,7 +514,7 @@
     <value>Top</value>
   </data>
   <data name="panelStorageLink.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 572</value>
+    <value>0, 616</value>
   </data>
   <data name="panelStorageLink.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -536,6 +536,72 @@
   </data>
   <data name="&gt;&gt;panelStorageLink.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="panelUpdates.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelUpdates.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionUpdates.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pdSectionUpdates.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionUpdates.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionUpdates.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionUpdates.SectionTitle" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="pdSectionUpdates.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 34</value>
+  </data>
+  <data name="pdSectionUpdates.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.Name" xml:space="preserve">
+    <value>pdSectionUpdates</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.Parent" xml:space="preserve">
+    <value>panelUpdates</value>
+  </data>
+  <data name="&gt;&gt;pdSectionUpdates.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelUpdates.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelUpdates.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 572</value>
+  </data>
+  <data name="panelUpdates.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelUpdates.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 44</value>
+  </data>
+  <data name="panelUpdates.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.Name" xml:space="preserve">
+    <value>panelUpdates</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelUpdates.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="panelMemoryAndVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1066,7 +1132,7 @@
     <value>Top</value>
   </data>
   <data name="panelManagementInterfaces.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 220</value>
+    <value>0, 264</value>
   </data>
   <data name="panelManagementInterfaces.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -1135,7 +1201,7 @@
     <value>Top</value>
   </data>
   <data name="panelUpdates.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 176</value>
+    <value>0, 220</value>
   </data>
   <data name="panelUpdates.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -1204,7 +1270,7 @@
     <value>Top</value>
   </data>
   <data name="panelVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 132</value>
+    <value>0, 176</value>
   </data>
   <data name="panelVersion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -1273,7 +1339,7 @@
     <value>Top</value>
   </data>
   <data name="panelLicense.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 88</value>
+    <value>0, 132</value>
   </data>
   <data name="panelLicense.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 5, 0, 5</value>
@@ -1295,6 +1361,72 @@
   </data>
   <data name="&gt;&gt;panelLicense.ZOrder" xml:space="preserve">
     <value>16</value>
+  </data>
+  <data name="panelBios.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panelBios.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="pdSectionBios.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pdSectionBios.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 5</value>
+  </data>
+  <data name="pdSectionBios.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 34</value>
+  </data>
+  <data name="pdSectionBios.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
+  <data name="pdSectionBios.SectionTitle" xml:space="preserve">
+    <value>BIOS</value>
+  </data>
+  <data name="pdSectionBios.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 34</value>
+  </data>
+  <data name="pdSectionBios.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pdSectionBios.Name" xml:space="preserve">
+    <value>pdSectionBios</value>
+  </data>
+  <data name="&gt;&gt;pdSectionBios.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;pdSectionBios.Parent" xml:space="preserve">
+    <value>panelBios</value>
+  </data>
+  <data name="&gt;&gt;pdSectionBios.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panelBios.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelBios.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 88</value>
+  </data>
+  <data name="panelBios.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 5</value>
+  </data>
+  <data name="panelBios.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 44</value>
+  </data>
+  <data name="panelBios.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;panelBios.Name" xml:space="preserve">
+    <value>panelBios</value>
+  </data>
+  <data name="&gt;&gt;panelBios.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelBios.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panelBios.ZOrder" xml:space="preserve">
+    <value>17</value>
   </data>
   <data name="panelCustomFields.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1363,7 +1495,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelCustomFields.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="panelGeneral.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1432,7 +1564,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panelGeneral.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>19</value>
   </data>
   <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>


### PR DESCRIPTION
It would be great if we could see the BIOS strings in xenadmin, to know which mainboard/bios version is used.

![grafik](https://user-images.githubusercontent.com/5782951/58128950-01ef5700-7c19-11e9-801b-4634dbb1e7d4.png)

Reference: https://github.com/xcp-ng/xenadmin/issues/147