### PR TITLE
CA-314720: Replaced "Still waiting" dialog popping up during RPU with…

### DIFF
--- a/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
+++ b/XenModel/Actions/SupplementalPack/UploadSupplementalPackAction.cs
@@ -47,7 +47,7 @@ namespace XenAdmin.Actions
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         private readonly string suppPackFilePath;
-        private readonly long _totalUpdateSize;
+        private long _totalUpdateSize;
         private readonly List<Host> servers;
         private long totalCount;
         private long totalUploaded;
@@ -77,13 +77,14 @@ namespace XenAdmin.Actions
             
             suppPackFilePath = path;
             _updateName = Path.GetFileNameWithoutExtension(suppPackFilePath);
-            _totalUpdateSize = (new FileInfo(path)).Length;
             servers = selectedServers;
         }
 
         protected override void Run()
         {
             SafeToExit = false;
+
+            _totalUpdateSize = new FileInfo(suppPackFilePath).Length;
 
             var srList = SelectTargetSr();
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8692,7 +8692,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot connect to {0} because of license restriction.
+        ///   Looks up a localized string similar to Cannot connect to {0} due to license restrictions on the server.
         /// </summary>
         public static string CONNECTION_RESTRICTED_NOTICE_TITLE {
             get {
@@ -35257,7 +35257,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: Cannot migrate VM &apos;{1}&apos; due to license restrictions..
+        ///   Looks up a localized string similar to {0}: Cannot migrate VM &apos;{1}&apos; due to license restrictions on the server..
         /// </summary>
         public static string UPDATES_WIZARD_CANNOT_MIGRATE_VM_LICENSE_REASON {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20317,15 +20317,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &amp;Keep waiting.
-        /// </summary>
-        public static string KEEP_WAITING_BUTTON_LABEL {
-            get {
-                return ResourceManager.GetString("KEEP_WAITING_BUTTON_LABEL", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Attempting to connect to {0}....
         /// </summary>
         public static string LABEL_ATTEMPT {
@@ -31271,15 +31262,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Still waiting for the upgrade to complete.
-        ///
-        ///Please check the server console for possible errors.
-        ///    
-        ///Click Keep Waiting if the upgrade is still running or Cancel if an error occurred..
+        ///   Looks up a localized string similar to Still waiting for the installation of [XenServer] on &apos;{0}&apos; to complete. Please check the server console for possible errors. Keep waiting if the installation is still running....
         /// </summary>
         public static string ROLLING_UPGRADE_TIMEOUT {
             get {
                 return ResourceManager.GetString("ROLLING_UPGRADE_TIMEOUT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Still waiting for the installation of [XenServer] {0} on &apos;{1}&apos; to complete. Please check the server console for possible errors. Keep waiting if the installation is still running....
+        /// </summary>
+        public static string ROLLING_UPGRADE_TIMEOUT_VERSION {
+            get {
+                return ResourceManager.GetString("ROLLING_UPGRADE_TIMEOUT_VERSION", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3143,7 +3143,7 @@ Would you like to carry out the operation at this time?</value>
 You can only connect to a single [Citrix XenServer] Express Edition server at a time. To find out how to upgrade your license, follow the link below.</value>
   </data>
   <data name="CONNECTION_RESTRICTED_NOTICE_TITLE" xml:space="preserve">
-    <value>Cannot connect to {0} because of license restriction</value>
+    <value>Cannot connect to {0} due to license restrictions on the server</value>
     <comment>Title of notice shown when connection to a host is restricted by license</comment>
   </data>
   <data name="CONNECTION_RETRYING_SLAVE" xml:space="preserve">
@@ -12169,7 +12169,7 @@ Verify that the file is a valid {1} export.</value>
     <value>{0}: Cannot migrate VM '{1}'</value>
   </data>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_LICENSE_REASON" xml:space="preserve">
-    <value>{0}: Cannot migrate VM '{1}' due to license restrictions.</value>
+    <value>{0}: Cannot migrate VM '{1}' due to license restrictions on the server.</value>
   </data>
   <data name="UPDATES_WIZARD_CANNOT_MIGRATE_VM_NO_GPU" xml:space="preserve">
     <value>{0}: Cannot migrate VM '{1}', because it has a virtual GPU attached and there is no suitable GPU available on other servers.</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7080,9 +7080,6 @@ Size: {3}</value>
   <data name="JOINING_AD" xml:space="preserve">
     <value>Please enter a user name and password with sufficient privileges to add servers to domain '{0}'.</value>
   </data>
-  <data name="KEEP_WAITING_BUTTON_LABEL" xml:space="preserve">
-    <value>&amp;Keep waiting</value>
-  </data>
   <data name="LABEL_ATTEMPT" xml:space="preserve">
     <value>Attempting to connect to {0}...</value>
   </data>
@@ -10877,11 +10874,10 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
     <value>The rolling pool upgrade process was completed successfully.</value>
   </data>
   <data name="ROLLING_UPGRADE_TIMEOUT" xml:space="preserve">
-    <value>Still waiting for the upgrade to complete.
-
-Please check the server console for possible errors.
-    
-Click Keep Waiting if the upgrade is still running or Cancel if an error occurred.</value>
+    <value>Still waiting for the installation of [XenServer] on '{0}' to complete. Please check the server console for possible errors. Keep waiting if the installation is still running...</value>
+  </data>
+  <data name="ROLLING_UPGRADE_TIMEOUT_VERSION" xml:space="preserve">
+    <value>Still waiting for the installation of [XenServer] {0} on '{1}' to complete. Please check the server console for possible errors. Keep waiting if the installation is still running...</value>
   </data>
   <data name="ROLLING_UPGRADE_TITLE_MODE" xml:space="preserve">
     <value>Upgrade Mode</value>


### PR DESCRIPTION
… a message displayed in the upgrade output.

Also, fixed issue where uploading a supp-pack resulted in a perpetually
pending action if the file had disappeared from the disk.