### PR TITLE
CA-335633: crash and leaking forms

### DIFF
--- a/XenAdmin/Actions/GUIActions/Wlb/WlbOptimizePoolAction.cs
+++ b/XenAdmin/Actions/GUIActions/Wlb/WlbOptimizePoolAction.cs
@@ -161,7 +161,7 @@ namespace XenAdmin.Actions.Wlb
                                         // Set new ntol, then retry action
                                         XenAPI.Pool.set_ha_host_failures_to_tolerate(session, this.Pool.opaque_ref, newNtol);
                                         // ntol set succeeded, start new action
-                                        Program.MainWindow.CloseActiveWizards(vm);
+                                        Program.Invoke(Program.MainWindow, () => XenDialogBase.CloseAll(vm));
                                         new VMMigrateAction(vm,toHost).RunAsync();
                                     });
                                     action.RunAsync();

--- a/XenAdmin/Commands/AddVirtualDiskCommand.cs
+++ b/XenAdmin/Commands/AddVirtualDiskCommand.cs
@@ -76,7 +76,7 @@ namespace XenAdmin.Commands
             {
                 if (vm.VBDs.Count < vm.MaxVBDsAllowed())
                 {
-                    MainWindowCommandInterface.ShowPerXenModelObjectWizard(vm, new NewDiskDialog(vm.Connection, vm));
+                    new NewDiskDialog(vm.Connection, vm).ShowPerXenObject(vm, Program.MainWindow);
                 }
                 else
                 {

--- a/XenAdmin/Commands/AttachVirtualDiskCommand.cs
+++ b/XenAdmin/Commands/AttachVirtualDiskCommand.cs
@@ -80,7 +80,7 @@ namespace XenAdmin.Commands
             }
             else
             {
-                MainWindowCommandInterface.ShowPerXenModelObjectWizard(vm, new AttachDiskDialog(vm));
+                new AttachDiskDialog(vm).ShowPerXenObject(vm, Program.MainWindow);
             }
         }
 

--- a/XenAdmin/Commands/ConvertVMToTemplateCommand.cs
+++ b/XenAdmin/Commands/ConvertVMToTemplateCommand.cs
@@ -82,7 +82,7 @@ namespace XenAdmin.Commands
                     actions.Add(new SetVMOtherConfigAction(vm.Connection, vm, "instant", "true"));
                     actions.Add(new VMToTemplateAction(vm));
 
-                    MainWindowCommandInterface.CloseActiveWizards(vm);
+                    XenDialogBase.CloseAll(vm);
 
                     RunMultipleActions(actions, string.Format(Messages.ACTION_VM_TEMPLATIZING_TITLE, vm.Name()),
                                        Messages.ACTION_VM_TEMPLATIZING, Messages.ACTION_VM_TEMPLATIZED, true);

--- a/XenAdmin/Commands/CopyTemplateCommand.cs
+++ b/XenAdmin/Commands/CopyTemplateCommand.cs
@@ -69,7 +69,7 @@ namespace XenAdmin.Commands
             if (CrossPoolCopyTemplateCommand.CanExecute(template, null))
                 new CrossPoolCopyTemplateCommand(MainWindowCommandInterface, selection).Execute();
             else
-                MainWindowCommandInterface.ShowPerXenModelObjectWizard(template, new CopyVMDialog(template));
+                new CopyVMDialog(template).ShowPerXenObject(template, Program.MainWindow);
         }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)

--- a/XenAdmin/Commands/CopyVMCommand.cs
+++ b/XenAdmin/Commands/CopyVMCommand.cs
@@ -69,7 +69,7 @@ namespace XenAdmin.Commands
             if (CrossPoolCopyVMCommand.CanExecute(vm, null))
                 new CrossPoolCopyVMCommand(MainWindowCommandInterface, selection).Execute();
             else
-                MainWindowCommandInterface.ShowPerXenModelObjectWizard(vm, new CopyVMDialog(vm));
+                new CopyVMDialog(vm).ShowPerXenObject(vm, Program.MainWindow);
         }
 
         protected override bool CanExecuteCore(SelectedItemCollection selection)

--- a/XenAdmin/Commands/HostMaintenanceModeCommand.cs
+++ b/XenAdmin/Commands/HostMaintenanceModeCommand.cs
@@ -102,7 +102,7 @@ namespace XenAdmin.Commands
                 return;
             }
             
-            MainWindowCommandInterface.ShowPerXenModelObjectWizard(host, new EvacuateHostDialog(host));
+            new EvacuateHostDialog(host).ShowPerXenObject(host, Program.MainWindow);
         }
 
         private void ExitMaintenanceMode(Host host)

--- a/XenAdmin/Commands/InstallToolsCommand.cs
+++ b/XenAdmin/Commands/InstallToolsCommand.cs
@@ -256,7 +256,7 @@ namespace XenAdmin.Commands
            
             MainWindowCommandInterface.Invoke(delegate
             {
-                Program.MainWindow.SelectObject(action.VM);
+                Program.MainWindow.SelectObjectInTree(action.VM);
                 Program.MainWindow.TheTabControl.SelectedTab = Program.MainWindow.TabPageConsole;
             });
         }

--- a/XenAdmin/Commands/MoveVMCommand.cs
+++ b/XenAdmin/Commands/MoveVMCommand.cs
@@ -69,7 +69,7 @@ namespace XenAdmin.Commands
             else
             {
                 VM vm = (VM) selection[0].XenObject;
-                MainWindowCommandInterface.ShowPerXenModelObjectWizard(vm, new MoveVMDialog(vm));
+                new MoveVMDialog(vm).ShowPerXenObject(vm, Program.MainWindow);
             }
         }
 

--- a/XenAdmin/Commands/VMOperationCommand.cs
+++ b/XenAdmin/Commands/VMOperationCommand.cs
@@ -129,7 +129,7 @@ namespace XenAdmin.Commands
                 endDescription = Messages.ACTION_VM_MIGRATED;
                 foreach (VM vm in selection.AsXenObjects<VM>(CanExecute))
                 {
-                    this.MainWindowCommandInterface.CloseActiveWizards(vm);
+                    XenDialogBase.CloseAll(vm);
                     Host host = GetHost(vm);
                     actions.Add(new VMMigrateAction(vm, host));
                 }

--- a/XenAdmin/Controls/XenSearch/QueryPanel.cs
+++ b/XenAdmin/Controls/XenSearch/QueryPanel.cs
@@ -659,7 +659,7 @@ namespace XenAdmin.Controls.XenSearch
                                     } :
                                     (EventHandler)delegate
                                     {
-                                        if (Program.MainWindow.SelectObject(ixmo)
+                                        if (Program.MainWindow.SelectObjectInTree(ixmo)
                                             && Program.MainWindow.TheTabControl.TabPages.Contains(Program.MainWindow.TabPageGeneral))
                                             Program.MainWindow.SwitchToTab(MainWindow.Tab.General);
                                     };

--- a/XenAdmin/Core/History.cs
+++ b/XenAdmin/Core/History.cs
@@ -177,7 +177,7 @@ namespace XenAdmin.Core
 
         public bool Go()
         {
-            if (Program.MainWindow.SelectObject(o))
+            if (Program.MainWindow.SelectObjectInTree(o))
             {
                 Program.MainWindow.TheTabControl.SelectedTab = tab;
                 return true;
@@ -286,7 +286,7 @@ namespace XenAdmin.Core
 
         public bool Go()
         {
-            if (Program.MainWindow.SelectObject(o))
+            if (Program.MainWindow.SelectObjectInTree(o))
             {
                 Program.MainWindow.TheTabControl.SelectedTab = Program.MainWindow.TabPageSearch;
                 Program.MainWindow.SearchPage.Search = search;

--- a/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.cs
+++ b/XenAdmin/Dialogs/WarningDialogs/VcpuWarningDialog.cs
@@ -73,7 +73,7 @@ namespace XenAdmin.Dialogs
                     vm.Locked = false;
                 }
             }
-            else if (Program.MainWindow.SelectObject(vm))
+            else if (Program.MainWindow.SelectObjectInTree(vm))
             {
                 Program.MainWindow.SwitchToTab(MainWindow.Tab.General);
             }

--- a/XenAdmin/IMainWindow.cs
+++ b/XenAdmin/IMainWindow.cs
@@ -51,12 +51,10 @@ namespace XenAdmin
         void TrySelectNewObjectInTree(Predicate<object> tagMatch, bool selectNode, bool expandNode, bool ensureNodeVisible);
         void TrySelectNewObjectInTree(IXenConnection c, bool selectNode, bool expandNode, bool ensureNodeVisible);
         void RequestRefreshTreeView();
-        void ShowPerXenModelObjectWizard(IXenObject obj, Form wizard);
         void ShowPerConnectionWizard(IXenConnection connection, Form wizard, Form parentForm = null);
         Form ShowForm(Type type);
         Form ShowForm(Type type, object[] args);
         void CloseActiveWizards(IXenConnection connection);
-        void CloseActiveWizards(IXenObject xenObject);
         Collection<IXenConnection> GetXenConnectionsCopy();
         void SaveServerList();
         bool DoSearch(string filename);

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -118,7 +118,6 @@ namespace XenAdmin
         private bool mainWindowResized = false;
 
         private readonly Dictionary<IXenConnection, IList<Form>> activePoolWizards = new Dictionary<IXenConnection, IList<Form>>();
-        private readonly Dictionary<IXenObject, Form> activeXenModelObjectWizards = new Dictionary<IXenObject, Form>();
 
         /// <summary>
         /// The arguments passed in on the command line.
@@ -1015,7 +1014,7 @@ namespace XenAdmin
         {
             if (host.IsLive() && host.MaintenanceMode() && host.enabled)
             {
-                Program.MainWindow.CloseActiveWizards(host);
+                Program.Invoke(this, () => XenDialogBase.CloseAll(host));
 
                 var action = new DisableHostAction(host);
                 action.Completed += action_Completed;
@@ -1071,7 +1070,7 @@ namespace XenAdmin
                 {
                     VM vm = (VM)e.Element;
                     ConsolePanel.closeVNCForSource(vm);
-                    CloseActiveWizards(vm);
+                    XenDialogBase.CloseAll(vm);
                 }
 
                 selectedTabs.Remove(o);
@@ -2219,24 +2218,15 @@ namespace XenAdmin
         #region IMainWindowCommandInterface Members
 
         /// <summary>
-        /// Closes all per-Connection and per-VM wizards for the given connection.
+        /// Closes all per-Connection and per-XenObject forms for the given connection.
         /// </summary>
         /// <param name="connection"></param>
         public void CloseActiveWizards(IXenConnection connection)
         {
             Program.Invoke(Program.MainWindow, delegate
             {
-                var vms = connection.Cache.VMs;
-                foreach (var kvp in activeXenModelObjectWizards)
-                {
-                    if (kvp.Key is VM vm && vms.Contains(vm))
-                    {
-                        if (kvp.Value is Form wizard && !wizard.IsDisposed)
-                            wizard.Close();
-
-                        activeXenModelObjectWizards.Remove(vm);
-                    }
-                }
+                //so far we show per-xenObject forms only for VMs and Hosts
+                XenDialogBase.CloseAll(connection.Cache.VMs.Cast<IXenObject>().Union(connection.Cache.Hosts).ToArray());
 
                 if (activePoolWizards.TryGetValue(connection, out IList<Form> wizards))
                 {
@@ -2249,36 +2239,6 @@ namespace XenAdmin
                     activePoolWizards.Remove(connection);
                 }
             });
-        }
-
-        /// <summary>
-        /// Closes all per-XenObject wizards.
-        /// </summary>
-        /// <param name="obj"></param>
-        public void CloseActiveWizards(IXenObject obj)
-        {
-            Program.Invoke(Program.MainWindow, delegate
-            {
-                if (activeXenModelObjectWizards.TryGetValue(obj, out Form wizard))
-                {
-                    if (!wizard.IsDisposed)
-                        wizard.Close();
-
-                    activeXenModelObjectWizards.Remove(obj);
-                }
-            });
-        }
-
-        /// <summary>
-        /// Show the given wizard, and impose a one-wizard-per-XenObject limit.
-        /// </summary>
-        /// <param name="obj">The relevant VM</param>
-        /// <param name="wizard">The new wizard to show</param>
-        public void ShowPerXenModelObjectWizard(IXenObject obj, Form wizard)
-        {
-            CloseActiveWizards(obj);
-            activeXenModelObjectWizards.Add(obj, wizard);
-            wizard.Show(this);
         }
 
         /// <summary>

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -2366,9 +2366,14 @@ namespace XenAdmin
             Program.Invoke(this, method);
         }
 
+        /// <summary>
+        /// Selects the specified object in the treeview.
+        /// </summary>
+        /// <param name="xenObject">The object to be selected.</param>
+        /// <returns>A value indicating whether selection was successful.</returns>
         public bool SelectObjectInTree(IXenObject xenObject)
         {
-            return SelectObject(xenObject);
+            return navigationPane.SelectObject(xenObject);
         }
 
         public Collection<IXenConnection> GetXenConnectionsCopy()
@@ -2395,7 +2400,6 @@ namespace XenAdmin
         {
             EditSelectedNodeInTreeView();
         }
-
 
         public void TrySelectNewObjectInTree(Predicate<object> tagMatch, bool selectNode, bool expandNode, bool ensureNodeVisible)
         {
@@ -2554,16 +2558,6 @@ namespace XenAdmin
                     Thread.Sleep(500);
                 }
             });
-        }
-
-        /// <summary>
-        /// Selects the specified object in the treeview.
-        /// </summary>
-        /// <param name="o">The object to be selected.</param>
-        /// <returns>A value indicating whether selection was successful.</returns>
-        public bool SelectObject(IXenObject o)
-        {
-            return navigationPane.SelectObject(o);
         }
 
         private void eventsPage_GoToXenObjectRequested(IXenObject obj)

--- a/XenAdmin/XenSearch/Columns.cs
+++ b/XenAdmin/XenSearch/Columns.cs
@@ -264,7 +264,7 @@ namespace XenAdmin.XenSearch
 
         private void ClickHandler(IXenObject o)
         {
-            if (Program.MainWindow.SelectObject(o) && Program.MainWindow.TheTabControl.TabPages.Contains(Program.MainWindow.TabPageGeneral))
+            if (Program.MainWindow.SelectObjectInTree(o) && Program.MainWindow.TheTabControl.TabPages.Contains(Program.MainWindow.TabPageGeneral))
             {
                 Program.MainWindow.SwitchToTab(MainWindow.Tab.General);
             }

--- a/XenAdminTests/MainWindowWrapper/MockMainWindow.cs
+++ b/XenAdminTests/MainWindowWrapper/MockMainWindow.cs
@@ -59,11 +59,6 @@ namespace XenAdminTests
         {
         }
 
-        public void ShowPerXenModelObjectWizard(IXenObject obj, Form wizard)
-        {
-
-        }
-
         public void ShowPerConnectionWizard(IXenConnection connection, Form wizard, Form parentForm = null)
         {
 
@@ -80,11 +75,6 @@ namespace XenAdminTests
         }
 
         public void CloseActiveWizards(IXenConnection connection)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void CloseActiveWizards(IXenObject xenObject)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
- CA-335633: Prevent crash due to iterating through modified dictionary. Ensure that per-XenObject dialogs closed by the user are removed from the tracking table.
- Removed duplicate method.
Commits best reviewed separately.