### PR TITLE
CA-339374: Changed order of control disposal. Also, fixed wrong title of the undocked console.

### DIFF
--- a/XenAdmin/ConsoleView/VNCView.Designer.cs
+++ b/XenAdmin/ConsoleView/VNCView.Designer.cs
@@ -17,22 +17,21 @@ namespace XenAdmin.ConsoleView
 
             UnregisterEventListeners();
 
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-
             if (this.undockedForm != null)
             {
                 undockedForm.Hide();
                 undockedForm.Dispose();
             }
 
-            if (disposing && this.vncTabView != null)
+            if (disposing)
             {
-                this.vncTabView.Dispose();
+                if (vncTabView != null && !vncTabView.IsDisposed)
+                    vncTabView.Dispose();
+
+                if (components != null)
+                    components.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         #region Component Designer generated code

--- a/XenAdmin/ConsoleView/VNCView.cs
+++ b/XenAdmin/ConsoleView/VNCView.cs
@@ -234,7 +234,7 @@ namespace XenAdmin.ConsoleView
         {
             if (e.PropertyName == "name_label" && undockedForm != null)
             {
-                undockedForm.Text = source.name_label;
+                undockedForm.Text = UndockedWindowTitle(source);
             }
         }
 


### PR DESCRIPTION
Disposing the vncTabView disconnects the RdpClient and should not be called after
base.Dispose() is called on VNCView, because the latter has released the COM objects
and causes an InvalidComObjectException to be thrown.