### PR TITLE
CP-32070: Fix icon visibility + some improvements

### DIFF
--- a/XenAdmin/Commands/Controls/AssignVMGroupToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/AssignVMGroupToolStripMenuItem.cs
@@ -68,9 +68,6 @@ namespace XenAdmin.Commands
 
             T[] groups = VMGroup<T>.GroupsInCache(Command.GetSelection()[0].Connection.Cache);
 
-            if (groups.Length > 0)
-                base.DropDownItems.Add(new ToolStripSeparator());
-
             Array.Sort(groups);
 
             for (int index = 0, offset = 0; index < groups.Length; index++)
@@ -101,6 +98,8 @@ namespace XenAdmin.Commands
                     itemGroup.Checked = true;
                 base.DropDownItems.Add(itemGroup);
             }
+            if (base.DropDownItems.Count > 1)
+                base.DropDownItems.Insert(1, new ToolStripSeparator());
         }
 
         [Browsable(false)]

--- a/XenAdmin/Dialogs/VmSnapshotDialog.Designer.cs
+++ b/XenAdmin/Dialogs/VmSnapshotDialog.Designer.cs
@@ -28,34 +28,31 @@ namespace XenAdmin.Dialogs
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(VmSnapshotDialog));
             this.labelName = new System.Windows.Forms.Label();
             this.textBoxName = new System.Windows.Forms.TextBox();
-            this.buttonCancel = new System.Windows.Forms.Button();
-            this.buttonOk = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this.textBoxDescription = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.buttonOk = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
-            this.memoryRadioButton = new System.Windows.Forms.RadioButton();
-            this.CheckpointInfoPictureBox = new System.Windows.Forms.PictureBox();
-            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
-            this.quiesceCheckBox = new System.Windows.Forms.CheckBox();
-            this.pictureBoxQuiesceInfo = new System.Windows.Forms.PictureBox();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.labelCheckpointInfo = new System.Windows.Forms.Label();
+            this.labelQuiesceInfo = new System.Windows.Forms.Label();
+            this.labelSnapshotInfo = new System.Windows.Forms.Label();
             this.diskRadioButton = new System.Windows.Forms.RadioButton();
+            this.quiesceCheckBox = new System.Windows.Forms.CheckBox();
+            this.memoryRadioButton = new System.Windows.Forms.RadioButton();
             this.pictureBoxSnapshotsInfo = new System.Windows.Forms.PictureBox();
-            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.CheckpointInfoPictureBox = new System.Windows.Forms.PictureBox();
+            this.pictureBoxQuiesceInfo = new System.Windows.Forms.PictureBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
-            this.flowLayoutPanel3.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.CheckpointInfoPictureBox)).BeginInit();
-            this.flowLayoutPanel2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxQuiesceInfo)).BeginInit();
-            this.flowLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSnapshotsInfo)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.CheckpointInfoPictureBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxQuiesceInfo)).BeginInit();
             this.SuspendLayout();
             // 
             // labelName
@@ -65,9 +62,40 @@ namespace XenAdmin.Dialogs
             // 
             // textBoxName
             // 
+            this.tableLayoutPanel1.SetColumnSpan(this.textBoxName, 2);
             resources.ApplyResources(this.textBoxName, "textBoxName");
             this.textBoxName.Name = "textBoxName";
             this.textBoxName.TextChanged += new System.EventHandler(this.textBoxName_TextChanged);
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
+            // 
+            // textBoxDescription
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.textBoxDescription, 2);
+            resources.ApplyResources(this.textBoxDescription, "textBoxDescription");
+            this.textBoxDescription.Name = "textBoxDescription";
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.buttonOk, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.labelName, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.buttonCancel, 2, 3);
+            this.tableLayoutPanel1.Controls.Add(this.textBoxName, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.textBoxDescription, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 2);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // buttonOk
+            // 
+            resources.ApplyResources(this.buttonOk, "buttonOk");
+            this.buttonOk.Name = "buttonOk";
+            this.buttonOk.UseVisualStyleBackColor = true;
+            this.buttonOk.Click += new System.EventHandler(this.buttonOk_Click);
             // 
             // buttonCancel
             // 
@@ -77,117 +105,93 @@ namespace XenAdmin.Dialogs
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
             // 
-            // buttonOk
-            // 
-            resources.ApplyResources(this.buttonOk, "buttonOk");
-            this.buttonOk.Name = "buttonOk";
-            this.buttonOk.UseVisualStyleBackColor = true;
-            this.buttonOk.Click += new System.EventHandler(this.buttonOk_Click);
-            // 
-            // label1
-            // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
-            // 
-            // textBoxDescription
-            // 
-            resources.ApplyResources(this.textBoxDescription, "textBoxDescription");
-            this.textBoxDescription.Name = "textBoxDescription";
-            // 
-            // tableLayoutPanel1
-            // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.labelName, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.textBoxName, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.textBoxDescription, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 2);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
             // groupBox1
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.groupBox1, 2);
-            this.groupBox1.Controls.Add(this.flowLayoutPanel3);
-            this.groupBox1.Controls.Add(this.flowLayoutPanel2);
-            this.groupBox1.Controls.Add(this.flowLayoutPanel1);
             resources.ApplyResources(this.groupBox1, "groupBox1");
+            this.tableLayoutPanel1.SetColumnSpan(this.groupBox1, 3);
+            this.groupBox1.Controls.Add(this.tableLayoutPanel2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.TabStop = false;
             // 
-            // flowLayoutPanel3
+            // tableLayoutPanel2
             // 
-            resources.ApplyResources(this.flowLayoutPanel3, "flowLayoutPanel3");
-            this.flowLayoutPanel3.Controls.Add(this.memoryRadioButton);
-            this.flowLayoutPanel3.Controls.Add(this.CheckpointInfoPictureBox);
-            this.flowLayoutPanel3.Name = "flowLayoutPanel3";
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this.labelCheckpointInfo, 2, 5);
+            this.tableLayoutPanel2.Controls.Add(this.labelQuiesceInfo, 2, 3);
+            this.tableLayoutPanel2.Controls.Add(this.labelSnapshotInfo, 2, 1);
+            this.tableLayoutPanel2.Controls.Add(this.diskRadioButton, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.quiesceCheckBox, 1, 2);
+            this.tableLayoutPanel2.Controls.Add(this.memoryRadioButton, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.pictureBoxSnapshotsInfo, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.CheckpointInfoPictureBox, 1, 5);
+            this.tableLayoutPanel2.Controls.Add(this.pictureBoxQuiesceInfo, 1, 3);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
-            // memoryRadioButton
+            // labelCheckpointInfo
             // 
-            resources.ApplyResources(this.memoryRadioButton, "memoryRadioButton");
-            this.memoryRadioButton.Name = "memoryRadioButton";
-            this.memoryRadioButton.TabStop = true;
-            this.memoryRadioButton.UseVisualStyleBackColor = true;
-            this.memoryRadioButton.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
+            resources.ApplyResources(this.labelCheckpointInfo, "labelCheckpointInfo");
+            this.labelCheckpointInfo.Name = "labelCheckpointInfo";
             // 
-            // CheckpointInfoPictureBox
+            // labelQuiesceInfo
             // 
-            this.CheckpointInfoPictureBox.Cursor = System.Windows.Forms.Cursors.Hand;
-            resources.ApplyResources(this.CheckpointInfoPictureBox, "CheckpointInfoPictureBox");
-            this.CheckpointInfoPictureBox.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
-            this.CheckpointInfoPictureBox.Name = "CheckpointInfoPictureBox";
-            this.CheckpointInfoPictureBox.TabStop = false;
-            this.CheckpointInfoPictureBox.MouseLeave += new System.EventHandler(this.CheckpointInfoPictureBox_MouseLeave);
-            this.CheckpointInfoPictureBox.Click += new System.EventHandler(this.CheckpointInfoPictureBox_Click);
+            resources.ApplyResources(this.labelQuiesceInfo, "labelQuiesceInfo");
+            this.labelQuiesceInfo.Name = "labelQuiesceInfo";
             // 
-            // flowLayoutPanel2
+            // labelSnapshotInfo
             // 
-            resources.ApplyResources(this.flowLayoutPanel2, "flowLayoutPanel2");
-            this.flowLayoutPanel2.Controls.Add(this.quiesceCheckBox);
-            this.flowLayoutPanel2.Controls.Add(this.pictureBoxQuiesceInfo);
-            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            // 
-            // quiesceCheckBox
-            // 
-            resources.ApplyResources(this.quiesceCheckBox, "quiesceCheckBox");
-            this.quiesceCheckBox.Name = "quiesceCheckBox";
-            this.quiesceCheckBox.UseVisualStyleBackColor = true;
-            this.quiesceCheckBox.CheckedChanged += new System.EventHandler(this.quiesceCheckBox_CheckedChanged);
-            // 
-            // pictureBoxQuiesceInfo
-            // 
-            this.pictureBoxQuiesceInfo.Cursor = System.Windows.Forms.Cursors.Hand;
-            resources.ApplyResources(this.pictureBoxQuiesceInfo, "pictureBoxQuiesceInfo");
-            this.pictureBoxQuiesceInfo.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
-            this.pictureBoxQuiesceInfo.Name = "pictureBoxQuiesceInfo";
-            this.pictureBoxQuiesceInfo.TabStop = false;
-            this.pictureBoxQuiesceInfo.MouseLeave += new System.EventHandler(this.pictureBoxQuiesceInfo_MouseLeave);
-            this.pictureBoxQuiesceInfo.Click += new System.EventHandler(this.pictureBoxQuiesceInfo_Click);
-            // 
-            // flowLayoutPanel1
-            // 
-            resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
-            this.flowLayoutPanel1.Controls.Add(this.diskRadioButton);
-            this.flowLayoutPanel1.Controls.Add(this.pictureBoxSnapshotsInfo);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            resources.ApplyResources(this.labelSnapshotInfo, "labelSnapshotInfo");
+            this.labelSnapshotInfo.Name = "labelSnapshotInfo";
             // 
             // diskRadioButton
             // 
             resources.ApplyResources(this.diskRadioButton, "diskRadioButton");
             this.diskRadioButton.Checked = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.diskRadioButton, 3);
             this.diskRadioButton.Name = "diskRadioButton";
             this.diskRadioButton.TabStop = true;
             this.diskRadioButton.UseVisualStyleBackColor = true;
             this.diskRadioButton.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
             // 
+            // quiesceCheckBox
+            // 
+            resources.ApplyResources(this.quiesceCheckBox, "quiesceCheckBox");
+            this.tableLayoutPanel2.SetColumnSpan(this.quiesceCheckBox, 2);
+            this.quiesceCheckBox.Name = "quiesceCheckBox";
+            this.quiesceCheckBox.UseVisualStyleBackColor = true;
+            this.quiesceCheckBox.CheckedChanged += new System.EventHandler(this.quiesceCheckBox_CheckedChanged);
+            // 
+            // memoryRadioButton
+            // 
+            resources.ApplyResources(this.memoryRadioButton, "memoryRadioButton");
+            this.tableLayoutPanel2.SetColumnSpan(this.memoryRadioButton, 3);
+            this.memoryRadioButton.Name = "memoryRadioButton";
+            this.memoryRadioButton.TabStop = true;
+            this.memoryRadioButton.UseVisualStyleBackColor = true;
+            this.memoryRadioButton.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
+            // 
             // pictureBoxSnapshotsInfo
             // 
-            this.pictureBoxSnapshotsInfo.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.pictureBoxSnapshotsInfo.Cursor = System.Windows.Forms.Cursors.Default;
             resources.ApplyResources(this.pictureBoxSnapshotsInfo, "pictureBoxSnapshotsInfo");
             this.pictureBoxSnapshotsInfo.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
             this.pictureBoxSnapshotsInfo.Name = "pictureBoxSnapshotsInfo";
             this.pictureBoxSnapshotsInfo.TabStop = false;
-            this.pictureBoxSnapshotsInfo.MouseLeave += new System.EventHandler(this.pictureBoxSnapshotsInfo_MouseLeave);
-            this.pictureBoxSnapshotsInfo.Click += new System.EventHandler(this.pictureBoxSnapshotsInfo_Click);
+            // 
+            // CheckpointInfoPictureBox
+            // 
+            this.CheckpointInfoPictureBox.Cursor = System.Windows.Forms.Cursors.Default;
+            resources.ApplyResources(this.CheckpointInfoPictureBox, "CheckpointInfoPictureBox");
+            this.CheckpointInfoPictureBox.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
+            this.CheckpointInfoPictureBox.Name = "CheckpointInfoPictureBox";
+            this.CheckpointInfoPictureBox.TabStop = false;
+            // 
+            // pictureBoxQuiesceInfo
+            // 
+            this.pictureBoxQuiesceInfo.Cursor = System.Windows.Forms.Cursors.Default;
+            resources.ApplyResources(this.pictureBoxQuiesceInfo, "pictureBoxQuiesceInfo");
+            this.pictureBoxQuiesceInfo.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
+            this.pictureBoxQuiesceInfo.Name = "pictureBoxQuiesceInfo";
+            this.pictureBoxQuiesceInfo.TabStop = false;
             // 
             // VmSnapshotDialog
             // 
@@ -195,8 +199,6 @@ namespace XenAdmin.Dialogs
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.buttonCancel;
-            this.Controls.Add(this.buttonCancel);
-            this.Controls.Add(this.buttonOk);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "VmSnapshotDialog";
             this.Load += new System.EventHandler(this.VmSnapshotDialog_Load);
@@ -204,16 +206,13 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel1.PerformLayout();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
-            this.flowLayoutPanel3.ResumeLayout(false);
-            this.flowLayoutPanel3.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.CheckpointInfoPictureBox)).EndInit();
-            this.flowLayoutPanel2.ResumeLayout(false);
-            this.flowLayoutPanel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxQuiesceInfo)).EndInit();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSnapshotsInfo)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.CheckpointInfoPictureBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxQuiesceInfo)).EndInit();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -221,21 +220,21 @@ namespace XenAdmin.Dialogs
 
         private System.Windows.Forms.Label labelName;
         private System.Windows.Forms.TextBox textBoxName;
-        private System.Windows.Forms.Button buttonCancel;
-        private System.Windows.Forms.Button buttonOk;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TextBox textBoxDescription;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel3;
         private System.Windows.Forms.RadioButton memoryRadioButton;
         private System.Windows.Forms.PictureBox CheckpointInfoPictureBox;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
         private System.Windows.Forms.CheckBox quiesceCheckBox;
         private System.Windows.Forms.PictureBox pictureBoxQuiesceInfo;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.RadioButton diskRadioButton;
         private System.Windows.Forms.PictureBox pictureBoxSnapshotsInfo;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Label labelCheckpointInfo;
+        private System.Windows.Forms.Label labelQuiesceInfo;
+        private System.Windows.Forms.Label labelSnapshotInfo;
+        private System.Windows.Forms.Button buttonOk;
+        private System.Windows.Forms.Button buttonCancel;
     }
 }

--- a/XenAdmin/Dialogs/VmSnapshotDialog.cs
+++ b/XenAdmin/Dialogs/VmSnapshotDialog.cs
@@ -46,37 +46,26 @@ namespace XenAdmin.Dialogs
         {
             InitializeComponent();
             _VM = vm;
+            UpdateWarnings();
             diskRadioButton.Enabled = _VM.allowed_operations.Contains(vm_operations.snapshot);
-            pictureBoxSnapshotsInfo.Visible = !diskRadioButton.Enabled;
+            pictureBoxSnapshotsInfo.Visible = labelSnapshotInfo.Visible = !diskRadioButton.Enabled;
             var quiesceAvailable = !Helpers.QuebecOrGreater(_VM.Connection);
             quiesceCheckBox.Visible = quiesceAvailable;
             quiesceCheckBox.Enabled = quiesceAvailable && _VM.allowed_operations.Contains(vm_operations.snapshot_with_quiesce) 
                 && !Helpers.FeatureForbidden(_VM, Host.RestrictVss);
-            pictureBoxQuiesceInfo.Visible = !quiesceCheckBox.Enabled;
+            pictureBoxQuiesceInfo.Visible = labelQuiesceInfo.Visible = quiesceAvailable && !quiesceCheckBox.Enabled;
             memoryRadioButton.Enabled = _VM.allowed_operations.Contains(vm_operations.checkpoint)
                 && !Helpers.FeatureForbidden(_VM, Host.RestrictCheckpoint);
-            CheckpointInfoPictureBox.Visible = !memoryRadioButton.Enabled;
+            CheckpointInfoPictureBox.Visible = labelCheckpointInfo.Visible = !memoryRadioButton.Enabled;
             UpdateOK();
         }
 
         /// <summary>
         /// Must be accessed on the GUI thread.
         /// </summary>
-        public string SnapshotName
-        {
-            get
-            {
-                return textBoxName.Text;
-            }
-        }
+        public string SnapshotName => textBoxName.Text;
 
-        public string SnapshotDescription
-        {
-            get
-            {
-                return textBoxDescription.Text;
-            }
-        }
+        public string SnapshotDescription => textBoxDescription.Text;
 
         public SnapshotType SnapshotType
         {
@@ -84,23 +73,22 @@ namespace XenAdmin.Dialogs
             {
                 if (quiesceCheckBox.Checked)
                     return SnapshotType.QUIESCED_DISK;
-                else if (diskRadioButton.Checked)
+                if (diskRadioButton.Checked)
                     return SnapshotType.DISK;
-                else
-                    return SnapshotType.DISK_AND_MEMORY;
+                return SnapshotType.DISK_AND_MEMORY;
             }
         }
 
         private void buttonOk_Click(object sender, EventArgs e)
         {
-            this.DialogResult = DialogResult.OK;
-            this.Close();
+            DialogResult = DialogResult.OK;
+            Close();
         }
 
         private void buttonCancel_Click(object sender, EventArgs e)
         {
-            this.DialogResult = DialogResult.Cancel;
-            this.Close();
+            DialogResult = DialogResult.Cancel;
+            Close();
         }
 
         private void textBoxName_TextChanged(object sender, EventArgs e)
@@ -110,7 +98,7 @@ namespace XenAdmin.Dialogs
 
         private void UpdateOK()
         {
-            buttonOk.Enabled = !String.IsNullOrEmpty(textBoxName.Text.Trim())&&(diskRadioButton.Enabled ||quiesceCheckBox.Enabled||memoryRadioButton.Enabled );
+            buttonOk.Enabled = !String.IsNullOrEmpty(textBoxName.Text.Trim()) && (diskRadioButton.Enabled || quiesceCheckBox.Enabled || memoryRadioButton.Enabled );
         }
 
         private void RadioButton_CheckedChanged(object sender, EventArgs e)
@@ -143,54 +131,29 @@ namespace XenAdmin.Dialogs
             }
         }
 
-        private void pictureBoxQuiesceInfo_Click(object sender, EventArgs e)
+        private void UpdateWarnings()
         {
-            string tt;
+            labelSnapshotInfo.Text = Messages.INFO_DISK_MODE;
+
             if (Helpers.FeatureForbidden(_VM, Host.RestrictVss))
-                tt = Messages.FIELD_DISABLED;
+                labelQuiesceInfo.Text = Messages.FIELD_DISABLED;
             else if (_VM.power_state != vm_power_state.Running)
-                tt = Messages.INFO_QUIESCE_MODE_POWER_STATE.Replace("\\n", "\n");
+                labelQuiesceInfo.Text = Messages.INFO_QUIESCE_MODE_POWER_STATE;
             else if (!_VM.GetVirtualisationStatus().HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED))
-                tt = (_VM.HasNewVirtualisationStates() ? Messages.INFO_QUIESCE_MODE_NO_MGMNT : Messages.INFO_QUIESCE_MODE_NO_TOOLS).Replace("\\n", "\n");
+                labelQuiesceInfo.Text = _VM.HasNewVirtualisationStates()
+                    ? Messages.INFO_QUIESCE_MODE_NO_MGMNT
+                    : Messages.INFO_QUIESCE_MODE_NO_TOOLS;
             else
-                tt = Messages.INFO_QUIESCE_MODE.Replace("\\n","\n");  // This says that VSS must be enabled. This is a guess, because we can't tell whether it is or not.
-            toolTip.Show(tt ,pictureBoxQuiesceInfo, 20, 0);
-        }
+                labelQuiesceInfo.Text = Messages.INFO_QUIESCE_MODE; // This says that VSS must be enabled. This is a guess, because we can't tell whether it is or not.
 
-        private void pictureBoxQuiesceInfo_MouseLeave(object sender, EventArgs e)
-        {
-            toolTip.Hide(pictureBoxQuiesceInfo);
-        }
-
-        private void pictureBoxSnapshotsInfo_Click(object sender, EventArgs e)
-        {
-            toolTip.Show(Messages.INFO_DISK_MODE.Replace("\\n","\n"), pictureBoxSnapshotsInfo, 20, 0);
-        }
-
-        private void pictureBoxSnapshotsInfo_MouseLeave(object sender, EventArgs e)
-        {
-            toolTip.Hide(pictureBoxSnapshotsInfo);
-        }
-
-        private void CheckpointInfoPictureBox_Click(object sender, EventArgs e)
-        {
-            string tt;
             if (Helpers.FeatureForbidden(_VM, Host.RestrictCheckpoint))
-                tt = Messages.FIELD_DISABLED;
+                labelCheckpointInfo.Text = Messages.FIELD_DISABLED;
             else if (_VM.power_state != vm_power_state.Running)
-                tt = Messages.INFO_DISKMEMORY_MODE_POWER_STATE.Replace("\\n", "\n");
+                labelCheckpointInfo.Text = Messages.INFO_DISKMEMORY_MODE_POWER_STATE;
             else if (!_VM.GetVirtualisationStatus().HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
-                tt = (_VM.HasNewVirtualisationStates() ? Messages.INFO_DISKMEMORY_MODE_NO_IO_DRIVERS : Messages.INFO_DISKMEMORY_MODE_NO_TOOLS).Replace("\\n", "\n");
+                labelCheckpointInfo.Text = (_VM.HasNewVirtualisationStates() ? Messages.INFO_DISKMEMORY_MODE_NO_IO_DRIVERS : Messages.INFO_DISKMEMORY_MODE_NO_TOOLS);
             else
-                tt = Messages.INFO_DISKMEMORY_MODE_MISC.Replace("\\n", "\n");
-            toolTip.Show(tt, CheckpointInfoPictureBox, 20, 0);
+                labelCheckpointInfo.Text = Messages.INFO_DISKMEMORY_MODE_MISC;
         }
-
-        private void CheckpointInfoPictureBox_MouseLeave(object sender, EventArgs e)
-        {
-            toolTip.Hide(CheckpointInfoPictureBox);
-        }
-
-
     }
 }

--- a/XenAdmin/Dialogs/VmSnapshotDialog.resx
+++ b/XenAdmin/Dialogs/VmSnapshotDialog.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelName.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="labelName.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -148,76 +148,25 @@
     <value>labelName</value>
   </data>
   <data name="&gt;&gt;labelName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelName.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelName.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="textBoxName.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="textBoxName.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="textBoxName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>123, 13</value>
-  </data>
-  <data name="textBoxName.MaxLength" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="textBoxName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>332, 23</value>
-  </data>
-  <data name="textBoxName.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;textBoxName.Name" xml:space="preserve">
-    <value>textBoxName</value>
+  <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;textBoxName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <data name="&gt;&gt;textBoxName.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;textBoxName.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="buttonCancel.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>383, 227</value>
-  </data>
-  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="buttonCancel.Text" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="&gt;&gt;buttonCancel.Name" xml:space="preserve">
-    <value>buttonCancel</value>
-  </data>
-  <data name="&gt;&gt;buttonCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonCancel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
   <data name="buttonOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+    <value>Top, Right</value>
   </data>
   <data name="buttonOk.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -225,8 +174,14 @@
   <data name="buttonOk.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
+  <data name="buttonOk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="buttonOk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>275, 227</value>
+    <value>296, 268</value>
+  </data>
+  <data name="buttonOk.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 10, 3, 3</value>
   </data>
   <data name="buttonOk.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 23</value>
@@ -241,13 +196,49 @@
     <value>buttonOk</value>
   </data>
   <data name="&gt;&gt;buttonOk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;buttonOk.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;buttonOk.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
+  </data>
+  <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="buttonCancel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>405, 268</value>
+  </data>
+  <data name="buttonCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 10, 3, 3</value>
+  </data>
+  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="buttonCancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Name" xml:space="preserve">
+    <value>buttonCancel</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -277,13 +268,13 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="textBoxDescription.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -301,7 +292,7 @@
     <value>True</value>
   </data>
   <data name="textBoxDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>332, 44</value>
+    <value>357, 44</value>
   </data>
   <data name="textBoxDescription.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -310,429 +301,135 @@
     <value>textBoxDescription</value>
   </data>
   <data name="&gt;&gt;textBoxDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;textBoxDescription.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;textBoxDescription.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
-  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="tableLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>10, 10, 10, 10</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>468, 208</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelName" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxName" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxDescription" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="groupBox1" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,110,Percent,100" /&gt;&lt;Rows Styles="Absolute,28,Absolute,50,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Name" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Name" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="groupBox1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 88</value>
-  </data>
-  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 110</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="groupBox1.Text" xml:space="preserve">
-    <value>Snapshot mode</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="flowLayoutPanel3.AutoSize" type="System.Boolean, mscorlib">
+  <data name="groupBox1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;memoryRadioButton.Name" xml:space="preserve">
-    <value>memoryRadioButton</value>
+  <data name="groupBox1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <data name="&gt;&gt;memoryRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;memoryRadioButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
+  <data name="tableLayoutPanel2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <data name="&gt;&gt;memoryRadioButton.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.Name" xml:space="preserve">
-    <value>CheckpointInfoPictureBox</value>
+  <data name="labelCheckpointInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="labelCheckpointInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="flowLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="flowLayoutPanel3.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="labelCheckpointInfo.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <data name="flowLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 71</value>
+  <data name="labelCheckpointInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="flowLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 25</value>
+  <data name="labelCheckpointInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>45, 122</value>
   </data>
-  <data name="flowLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
+  <data name="labelCheckpointInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="labelCheckpointInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>412, 16</value>
+  </data>
+  <data name="labelCheckpointInfo.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Name" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
+  <data name="&gt;&gt;labelCheckpointInfo.Name" xml:space="preserve">
+    <value>labelCheckpointInfo</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;labelCheckpointInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="&gt;&gt;labelCheckpointInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel3.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;labelCheckpointInfo.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="memoryRadioButton.AutoSize" type="System.Boolean, mscorlib">
+  <data name="labelQuiesceInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="memoryRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="memoryRadioButton.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="memoryRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="memoryRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="memoryRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>287, 19</value>
-  </data>
-  <data name="memoryRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="memoryRadioButton.Text" xml:space="preserve">
-    <value>Sn&amp;apshot the virtual machine's disks and memory</value>
-  </data>
-  <data name="&gt;&gt;memoryRadioButton.Name" xml:space="preserve">
-    <value>memoryRadioButton</value>
-  </data>
-  <data name="&gt;&gt;memoryRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryRadioButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;memoryRadioButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CheckpointInfoPictureBox.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="CheckpointInfoPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckpointInfoPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>296, 3</value>
-  </data>
-  <data name="CheckpointInfoPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 16</value>
-  </data>
-  <data name="CheckpointInfoPictureBox.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.Name" xml:space="preserve">
-    <value>CheckpointInfoPictureBox</value>
-  </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;CheckpointInfoPictureBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="flowLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;quiesceCheckBox.Name" xml:space="preserve">
-    <value>quiesceCheckBox</value>
-  </data>
-  <data name="&gt;&gt;quiesceCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;quiesceCheckBox.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;quiesceCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.Name" xml:space="preserve">
-    <value>pictureBoxQuiesceInfo</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="flowLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="flowLayoutPanel2.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="flowLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 46</value>
-  </data>
-  <data name="flowLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>25, 3, 3, 3</value>
-  </data>
-  <data name="flowLayoutPanel2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>15, 0, 0, 0</value>
-  </data>
-  <data name="flowLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 25</value>
-  </data>
-  <data name="flowLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Name" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="quiesceCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="quiesceCheckBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="labelQuiesceInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="quiesceCheckBox.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="labelQuiesceInfo.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <data name="quiesceCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="labelQuiesceInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="quiesceCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 3</value>
+  <data name="labelQuiesceInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>45, 75</value>
   </data>
-  <data name="quiesceCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>339, 19</value>
+  <data name="labelQuiesceInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="quiesceCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="labelQuiesceInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>412, 16</value>
   </data>
-  <data name="quiesceCheckBox.Text" xml:space="preserve">
-    <value>&amp;Quiesce the VM before taking the snapshot (Windows only)</value>
+  <data name="labelQuiesceInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
   </data>
-  <data name="&gt;&gt;quiesceCheckBox.Name" xml:space="preserve">
-    <value>quiesceCheckBox</value>
+  <data name="&gt;&gt;labelQuiesceInfo.Name" xml:space="preserve">
+    <value>labelQuiesceInfo</value>
   </data>
-  <data name="&gt;&gt;quiesceCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;labelQuiesceInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;quiesceCheckBox.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
+  <data name="&gt;&gt;labelQuiesceInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;quiesceCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="pictureBoxQuiesceInfo.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="pictureBoxQuiesceInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="pictureBoxQuiesceInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>363, 3</value>
-  </data>
-  <data name="pictureBoxQuiesceInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 16</value>
-  </data>
-  <data name="pictureBoxQuiesceInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.Name" xml:space="preserve">
-    <value>pictureBoxQuiesceInfo</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxQuiesceInfo.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;labelQuiesceInfo.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="flowLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+  <data name="labelSnapshotInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;diskRadioButton.Name" xml:space="preserve">
-    <value>diskRadioButton</value>
+  <data name="labelSnapshotInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="&gt;&gt;diskRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;diskRadioButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;diskRadioButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxSnapshotsInfo.Name" xml:space="preserve">
-    <value>pictureBoxSnapshotsInfo</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxSnapshotsInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxSnapshotsInfo.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;pictureBoxSnapshotsInfo.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="flowLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="labelSnapshotInfo.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 21</value>
+  <data name="labelSnapshotInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 25</value>
+  <data name="labelSnapshotInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>45, 28</value>
   </data>
-  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+  <data name="labelSnapshotInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="labelSnapshotInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>412, 16</value>
+  </data>
+  <data name="labelSnapshotInfo.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
+  <data name="&gt;&gt;labelSnapshotInfo.Name" xml:space="preserve">
+    <value>labelSnapshotInfo</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;labelSnapshotInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="&gt;&gt;labelSnapshotInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;labelSnapshotInfo.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="diskRadioButton.AutoSize" type="System.Boolean, mscorlib">
@@ -751,7 +448,7 @@
     <value>3, 3</value>
   </data>
   <data name="diskRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 19</value>
+    <value>454, 19</value>
   </data>
   <data name="diskRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -763,13 +460,85 @@
     <value>diskRadioButton</value>
   </data>
   <data name="&gt;&gt;diskRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;diskRadioButton.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
+    <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;diskRadioButton.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
+  </data>
+  <data name="quiesceCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="quiesceCheckBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="quiesceCheckBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="quiesceCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="quiesceCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 50</value>
+  </data>
+  <data name="quiesceCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>434, 19</value>
+  </data>
+  <data name="quiesceCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="quiesceCheckBox.Text" xml:space="preserve">
+    <value>&amp;Quiesce the VM before taking the snapshot (Windows only)</value>
+  </data>
+  <data name="&gt;&gt;quiesceCheckBox.Name" xml:space="preserve">
+    <value>quiesceCheckBox</value>
+  </data>
+  <data name="&gt;&gt;quiesceCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;quiesceCheckBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;quiesceCheckBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="memoryRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="memoryRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="memoryRadioButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="memoryRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="memoryRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 97</value>
+  </data>
+  <data name="memoryRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>454, 19</value>
+  </data>
+  <data name="memoryRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="memoryRadioButton.Text" xml:space="preserve">
+    <value>Sn&amp;apshot the virtual machine's disks and memory</value>
+  </data>
+  <data name="&gt;&gt;memoryRadioButton.Name" xml:space="preserve">
+    <value>memoryRadioButton</value>
+  </data>
+  <data name="&gt;&gt;memoryRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;memoryRadioButton.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="pictureBoxSnapshotsInfo.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -778,7 +547,7 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBoxSnapshotsInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>225, 3</value>
+    <value>23, 28</value>
   </data>
   <data name="pictureBoxSnapshotsInfo.Size" type="System.Drawing.Size, System.Drawing">
     <value>16, 16</value>
@@ -790,40 +559,226 @@
     <value>pictureBoxSnapshotsInfo</value>
   </data>
   <data name="&gt;&gt;pictureBoxSnapshotsInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBoxSnapshotsInfo.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
+    <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;pictureBoxSnapshotsInfo.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="CheckpointInfoPictureBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="CheckpointInfoPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckpointInfoPictureBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 122</value>
+  </data>
+  <data name="CheckpointInfoPictureBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="CheckpointInfoPictureBox.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;CheckpointInfoPictureBox.Name" xml:space="preserve">
+    <value>CheckpointInfoPictureBox</value>
+  </data>
+  <data name="&gt;&gt;CheckpointInfoPictureBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckpointInfoPictureBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;CheckpointInfoPictureBox.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="pictureBoxQuiesceInfo.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="pictureBoxQuiesceInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBoxQuiesceInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 75</value>
+  </data>
+  <data name="pictureBoxQuiesceInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBoxQuiesceInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxQuiesceInfo.Name" xml:space="preserve">
+    <value>pictureBoxQuiesceInfo</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxQuiesceInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxQuiesceInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxQuiesceInfo.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="tableLayoutPanel2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 21</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>460, 141</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelCheckpointInfo" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="labelQuiesceInfo" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="labelSnapshotInfo" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="diskRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="quiesceCheckBox" Row="2" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="memoryRadioButton" Row="4" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="pictureBoxSnapshotsInfo" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="CheckpointInfoPictureBox" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pictureBoxQuiesceInfo" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,20,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="groupBox1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 88</value>
+  </data>
+  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 3, 0</value>
+  </data>
+  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 5, 5, 8</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>470, 170</value>
+  </data>
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>Snapshot mode</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 10, 10, 10</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>493, 300</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="buttonOk" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelName" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonCancel" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="textBoxName" Row="0" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxDescription" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="groupBox1" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,110,Percent,100,AutoSize,20" /&gt;&lt;Rows Styles="Absolute,28,Absolute,50,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="textBoxName.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="textBoxName.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="textBoxName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>123, 13</value>
+  </data>
+  <data name="textBoxName.MaxLength" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="textBoxName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>357, 23</value>
+  </data>
+  <data name="textBoxName.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="&gt;&gt;textBoxName.Name" xml:space="preserve">
+    <value>textBoxName</value>
+  </data>
+  <data name="&gt;&gt;textBoxName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBoxName.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;textBoxName.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>468, 263</value>
+    <value>493, 300</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>420, 260</value>
+    <value>420, 200</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Take Snapshot</value>
-  </data>
-  <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
-    <value>toolTip</value>
-  </data>
-  <data name="&gt;&gt;toolTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>VmSnapshotDialog</value>


### PR DESCRIPTION
- make the info messages icon+text instead of clickable icons. Some rearrangements of the controls on the dialog to accommodate them.
- in the "Assign To Snapshot Schedule" dropdown item, do not add a separator if there are no suitable policies listed.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>