### PR TITLE
CA-280117 + Crash on HA configure corner case

### DIFF
--- a/XenAdmin/Dialogs/EditVmHaPrioritiesDialog.cs
+++ b/XenAdmin/Dialogs/EditVmHaPrioritiesDialog.cs
@@ -59,16 +59,13 @@ namespace XenAdmin.Dialogs
         /// </summary>
         private readonly long originalNtol;
 
-        /// <summary>
-        /// 
-        /// </summary>
         /// <param name="pool">May not be null. HA must be turned off on the pool.</param>
         public EditVmHaPrioritiesDialog(Pool pool)
         {
             if (pool == null)
                 throw new ArgumentNullException("pool");
             if (!pool.ha_enabled)
-                throw new ArgumentException("You may only show the EditVmHaPrioritiesDialog for pools that already have HA turned on");
+                throw new ArgumentException("Can only configure HA for pools that already have HA turned on");
 
             this.pool = pool;
             InitializeComponent();
@@ -77,23 +74,6 @@ namespace XenAdmin.Dialogs
 
             pool.PropertyChanged += pool_PropertyChanged;
             originalNtol = pool.ha_host_failures_to_tolerate;
-
-            if (pool.ha_statefiles.Length != 1)
-            {
-                log.ErrorFormat("Cannot show dialog: pool {0} has {1} statefiles, but this dialog can only handle exactly 1. Closing dialog.",
-                    pool.Name(), pool.ha_statefiles.Length);
-                this.Close();
-                return;
-            }
-
-            XenRef<VDI> vdiRef = new XenRef<VDI>(pool.ha_statefiles[0]);
-            VDI vdi = pool.Connection.Resolve(vdiRef);
-            if (vdi == null)
-            {
-                log.Error("Could not resolve HA statefile reference. Closing dialog.");
-                this.Close();
-                return;
-            }
 
             pictureBoxWarningIcon.Image = SystemIcons.Warning.ToBitmap();
             Rebuild();

--- a/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
+++ b/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
@@ -194,6 +194,9 @@ namespace XenAdmin.Wizards.HAWizard_Pages
 
         private void DeregisterEvents()
         {
+            if (connection == null)
+                return;
+
             // Remove listeners
             connection.Cache.DeregisterCollectionChanged<VM>(VM_CollectionChangedWithInvoke);
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -7492,6 +7492,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Configure HA.
+        /// </summary>
+        public static string CONFIGURE_HA {
+            get {
+                return ResourceManager.GetString("CONFIGURE_HA", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &amp;Configure HA....
         /// </summary>
         public static string CONFIGURE_HA_ELLIPSIS {
@@ -17013,6 +17022,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot configure HA for pool &apos;{0}&apos; because an HA Statefile VDI could not be found in the pool..
+        /// </summary>
+        public static string HA_CONFIGURE_NO_STATEFILE {
+            get {
+                return ResourceManager.GetString("HA_CONFIGURE_NO_STATEFILE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Configure HA now....
         /// </summary>
         public static string HA_CONFIGURE_NOW {
@@ -17099,6 +17117,15 @@ namespace XenAdmin {
         public static string HA_CURRENT_CAPACITY {
             get {
                 return ResourceManager.GetString("HA_CURRENT_CAPACITY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot disable HA for pool &apos;{0}&apos; because an HA Statefile VDI could not be found in the pool..
+        /// </summary>
+        public static string HA_DISABLE_NO_STATEFILE {
+            get {
+                return ResourceManager.GetString("HA_DISABLE_NO_STATEFILE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2706,6 +2706,9 @@ Do you want to assign it to the schedule '{2}' instead?</value>
   <data name="COMPRESSING_FILES" xml:space="preserve">
     <value>Compressing appliance files...</value>
   </data>
+  <data name="CONFIGURE_HA" xml:space="preserve">
+    <value>Configure HA</value>
+  </data>
   <data name="CONFIGURE_HA_ELLIPSIS" xml:space="preserve">
     <value>&amp;Configure HA...</value>
   </data>
@@ -5976,6 +5979,9 @@ not currently live:
   <data name="HA_CONFIGURE_NOW" xml:space="preserve">
     <value>Configure HA now...</value>
   </data>
+  <data name="HA_CONFIGURE_NO_STATEFILE" xml:space="preserve">
+    <value>Cannot configure HA for pool '{0}' because an HA Statefile VDI could not be found in the pool.</value>
+  </data>
   <data name="HA_CONFIRM_FORCESHUTDOWN_VM" xml:space="preserve">
     <value>The selected VM is currently protected by HA. Are you sure you want to force the shut down of this VM? This operation will cancel all running tasks for the VM and can result in data loss.</value>
   </data>
@@ -5996,6 +6002,9 @@ not currently live:
   </data>
   <data name="HA_CURRENT_CAPACITY" xml:space="preserve">
     <value>Current failure capacity:</value>
+  </data>
+  <data name="HA_DISABLE_NO_STATEFILE" xml:space="preserve">
+    <value>Cannot disable HA for pool '{0}' because an HA Statefile VDI could not be found in the pool.</value>
   </data>
   <data name="HA_DISABLE_QUERY" xml:space="preserve">
     <value>Are you sure you want to disable HA for pool '{0}'?</value>


### PR DESCRIPTION
When the statefile is missing (or when there are multiple statefiles, but I can't find any justification for this restriction), the code returns half way through the EditVmHaPrioritiesDialog's constructor, and Dispose is called. The latter tries to deregister events on AssignPriorities, however crashes because there is no connection. Adding a null check fixes the crash, however afterwards the code returns silently leaving the user wondering why nothing happened when the button was clicked. The behaviour is improved by adding relevant error pop-ups. Did some refactoring too to avoid code duplication.