### PR TITLE
CA-330890: update storage select wizard in XCM

### DIFF
--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -306,7 +306,7 @@ namespace XenAdmin.Controls
                     return string.Format(Messages.SR_PICKER_INSUFFICIENT_SPACE, Util.DiskSizeString(DiskSize, 2),
                                          Util.DiskSizeString(TheSR.FreeSpace(), 2));
                 if (DiskSize > SR.DISK_MAX_SIZE)
-                    return string.Format(Messages.SR_PICKER_DISKSIZE_EXCEEDS_DISK_MAX_SIZE,
+                    return string.Format(Messages.SR_DISKSIZE_EXCEEDS_DISK_MAX_SIZE,
                         Util.DiskSizeString(SR.DISK_MAX_SIZE, 0));
                 return "";
             }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -9497,6 +9497,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The SR is overcommitted.
+        /// </summary>
+        public static string CONVERSION_STORAGE_PAGE_SR_OVERCOMMIT {
+            get {
+                return ResourceManager.GetString("CONVERSION_STORAGE_PAGE_SR_OVERCOMMIT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There is not enough available space on this SR.
         /// </summary>
         public static string CONVERSION_STORAGE_PAGE_SR_TOO_SMALL {
@@ -18239,7 +18248,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When overcommited the pool cannot guarantee to tolerate the number of server failures specified.
+        ///   Looks up a localized string similar to When overcommitted the pool cannot guarantee to tolerate the number of server failures specified.
         ///
         ///Reduce protection levels, or bring more servers online to increase the maximum supported capacity..
         /// </summary>
@@ -27054,7 +27063,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The SR &apos;{0}&apos; is over committed. There is only {1} of free space and the new VM requires {2}..
+        ///   Looks up a localized string similar to The SR &apos;{0}&apos; is overcommitted. There is only {1} of free space and the new VM requires {2}..
         /// </summary>
         public static string NEWVMWIZARD_STORAGEPAGE_SROVERCOMMIT {
             get {
@@ -33923,6 +33932,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You cannot create a disk greater than {0} on this SR..
+        /// </summary>
+        public static string SR_DISKSIZE_EXCEEDS_DISK_MAX_SIZE {
+            get {
+                return ResourceManager.GetString("SR_DISKSIZE_EXCEEDS_DISK_MAX_SIZE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This SR does not need to be upgraded..
         /// </summary>
         public static string SR_DOES_NOT_NEED_UPGRADE {
@@ -33982,15 +34000,6 @@ namespace XenAdmin {
         public static string SR_PICKER_DISK_TOO_BIG {
             get {
                 return ResourceManager.GetString("SR_PICKER_DISK_TOO_BIG", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You cannot create a disk greater than {0} on this SR..
-        /// </summary>
-        public static string SR_PICKER_DISKSIZE_EXCEEDS_DISK_MAX_SIZE {
-            get {
-                return ResourceManager.GetString("SR_PICKER_DISKSIZE_EXCEEDS_DISK_MAX_SIZE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.ja.resx
+++ b/XenModel/Messages.ja.resx
@@ -3427,6 +3427,9 @@ VM {2} をエクスポートしてもよろしいですか?</value>
   <data name="CONVERSION_STORAGE_PAGE_REQUIRED_SPACE" xml:space="preserve">
     <value>必要な容量 {0}</value>
   </data>
+  <data name="CONVERSION_STORAGE_PAGE_SR_OVERCOMMIT" xml:space="preserve">
+    <value>SR はオーバーコミットされており</value>
+  </data>
   <data name="CONVERSION_STORAGE_PAGE_SR_TOO_SMALL" xml:space="preserve">
     <value>この SR には十分な空き容量がありません</value>
   </data>
@@ -11812,6 +11815,9 @@ SR-IOV ネットワークを有効にするには、サーバーの再起動が�
     <value>初回割り当て: {0} 
 増分割り当て: {1}</value>
   </data>
+  <data name="SR_DISKSIZE_EXCEEDS_DISK_MAX_SIZE" xml:space="preserve">
+    <value>この SR には、{0} を超えるサイズのディスクを作成できません。</value>
+  </data>
   <data name="SR_DOES_NOT_NEED_UPGRADE" xml:space="preserve">
     <value>この SR をアップグレードする必要はありません。</value>
   </data>
@@ -11829,9 +11835,6 @@ SR-IOV ネットワークを有効にするには、サーバーの再起動が�
   </data>
   <data name="SR_IS_LOCAL" xml:space="preserve">
     <value>ホーム サーバーが設定されていない VM はローカル ストレージにディスクを持つことはできません</value>
-  </data>
-  <data name="SR_PICKER_DISKSIZE_EXCEEDS_DISK_MAX_SIZE" xml:space="preserve">
-    <value>この SR には、{0} を超えるサイズのディスクを作成できません。</value>
   </data>
   <data name="SR_PICKER_DISK_TOO_BIG" xml:space="preserve">
     <value>ディスク サイズ ({0}) が SR サイズ ({1}) を超過しています</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3422,6 +3422,9 @@ This action cannot be undone. Are you sure you want to continue?</value>
   <data name="CONVERSION_STORAGE_PAGE_REQUIRED_SPACE" xml:space="preserve">
     <value>Required space {0}</value>
   </data>
+  <data name="CONVERSION_STORAGE_PAGE_SR_OVERCOMMIT" xml:space="preserve">
+    <value>The SR is overcommitted</value>
+  </data> 
   <data name="CONVERSION_STORAGE_PAGE_SR_TOO_SMALL" xml:space="preserve">
     <value>There is not enough available space on this SR</value>
   </data>
@@ -6392,7 +6395,7 @@ Do you want to apply this HA configuration anyway?</value>
     <value>{0} - pool is overcommitted</value>
   </data>
   <data name="HA_OVERCOMMIT_BLURB" xml:space="preserve">
-    <value>When overcommited the pool cannot guarantee to tolerate the number of server failures specified.
+    <value>When overcommitted the pool cannot guarantee to tolerate the number of server failures specified.
 
 Reduce protection levels, or bring more servers online to increase the maximum supported capacity.</value>
   </data>
@@ -9238,7 +9241,7 @@ Review these settings, then click Previous if you need to change anything. Other
     <value>&lt;no suitable storage&gt;</value>
   </data>
   <data name="NEWVMWIZARD_STORAGEPAGE_SROVERCOMMIT" xml:space="preserve">
-    <value>The SR '{0}' is over committed. There is only {1} of free space and the new VM requires {2}.</value>
+    <value>The SR '{0}' is overcommitted. There is only {1} of free space and the new VM requires {2}.</value>
   </data>
   <data name="NEWVMWIZARD_STORAGEPAGE_TITLE" xml:space="preserve">
     <value>Configure storage for the new VM</value>
@@ -11810,6 +11813,9 @@ You may need to reboot your server(s) to enable SR-IOV network.</value>
     <value>Initial allocation: {0}
 Incremental allocation: {1}</value>
   </data>
+  <data name="SR_DISKSIZE_EXCEEDS_DISK_MAX_SIZE" xml:space="preserve">
+    <value>You cannot create a disk greater than {0} on this SR.</value>
+  </data>
   <data name="SR_DOES_NOT_NEED_UPGRADE" xml:space="preserve">
     <value>This SR does not need to be upgraded.</value>
   </data>
@@ -11827,9 +11833,6 @@ Incremental allocation: {1}</value>
   </data>
   <data name="SR_IS_LOCAL" xml:space="preserve">
     <value>VMs without a home server cannot have disks on local storage</value>
-  </data>
-  <data name="SR_PICKER_DISKSIZE_EXCEEDS_DISK_MAX_SIZE" xml:space="preserve">
-    <value>You cannot create a disk greater than {0} on this SR.</value>
   </data>
   <data name="SR_PICKER_DISK_TOO_BIG" xml:space="preserve">
     <value>Disk size ({0}) exceeds SR size ({1})</value>

--- a/XenModel/Messages.zh-CN.resx
+++ b/XenModel/Messages.zh-CN.resx
@@ -3423,6 +3423,9 @@
   <data name="CONVERSION_STORAGE_PAGE_REQUIRED_SPACE" xml:space="preserve">
     <value>所需空间 {0}</value>
   </data>
+  <data name="CONVERSION_STORAGE_PAGE_SR_OVERCOMMIT" xml:space="preserve">
+    <value>SR 过量使用</value>
+  </data>
   <data name="CONVERSION_STORAGE_PAGE_SR_TOO_SMALL" xml:space="preserve">
     <value>此 SR 上的可用空间不足</value>
   </data>
@@ -11811,6 +11814,9 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
     <value>初始分配: {0}
 增量分配: {1}</value>
   </data>
+  <data name="SR_DISKSIZE_EXCEEDS_DISK_MAX_SIZE" xml:space="preserve">
+    <value>无法在此 SR 上创建大于 {0} 的磁盘。</value>
+  </data>
   <data name="SR_DOES_NOT_NEED_UPGRADE" xml:space="preserve">
     <value>该 SR 不需要升级。</value>
   </data>
@@ -11828,9 +11834,6 @@ VM 克隆使用文件管理器的快照和克隆功能来实现高性能，并�
   </data>
   <data name="SR_IS_LOCAL" xml:space="preserve">
     <value>没有主服务器的 VM 不能在本地存储中包含磁盘</value>
-  </data>
-  <data name="SR_PICKER_DISKSIZE_EXCEEDS_DISK_MAX_SIZE" xml:space="preserve">
-    <value>无法在此 SR 上创建大于 {0} 的磁盘。</value>
   </data>
   <data name="SR_PICKER_DISK_TOO_BIG" xml:space="preserve">
     <value>磁盘大小({0})超过 SR 大小({1})</value>


### PR DESCRIPTION
Signed-off-by: Xueqing Zhang <xueqing.zhang@citrix.com>
Add two kinds of warning in SR select wizard in Conversion Manager. One for the limit in Xapi that 'MAX_VHD_SIZE = 2040 * 1024 * 1024 * 1024' in sm/drivers/vhdutil.py , another for supporting to select a gfs2 SR smaller than request.
