### PR TITLE
Fix menu and dialog title inconsistencies for Snapshot schedules.

### DIFF
--- a/XenAdmin/Dialogs/ScheduledSnapshots/ScheduledSnapshotsDialog.resx
+++ b/XenAdmin/Dialogs/ScheduledSnapshots/ScheduledSnapshotsDialog.resx
@@ -1054,7 +1054,7 @@
     <value>12, 12, 12, 12</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Snapshot Schedules</value>
+    <value>VM Snapshot Schedules</value>
   </data>
   <data name="&gt;&gt;ColumnName.Name" xml:space="preserve">
     <value>ColumnName</value>

--- a/XenAdmin/Wizards/NewPolicyWizard/NewPolicySnapshotTypePage.Designer.cs
+++ b/XenAdmin/Wizards/NewPolicyWizard/NewPolicySnapshotTypePage.Designer.cs
@@ -83,7 +83,7 @@ namespace XenAdmin.Wizards.NewPolicyWizard
             // 
             // pictureBoxWarning
             // 
-            this.pictureBoxWarning.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            this.pictureBoxWarning.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
             resources.ApplyResources(this.pictureBoxWarning, "pictureBoxWarning");
             this.pictureBoxWarning.Name = "pictureBoxWarning";
             this.pictureBoxWarning.TabStop = false;

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -37956,7 +37956,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Snapsh&amp;ot Schedules....
+        ///   Looks up a localized string similar to VM Snapsh&amp;ot Schedules....
         /// </summary>
         public static string VMSS_CONTEXT_MENU {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12891,7 +12891,7 @@ To start a [XenServer] trial, click the button below.</value>
     <value>{0}. {1}: {2}</value>
   </data>
   <data name="VMSS_CONTEXT_MENU" xml:space="preserve">
-    <value>Snapsh&amp;ot Schedules...</value>
+    <value>VM Snapsh&amp;ot Schedules...</value>
   </data>
   <data name="VMSS_EMAIL_CHECKBOX_TEXT" xml:space="preserve">
     <value>Send &amp;email notifications about snapshot schedule job alerts</value>


### PR DESCRIPTION
Also, use an info (instead of warning) icon on the message for Disk and memory snapshot

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>