### PR TITLE
CA-325439 Pre-populate download locations. Validation corrections on  the server status report wizard.

### DIFF
--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolWizard.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolWizard.cs
@@ -29,15 +29,10 @@
  * SUCH DAMAGE.
  */
 
-using System;
+
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using System.IO;
 using XenAdmin.Controls;
 using XenAdmin.Core;
 using XenAPI;
@@ -77,50 +72,6 @@ namespace XenAdmin.Wizards
 
         protected override void FinishWizard()
         {
-            // If the user has chosen a file that already exists, get confirmation
-            string path = bugToolPageDestination1.OutputFile;
-            if (File.Exists(path))
-            {
-                DialogResult dialogResult;
-                using (var dlg = new ThreeButtonDialog(
-                        new ThreeButtonDialog.Details(SystemIcons.Warning, string.Format(Messages.FILE_X_EXISTS_OVERWRITE, path), Messages.XENCENTER),
-                        ThreeButtonDialog.ButtonOK,
-                        new ThreeButtonDialog.TBDButton(Messages.CANCEL, DialogResult.Cancel, ThreeButtonDialog.ButtonType.CANCEL, true)))
-                {
-                    dialogResult = dlg.ShowDialog(this);
-                }
-                if (dialogResult != DialogResult.OK)
-                {
-                    FinishCanceled();
-                    return;
-                }
-            }
-
-            // Check we can write to the destination file - otherwise we only find out at the 
-            // end of the ZipStatusReportAction, and the downloaded server files are lost,
-            // and the user will have to run the wizard again.
-            try
-            {
-                using (FileStream temp = File.OpenWrite(path))
-                {
-                    // Yay, it worked
-                }
-            }
-            catch (Exception exn)
-            {
-                // Failure
-                using (var dlg = new ThreeButtonDialog(
-                   new ThreeButtonDialog.Details(
-                       SystemIcons.Error,
-                       string.Format(Messages.COULD_NOT_WRITE_FILE, path, exn.Message),
-                       Messages.XENCENTER)))
-                {
-                    dlg.ShowDialog(this);
-                }
-                FinishCanceled();
-                return;
-            }
-
             AsyncAction action;
             if (bugToolPageDestination1.Upload)
             {
@@ -142,10 +93,6 @@ namespace XenAdmin.Wizards
             }
 
             action.RunAsync();
-
-
-            // Save away the output path for next time
-            XenAdmin.Properties.Settings.Default.ServerStatusPath = bugToolPageDestination1.OutputFile;
 
             log.Debug("Cleaning up crash dump logs on server");
             var capabilities = bugToolPageSelectCapabilities1.Capabilities;

--- a/XenAdmin/Wizards/ExportWizard/ExportAppliancePage.cs
+++ b/XenAdmin/Wizards/ExportWizard/ExportAppliancePage.cs
@@ -109,8 +109,11 @@ namespace XenAdmin.Wizards.ExportWizard
 
         protected override void PageLoadedCore(PageLoadedDirection direction)
 		{
-			if (direction == PageLoadedDirection.Forward)
-				PerformCheck(CheckPathValid);
+            if (direction == PageLoadedDirection.Forward)
+            {
+                m_textBoxFolderName.Text = Win32.GetKnownFolderPath(Win32.KnownFolders.Downloads);
+                PerformCheck(CheckPathValid);
+            }
 		}
 
         protected override void PageLeaveCore(PageLoadedDirection direction, ref bool cancel)
@@ -211,7 +214,7 @@ namespace XenAdmin.Wizards.ExportWizard
 			if (Directory.Exists(ApplianceDirectory))
 				return true;
 
-			error = Messages.EXPORT_APPLIANCE_PAGE_ERROR_NON_EXIST_DIR;
+			error = Messages.ERROR_DESTINATION_DIR_NON_EXIST;
 			return false;
 		}
 
@@ -234,7 +237,11 @@ namespace XenAdmin.Wizards.ExportWizard
 
 		private void m_buttonBrowse_Click(object sender, EventArgs e)
 		{
-            using (FolderBrowserDialog dlog = new FolderBrowserDialog { Description = Messages.FOLDER_BROWSER_EXPORT_APPLIANCE })
+            using (var dlog = new FolderBrowserDialog
+            {
+                Description = Messages.FOLDER_BROWSER_EXPORT_APPLIANCE,
+                SelectedPath = ApplianceDirectory
+            })
 			{
 				if (dlog.ShowDialog() == DialogResult.OK)
 					m_textBoxFolderName.Text = dlog.SelectedPath;

--- a/XenAdmin/Wizards/ImportWizard/ImportSourcePage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSourcePage.cs
@@ -604,7 +604,11 @@ namespace XenAdmin.Wizards.ImportWizard
 
         private bool Download()
         {
-            using (var dlog = new FolderBrowserDialog { Description = Messages.FOLDER_BROWSER_DOWNLOAD_APPLIANCE })
+            using (var dlog = new FolderBrowserDialog
+            {
+                Description = Messages.FOLDER_BROWSER_DOWNLOAD_APPLIANCE,
+                SelectedPath = Win32.GetKnownFolderPath(Win32.KnownFolders.Downloads)
+            })
             {
                 if (dlog.ShowDialog() == DialogResult.OK)
                 {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -14165,6 +14165,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Destination directory does not exist..
+        /// </summary>
+        public static string ERROR_DESTINATION_DIR_NON_EXIST {
+            get {
+                return ResourceManager.GetString("ERROR_DESTINATION_DIR_NON_EXIST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The following storage could not be destroyed:.
         /// </summary>
         public static string ERROR_DESTROYING_STORAGE_ITEMS_MESSAGE {
@@ -14956,15 +14965,6 @@ namespace XenAdmin {
         public static string EXPORT_APPLIANCE_PAGE_ERROR_INVALID_DIR {
             get {
                 return ResourceManager.GetString("EXPORT_APPLIANCE_PAGE_ERROR_INVALID_DIR", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Destination directory does not exist..
-        /// </summary>
-        public static string EXPORT_APPLIANCE_PAGE_ERROR_NON_EXIST_DIR {
-            get {
-                return ResourceManager.GetString("EXPORT_APPLIANCE_PAGE_ERROR_NON_EXIST_DIR", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -4992,6 +4992,9 @@ Would you like to eject these ISOs before continuing?</value>
   <data name="ERROR_DEACTIVATING_MULTIPLE_VDIS_TITLE" xml:space="preserve">
     <value>Error Deactivating Virtual Disks</value>
   </data>
+  <data name="ERROR_DESTINATION_DIR_NON_EXIST" xml:space="preserve">
+    <value>Destination directory does not exist.</value>
+  </data>
   <data name="ERROR_DESTROYING_STORAGE_ITEMS_MESSAGE" xml:space="preserve">
     <value>The following storage could not be destroyed:</value>
   </data>
@@ -5285,9 +5288,6 @@ Warning: to prevent data loss you must ensure that the LUN is not in use by any 
   </data>
   <data name="EXPORT_APPLIANCE_PAGE_ERROR_INVALID_DIR" xml:space="preserve">
     <value>Destination directory is invalid.</value>
-  </data>
-  <data name="EXPORT_APPLIANCE_PAGE_ERROR_NON_EXIST_DIR" xml:space="preserve">
-    <value>Destination directory does not exist.</value>
   </data>
   <data name="EXPORT_APPLIANCE_PAGE_ERROR_PERMISSIONS" xml:space="preserve">
     <value>You do not have write permission on the destination directory.</value>


### PR DESCRIPTION
- Moved path validation checks from the wizard to its last page (planning
to remove XenWizardBase.FinishCancelled in future).
- If the directory did not exist, the user saw a message about inability
to write a file which was misleading. Check directory existence explicitly.
- Populate the last wizard page on load rather than on construction to
avoid unnecessary validations.
- Save in the settings the report output directory, not the filename.