### PR TITLE
CA-333236:  Calculate local time for HotfixEligibilityAlert properties on the UI thread.

### DIFF
--- a/XenAdmin/Alerts/Types/HotfixEligibilityAlert.cs
+++ b/XenAdmin/Alerts/Types/HotfixEligibilityAlert.cs
@@ -47,7 +47,7 @@ namespace XenAdmin.Alerts.Types
             this.Version = version;
             pool = Helpers.GetPoolOfOne(connection);
             _timestamp = DateTime.Now;
-         }
+        }
 
         #region Overrides of Alert
 
@@ -67,7 +67,8 @@ namespace XenAdmin.Alerts.Types
                 {
                     // all + the EOL date is known -> "Approaching EOL" alert
                     case hotfix_eligibility.all when Version.EolDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_TITLE_APPROACHING_EOL, productVersionText, HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true));
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_TITLE_APPROACHING_EOL,
+                            productVersionText, GetEolDate());
 
                     // premium + unlicensed host -> "EOL for express customers" alert
                     case hotfix_eligibility.premium when unlicensed:
@@ -75,7 +76,8 @@ namespace XenAdmin.Alerts.Types
 
                     // premium + licensed host and the EOL date is known -> "Approaching EOL" alert
                     case hotfix_eligibility.premium when Version.EolDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_TITLE_APPROACHING_EOL, productVersionText, HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true));
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_TITLE_APPROACHING_EOL,
+                            productVersionText, GetEolDate());
 
                     // cu -> "EOL for express customers" / "CU for licensed customers" alert
                     case hotfix_eligibility.cu when pool.IsFreeLicenseOrExpired():
@@ -111,29 +113,37 @@ namespace XenAdmin.Alerts.Types
                 {
                     // all + the EOL date is known -> "Approaching EOL" alert
                     case hotfix_eligibility.all when unlicensed && Version.EolDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_APPROACHING_EOL_FREE, productVersionText, HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true), versionText);
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_APPROACHING_EOL_FREE,
+                            productVersionText, GetEolDate(), versionText);
                     case hotfix_eligibility.all when Version.EolDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_APPROACHING_EOL, productVersionText, HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true), versionText);
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_APPROACHING_EOL,
+                            productVersionText, GetEolDate(), versionText);
 
                     // premium + unlicensed host -> "EOL for express customers" alert
                     case hotfix_eligibility.premium when unlicensed && Version.HotfixEligibilityPremiumDate != DateTime.MinValue: 
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_FREE, productVersionText, HelpersGUI.DateTimeToString(Version.HotfixEligibilityPremiumDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true));
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_FREE,
+                            productVersionText, GetPremiumDate());
                     
                     // premium + licensed host and the EOL date is known -> "Approaching EOL" alert
                     case hotfix_eligibility.premium when !unlicensed && Version.EolDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_APPROACHING_EOL, productVersionText, HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true), versionText);
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_APPROACHING_EOL,
+                            productVersionText, GetEolDate(), versionText);
 
                     // cu -> "EOL for express customers" / "CU for licensed customers" alert
                     case hotfix_eligibility.cu when unlicensed && Version.HotfixEligibilityPremiumDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_FREE, productVersionText, HelpersGUI.DateTimeToString(Version.HotfixEligibilityPremiumDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true));
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_FREE,
+                            productVersionText, GetPremiumDate());
                     case hotfix_eligibility.cu when !unlicensed && Version.HotfixEligibilityNoneDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_CU, productVersionText, HelpersGUI.DateTimeToString(Version.HotfixEligibilityNoneDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true), versionText);
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_CU, productVersionText,
+                            GetNoneDate(), versionText);
 
                     // none -> EOL alert
                     case hotfix_eligibility.none when unlicensed && Version.EolDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_EOL_FREE, productVersionText, HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true));
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_EOL_FREE,
+                            productVersionText, GetEolDate());
                     case hotfix_eligibility.none when Version.EolDate != DateTime.MinValue:
-                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_EOL, productVersionText, HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true));
+                        return string.Format(Messages.HOTFIX_ELIGIBILITY_ALERT_DESCRIPTION_EOL,
+                            productVersionText, GetEolDate());
 
                     // everything else
                     default:
@@ -191,6 +201,45 @@ namespace XenAdmin.Alerts.Types
                 default:
                     return false;
             }
+        }
+
+
+        private string GetEolDate()
+        {
+            string date = string.Empty;
+
+            Program.Invoke(Program.MainWindow, () =>
+            {
+                date = HelpersGUI.DateTimeToString(Version.EolDate.ToLocalTime(), Messages.DATEFORMAT_DMY, true);
+            });
+
+            return date;
+        }
+
+        private string GetPremiumDate()
+        {
+            string date = string.Empty;
+
+            Program.Invoke(Program.MainWindow, () =>
+            {
+                date = HelpersGUI.DateTimeToString(Version.HotfixEligibilityPremiumDate.ToLocalTime(),
+                    Messages.DATEFORMAT_DMY, true);
+            });
+
+            return date;
+        }
+
+        private string GetNoneDate()
+        {
+            string date = string.Empty;
+
+            Program.Invoke(Program.MainWindow, () =>
+            {
+                date = HelpersGUI.DateTimeToString(Version.HotfixEligibilityNoneDate.ToLocalTime(),
+                    Messages.DATEFORMAT_DMY, true);
+            });
+
+            return date;
         }
     }
 }

--- a/XenModel/Alerts/Types/Alert.cs
+++ b/XenModel/Alerts/Types/Alert.cs
@@ -44,8 +44,8 @@ namespace XenAdmin.Alerts
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private readonly static object XenCenterAlertsLock = new object();
-        private readonly static ChangeableList<Alert> XenCenterAlerts = new ChangeableList<Alert>();
+        private static readonly object XenCenterAlertsLock = new object();
+        private static readonly ChangeableList<Alert> XenCenterAlerts = new ChangeableList<Alert>();
 
         public bool Dismissing;
 
@@ -61,6 +61,7 @@ namespace XenAdmin.Alerts
                 log.Error("Failed to add incoming alert", e);
             }
         }
+
         public static void AddAlertRange(IEnumerable<Alert> collection)
         {
             try
@@ -76,10 +77,15 @@ namespace XenAdmin.Alerts
 
         public static void RemoveAlert(Alert a)
         {
-            lock (XenCenterAlertsLock)
-                XenCenterAlerts.Remove(a);
-
-            log.InfoFormat("Removed {0}: {1} - {2}", a.GetType().Name, a.Title, a.Description);
+            try
+            {
+                lock (XenCenterAlertsLock)
+                    XenCenterAlerts.Remove(a);
+            }
+            catch (Exception e)
+            {
+                log.Error("Failed to remove alert. ", e);
+            }
         }
 
         public static void RemoveAlert(Predicate<Alert> predicate)
@@ -208,18 +214,11 @@ namespace XenAdmin.Alerts
         /// <summary>
         /// When the Alert was raised.
         /// </summary>
-        public DateTime Timestamp
-        {
-            get
-            {
-                return _timestamp;
-            }
-        }
+        public DateTime Timestamp => _timestamp;
 
         /// <summary>
         /// Dismisses the Alert: marks it as dealt with in some way. May only be called once.
         /// </summary>
-        /// <param name="username">The name of whoever is dismissing the Alert. Must not be null.</param>
         public virtual void Dismiss()
         {
             RemoveAlert(this);
@@ -242,9 +241,9 @@ namespace XenAdmin.Alerts
             return false;
         }
 
-        public virtual string Name { get { return null; } }
+        public virtual string Name => null;
 
-        public virtual string WebPageLabel { get { return null; } }
+        public virtual string WebPageLabel => null;
 
         public abstract string Title { get; }
 
@@ -272,10 +271,7 @@ namespace XenAdmin.Alerts
         /// <summary>
         /// The text for the 'click here for help...' link.
         /// </summary>
-        public virtual string HelpLinkText
-        {
-            get { return Messages.ALERT_GENERIC_HELP; }
-        }
+        public virtual string HelpLinkText => Messages.ALERT_GENERIC_HELP;
 
         /// <summary>
         /// The helpid opened when the 'click here for help...' link is clicked.
@@ -377,9 +373,6 @@ namespace XenAdmin.Alerts
                                     where alert != null && !alert.Dismissing
                                     let con = alert.Connection
                                     select con).Distinct();
-
-            if (alertConnections.Count() == 0)
-                return false;
 
             return alertConnections.Any(AllowedToDismiss);
         }


### PR DESCRIPTION
The Title and Description of HotfixEligibilityAlert  involve calculation of local
time which should be done on the UI thread, otherwise the time is not localised
correctly, and additionally the application crashes when dismissing or sorting
these alerts.
Also, stop spamming the logs with each alert removal; code efficiency correction.