### PR TITLE
CP-33433: Limit XE client to PUT the same file with initial XE commands.

### DIFF
--- a/CommandLib/thinCLIProtocol.cs
+++ b/CommandLib/thinCLIProtocol.cs
@@ -77,6 +77,8 @@ namespace CommandLib
 	    public int major = 0;
 	    public int minor = 1;
         public bool dropOut;
+        public bool uploadCheck;
+        public string uploadFilename;
 
         public thinCLIProtocol(delegateGlobalError dGlobalError, 
             delegateGlobalUsage dGlobalUsage, 
@@ -98,6 +100,8 @@ namespace CommandLib
             this.dProgress = dProgress;
             this.conf = conf;
             dropOut = false;
+            uploadCheck = false;
+            uploadFilename = "";
         }
         
     }        
@@ -495,6 +499,14 @@ namespace CommandLib
             }
         }
 
+
+        public static void checkUploadFiles(String filename, thinCLIProtocol tCLIprotocol)
+        {
+            if (tCLIprotocol.uploadCheck == true && !filename.Equals(tCLIprotocol.uploadFilename)) {
+                throw new Exception(string.Format("The file '{0}' to upload is not same with initial one '{1}'", filename, tCLIprotocol.uploadFilename));
+            }
+        }
+
         public static void interpreter(Stream stream, thinCLIProtocol tCLIprotocol)
         {
             string filename = "";
@@ -560,11 +572,13 @@ namespace CommandLib
                                 break;
                             case Messages.tag.Load:
                                 filename = Types.unmarshal_string(stream);
+                                checkUploadFiles(filename, tCLIprotocol);
                                 tCLIprotocol.dGlobalDebug("Read: Load " + filename, tCLIprotocol);
                                 Messages.load(stream, filename, tCLIprotocol);
                                 break;
                             case Messages.tag.HttpPut:
                                 filename = Types.unmarshal_string(stream);
+                                checkUploadFiles(filename, tCLIprotocol);
                                 path = Types.unmarshal_string(stream);
                                 Uri uri = ParseUri(path, tCLIprotocol);
                                 tCLIprotocol.dGlobalDebug("Read: HttpPut " + filename + " -> " + uri, tCLIprotocol);

--- a/xe/Xe.cs
+++ b/xe/Xe.cs
@@ -30,7 +30,9 @@
  */
 
 using System;
+using System.Linq;
 using CommandLib;
+using System.Collections.Generic;
 
 
 namespace ThinCLI
@@ -45,6 +47,10 @@ namespace ThinCLI
 
             string body = "";
             char[] eqsep = {'='};
+
+            var uploadCmds = new List<string> {"pool-certificate-install", "pool-crl-install", "host-license-add", "vdi-import", "blob-put",
+            "pool-restore-database", "host-restore", "patch-upload", "update-upload"};
+            var fileName = new List<string> {"filename", "license-file", "file-name"};
 
             for (int i = 0; i < args.Length; i++)
             {
@@ -83,6 +89,17 @@ namespace ThinCLI
                     {
                         Console.WriteLine("ThinCLI protocol: " + tCliProtocol.major + "." + tCliProtocol.minor);
                         Environment.Exit(0);
+                    }
+                    // Specify the upload cmds since download cmds also get 'filename' key
+                    else if(uploadCmds.Contains(s))
+                    {
+                        tCliProtocol.uploadCheck = true;
+                        body += s + "\n";
+                    }
+                    else if(fileName.Any(x => s.StartsWith(x)))
+                    {
+                        tCliProtocol.uploadFilename = s.Split(eqsep)[1];
+                        body += s + "\n";
                     }
                     else
                     {


### PR DESCRIPTION
There are XE commands that need to upload files to the server which is running on dom0, this PR to add file-name checks to avoid a compromised server ask XE client to upload whatever files it has access to.

Signed-off-by: Min Li <min.li1@citrix.com>