### PR TITLE
Test corrections. Fixes build failure.

### DIFF
--- a/XenAdmin/Properties/AssemblyInfo.cs
+++ b/XenAdmin/Properties/AssemblyInfo.cs
@@ -63,5 +63,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("0.0.0.0")]
 [assembly: AssemblyFileVersion("0000")]
 [assembly: XenCenterLib.XSVersion("[BRANDING_PRODUCT_VERSION]")]
-[assembly: InternalsVisibleTo("XenAdminTests"),
-           InternalsVisibleTo("XenAdminScalabilityTests")]
+[assembly: InternalsVisibleTo("XenAdminTests")]

--- a/XenAdminTests/CodeTests/AssemblyTests.cs
+++ b/XenAdminTests/CodeTests/AssemblyTests.cs
@@ -51,7 +51,7 @@ namespace XenAdminTests.CodeTests
             var assembly = FindAssemblyByNameRecursively(assemblyName);
             Assert.NotNull($"Assembly {assemblyName} was not found.");
 
-            var excludeFromCheck = new[] {"XenAdmin.Help.HelpManager", "XenAdmin.Branding"};
+            var excludeFromCheck = new[] {"XenAdmin.Help.HelpManager", "XenAdmin.Branding", "DotNetVnc.KeyMap"};
             var missing = new List<string>();
             var extra = new List<string>();
 

--- a/XenAdminTests/Properties/AssemblyInfo.cs
+++ b/XenAdminTests/Properties/AssemblyInfo.cs
@@ -64,4 +64,3 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: InternalsVisibleTo("XenAdminScalabilityTests")]

--- a/XenCenterLib/Archive/TarArchiveIterator.cs
+++ b/XenCenterLib/Archive/TarArchiveIterator.cs
@@ -44,6 +44,10 @@ namespace XenCenterLib.Archive
         private TarEntry tarEntry;
         private bool disposed;
 
+        public SharpZipTarArchiveIterator()
+        {
+        }
+
         public SharpZipTarArchiveIterator(Stream compressedTarFile, CompressionFactory.Type compressionType)
         {
             if (compressionType == CompressionFactory.Type.Gz)

--- a/XenCenterLib/Archive/TarArchiveWriter.cs
+++ b/XenCenterLib/Archive/TarArchiveWriter.cs
@@ -43,6 +43,10 @@ namespace XenCenterLib.Archive
         private const long bufferSize = 32*1024;
         protected bool disposed;
 
+        public SharpZipTarArchiveWriter()
+        {
+        }
+
         public SharpZipTarArchiveWriter(Stream outputStream)
         {
             tar = new TarOutputStream(outputStream);

--- a/XenCenterLib/Archive/ZipArchiveIterator.cs
+++ b/XenCenterLib/Archive/ZipArchiveIterator.cs
@@ -49,6 +49,10 @@ namespace XenCenterLib.Archive
         public event Action<long, long> CurrentFileExtractProgressChanged;
         public event Action CurrentFileExtractCompleted;
 
+        public DotNetZipZipIterator()
+        {
+        }
+
         public DotNetZipZipIterator(Stream inputStream)
         {
             Initialise(inputStream);

--- a/XenCenterLib/Archive/ZipArchiveWriter.cs
+++ b/XenCenterLib/Archive/ZipArchiveWriter.cs
@@ -38,17 +38,17 @@ namespace XenCenterLib.Archive
 {
     class DotNetZipZipWriter : ArchiveWriter
     {
-        private ZipOutputStream zip = null;
+        private ZipOutputStream zip;
         private bool disposed;
 
-        public DotNetZipZipWriter(Stream outputStream) : this()
+        public DotNetZipZipWriter(Stream outputStream)
         {
             zip = new ZipOutputStream( outputStream ) {EnableZip64 = Zip64Option.AsNecessary};
+            disposed = false;
         }
 
         public DotNetZipZipWriter()
         {
-            disposed = false;
         }
 
         public override void SetBaseStream(Stream outputStream)


### PR DESCRIPTION
- Exclude VNC key map from l10n tests.
- Added parameterless constructors to the archive classes for use by the tests.
- Scalability tests were removed.