### PR TITLE
CA-320203: Fixed the update wizard failure when installing two cumula…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/ApplyXenServerPatchPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/ApplyXenServerPatchPlanAction.cs
@@ -76,12 +76,20 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 AddProgressStep(string.Format(Messages.UPDATES_WIZARD_APPLYING_UPDATE, xenServerPatch.Name,
                     host.Name()));
 
+                PatchPrecheckOnHostPlanAction.RefreshUpdate(host, mapping, session);
+
                 XenRef<Task> task = null;
 
                 if (mapping is PoolPatchMapping patchMapping)
+                {
+                    log.InfoFormat("Allpying patch on `{0}`. Update = `{1}` (uuid = `{2}`; opaque_ref = `{3}`)", host.Name(), patchMapping.Pool_patch.Name(), patchMapping.Pool_patch.uuid, patchMapping.Pool_patch.opaque_ref);
                     task = Pool_patch.async_apply(session, patchMapping.Pool_patch.opaque_ref, host.opaque_ref);
+                }
                 else if (mapping is PoolUpdateMapping updateMapping)
+                {
+                    log.InfoFormat("Applying update on `{0}`. Update = `{1}` (uuid = `{2}`; opaque_ref = `{3}`)", host.Name(), updateMapping.Pool_update.Name(), updateMapping.Pool_update.uuid, updateMapping.Pool_update.opaque_ref);
                     task = Pool_update.async_apply(session, updateMapping.Pool_update.opaque_ref, host.opaque_ref);
+                }
 
                 PollTaskForResultAndDestroy(Connection, ref session, task);
             }

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/ApplyXenServerPatchPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/ApplyXenServerPatchPlanAction.cs
@@ -82,12 +82,12 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
 
                 if (mapping is PoolPatchMapping patchMapping)
                 {
-                    log.InfoFormat("Allpying patch on `{0}`. Update = `{1}` (uuid = `{2}`; opaque_ref = `{3}`)", host.Name(), patchMapping.Pool_patch.Name(), patchMapping.Pool_patch.uuid, patchMapping.Pool_patch.opaque_ref);
+                    log.InfoFormat("Applying patch on '{0}'. Patch{1}' (uuid = '{2}'; opaque_ref = '{3}')", host.Name(), patchMapping.Pool_patch.Name(), patchMapping.Pool_patch.uuid, patchMapping.Pool_patch.opaque_ref);
                     task = Pool_patch.async_apply(session, patchMapping.Pool_patch.opaque_ref, host.opaque_ref);
                 }
                 else if (mapping is PoolUpdateMapping updateMapping)
                 {
-                    log.InfoFormat("Applying update on `{0}`. Update = `{1}` (uuid = `{2}`; opaque_ref = `{3}`)", host.Name(), updateMapping.Pool_update.Name(), updateMapping.Pool_update.uuid, updateMapping.Pool_update.opaque_ref);
+                    log.InfoFormat("Applying update on '{0}'. Update = '{1}' (uuid = '{2}'; opaque_ref = '{3}')", host.Name(), updateMapping.Pool_update.Name(), updateMapping.Pool_update.uuid, updateMapping.Pool_update.opaque_ref);
                     task = Pool_update.async_apply(session, updateMapping.Pool_update.opaque_ref, host.opaque_ref);
                 }
 


### PR DESCRIPTION
…tive updates

The issue was that when installing 2 new versions in one go (e.g. two cumulative updates), the installation succeeds on master but it cannot continue on slaves, because it cannot find the first CU update anymore.
The fix is to refresh the update record before applying the update, with the record found in the cache. Also, if there is no update in the cache, try to re-introduce the update.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>