### PR TITLE
CA-322790: Fix unhandled exception when the host cannot be reached to…

### DIFF
--- a/XenAdmin/Commands/VMOperationHostCommand.cs
+++ b/XenAdmin/Commands/VMOperationHostCommand.cs
@@ -147,8 +147,7 @@ namespace XenAdmin.Commands
             }
             catch (Exception e)
             {
-                log.ErrorFormat("There was an error calling assert_can_boot_here on host {0}", host.Name());
-                log.Error(e, e);
+                log.ErrorFormat("There was an error calling assert_can_boot_here on host {0}: {1}", host.Name(), e.Message);
                 return Messages.HOST_MENU_UNKNOWN_ERROR;
             }
 

--- a/XenAdmin/Diagnostics/Checks/HostMemoryPostUpgradeCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/HostMemoryPostUpgradeCheck.cs
@@ -95,9 +95,10 @@ namespace XenAdmin.Diagnostics.Checks
                 var result = Host.call_plugin(Host.Connection.Session, Host.opaque_ref, "prepare_host_upgrade.py", "getDom0DefaultMemory", installMethodConfig);
                 return long.TryParse(result, out dom0MemoryAfterUpgrade);
             }
-            catch (Failure failure)
+            catch (Exception exception)
             {
-                log.WarnFormat("Plugin call prepare_host_upgrade.getDom0DefaultMemory on {0} failed with {1}", Host.Name(), failure.Message);
+                var failure = exception as Failure;
+                log.WarnFormat("Plugin call prepare_host_upgrade.getDom0DefaultMemory on {0} failed with {1}({2})", Host.Name(), exception.Message, failure?.ErrorDescription.Count>3? failure.ErrorDescription[3]:"");
                 return false;
             }
         }
@@ -114,16 +115,9 @@ namespace XenAdmin.Diagnostics.Checks
                 productVersion = version.ContainsKey("product-version") ? (string)version["product-version"] : null;
                 return platformVersion != null || productVersion != null;
             }
-            catch (Failure failure)
-            {
-                log.WarnFormat("Plugin call prepare_host_upgrade.getVersion on {0} failed with {1}", Host.Name(), failure.Message);
-                
-                return false;
-            }
             catch (Exception exception)
             {
-                log.WarnFormat("Exception while trying to get the upgrade version: {0}", exception.Message);
-
+                log.WarnFormat("Plugin call prepare_host_upgrade.getVersion on {0} failed with {1}", Host.Name(), exception.Message);
                 return false;
             }
         }

--- a/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PatchPrecheckCheck.cs
@@ -261,9 +261,9 @@ namespace XenAdmin.Diagnostics.Checks
                         var resultReclaimable = Host.call_plugin(Host.Connection.Session, Host.opaque_ref, "disk-space", "get_reclaimable_disk_space", args);
                         reclaimableDiskSpace = Convert.ToInt64(resultReclaimable);
                     }
-                    catch (Failure failure)
+                    catch (Exception exception)
                     {
-                        log.WarnFormat("Plugin call disk-space.get_reclaimable_disk_space on {0} failed with {1}", Host.Name(), failure.Message);
+                        log.WarnFormat("Plugin call disk-space.get_reclaimable_disk_space on {0} failed with {1}", Host.Name(), exception.Message);
                     }
 
                     diskSpaceReq = new DiskSpaceRequirements(DiskSpaceRequirements.OperationTypes.install, Host, Patch.Name(), requiredSpace, foundSpace, reclaimableDiskSpace);

--- a/XenAdmin/Diagnostics/Checks/PrepareToUpgradeCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PrepareToUpgradeCheck.cs
@@ -62,16 +62,13 @@ namespace XenAdmin.Diagnostics.Checks
                 if (result.ToLower() == "true")
                     return null;
             }
-            catch (Failure failure)
+            catch (Exception exception)
             {
-                if (failure.ErrorDescription.Count == 4)
+                var failure = exception as Failure;
+                if (failure?.ErrorDescription.Count == 4)
                     return new HostPrepareToUpgradeProblem(this, Host, failure.ErrorDescription[3]);
 
-                log.ErrorFormat("Error testing upgrade hotfix: {0}", failure);
-            }
-            catch (Exception e)
-            {
-                log.ErrorFormat("Error testing upgrade hotfix: {0}", e);
+                log.ErrorFormat("Error testing upgrade hotfix: {0}", exception);
             }
 
             return new HostPrepareToUpgradeProblem(this, Host);

--- a/XenAdmin/Diagnostics/Checks/SafeToUpgradeCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/SafeToUpgradeCheck.cs
@@ -67,10 +67,10 @@ namespace XenAdmin.Diagnostics.Checks
                         return new HostNotSafeToUpgradeWarning(this, Host, HostNotSafeToUpgradeReason.Default);
                 }
             }
-            catch (Failure failure)
+            catch (Exception exception)
             {
                 //note: handle the case when we get UNKNOWN_XENAPI_PLUGIN_FUNCTION - testSafe2Upgrade
-                log.WarnFormat("Plugin call prepare_host_upgrade.testSafe2Upgrade on {0} failed with {1}", Host.Name(), failure.Message);
+                log.WarnFormat("Plugin call prepare_host_upgrade.testSafe2Upgrade on {0} failed with {1}", Host.Name(), exception.Message);
             }
 
             return null;

--- a/XenAdmin/TabPages/DockerDetailsPage.cs
+++ b/XenAdmin/TabPages/DockerDetailsPage.cs
@@ -176,7 +176,7 @@ namespace XenAdmin.TabPages
                     }
                 }
             }
-            catch (Failure)
+            catch (Exception)
             {
                 ShowInvalidInfo();
             }

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -187,6 +187,12 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
 
                         vmIsMigratable = false;
                     }
+                    catch (Exception e)
+                    {
+                        log.ErrorFormat("There was an error while asserting if the VM {0} can be migrated to {1}: {2}", vm.Name(), itemToFilterOn, e.Message);
+                        disableReason = Messages.HOST_MENU_UNKNOWN_ERROR;
+                        vmIsMigratable = false;
+                    }
                 }
 
                 // if at least one VM is not migratable to the target pool, then there is no point checking the remaining VMs


### PR DESCRIPTION
… execute an API call.

In the CrossPoolMigrateCanMigrateFilter a WebException can be raised if the host cannot be reached to execute the API call that asserts is the VM can be migrated there. With these changes, we catch any exception (not just Failure) and mark the VM as not migratable (because we couldn't assert if it can be migrated to that host).

Also fixed other places where the same error might occur.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>