### PR TITLE
CA-329399: Improve the error message displayed if the update wizard i…

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.resx
@@ -136,13 +136,13 @@
     <value>15, 3, 3, 3</value>
   </data>
   <data name="ManualRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>547, 41</value>
+    <value>547, 17</value>
   </data>
   <data name="ManualRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="ManualRadioButton.Text" xml:space="preserve">
-    <value>I will carry out the post-update tasks &amp;myself. If you are intending to apply further updates immediately after this one, choose this option and carry out the post-update tasks once at the end.</value>
+    <value>I will carry out the post-update tasks &amp;myself.</value>
   </data>
   <data name="ManualRadioButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>TopLeft</value>
@@ -163,7 +163,7 @@
     <value>True</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 137</value>
+    <value>3, 113</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 10, 3, 0</value>
@@ -193,7 +193,7 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="textBoxLog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 153</value>
+    <value>3, 129</value>
   </data>
   <data name="textBoxLog.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -202,7 +202,7 @@
     <value>Vertical</value>
   </data>
   <data name="textBoxLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>559, 248</value>
+    <value>559, 272</value>
   </data>
   <data name="textBoxLog.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -379,7 +379,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AutomaticRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="autoHeightLabel1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ManualRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button1" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="removeUpdateFileCheckBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxLog" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,47,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AutomaticRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="autoHeightLabel1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ManualRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button1" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="removeUpdateFileCheckBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxLog" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,47,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="automaticRadioButtonTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PatchingPage.cs
@@ -127,7 +127,10 @@ namespace XenAdmin.Wizards.PatchingWizard
             sb.AppendLine(string.Format(Messages.PATCHINGWIZARD_SINGLEUPDATE_SUCCESS_ONE, GetUpdateName())).AppendLine();
 
             if (!IsAutomaticMode && ManualTextInstructions != null && ManualTextInstructions.ContainsKey(pool))
+            {
+                sb.AppendLine(Messages.PATCHINGWIZARD_SINGLEUPDATE_MANUAL_POST_UPDATE);
                 sb.Append(ManualTextInstructions[pool]).AppendLine();
+            }
             
             return sb.ToString();
         }

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using XenAPI;
 
@@ -89,6 +90,13 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                     {
                         log.WarnFormat("Host {0} cannot be avacuated: {1}", hostObj.Name(), f.Message);
                         throw new Exception(string.Format(Messages.PLAN_ACTION_FAILURE_NOT_ENOUGH_MEMORY, hostObj.Name()), f);
+                    }
+
+                    if (f.ErrorDescription.Count > 0 && f.ErrorDescription[0] == Failure.NO_HOSTS_AVAILABLE)
+                    {
+                        log.WarnFormat("Host {0} cannot be avacuated: {1}", hostObj.Name(), f.Message);
+                        if (hostObj.Connection.Cache.Hosts.Any(h=>h.updates_requiring_reboot.Count > 0 && h.enabled == false))
+                            throw new Exception(string.Format(Messages.PLAN_ACTION_FAILURE_NO_HOSTS_AVAILABLE, hostObj.Name()));
                     }
                     throw;
                 }

--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/HostPlanAction.cs
@@ -88,14 +88,14 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 {
                     if (f.ErrorDescription.Count > 0 && f.ErrorDescription[0] == Failure.HOST_NOT_ENOUGH_FREE_MEMORY)
                     {
-                        log.WarnFormat("Host {0} cannot be avacuated: {1}", hostObj.Name(), f.Message);
+                        log.WarnFormat("Host {0} cannot be evacuated: {1}", hostObj.Name(), f.Message);
                         throw new Exception(string.Format(Messages.PLAN_ACTION_FAILURE_NOT_ENOUGH_MEMORY, hostObj.Name()), f);
                     }
 
                     if (f.ErrorDescription.Count > 0 && f.ErrorDescription[0] == Failure.NO_HOSTS_AVAILABLE)
                     {
-                        log.WarnFormat("Host {0} cannot be avacuated: {1}", hostObj.Name(), f.Message);
-                        if (hostObj.Connection.Cache.Hosts.Any(h=>h.updates_requiring_reboot.Count > 0 && h.enabled == false))
+                        log.WarnFormat("Host {0} cannot be evacuated: {1}", hostObj.Name(), f.Message);
+                        if (hostObj.Connection.Cache.Hosts.Any(h=>h.updates_requiring_reboot.Count > 0 && !h.enabled))
                             throw new Exception(string.Format(Messages.PLAN_ACTION_FAILURE_NO_HOSTS_AVAILABLE, hostObj.Name()));
                     }
                     throw;

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -29235,6 +29235,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please carry out any pending post-update tasks from the list below:.
+        /// </summary>
+        public static string PATCHINGWIZARD_SINGLEUPDATE_MANUAL_POST_UPDATE {
+            get {
+                return ResourceManager.GetString("PATCHINGWIZARD_SINGLEUPDATE_MANUAL_POST_UPDATE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The installation of update {0} on all selected servers was completed successfully..
         /// </summary>
         public static string PATCHINGWIZARD_SINGLEUPDATE_SUCCESS_MANY {
@@ -29620,6 +29629,15 @@ namespace XenAdmin {
         public static string PLAN_ACTION_ERROR {
             get {
                 return ResourceManager.GetString("PLAN_ACTION_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Server &apos;{0}&apos; could not be evacuated because there were no servers available to accommodate all the VMs being migrated from this server. Please reboot the other servers that are pending a reboot following the update installation, and then press Retry to resume the process..
+        /// </summary>
+        public static string PLAN_ACTION_FAILURE_NO_HOSTS_AVAILABLE {
+            get {
+                return ResourceManager.GetString("PLAN_ACTION_FAILURE_NO_HOSTS_AVAILABLE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10091,6 +10091,9 @@ Servers where this update cannot be applied appear disabled in this list.</value
   <data name="PATCHINGWIZARD_SINGLEUPDATE_FAILURE_PER_POOL_ONE" xml:space="preserve">
     <value>The following error occurred while the installation of update {0} was in progress:</value>
   </data>
+  <data name="PATCHINGWIZARD_SINGLEUPDATE_MANUAL_POST_UPDATE" xml:space="preserve">
+    <value>Please carry out any pending post-update tasks from the list below:</value>
+  </data>
   <data name="PATCHINGWIZARD_SINGLEUPDATE_SUCCESS_MANY" xml:space="preserve">
     <value>The installation of update {0} on all selected servers was completed successfully.</value>
   </data>
@@ -10308,6 +10311,9 @@ File not found</value>
   </data>
   <data name="PLAN_ACTION_ERROR" xml:space="preserve">
     <value> error.</value>
+  </data>
+  <data name="PLAN_ACTION_FAILURE_NO_HOSTS_AVAILABLE" xml:space="preserve">
+    <value>Server '{0}' could not be evacuated because there were no servers available to accommodate all the VMs being migrated from this server. Please reboot the other servers that are pending a reboot following the update installation, and then press Retry to resume the process.</value>
   </data>
   <data name="PLAN_ACTION_FAILURE_NOT_ENOUGH_MEMORY" xml:space="preserve">
     <value>Server '{0}' could not be evacuated because there was not enough free memory on the other servers to migrate all the VMs from this server. Please suspend or shutdown some VMs and then press Retry to resume the process.</value>


### PR DESCRIPTION
…f a host cannot be evacuated

If a host cannot be evacuated because other hosts in the pool are maintenance mode and pending a reboot following an update installation, then include instructions to reboot those hosts and then press Retry.
Also updated the text for the Manual mode, removing the reference to installing other updates and doing a reboot manually at the end, because that won't be always possible, due to the fact that now we put the hosts in maintenance mode before installing the update.

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>