### PR TITLE
CA-322529: Do not add nulls to the sub-actions list for a multiple ac…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.cs
@@ -261,21 +261,30 @@ namespace XenAdmin.Wizards.PatchingWizard
                     if (PatchingWizard_UploadPage.Patch == null ||
                         !string.Equals(patch.uuid, PatchingWizard_UploadPage.Patch.uuid, StringComparison.OrdinalIgnoreCase) ||
                         forceCleanSelectedPatch)
-                        list.Add(GetCleanActionForPoolPatch(patch));
-
+                    {
+                        var action = GetCleanActionForPoolPatch(patch);
+                        if (action != null)
+                            list.Add(action);
+                    }
                     continue;
                 }
                 
                 if (mapping is PoolUpdateMapping updateMapping)
                 {
-                    list.Add(GetCleanActionForPoolUpdate(updateMapping.Pool_update));
+                    var action = GetCleanActionForPoolUpdate(updateMapping.Pool_update);
+                    if (action != null)
+                        list.Add(action);
                     continue;
                 }
                 
                 if (mapping is SuppPackMapping suppPackMapping)
                 {
                     if (suppPackMapping.Pool_update!= null)
-                        list.Add(GetCleanActionForPoolUpdate(suppPackMapping.Pool_update));
+                    {
+                        var action = GetCleanActionForPoolUpdate(suppPackMapping.Pool_update);
+                        if (action != null)
+                            list.Add(action);
+                    }                        
                     else
                         list.AddRange(GetRemoveVdiActions(suppPackMapping.SuppPackVdis.Values.ToList()));
                 }


### PR DESCRIPTION
…tion

- This fixes the issue where we create a multiple action to delete the update installation files, but the sub-actions list contains null values because the connection to the host has been lost

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>