### PR TITLE
CP-32033 Add PV guests precheck in Xencenter

### DIFF
--- a/XenAdmin/Diagnostics/Checks/PVGuestsCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PVGuestsCheck.cs
@@ -1,0 +1,86 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Linq;
+using XenAdmin.Core;
+using XenAPI;
+using XenAdmin.Diagnostics.Problems;
+using XenAdmin.Diagnostics.Problems.PoolProblem;
+using System.Collections.Generic;
+using System.Web.Script.Serialization;
+
+namespace XenAdmin.Diagnostics.Checks
+{
+    class PVGuestsCheck : HostPostLivenessCheck
+    {
+        private readonly Pool _pool;
+        private readonly bool _upgrade;
+        private readonly Dictionary<string, string> _installMethodConfig;
+        private readonly bool _manualUpgrade;
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        public PVGuestsCheck(Pool pool, bool upgrade, Dictionary<string, string> installMethodConfig = null, bool manualUpgrade = false)
+            : base(Helpers.GetMaster(pool.Connection))
+        {
+            _pool = pool;
+            _upgrade = upgrade;
+            _installMethodConfig = installMethodConfig;
+            _manualUpgrade = manualUpgrade;
+        }
+
+        protected override Problem RunHostCheck()
+        {
+            string upgradePlatformVersion;
+            if (!_pool.Connection.Cache.VMs.Any(vm => vm.IsPvVm()))
+                return null;
+            if (!_upgrade || _manualUpgrade)
+                return new PoolHasPVGuestWarningUrl(this, _pool, _upgrade);
+            try
+            {
+                var result = Host.call_plugin(Host.Connection.Session, Host.opaque_ref, "prepare_host_upgrade.py", "getVersion", _installMethodConfig);
+                var serializer = new JavaScriptSerializer();
+                var version = (Dictionary<string, object>)serializer.DeserializeObject(result);
+                upgradePlatformVersion = version.ContainsKey("platform-version") ? (string)version["platform-version"] : null;
+            }
+            catch (Exception exception)
+            {
+                log.WarnFormat("Plugin call prepare_host_upgrade.getVersion on {0} failed with {1}", Host.Name(), exception.Message);
+                return new PoolHasPVGuestWarningUrl(this, _pool, _upgrade);
+            }
+            if (Helpers.QuebecOrGreater(upgradePlatformVersion))
+                return new PoolHasPVGuestWarningUrl(this, _pool, _upgrade);
+            return null;
+        }
+
+        public override string Description => Messages.PV_GUESTS_CHECK_DESCRIPTION;
+    }
+}

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasPVGuestWarningUrl.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasPVGuestWarningUrl.cs
@@ -1,0 +1,57 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using XenAdmin.Diagnostics.Checks;
+using System;
+using XenAPI;
+
+namespace XenAdmin.Diagnostics.Problems.PoolProblem
+{
+    class PoolHasPVGuestWarningUrl : WarningWithInformationUrl
+    {
+        private readonly bool _upgrade;
+        private readonly Pool _pool;
+
+        public PoolHasPVGuestWarningUrl(Check check, Pool pool, bool upgrade)
+            : base(check)
+        {
+            _pool = pool;
+            _upgrade = upgrade;
+        }
+
+        private string PVGuestCheckUrl => string.Format(InvisibleMessages.PV_GUESTS_CHECK_URL);
+        public override Uri UriToLaunch => new Uri(PVGuestCheckUrl);
+        public override string Title => Description;
+        public override string Description => _upgrade ? string.Format(Messages.POOL_HAS_PV_GUEST_UPGRADE_WARNING, _pool.Name()) : string.Format(Messages.POOL_HAS_PV_GUEST_UPDATE_WARNING, _pool.Name());
+        public override string HelpMessage => LinkText;
+        public override string LinkText => Messages.LEARN_MORE;
+    }
+}

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -489,6 +489,19 @@ namespace XenAdmin.Wizards.PatchingWizard
                 
             }
 
+            //PVGuestsCheck checks
+            if (highestNewVersion != null || UpdateAlert?.NewServerVersion != null)
+            {
+                var pvChecks = new List<Check>();
+                foreach (var pool in SelectedPools.Where(p => Helpers.NaplesOrGreater(p.Connection)))
+                {
+                    if (pool.Connection.Resolve(pool.master) != null)
+                        pvChecks.Add(new PVGuestsCheck(pool, false));
+                }
+                if (pvChecks.Count > 0)
+                    groups.Add(new CheckGroup(Messages.CHECKING_PV_GUESTS, pvChecks));
+            }
+            
             return groups;
         }
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -234,6 +234,16 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 groups.Add(new CheckGroup(Messages.CHECKING_CLUSTERING_STATUS, gfs2Checks));
             }
 
+            //Checking PV guests - for hosts that have any PV guests and warn the user before the upgrade.
+            var pvChecks = new List<Check>();
+            foreach (Pool pool in SelectedPools.Where(p => !Helpers.QuebecOrGreater(p.Connection)))
+            {
+                if (pool.Connection.Resolve(pool.master) != null)
+                    pvChecks.Add(new PVGuestsCheck(pool, true, InstallMethodConfig, ManualUpgrade)); 
+            }
+            if (pvChecks.Count > 0)
+                groups.Add(new CheckGroup(Messages.CHECKING_PV_GUESTS, pvChecks));
+
             //Checking automated updates are possible if apply updates checkbox is ticked
             if (ApplyUpdatesToNewVersion)
             {

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Diagnostics\Checks\DiskSpaceForBatchUpdatesCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostCheck.cs" />
     <Compile Include="Diagnostics\Checks\PrepareToUpgradeCheck.cs" />
+    <Compile Include="Diagnostics\Checks\PVGuestsCheck.cs" />
     <Compile Include="Diagnostics\Checks\RebootPendingOnMasterCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostNeedsRebootCheck.cs" />
     <Compile Include="Diagnostics\Checks\SafeToUpgradeCheck.cs" />
@@ -233,6 +234,7 @@
     <Compile Include="Diagnostics\Checks\ServerSelectionCheck.cs" />
     <Compile Include="Diagnostics\Checks\XenCenterVersionCheck.cs" />
     <Compile Include="Diagnostics\Checks\HostMemoryPostUpgradeCheck.cs" />
+    <Compile Include="Diagnostics\Problems\PoolProblem\PoolHasPVGuestWarningUrl.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostMemoryPostUpgradeWarning.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostPrepareToUpgradeProblem.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\LicenseRestrictionProblem.cs" />

--- a/XenModel/InvisibleMessages.Designer.cs
+++ b/XenModel/InvisibleMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InvisibleMessages {
@@ -237,6 +237,15 @@ namespace XenAdmin {
         public static string PRIVACY {
             get {
                 return ResourceManager.GetString("PRIVACY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://docs.citrix.com/en-us/citrix-hypervisor/system-requirements/guest-os-support.html.
+        /// </summary>
+        public static string PV_GUESTS_CHECK_URL {
+            get {
+                return ResourceManager.GetString("PV_GUESTS_CHECK_URL", resourceCulture);
             }
         }
         

--- a/XenModel/InvisibleMessages.ja.resx
+++ b/XenModel/InvisibleMessages.ja.resx
@@ -168,6 +168,9 @@
   <data name="PRIVACY" xml:space="preserve">
     <value>http://citrix.com/English/aboutCitrix/legal/privacyStatement.asp?ntref=hp_nav_US</value>
   </data>
+  <data name="PV_GUESTS_CHECK_URL" xml:space="preserve">
+    <value>https://docs.citrix.com/ja-jp/citrix-hypervisor/system-requirements/guest-os-support.html</value>
+  </data>
   <data name="XEN_SEARCH" xml:space="preserve">
     <value>xensearch</value>
   </data>

--- a/XenModel/InvisibleMessages.resx
+++ b/XenModel/InvisibleMessages.resx
@@ -168,6 +168,9 @@
   <data name="PRIVACY" xml:space="preserve">
     <value>http://citrix.com/English/aboutCitrix/legal/privacyStatement.asp?ntref=hp_nav_US</value>
   </data>
+  <data name="PV_GUESTS_CHECK_URL" xml:space="preserve">
+    <value>https://docs.citrix.com/en-us/citrix-hypervisor/system-requirements/guest-os-support.html</value>
+  </data>
   <data name="XEN_SEARCH" xml:space="preserve">
     <value>xensearch</value>
   </data>

--- a/XenModel/InvisibleMessages.zh-CN.resx
+++ b/XenModel/InvisibleMessages.zh-CN.resx
@@ -168,6 +168,9 @@
   <data name="PRIVACY" xml:space="preserve">
     <value>http://citrix.com/English/aboutCitrix/legal/privacyStatement.asp?ntref=hp_nav_US</value>
   </data>
+  <data name="PV_GUESTS_CHECK_URL" xml:space="preserve">
+    <value>https://docs.citrix.com/zh-cn/citrix-hypervisor/system-requirements/guest-os-support.html</value>
+  </data>
   <data name="XEN_SEARCH" xml:space="preserve">
     <value>xensearch</value>
   </data>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -7200,6 +7200,15 @@ namespace XenAdmin {
         public static string CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION {
             get {
                 return ResourceManager.GetString("CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Checking guest compatibility.
+        /// </summary>
+        public static string CHECKING_PV_GUESTS {
+            get {
+                return ResourceManager.GetString("CHECKING_PV_GUESTS", resourceCulture);
             }
         }
         
@@ -20587,6 +20596,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Learn more.
+        /// </summary>
+        public static string LEARN_MORE {
+            get {
+                return ResourceManager.GetString("LEARN_MORE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter a user name and password with sufficient privileges to remove your machine account from AD. Authentication will be disabled even if the machine account cannot be removed..
         /// </summary>
         public static string LEAVING_AD {
@@ -29298,6 +29316,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}: Support for paravirtualized (PV) guests is dropped as of [XenServer] [BRANDING_VERSION_8_1]. Click &quot;Learn more&quot; to see the list of supported guest operating systems. .
+        /// </summary>
+        public static string POOL_HAS_PV_GUEST_UPDATE_WARNING {
+            get {
+                return ResourceManager.GetString("POOL_HAS_PV_GUEST_UPDATE_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: Support for paravirtualized (PV) guests is dropped as of [XenServer] [BRANDING_VERSION_8_1]. Click &quot;Learn more&quot; to see the list of supported guest operating systems. .
+        /// </summary>
+        public static string POOL_HAS_PV_GUEST_UPGRADE_WARNING {
+            get {
+                return ResourceManager.GetString("POOL_HAS_PV_GUEST_UPGRADE_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The pool is partially licensed.
         /// </summary>
         public static string POOL_IS_PARTIALLY_LICENSED {
@@ -29858,6 +29894,15 @@ namespace XenAdmin {
         public static string PV_DRIVERS_OUT_OF_DATE_UNKNOWN_VERSION {
             get {
                 return ResourceManager.GetString("PV_DRIVERS_OUT_OF_DATE_UNKNOWN_VERSION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Guest compatibility check.
+        /// </summary>
+        public static string PV_GUESTS_CHECK_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("PV_GUESTS_CHECK_DESCRIPTION", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.ja.resx
+++ b/XenModel/Messages.ja.resx
@@ -2611,6 +2611,9 @@ SR の物理使用量が {2} を超えるとアラートが送信されます。
   <data name="CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION" xml:space="preserve">
     <value>ホストのアップグレードの準備チェック</value>
   </data>
+  <data name="CHECKING_PV_GUESTS" xml:space="preserve">
+    <value>PV ゲストの互換性チェック</value>
+  </data>
   <data name="CHECKING_ROLE" xml:space="preserve">
     <value>役割を確認しています...</value>
   </data>
@@ -7118,6 +7121,9 @@ SCSI ID: {2}
   <data name="LAUNCH_LICENSE_MANAGER" xml:space="preserve">
     <value>ライセンス マネージャ</value>
   </data>
+  <data name="LEARN_MORE" xml:space="preserve">
+    <value>より多くを理解する</value>
+  </data>
   <data name="LEAVING_AD" xml:space="preserve">
     <value>マシン アカウントを Active Directory ドメインから削除するためのユーザー名およびパスワードを入力します。マシン アカウントを削除できない場合でも、Active Directory 認証は無効になります。</value>
   </data>
@@ -10161,6 +10167,12 @@ VM が再起動したら、[[Citrix VM Tools] をインストール] を再度�
   <data name="POOL_HAS_NO_SHARED_STORAGE" xml:space="preserve">
     <value>このプールには共有ストレージがありません</value>
   </data>
+  <data name="POOL_HAS_PV_GUEST_UPDATE_WARNING" xml:space="preserve">
+    <value>{0}: [XenServer] [BRANDING_VERSION_8_1] 以降、準仮想化（PV）ゲストはサポートされなくなりました。[詳細]をクリックして、サポートされているゲストオペレーティングシステムのリストを表示します。 </value>
+  </data>
+  <data name="POOL_HAS_PV_GUEST_UPGRADE_WARNING" xml:space="preserve">
+    <value>{0}: [XenServer] [BRANDING_VERSION_8_1] 以降、準仮想化（PV）ゲストはサポートされなくなりました。[詳細]をクリックして、サポートされているゲストオペレーティングシステムのリストを表示します。 </value>
+  </data>
   <data name="POOL_IS_PARTIALLY_LICENSED" xml:space="preserve">
     <value>このプールは一部のみライセンスが適用されています</value>
   </data>
@@ -10316,6 +10328,9 @@ VM が再起動したら、[[Citrix VM Tools] をインストール] を再度�
   </data>
   <data name="PROXY_SERVERS_NOT_SUPPORTED" xml:space="preserve">
     <value>プロキシ サーバーはサポートされません。</value>
+  </data>
+  <data name="PV_GUESTS_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>ゲストの互換性チェック</value>
   </data>
   <data name="PVS_CACHE_CONFIG_DIALOG_TITLE" xml:space="preserve">
     <value>PVS アクセラレータ構成 - '{0}'</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2607,6 +2607,9 @@ Do you want to assign it to the schedule '{2}' instead?</value>
   <data name="CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION" xml:space="preserve">
     <value>Host upgrade readiness check</value>
   </data>
+  <data name="CHECKING_PV_GUESTS" xml:space="preserve">
+    <value>Checking guest compatibility</value>
+  </data>
   <data name="CHECKING_ROLE" xml:space="preserve">
     <value>Checking role...</value>
   </data>
@@ -7170,6 +7173,9 @@ Size: {3}</value>
   <data name="LAUNCH_LICENSE_MANAGER" xml:space="preserve">
     <value>License Manager</value>
   </data>
+  <data name="LEARN_MORE" xml:space="preserve">
+    <value>Learn more</value>
+  </data>
   <data name="LEAVING_AD" xml:space="preserve">
     <value>Enter a user name and password with sufficient privileges to remove your machine account from AD. Authentication will be disabled even if the machine account cannot be removed.</value>
   </data>
@@ -10208,6 +10214,12 @@ Please reconnect the host and try again</value>
   <data name="POOL_HAS_NO_SHARED_STORAGE" xml:space="preserve">
     <value>This pool has no shared storage</value>
   </data>
+  <data name="POOL_HAS_PV_GUEST_UPDATE_WARNING" xml:space="preserve">
+    <value>{0}: Support for paravirtualized (PV) guests is dropped as of [XenServer] [BRANDING_VERSION_8_1]. Click "Learn more" to see the list of supported guest operating systems. </value>
+  </data>
+  <data name="POOL_HAS_PV_GUEST_UPGRADE_WARNING" xml:space="preserve">
+    <value>{0}: Support for paravirtualized (PV) guests is dropped as of [XenServer] [BRANDING_VERSION_8_1]. Click "Learn more" to see the list of supported guest operating systems. </value>
+  </data>
   <data name="POOL_IS_PARTIALLY_LICENSED" xml:space="preserve">
     <value>The pool is partially licensed</value>
   </data>
@@ -10363,6 +10375,9 @@ Press OK to continue the wizard and return to the server and follow the instruct
   </data>
   <data name="PROXY_SERVERS_NOT_SUPPORTED" xml:space="preserve">
     <value>Proxy servers are not supported.</value>
+  </data>
+  <data name="PV_GUESTS_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>Guest compatibility check</value>
   </data>
   <data name="PVS_CACHE_CONFIG_DIALOG_TITLE" xml:space="preserve">
     <value>PVS-Accelerator configuration - '{0}'</value>

--- a/XenModel/Messages.zh-CN.resx
+++ b/XenModel/Messages.zh-CN.resx
@@ -2607,6 +2607,9 @@
   <data name="CHECKING_PREPARE_TO_UPGRADE_DESCRIPTION" xml:space="preserve">
     <value>主机升级准备情况检查</value>
   </data>
+  <data name="CHECKING_PV_GUESTS" xml:space="preserve">
+    <value>PV 来宾兼容性检查</value>
+  </data>
   <data name="CHECKING_ROLE" xml:space="preserve">
     <value>正在检查角色...</value>
   </data>
@@ -7112,6 +7115,9 @@ SCSI ID: {2}
   <data name="LAUNCH_LICENSE_MANAGER" xml:space="preserve">
     <value>许可证管理器</value>
   </data>
+  <data name="LEARN_MORE" xml:space="preserve">
+    <value>了解更多</value>
+  </data>
   <data name="LEAVING_AD" xml:space="preserve">
     <value>输入具有足够的从 AD 中删除计算机帐户权限的用户名和密码。即使无法删除计算机帐户，也将禁用身份验证。</value>
   </data>
@@ -10159,6 +10165,12 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
   <data name="POOL_HAS_NO_SHARED_STORAGE" xml:space="preserve">
     <value>该池无共享存储</value>
   </data>
+  <data name="POOL_HAS_PV_GUEST_UPDATE_WARNING" xml:space="preserve">
+    <value>{0}: 从 [XenServer] [BRANDING_VERSION_8_1] 开始，不再支持半虚拟化（PV）来宾。单击“了解更多”以查看支持的来宾操作系统列表。 </value>
+  </data>
+  <data name="POOL_HAS_PV_GUEST_UPGRADE_WARNING" xml:space="preserve">
+    <value>{0}: 从 [XenServer] [BRANDING_VERSION_8_1] 开始，不再支持半虚拟化（PV）来宾。单击“了解更多”以查看支持的来宾操作系统列表。 </value>
+  </data>
   <data name="POOL_IS_PARTIALLY_LICENSED" xml:space="preserve">
     <value>池获得部分许可</value>
   </data>
@@ -10314,6 +10326,9 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
   </data>
   <data name="PROXY_SERVERS_NOT_SUPPORTED" xml:space="preserve">
     <value>不支持代理服务器。</value>
+  </data>
+  <data name="PV_GUESTS_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>来宾兼容性检查</value>
   </data>
   <data name="PVS_CACHE_CONFIG_DIALOG_TITLE" xml:space="preserve">
     <value>PVS 加速器配置 - {0}</value>

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -478,6 +478,10 @@ namespace XenAdmin.Core
             string platform_version = HostPlatformVersion(host);
             return platform_version != null && productVersionCompare(platform_version, "3.0.50") >= 0;
         }
+        public static bool QuebecOrGreater(string platformVersion)
+        {
+            return platformVersion != null && productVersionCompare(platformVersion, "3.0.50") >= 0;
+        }
 
         // CP-3435: Disable Check for Updates in Common Criteria Certification project
         public static bool CommonCriteriaCertificationRelease

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -331,6 +331,11 @@ namespace XenAPI
             HVM_boot_params = SetDictionaryKey(HVM_boot_params, "order", value.ToLower());
         }
 
+        public bool IsPvVm()
+        {
+            return is_a_real_vm() && !IsHVM() && !other_config.ContainsKey("pvcheckpass");
+        }
+
         public bool IsUEFIEnabled()
         {
             if (!IsHVM())


### PR DESCRIPTION
Signed-off-by: Xueqing Zhang <Xueqing.Zhang@citrix.com>
Add the PV guests precheck in both 'Install update' and 'RPU'. This precheck will give a warning when host have pv guess. 
The warning link is not ready yet , a likely link given for example.
The PV guests want to skip this check can add one key in vm.other_config named "pvcheckpass".