### PR TITLE
Renamed property as there are clashes with a child class (will have t…

### DIFF
--- a/CFUValidator/CFUValidator.csproj
+++ b/CFUValidator/CFUValidator.csproj
@@ -38,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/CommandLib/CommandLib.csproj
+++ b/CommandLib/CommandLib.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/XenAdmin/Controls/FilterStatusToolStripDropDownButton.cs
+++ b/XenAdmin/Controls/FilterStatusToolStripDropDownButton.cs
@@ -122,7 +122,7 @@ namespace XenAdmin.Controls
             return !(toolStripMenuItemComplete.Checked && iStatus.Succeeded
                 || toolStripMenuItemError.Checked && iStatus.IsError
                 || toolStripMenuItemInProgress.Checked && iStatus.InProgress
-                || toolStripMenuItemCancelled.Checked && iStatus.Cancelled
+                || toolStripMenuItemCancelled.Checked && iStatus.IsCancelled
                 || toolStripMenuItemIncomplete.Checked && iStatus.IsIncomplete
                 || toolStripMenuItemQueued.Checked && iStatus.IsQueued);
         }

--- a/XenAdminTests/XenAdminTests.csproj
+++ b/XenAdminTests/XenAdminTests.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/XenCenterLib/XenCenterLib.csproj
+++ b/XenCenterLib/XenCenterLib.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/XenCenterVNC/XenCenterVNC.csproj
+++ b/XenCenterVNC/XenCenterVNC.csproj
@@ -24,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/XenModel/Actions/Action.cs
+++ b/XenModel/Actions/Action.cs
@@ -43,7 +43,7 @@ namespace XenAdmin.Actions
         bool InProgress { get; }
         bool IsCompleted { get; }
         bool Succeeded { get; }
-        bool Cancelled { get; }
+        bool IsCancelled { get; }
         bool IsError { get; }
         bool IsIncomplete { get; }
         bool IsQueued { get; }
@@ -327,7 +327,7 @@ namespace XenAdmin.Actions
         }
 
         public bool Succeeded => IsCompleted && Exception == null;
-        public bool Cancelled => IsCompleted && !Succeeded && Exception is CancelledException;
+        public bool IsCancelled => IsCompleted && !Succeeded && Exception is CancelledException;
         public bool IsError => IsCompleted && !Succeeded && !(Exception is CancelledException);
         public bool IsIncomplete => false;
         public bool IsQueued => false;

--- a/XenModel/XCM/ConversionDescriptors.cs
+++ b/XenModel/XCM/ConversionDescriptors.cs
@@ -132,7 +132,7 @@ namespace XenAdmin.XCM
         public bool Succeeded => Status == (int)ConversionStatus.Successful;
 
         [XmlRpcMissingMapping(MappingAction.Ignore)]
-        public bool Cancelled => Status == (int)ConversionStatus.Cancelled;
+        public bool IsCancelled => Status == (int)ConversionStatus.Cancelled;
 
         [XmlRpcMissingMapping(MappingAction.Ignore)]
         public bool IsError => Status == (int)ConversionStatus.Failed;

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/XenOvfApi/XenOvfApi.csproj
+++ b/XenOvfApi/XenOvfApi.csproj
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -182,7 +183,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties StartDate="20090814" AssemblyFileVersion="1" AssemblyVersion="1" Reset="1" />
+      <UserProperties Reset="1" AssemblyVersion="1" AssemblyFileVersion="1" StartDate="20090814" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/XenOvfTransport/XenOvfTransport.csproj
+++ b/XenOvfTransport/XenOvfTransport.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -110,7 +111,7 @@
   -->
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties Reset="1" AssemblyVersion="1" AssemblyFileVersion="1" StartDate="20090814" />
+      <UserProperties StartDate="20090814" AssemblyFileVersion="1" AssemblyVersion="1" Reset="1" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/XenServerHealthCheck/XenServerHealthCheck.csproj
+++ b/XenServerHealthCheck/XenServerHealthCheck.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/xe/Xe.csproj
+++ b/xe/Xe.csproj
@@ -29,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/xva_verify/xva_verify.csproj
+++ b/xva_verify/xva_verify.csproj
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
…o be refactored in future). Treat warnings as errors in all projects.