### PR TITLE
CA-314346: Fix Next button enablement on the Destination page of the …

### DIFF
--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -412,7 +412,8 @@ namespace XenAdmin.Wizards.GenericPages
                             cb.Items.Add(item);
                             item.ParentComboBox = cb;
                             item.PreferAsSelectedItem = m_selectedObject != null && m_selectedObject.opaque_ref == host.opaque_ref ||
-                                                 target.Item.opaque_ref == host.opaque_ref;
+                                                 target.Item.opaque_ref == host.opaque_ref || 
+                                                 sortedHosts.Count == 1;
                             item.ReasonUpdated += DelayLoadedGridComboBoxItem_ReasonChanged;
                             item.LoadAsync();
                         }
@@ -641,6 +642,8 @@ namespace XenAdmin.Wizards.GenericPages
 		{
 			m_dataGridView.CommitEdit(DataGridViewDataErrorContexts.Commit);
 			IsDirty = true;
+            if (!m_buttonNextEnabled)
+                SetButtonNextEnabled(true);
 		}
 
 		#endregion


### PR DESCRIPTION
…VM migrate and VM import wizards.

- if there is only one host in the selected pool, then preselect it.
- make sure that  the Next button is enabled when a target host is selected.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>