### PR TITLE
CA-329687: Fixed verification code error.

### DIFF
--- a/XenCenterLib/StreamUtilities.cs
+++ b/XenCenterLib/StreamUtilities.cs
@@ -103,7 +103,7 @@ namespace XenCenterLib
                 hashAlgorithm.TransformBlock(buffer, 0, bytesRead / 2, buffer, 0);
 
                 // Compute the final hash.
-                hashAlgorithm.TransformFinalBlock(buffer, bytesRead / 2, bytesRead / 2);
+                hashAlgorithm.TransformFinalBlock(buffer, bytesRead / 2, bytesRead / 2 + bytesRead % 2);
 
                 return cryptoServiceProvider == null
                     ? digest.SequenceEqual(hashAlgorithm.Hash)

--- a/XenOvfTransport/iSCSI.cs
+++ b/XenOvfTransport/iSCSI.cs
@@ -283,7 +283,7 @@ namespace XenOvfTransport
                     hashAlgorithm.TransformBlock(_buffer, 0, bytesRead / 2, _buffer, 0);
 
                     // Compute the final hash.
-                    hashAlgorithm.TransformFinalBlock(_buffer, bytesRead / 2, bytesRead / 2);
+                    hashAlgorithm.TransformFinalBlock(_buffer, bytesRead / 2, bytesRead / 2 + bytesRead % 2);
 
                     _copyHash = hashAlgorithm.Hash;
                 }
@@ -354,7 +354,7 @@ namespace XenOvfTransport
                 hashAlgorithm.TransformBlock(_buffer, 0, bytesRead / 2, _buffer, 0);
 
                 // Compute the final hash.
-                hashAlgorithm.TransformFinalBlock(_buffer, bytesRead / 2, bytesRead / 2);
+                hashAlgorithm.TransformFinalBlock(_buffer, bytesRead / 2, bytesRead / 2 + bytesRead % 2);
 
                 // Compare targetHash with copyHash.
                 if (!System.Linq.Enumerable.SequenceEqual(_copyHash, hashAlgorithm.Hash))


### PR DESCRIPTION
Do not leave out bytes if the number read is odd, which can happen if the file is smaller than the buffer used.