### PR TITLE
CP-32033 Add PV guests precheck in Xencenter

### DIFF
--- a/XenAdmin/Diagnostics/Checks/PVGuestsCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PVGuestsCheck.cs
@@ -1,0 +1,60 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using XenAdmin.Core;
+using XenAPI;
+using XenAdmin.Diagnostics.Problems;
+using XenAdmin.Diagnostics.Problems.HostProblem;
+using System.Collections.Generic;
+
+namespace XenAdmin.Diagnostics.Checks
+{
+    class PVGuestsCheck : HostCheck
+    {
+        public PVGuestsCheck(Host host)
+            : base(host)
+        {
+        }
+        protected override Problem RunCheck()
+        {
+            //return new HostHasPVGuestWarning(this);
+            return new HostHasPVGuestWarningUrl(this);
+        }
+        public override string Description
+        {
+            get
+            {
+                return Messages.PV_GUESTS_CHECK_DESCRIPTION;
+            }
+        }
+
+    }
+}

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostHasPVGuest.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostHasPVGuest.cs
@@ -1,0 +1,82 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using XenAdmin.Diagnostics.Checks;
+using System;
+
+namespace XenAdmin.Diagnostics.Problems.HostProblem
+{
+    class HostHasPVGuestWarning : WarningWithMoreInfo
+    {
+        public HostHasPVGuestWarning(Check check)
+            : base(check)
+        {
+        }
+        public override string Title => Description;
+        public override string Description
+        {
+            get { return string.Format(Messages.HOST_HAS_PV_GUEST_WARNING); }
+        }
+        public override string Message
+        {
+            get { return string.Format(Messages.HOST_HAS_PV_GUEST_WARNING); }
+        }   
+    }
+   
+    class HostHasPVGuestWarningUrl : WarningWithInformationUrl
+    {
+        public HostHasPVGuestWarningUrl(Check check)
+            : base(check)
+        {  
+        }
+        private string PVGuestCheckUrl
+        {
+            get { return string.Format(InvisibleMessages.PV_GUESTS_CHECK_URL); }
+        }
+        public override Uri UriToLaunch
+        {
+            get { return new Uri(PVGuestCheckUrl); }
+        }
+        public override string Title => Description;
+        public override string Description
+        {
+            get { return string.Format(Messages.HOST_HAS_PV_GUEST_WARNING); }
+        }
+        public override string HelpMessage
+        {
+           get { return LinkText; }
+        }
+        public override string LinkText
+        {
+            get { return Messages.PATCHING_WIZARD_WEBPAGE_CELL; }
+        }  
+    }
+}

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -364,7 +364,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                     haChecks.Add(new HAOffCheck(host));
             }
             groups.Add(new CheckGroup(Messages.CHECKING_HA_STATUS, haChecks));
-
+ 
             //PBDsPluggedCheck
             var pbdChecks = new List<Check>();
             foreach (Host host in applicableServers)
@@ -469,6 +469,22 @@ namespace XenAdmin.Wizards.PatchingWizard
                 groups.Insert(0, new CheckGroup(Messages.CHECKING_XENCENTER_VERSION,
                     new List<Check> { new XenCenterVersionCheck(highestNewVersion ?? UpdateAlert.NewServerVersion) }));
             }
+
+            //PVGuestsCheck checks
+            var pvChecks = new List<Check>();
+            foreach (Host host in applicableServers.Where(h => !Helpers.QuebecOrGreater(h.Connection)))
+             {
+                if (host.GetPvVMs() != null && host.GetPvVMs().Count > 0)
+                {
+                    pvChecks.Add(new PVGuestsCheck(host)); 
+                    break;
+                }   
+            }
+             if (pvChecks.Count > 0)
+             {
+                 groups.Add(new CheckGroup(Messages.CHECKING_PV_GUESTS, pvChecks));
+             }
+            
 
             //GFS2 check for version updates
             if (WizardMode == WizardMode.NewVersion)

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -165,6 +165,21 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 groups.Add(new CheckGroup(Messages.CHECKING_XENCENTER_VERSION, new List<Check> {new XenCenterVersionCheck(null)}));
             }
 
+            //Checking PV guests - for hosts that have any PV guests and warn the user before the update/upgrade.
+            var pvChecks = new List<Check>();
+            foreach (Host host in hostsToUpgradeOrUpdate.Where(h => !Helpers.QuebecOrGreater(h.Connection)))
+            {
+                if (host.GetPvVMs() != null && host.GetPvVMs().Count > 0)
+                {
+                    pvChecks.Add(new PVGuestsCheck(host));
+                    break;
+                }
+            }
+            if (pvChecks.Count > 0)
+            {
+                groups.Add(new CheckGroup(Messages.CHECKING_PV_GUESTS, pvChecks));
+            }
+
             //HostMaintenanceModeCheck checks - for hosts that will be upgraded or updated
             var livenessChecks = new List<Check>();
             foreach (Host host in hostsToUpgradeOrUpdate)
@@ -199,6 +214,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             var haChecks = (from Host server in SelectedMasters
                 select new HAOffCheck(server) as Check).ToList();
             groups.Add(new CheckGroup(Messages.CHECKING_HA_STATUS, haChecks));
+       
 
             //Checking can evacuate host - for hosts that will be upgraded or updated
             var evacuateChecks = new List<Check>();

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Diagnostics\Checks\DiskSpaceForBatchUpdatesCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostCheck.cs" />
     <Compile Include="Diagnostics\Checks\PrepareToUpgradeCheck.cs" />
+    <Compile Include="Diagnostics\Checks\PVGuestsCheck.cs" />
     <Compile Include="Diagnostics\Checks\RebootPendingOnMasterCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostNeedsRebootCheck.cs" />
     <Compile Include="Diagnostics\Checks\SafeToUpgradeCheck.cs" />
@@ -233,6 +234,7 @@
     <Compile Include="Diagnostics\Checks\ServerSelectionCheck.cs" />
     <Compile Include="Diagnostics\Checks\XenCenterVersionCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostMemoryPostUpgradeCheck.cs" />
+    <Compile Include="Diagnostics\Problems\HostProblem\HostHasPVGuest.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostMemoryPostUpgradeWarning.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostPrepareToUpgradeProblem.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\LicenseRestrictionProblem.cs" />

--- a/XenModel/InvisibleMessages.Designer.cs
+++ b/XenModel/InvisibleMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InvisibleMessages {
@@ -237,6 +237,15 @@ namespace XenAdmin {
         public static string PRIVACY {
             get {
                 return ResourceManager.GetString("PRIVACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://docs.citrix.com/en-us/citrix-hypervisor/whats-new.html.
+        /// </summary>
+        public static string PV_GUESTS_CHECK_URL {
+            get {
+                return ResourceManager.GetString("PV_GUESTS_CHECK_URL", resourceCulture);
             }
         }
         

--- a/XenModel/InvisibleMessages.ja.resx
+++ b/XenModel/InvisibleMessages.ja.resx
@@ -168,6 +168,9 @@
   <data name="PRIVACY" xml:space="preserve">
     <value>http://citrix.com/English/aboutCitrix/legal/privacyStatement.asp?ntref=hp_nav_US</value>
   </data>
+  <data name="PV_GUESTS_CHECK_URL" xml:space="preserve">
+    <value>https://docs.citrix.com/en-us/citrix-hypervisor/whats-new.html</value>
+  </data>
   <data name="XEN_SEARCH" xml:space="preserve">
     <value>xensearch</value>
   </data>

--- a/XenModel/InvisibleMessages.resx
+++ b/XenModel/InvisibleMessages.resx
@@ -168,6 +168,9 @@
   <data name="PRIVACY" xml:space="preserve">
     <value>http://citrix.com/English/aboutCitrix/legal/privacyStatement.asp?ntref=hp_nav_US</value>
   </data>
+  <data name="PV_GUESTS_CHECK_URL" xml:space="preserve">
+    <value>https://docs.citrix.com/en-us/citrix-hypervisor/whats-new.html</value>
+  </data>
   <data name="XEN_SEARCH" xml:space="preserve">
     <value>xensearch</value>
   </data>

--- a/XenModel/InvisibleMessages.zh-CN.resx
+++ b/XenModel/InvisibleMessages.zh-CN.resx
@@ -168,6 +168,9 @@
   <data name="PRIVACY" xml:space="preserve">
     <value>http://citrix.com/English/aboutCitrix/legal/privacyStatement.asp?ntref=hp_nav_US</value>
   </data>
+  <data name="PV_GUESTS_CHECK_URL" xml:space="preserve">
+    <value>https://docs.citrix.com/en-us/citrix-hypervisor/whats-new.html</value>
+  </data>
   <data name="XEN_SEARCH" xml:space="preserve">
     <value>xensearch</value>
   </data>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -7200,6 +7200,15 @@ namespace XenAdmin {
         public static string CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION {
             get {
                 return ResourceManager.GetString("CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Checking PV guests on hosts.
+        /// </summary>
+        public static string CHECKING_PV_GUESTS {
+            get {
+                return ResourceManager.GetString("CHECKING_PV_GUESTS", resourceCulture);
             }
         }
         
@@ -18167,6 +18176,15 @@ namespace XenAdmin {
         public static string HOST_GONE {
             get {
                 return ResourceManager.GetString("HOST_GONE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If you are upgrading to [XenServer] 8.1.0 or higher, some PV OS templates will be removed..
+        /// </summary>
+        public static string HOST_HAS_PV_GUEST_WARNING {
+            get {
+                return ResourceManager.GetString("HOST_HAS_PV_GUEST_WARNING", resourceCulture);
             }
         }
         
@@ -29858,6 +29876,15 @@ namespace XenAdmin {
         public static string PV_DRIVERS_OUT_OF_DATE_UNKNOWN_VERSION {
             get {
                 return ResourceManager.GetString("PV_DRIVERS_OUT_OF_DATE_UNKNOWN_VERSION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PV guest check..
+        /// </summary>
+        public static string PV_GUESTS_CHECK_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("PV_GUESTS_CHECK_DESCRIPTION", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.ja.resx
+++ b/XenModel/Messages.ja.resx
@@ -6385,6 +6385,9 @@ VM の再起動優先度をクリアしてもよろしいですか?</value>
   <data name="HOST_GONE" xml:space="preserve">
     <value>[XenCenter] のキャッシュにホストが見つかりません。</value>
   </data>
+  <data name="HOST_HAS_PV_GUEST_WARNING" xml:space="preserve">
+    <value>[XenServer] 8.1.0 以降のバージョンにアクセスする必要がある場合、一部のPV OSモジュールは削除されます。</value>
+  </data>
   <data name="HOST_INTERNAL_MANAGEMENT_NETWORK" xml:space="preserve">
     <value>ホスト内部管理ネットワーク</value>
   </data>
@@ -10316,6 +10319,9 @@ VM が再起動したら、[[Citrix VM Tools] をインストール] を再度�
   </data>
   <data name="PROXY_SERVERS_NOT_SUPPORTED" xml:space="preserve">
     <value>プロキシ サーバーはサポートされません。</value>
+  </data>
+  <data name="PV_GUESTS_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>PV guest 检測定.</value>
   </data>
   <data name="PVS_CACHE_CONFIG_DIALOG_TITLE" xml:space="preserve">
     <value>PVS アクセラレータ構成 - '{0}'</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2607,6 +2607,9 @@ Do you want to assign it to the schedule '{2}' instead?</value>
   <data name="CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION" xml:space="preserve">
     <value>Host upgrade readiness check</value>
   </data>
+  <data name="CHECKING_PV_GUESTS" xml:space="preserve">
+    <value>Checking PV guests on hosts</value>
+  </data>
   <data name="CHECKING_ROLE" xml:space="preserve">
     <value>Checking role...</value>
   </data>
@@ -6379,6 +6382,9 @@ Click Configure HA to alter the settings displayed below.</value>
   </data>
   <data name="HOST_GONE" xml:space="preserve">
     <value>Could not find host in [XenCenter]'s cache.</value>
+  </data>
+  <data name="HOST_HAS_PV_GUEST_WARNING" xml:space="preserve">
+    <value>If you are upgrading to [XenServer] 8.1.0 or higher, some PV OS templates will be removed.</value>
   </data>
   <data name="HOST_INTERNAL_MANAGEMENT_NETWORK" xml:space="preserve">
     <value>Host internal management network</value>
@@ -10363,6 +10369,9 @@ Press OK to continue the wizard and return to the server and follow the instruct
   </data>
   <data name="PROXY_SERVERS_NOT_SUPPORTED" xml:space="preserve">
     <value>Proxy servers are not supported.</value>
+  </data>
+  <data name="PV_GUESTS_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>PV guest check.</value>
   </data>
   <data name="PVS_CACHE_CONFIG_DIALOG_TITLE" xml:space="preserve">
     <value>PVS-Accelerator configuration - '{0}'</value>

--- a/XenModel/Messages.zh-CN.resx
+++ b/XenModel/Messages.zh-CN.resx
@@ -6379,6 +6379,9 @@
   <data name="HOST_GONE" xml:space="preserve">
     <value>在 [XenCenter] 的缓存中找不到主机。</value>
   </data>
+  <data name="HOST_HAS_PV_GUEST_WARNING" xml:space="preserve">
+    <value>如果要升级到[XenServer] 8.1.0 或更高版本，某些PV OS模板将被删除。</value>
+  </data>
   <data name="HOST_INTERNAL_MANAGEMENT_NETWORK" xml:space="preserve">
     <value>主机内部管理网络</value>
   </data>
@@ -10314,6 +10317,9 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
   </data>
   <data name="PROXY_SERVERS_NOT_SUPPORTED" xml:space="preserve">
     <value>不支持代理服务器。</value>
+  </data>
+  <data name="PV_GUESTS_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>PV Guests 检测。</value>
   </data>
   <data name="PVS_CACHE_CONFIG_DIALOG_TITLE" xml:space="preserve">
     <value>PVS 加速器配置 - {0}</value>

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -866,6 +866,15 @@ namespace XenAPI
             return vms.ToList();
         }
 
+        public List<VM> GetPvVMs()
+        {
+            var vms = from VM vm in Connection.Cache.VMs
+                      where vm != null && vm.is_a_real_vm() && !vm.IsHVM() && !vm.other_config.ContainsKey("pvcheckpass")
+                      select vm;
+            
+            return vms.ToList();   
+        }
+
         public List<XenRef<VM>> GetRunningHvmVMs()
         {
             var vms = from XenRef<VM> vmref in resident_VMs


### PR DESCRIPTION
Signed-off-by: Xueqing Zhang <Xueqing.Zhang@citrix.com>

Add the PV guests pre-check in both Install update and RPU. This check will give a warning while host have pv guess.(host product version lower than Quebec)
The warning link is not ready yet , a likely link given for example.
The PV guests need to skip this check can add one key in vm.other_config named "pvcheckpass". 