### PR TITLE
Activate the conversion VPX and get the service IP address without employing the conversion plug-in.

### DIFF
--- a/XenModel/Actions/XCM/ActivateConversionVpxAction.cs
+++ b/XenModel/Actions/XCM/ActivateConversionVpxAction.cs
@@ -1,0 +1,146 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+
+using System;
+using System.Linq;
+using System.Threading;
+using XenAdmin.Network;
+using XenAPI;
+
+
+namespace XenAdmin.Actions.Xcm
+{
+    public class ActivateConversionVpxAction : AsyncAction
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private const int TIMEOUT = 2 * 60 * 1000; //milliseconds
+        private const int SLEEP = 2000; //milliseconds
+
+        public ActivateConversionVpxAction(IXenConnection connection)
+            : base(connection, "", true)
+        {
+        }
+
+        public VM ConversionVm { get; private set; }
+        public string ServiceIp { get; private set; }
+
+        protected override void Run()
+        {
+            ConversionVm = Connection.Cache.VMs.FirstOrDefault(vm => vm.IsConversionVM());
+
+            if (ConversionVm == null)
+                throw new Exception(Messages.CONVERSION_CANNOT_FIND_VPX);
+
+            switch (ConversionVm.power_state)
+            {
+                case vm_power_state.Halted:
+                case vm_power_state.Paused:
+                case vm_power_state.Suspended:
+                case vm_power_state.Running:
+                    break;
+                default:
+                    log.Error($"The conversion VPX {ConversionVm.uuid} is in an unknown power state");
+                    throw new Exception(Messages.CONVERSION_VPX_UNKNOWN_POWER_STATE);
+            }
+
+            try
+            {
+                switch (ConversionVm.power_state)
+                {
+                    case vm_power_state.Halted:
+                        Description = Messages.CONVERSION_VPX_START;
+                        VM.start(Connection.Session, ConversionVm.opaque_ref, false, false);
+                        break;
+                    case vm_power_state.Paused:
+                        Description = Messages.CONVERSION_VPX_UNPAUSE;
+                        VM.unpause(Connection.Session, ConversionVm.opaque_ref);
+                        break;
+                    case vm_power_state.Suspended:
+                        Description = Messages.CONVERSION_VPX_RESUME;
+                        VM.resume(Connection.Session, ConversionVm.opaque_ref, false, false);
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is Failure f && f.ErrorDescription.Count > 0 && f.ErrorDescription[0] == Failure.VM_BAD_POWER_STATE)
+                {
+                    //ignore
+                }
+                else
+                {
+                    log.Error($"Failed to activate conversion VPX {ConversionVm.uuid}", e);
+                    throw new Exception(Messages.CONVERSION_INITIALIZING_VPX_FAILURE);
+                }
+            }
+
+            Description = Messages.CONVERSION_VPX_OBTAIN_IP;
+
+            string ipAddress = null;
+            var tries = TIMEOUT / SLEEP;
+
+            while (tries > 0)
+            {
+                if (Cancelling)
+                    throw new CancelledException();
+
+                if (Helper.IsNullOrEmptyOpaqueRef(ConversionVm.guest_metrics.opaque_ref))
+                {
+                    ConversionVm = Connection.Resolve(new XenRef<VM>(ConversionVm.opaque_ref));
+                }
+                else
+                {
+                    var metrics = Connection.Resolve(ConversionVm.guest_metrics);
+                    if (metrics != null)
+                    {
+                        // device 0 is the internal network for the VM; find an external one
+                        var vif = Connection.ResolveAll(ConversionVm.VIFs).FirstOrDefault(v => v.device != "0");
+                        if (vif != null && metrics.networks.TryGetValue($"{vif.device}/ip", out ipAddress))
+                            break;
+                    }
+                }
+
+                Thread.Sleep(SLEEP);
+                tries--;
+            }
+
+            if (string.IsNullOrEmpty(ipAddress))
+            {
+                log.Error($"Cannot obtain an IP address for conversion VPX {ConversionVm.uuid}.");
+                throw new Exception(Messages.CONVERSION_CANNOT_OBTAIN_VPX_IP);
+            }
+
+            ServiceIp = ipAddress;
+        }
+    }
+}

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8980,6 +8980,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot find a Conversion Manager Virtual Appliance..
+        /// </summary>
+        public static string CONVERSION_CANNOT_FIND_VPX {
+            get {
+                return ResourceManager.GetString("CONVERSION_CANNOT_FIND_VPX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot obtain an IP address for the Conversion Manager Virtual Appliance..
+        /// </summary>
+        public static string CONVERSION_CANNOT_OBTAIN_VPX_IP {
+            get {
+                return ResourceManager.GetString("CONVERSION_CANNOT_OBTAIN_VPX_IP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This action will clear all the completed conversions from the Conversion Manager Virtual Appliance history.
         ///
         ///This action cannot be undone. Are you sure you want to continue?.
@@ -9610,6 +9628,51 @@ namespace XenAdmin {
         public static string CONVERSION_VM_PAGE_TITLE {
             get {
                 return ResourceManager.GetString("CONVERSION_VM_PAGE_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Obtaining an IP address for the Conversion Manager Virtual Appliance....
+        /// </summary>
+        public static string CONVERSION_VPX_OBTAIN_IP {
+            get {
+                return ResourceManager.GetString("CONVERSION_VPX_OBTAIN_IP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resuming the Conversion Manager Virtual Appliance....
+        /// </summary>
+        public static string CONVERSION_VPX_RESUME {
+            get {
+                return ResourceManager.GetString("CONVERSION_VPX_RESUME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starting the Conversion Manager Virtual Appliance....
+        /// </summary>
+        public static string CONVERSION_VPX_START {
+            get {
+                return ResourceManager.GetString("CONVERSION_VPX_START", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot deduce the power state of the Conversion Manager Virtual Appliance..
+        /// </summary>
+        public static string CONVERSION_VPX_UNKNOWN_POWER_STATE {
+            get {
+                return ResourceManager.GetString("CONVERSION_VPX_UNKNOWN_POWER_STATE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Un-pausing the Conversion Manager Virtual Appliance....
+        /// </summary>
+        public static string CONVERSION_VPX_UNPAUSE {
+            get {
+                return ResourceManager.GetString("CONVERSION_VPX_UNPAUSE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3256,6 +3256,12 @@ This action cannot be undone. Are you sure you want to continue?</value>
   <data name="CONVERSION_CANCEL_FAILURE" xml:space="preserve">
     <value>Cannot cancel the conversion. Please see logs for details.</value>
   </data>
+  <data name="CONVERSION_CANNOT_FIND_VPX" xml:space="preserve">
+    <value>Cannot find a Conversion Manager Virtual Appliance.</value>
+  </data>
+  <data name="CONVERSION_CANNOT_OBTAIN_VPX_IP" xml:space="preserve">
+    <value>Cannot obtain an IP address for the Conversion Manager Virtual Appliance.</value>
+  </data>
   <data name="CONVERSION_CONNECTING_VMWARE" xml:space="preserve">
     <value>Connecting to the VMware server...</value>
   </data>
@@ -3461,6 +3467,21 @@ This action cannot be undone. Are you sure you want to continue?</value>
   </data>
   <data name="CONVERSION_VM_PAGE_TITLE" xml:space="preserve">
     <value>Select the VMs to convert</value>
+  </data>
+  <data name="CONVERSION_VPX_OBTAIN_IP" xml:space="preserve">
+    <value>Obtaining an IP address for the Conversion Manager Virtual Appliance...</value>
+  </data>
+  <data name="CONVERSION_VPX_RESUME" xml:space="preserve">
+    <value>Resuming the Conversion Manager Virtual Appliance...</value>
+  </data>
+  <data name="CONVERSION_VPX_START" xml:space="preserve">
+    <value>Starting the Conversion Manager Virtual Appliance...</value>
+  </data>
+  <data name="CONVERSION_VPX_UNPAUSE" xml:space="preserve">
+    <value>Un-pausing the Conversion Manager Virtual Appliance...</value>
+  </data>
+  <data name="CONVERSION_VPX_UNKNOWN_POWER_STATE" xml:space="preserve">
+    <value>Cannot deduce the power state of the Conversion Manager Virtual Appliance.</value>
   </data>
   <data name="CONVERSION_WIZARD_TEXT" xml:space="preserve">
     <value>New Conversion</value>

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Actions\VM\VMSnapshotCreateAction.cs" />
     <Compile Include="Actions\VM\VMStartAction.cs" />
     <Compile Include="Actions\WLB\WlbRetrieveVmRecommendationsAction.cs" />
+    <Compile Include="Actions\XCM\ActivateConversionVpxAction.cs" />
     <Compile Include="Actions\ZipStatusReportAction.cs" />
     <Compile Include="Alerts\Types\Alert.cs" />
     <Compile Include="XCM\ConversionClient.cs" />


### PR DESCRIPTION
This moves the functionality of the conversion-plugin in XenCenter, and adds two enhancements: (1) allows starting the VPX from states other than halted and (2) allows obtaining an IP address if the VPX external network is on vif.device!=1 (because I noticed that on some occasions no IP was obtained even if the VPX had started).