### PR TITLE
CA-339384: Take account of thin provisioning when placing a disk on a target SR.

### DIFF
--- a/XenAdmin/Controls/DiskSpinner.cs
+++ b/XenAdmin/Controls/DiskSpinner.cs
@@ -109,6 +109,7 @@ namespace XenAdmin.Controls
 
             if (string.IsNullOrEmpty(DiskSizeNumericUpDown.Text.Trim())) //do not issue error here
             {
+                SelectedSize = 0;
                 SetError(null);
                 IsSizeValid = false;
                 return;
@@ -119,6 +120,7 @@ namespace XenAdmin.Controls
 
             if (!decimal.TryParse(DiskSizeNumericUpDown.Text.Trim(), out decimal result) || result < 0)
             {
+                SelectedSize = 0;
                 SetError(Messages.INVALID_DISK_SIZE);
                 IsSizeValid = false;
                 return;

--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -53,7 +53,6 @@ namespace XenAdmin.Controls
         private VDI[] _existingVDIs;
         private IXenConnection _connection;
         private Host _affinity;
-        private long _diskSize;
         private SR defaultSR;
         private readonly CollectionChangeEventHandler SR_CollectionChangedWithInvoke;
         private volatile int _scanCount;
@@ -106,13 +105,12 @@ namespace XenAdmin.Controls
         }
 
         public void PopulateAsync(SRPickerType usage, IXenConnection connection, Host affinity,
-            SR preselectedSR, VDI[] existingVdis, long diskSize)
+            SR preselectedSR, VDI[] existingVdis)
         {
             _usage = usage;
             _connection = connection;
             _affinity = affinity;
             _existingVDIs = existingVdis;
-            _diskSize = diskSize;
 
             if (_connection == null)
                 return;
@@ -157,7 +155,7 @@ namespace XenAdmin.Controls
 
             foreach (SR sr in _connection.Cache.SRs)
             {
-                var item = SrPickerItem.Create(sr, _usage, _affinity, _diskSize, _existingVDIs);
+                var item = SrPickerItem.Create(sr, _usage, _affinity, _existingVDIs);
                 if (item.Show)
                     items.Add(item);
 
@@ -200,14 +198,11 @@ namespace XenAdmin.Controls
             _ = SelectSR(selectedSr) || SelectDefaultSR() || SelectAnySR();
         }
 
-        public void UpdateDiskSize(long diskSize = 0)
+        public void UpdateDiskSize(long diskSize)
         {
             Program.AssertOnEventThread();
             try
             {
-                if (diskSize == 0)
-                    diskSize = _diskSize;
-
                 foreach (SrPickerItem node in Items)
                     node.UpdateDiskSize(diskSize);
             }

--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -39,8 +39,8 @@ namespace XenAdmin.Controls
 {
     public class SrPickerLunPerVDIItem : SrPickerVmItem
     {
-        public SrPickerLunPerVDIItem(SR sr, Host aff, long diskSize, VDI[] vdis)
-            : base(sr, aff, diskSize, vdis)
+        public SrPickerLunPerVDIItem(SR sr, Host aff, VDI[] vdis)
+            : base(sr, aff, vdis)
         {
         }
 
@@ -60,8 +60,8 @@ namespace XenAdmin.Controls
 
     public class SrPickerMigrateItem : SrPickerItem
     {
-        public SrPickerMigrateItem(SR sr, Host aff, long diskSize, VDI[] vdis)
-            : base(sr, aff, diskSize, vdis)
+        public SrPickerMigrateItem(SR sr, Host aff, VDI[] vdis)
+            : base(sr, aff, vdis)
         {
         }
 
@@ -141,8 +141,8 @@ namespace XenAdmin.Controls
 
     public class SrPickerMoveCopyItem : SrPickerItem
     {
-        public SrPickerMoveCopyItem(SR sr, Host aff, long diskSize, VDI[] vdis)
-            : base(sr, aff, diskSize, vdis)
+        public SrPickerMoveCopyItem(SR sr, Host aff, VDI[] vdis)
+            : base(sr, aff, vdis)
         {
         }
 
@@ -172,8 +172,8 @@ namespace XenAdmin.Controls
 
     public class SrPickerInstallFromTemplateItem : SrPickerItem
     {
-        public SrPickerInstallFromTemplateItem(SR sr, Host aff, long diskSize, VDI[] vdis)
-            : base(sr, aff, diskSize, vdis)
+        public SrPickerInstallFromTemplateItem(SR sr, Host aff, VDI[] vdis)
+            : base(sr, aff, vdis)
         {
         }
 
@@ -197,8 +197,8 @@ namespace XenAdmin.Controls
 
     public class SrPickerVmItem : SrPickerItem
     {
-        public SrPickerVmItem(SR sr, Host aff, long diskSize, VDI[] vdis)
-            : base(sr, aff, diskSize, vdis)
+        public SrPickerVmItem(SR sr, Host aff, VDI[] vdis)
+            : base(sr, aff, vdis)
         {
         }
 
@@ -231,12 +231,13 @@ namespace XenAdmin.Controls
         protected long DiskSize { get; private set; }
         protected readonly VDI[] existingVDIs;
 
-        protected SrPickerItem(SR sr, Host aff, long diskSize, VDI[] vdis)
+        protected SrPickerItem(SR sr, Host aff, VDI[] vdis)
         {
             existingVDIs = vdis ?? new VDI[0];
             TheSR = sr;
             Affinity = aff;
-            DiskSize = diskSize;
+            DiskSize = existingVDIs.Sum(vdi =>
+                sr.GetSRType(true) == SR.SRTypes.gfs2 ? vdi.physical_utilisation : vdi.virtual_size);
             Update();
         }
 
@@ -332,20 +333,20 @@ namespace XenAdmin.Controls
         }
 
 
-        public static SrPickerItem Create(SR sr, SrPicker.SRPickerType usage, Host aff, long diskSize, VDI[] vdis)
+        public static SrPickerItem Create(SR sr, SrPicker.SRPickerType usage, Host aff, VDI[] vdis)
         {
             switch (usage)
             {
                 case SrPicker.SRPickerType.Migrate:
-                    return new SrPickerMigrateItem(sr, aff, diskSize, vdis);
+                    return new SrPickerMigrateItem(sr, aff, vdis);
                 case SrPicker.SRPickerType.MoveOrCopy:
-                    return new SrPickerMoveCopyItem(sr, aff, diskSize, vdis);
+                    return new SrPickerMoveCopyItem(sr, aff, vdis);
                 case SrPicker.SRPickerType.InstallFromTemplate:
-                    return new SrPickerInstallFromTemplateItem(sr, aff, diskSize, vdis);
+                    return new SrPickerInstallFromTemplateItem(sr, aff, vdis);
                 case SrPicker.SRPickerType.VM:
-                    return new SrPickerVmItem(sr, aff, diskSize, vdis);
+                    return new SrPickerVmItem(sr, aff, vdis);
                 case SrPicker.SRPickerType.LunPerVDI:
-                    return new SrPickerLunPerVDIItem(sr, aff, diskSize, vdis);
+                    return new SrPickerLunPerVDIItem(sr, aff, vdis);
                 default:
                     throw new ArgumentException("There is no SRPickerItem for the type: " + usage);
             }

--- a/XenAdmin/Dialogs/CopyVMDialog.cs
+++ b/XenAdmin/Dialogs/CopyVMDialog.cs
@@ -93,8 +93,15 @@ namespace XenAdmin.Dialogs
                 DescriptionTextBox.Text = _vm.Description();
 
             EnableMoveButton();
+
+            var vdis = (from VBD vbd in _vm.Connection.ResolveAll(_vm.VBDs)
+                where vbd.type != vbd_type.CD
+                let vdi = _vm.Connection.Resolve(vbd.VDI)
+                where vdi != null
+                select vdi).ToArray();
+
             srPicker1.PopulateAsync(SrPicker.SRPickerType.MoveOrCopy, _vm.Connection,
-                _vm.Home(), null, null, _vm.TotalVMSize());
+                _vm.Home(), null, vdis);
         }
 
         private void EnableMoveButton()

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
@@ -67,7 +67,7 @@ namespace XenAdmin.Dialogs
             base.OnLoad(e);
             
             UpdateButtons();
-            srPicker1.PopulateAsync(SrPickerType, connection, null, null, _vdis.ToArray(), _vdis.Sum(d => d.physical_utilisation));
+            srPicker1.PopulateAsync(SrPickerType, connection, null, null, _vdis.ToArray());
         }
 
         internal override string HelpName => "VDIMigrateDialog";

--- a/XenAdmin/Dialogs/NewDiskDialog.cs
+++ b/XenAdmin/Dialogs/NewDiskDialog.cs
@@ -63,7 +63,7 @@ namespace XenAdmin.Dialogs
             NameTextBox.Text = GetDefaultVDIName();
             diskSpinner1.Populate();
             UpdateErrorsAndButtons();
-            SrListBox.PopulateAsync(SrPicker.SRPickerType.InstallFromTemplate, connection, null, sr, null, 0);
+            SrListBox.PopulateAsync(SrPicker.SRPickerType.InstallFromTemplate, connection, null, sr, null);
         }
 
         public NewDiskDialog(IXenConnection connection, VM vm)
@@ -86,7 +86,7 @@ namespace XenAdmin.Dialogs
                 NameTextBox.Text = GetDefaultVDIName();
                 diskSpinner1.Populate(minSize: minSize);
                 UpdateErrorsAndButtons();
-                SrListBox.PopulateAsync(pickerUsage, connection, affinity, null, null, 0);
+                SrListBox.PopulateAsync(pickerUsage, connection, affinity, null, null);
             }
             else
             {
@@ -97,7 +97,7 @@ namespace XenAdmin.Dialogs
                 OkButton.Text = Messages.OK;
                 diskSpinner1.Populate(DiskTemplate.virtual_size, minSize);
                 UpdateErrorsAndButtons();
-                SrListBox.PopulateAsync(pickerUsage, connection, affinity, connection.Resolve(DiskTemplate.SR), null, 0);
+                SrListBox.PopulateAsync(pickerUsage, connection, affinity, connection.Resolve(DiskTemplate.SR), null);
             }
         }
 
@@ -283,13 +283,13 @@ namespace XenAdmin.Dialogs
             // Ordering is important here, we want to show the most relevant message
             // The error should be shown only for size errors
 
+            SrListBox.UpdateDiskSize(diskSpinner1.SelectedSize);
+
             if (!diskSpinner1.IsSizeValid)
             {
                 OkButton.Enabled = false;
                 return;
             }
-
-            SrListBox.UpdateDiskSize(diskSpinner1.SelectedSize);
 
             if (!SrListBox.ValidSelectionExists)//all SRs disabled
             {

--- a/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
+++ b/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
@@ -51,17 +51,16 @@ namespace XenAdmin.Dialogs.VMDialogs
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            Host affinity = vm.Home();
+            EnableMoveButton();
 
             var vdis = (from VBD vbd in vm.Connection.ResolveAll(vm.VBDs)
-                where vbd.GetIsOwner()
+                where vbd.GetIsOwner() && vbd.type != vbd_type.CD
                 let vdi = vm.Connection.Resolve(vbd.VDI)
                 where vdi != null
                 select vdi).ToArray();
 
-            EnableMoveButton();
             srPicker1.PopulateAsync(SrPicker.SRPickerType.MoveOrCopy, vm.Connection,
-                affinity, null, vdis, vm.TotalVMSize());
+                vm.Home(), null, vdis);
         }
 
         private void EnableMoveButton()

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using XenAdmin.Controls;
 using XenAdmin.Core;
 using XenAPI;
@@ -126,8 +127,15 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                                    : Messages.COPY_VM_INTRA_POOL_RUBRIC;
 
             UpdateButtons();
+
+            var vdis = (from VBD vbd in TheVM.Connection.ResolveAll(TheVM.VBDs)
+                where vbd.type != vbd_type.CD
+                let vdi = TheVM.Connection.Resolve(vbd.VDI)
+                where vdi != null
+                select vdi).ToArray();
+
             srPicker1.PopulateAsync(SrPicker.SRPickerType.MoveOrCopy, TheVM.Connection,
-                TheVM.Home(), null, null, TheVM.TotalVMSize());
+                TheVM.Home(), null, vdis);
         }
 
         public override bool EnableNext()

--- a/XenAdmin/Wizards/ImportWizard/StoragePickerPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/StoragePickerPage.cs
@@ -120,7 +120,7 @@ namespace XenAdmin.Wizards.ImportWizard
         public override void PopulatePage()
         {
             SetButtonNextEnabled(false);
-            m_srPicker.PopulateAsync(SrPicker.SRPickerType.VM, m_targetConnection, m_targetHost, null, null, 0);
+            m_srPicker.PopulateAsync(SrPicker.SRPickerType.VM, m_targetConnection, m_targetHost, null, null);
             IsDirty = true;
         }
 

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -150,24 +150,6 @@ namespace XenAPI
             return null;
         }
 
-
-        public long TotalVMSize()
-        {
-            long size = 0;
-            foreach (VBD vbd in Connection.ResolveAll<VBD>(VBDs))
-            {
-                if (vbd.type == vbd_type.CD)
-                    continue;
-
-                VDI vdi = Connection.Resolve<VDI>(vbd.VDI);
-                if (vdi == null)
-                    continue;
-
-                size += vdi.physical_utilisation;
-            }
-            return size;
-        }
-
         public VBD FindVMCDROM()
         {
             if (Connection == null)


### PR DESCRIPTION
Also, set the required disk size to zero when the disk spinner value is invalid.