### PR TITLE
CA-322735: Keep XenCenter showing the real device number used in the VM

### DIFF
--- a/XenModel/Actions/VM/GpuAssignAction.cs
+++ b/XenModel/Actions/VM/GpuAssignAction.cs
@@ -34,7 +34,6 @@ using System.Collections.Generic;
 using System.Text;
 
 using XenAdmin.Core;
-
 using XenAPI;
 
 namespace XenAdmin.Actions
@@ -64,7 +63,7 @@ namespace XenAdmin.Actions
 
             // New added vGPUs haven't opaque_ref
             foreach (var vGpu in vGpus.FindAll(x => x.opaque_ref == null))
-                AddGpu(vm.Connection.Resolve(vGpu.GPU_group), vm.Connection.Resolve(vGpu.type), vGpu.device);
+                AddGpu(vm.Connection.Resolve(vGpu.GPU_group), vm.Connection.Resolve(vGpu.type), vGpu.device ?? "0");
         }
 
         private void AddGpu(GPU_group gpuGroup, VGPU_type vGpuType, string device = "0")

--- a/XenModel/XenAPI/VGPU.cs
+++ b/XenModel/XenAPI/VGPU.cs
@@ -656,7 +656,7 @@ namespace XenAPI
         private XenRef<GPU_group> _GPU_group = new XenRef<GPU_group>(Helper.NullOpaqueRef);
 
         /// <summary>
-        /// Guest PCI slot (a value of 0 means auto-assign to first empty slot, valid slot is in range of [11,31] for multi-VGPU purpose)
+        /// Guest PCI slot (a value of 0 means auto-assign to first empty slot, valid slot is in range of [0,20] for multi-VGPU purpose)
         /// </summary>
         public virtual string device
         {


### PR DESCRIPTION
Signed-off-by: Lin Liu <lin.liu@citrix.com>

This commit change the valid `device` id range for a  VM from `[11,31]` to `[0,20]` for the backward compatibility