### PR TITLE
CA-337270: Perform authentication on a background thread.

### DIFF
--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckOverviewDialog.cs
@@ -367,10 +367,10 @@ namespace XenAdmin.Dialogs.HealthCheck
             if (healthCheckSettings.CanRequestNewUpload)
             {
                 healthCheckSettings.NewUploadRequest = HealthCheckSettings.DateTimeToString(DateTime.UtcNow);
-                var token = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_TOKEN_SECRET);
-                var diagnosticToken = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET);
-                var user = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET);
-                var password = healthCheckSettings.GetSecretyInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET);
+                var token = healthCheckSettings.GetSecretInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_TOKEN_SECRET);
+                var diagnosticToken = healthCheckSettings.GetSecretInfo(poolRow.Pool.Connection, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET);
+                var user = healthCheckSettings.GetSecretInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET);
+                var password = healthCheckSettings.GetSecretInfo(poolRow.Pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET);
                 new SaveHealthCheckSettingsAction(poolRow.Pool, healthCheckSettings, token, diagnosticToken, user, password, false).RunAsync();
             }
         }

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.Designer.cs
@@ -50,10 +50,10 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.existingAuthenticationRadioButton = new System.Windows.Forms.RadioButton();
             this.newAuthenticationRadioButton = new System.Windows.Forms.RadioButton();
             this.authRubricLinkLabel = new System.Windows.Forms.LinkLabel();
-            this.authRubricTextLabel = new System.Windows.Forms.Label();
+            this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
+            this.pictureBoxStatus = new System.Windows.Forms.PictureBox();
+            this.labelStatus = new System.Windows.Forms.Label();
             this.rubricLabel = new System.Windows.Forms.Label();
-            this.PolicyStatementLinkLabel = new System.Windows.Forms.LinkLabel();
-            this.m_ctrlError = new XenAdmin.Controls.Common.PasswordFailure();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.enrollmentCheckBox = new System.Windows.Forms.CheckBox();
             this.decentGroupBoxXSCredentials = new XenAdmin.Controls.DecentGroupBox();
@@ -68,12 +68,15 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.currentXsCredentialsRadioButton = new System.Windows.Forms.RadioButton();
             this.newXsCredentialsRadioButton = new System.Windows.Forms.RadioButton();
             this.testCredentialsButton = new System.Windows.Forms.Button();
+            this.PolicyStatementLinkLabel = new System.Windows.Forms.LinkLabel();
             this.tableLayoutPanel1.SuspendLayout();
             this.decentGroupBox2.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.frequencyNumericBox)).BeginInit();
             this.decentGroupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel5.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxStatus)).BeginInit();
             this.flowLayoutPanel1.SuspendLayout();
             this.decentGroupBoxXSCredentials.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
@@ -98,14 +101,13 @@ namespace XenAdmin.Dialogs.HealthCheck
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.decentGroupBox2, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.decentGroupBox1, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.decentGroupBox2, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.decentGroupBox1, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.rubricLabel, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.PolicyStatementLinkLabel, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.m_ctrlError, 0, 10);
-            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 1, 10);
-            this.tableLayoutPanel1.Controls.Add(this.enrollmentCheckBox, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.decentGroupBoxXSCredentials, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.enrollmentCheckBox, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.decentGroupBoxXSCredentials, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.PolicyStatementLinkLabel, 1, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // decentGroupBox2
@@ -195,14 +197,14 @@ namespace XenAdmin.Dialogs.HealthCheck
             // tableLayoutPanel2
             // 
             resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 4);
-            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 5);
-            this.tableLayoutPanel2.Controls.Add(this.textBoxMyCitrixPassword, 1, 5);
-            this.tableLayoutPanel2.Controls.Add(this.textBoxMyCitrixUsername, 1, 4);
-            this.tableLayoutPanel2.Controls.Add(this.existingAuthenticationRadioButton, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.newAuthenticationRadioButton, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.textBoxMyCitrixPassword, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this.textBoxMyCitrixUsername, 1, 3);
+            this.tableLayoutPanel2.Controls.Add(this.existingAuthenticationRadioButton, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.newAuthenticationRadioButton, 0, 2);
             this.tableLayoutPanel2.Controls.Add(this.authRubricLinkLabel, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.authRubricTextLabel, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel5, 1, 5);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
             // label1
@@ -254,11 +256,24 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.authRubricLinkLabel.TabStop = true;
             this.authRubricLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.authRubricLinkLabel_LinkClicked);
             // 
-            // authRubricTextLabel
+            // tableLayoutPanel5
             // 
-            resources.ApplyResources(this.authRubricTextLabel, "authRubricTextLabel");
-            this.tableLayoutPanel2.SetColumnSpan(this.authRubricTextLabel, 2);
-            this.authRubricTextLabel.Name = "authRubricTextLabel";
+            resources.ApplyResources(this.tableLayoutPanel5, "tableLayoutPanel5");
+            this.tableLayoutPanel5.Controls.Add(this.pictureBoxStatus, 0, 0);
+            this.tableLayoutPanel5.Controls.Add(this.labelStatus, 1, 0);
+            this.tableLayoutPanel5.Name = "tableLayoutPanel5";
+            // 
+            // pictureBoxStatus
+            // 
+            resources.ApplyResources(this.pictureBoxStatus, "pictureBoxStatus");
+            this.pictureBoxStatus.Name = "pictureBoxStatus";
+            this.pictureBoxStatus.TabStop = false;
+            // 
+            // labelStatus
+            // 
+            resources.ApplyResources(this.labelStatus, "labelStatus");
+            this.labelStatus.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.labelStatus.Name = "labelStatus";
             // 
             // rubricLabel
             // 
@@ -266,22 +281,10 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.tableLayoutPanel1.SetColumnSpan(this.rubricLabel, 2);
             this.rubricLabel.Name = "rubricLabel";
             // 
-            // PolicyStatementLinkLabel
-            // 
-            resources.ApplyResources(this.PolicyStatementLinkLabel, "PolicyStatementLinkLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.PolicyStatementLinkLabel, 2);
-            this.PolicyStatementLinkLabel.Name = "PolicyStatementLinkLabel";
-            this.PolicyStatementLinkLabel.TabStop = true;
-            this.PolicyStatementLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.PolicyStatementLinkLabel_LinkClicked);
-            // 
-            // m_ctrlError
-            // 
-            resources.ApplyResources(this.m_ctrlError, "m_ctrlError");
-            this.m_ctrlError.Name = "m_ctrlError";
-            // 
             // flowLayoutPanel1
             // 
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
+            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
             this.flowLayoutPanel1.Controls.Add(this.cancelButton);
             this.flowLayoutPanel1.Controls.Add(this.okButton);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
@@ -289,7 +292,6 @@ namespace XenAdmin.Dialogs.HealthCheck
             // enrollmentCheckBox
             // 
             resources.ApplyResources(this.enrollmentCheckBox, "enrollmentCheckBox");
-            this.tableLayoutPanel1.SetColumnSpan(this.enrollmentCheckBox, 2);
             this.enrollmentCheckBox.Name = "enrollmentCheckBox";
             this.enrollmentCheckBox.UseVisualStyleBackColor = true;
             this.enrollmentCheckBox.CheckedChanged += new System.EventHandler(this.enrollmentCheckBox_CheckedChanged);
@@ -319,8 +321,8 @@ namespace XenAdmin.Dialogs.HealthCheck
             // 
             // errorLabel
             // 
-            this.errorLabel.AutoEllipsis = true;
             resources.ApplyResources(this.errorLabel, "errorLabel");
+            this.errorLabel.AutoEllipsis = true;
             this.errorLabel.ForeColor = System.Drawing.Color.Red;
             this.errorLabel.Name = "errorLabel";
             // 
@@ -377,7 +379,7 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.newXsCredentialsRadioButton.Name = "newXsCredentialsRadioButton";
             this.newXsCredentialsRadioButton.TabStop = true;
             this.newXsCredentialsRadioButton.UseVisualStyleBackColor = true;
-            this.newXsCredentialsRadioButton.CheckedChanged += new System.EventHandler(this.radioButton2_CheckedChanged);
+            this.newXsCredentialsRadioButton.CheckedChanged += new System.EventHandler(this.newXsCredentialsRadioButton_CheckedChanged);
             // 
             // testCredentialsButton
             // 
@@ -385,6 +387,13 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.testCredentialsButton.Name = "testCredentialsButton";
             this.testCredentialsButton.UseVisualStyleBackColor = true;
             this.testCredentialsButton.Click += new System.EventHandler(this.testCredentialsButton_Click);
+            // 
+            // PolicyStatementLinkLabel
+            // 
+            resources.ApplyResources(this.PolicyStatementLinkLabel, "PolicyStatementLinkLabel");
+            this.PolicyStatementLinkLabel.Name = "PolicyStatementLinkLabel";
+            this.PolicyStatementLinkLabel.TabStop = true;
+            this.PolicyStatementLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.PolicyStatementLinkLabel_LinkClicked);
             // 
             // HealthCheckSettingsDialog
             // 
@@ -405,6 +414,9 @@ namespace XenAdmin.Dialogs.HealthCheck
             this.decentGroupBox1.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
+            this.tableLayoutPanel5.ResumeLayout(false);
+            this.tableLayoutPanel5.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxStatus)).EndInit();
             this.flowLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.PerformLayout();
             this.decentGroupBoxXSCredentials.ResumeLayout(false);
@@ -450,13 +462,14 @@ namespace XenAdmin.Dialogs.HealthCheck
         protected System.Windows.Forms.TextBox textboxXSUserName;
         private System.Windows.Forms.RadioButton currentXsCredentialsRadioButton;
         private System.Windows.Forms.RadioButton newXsCredentialsRadioButton;
-        private Controls.Common.PasswordFailure m_ctrlError;
         private System.Windows.Forms.Button testCredentialsButton;
         private System.Windows.Forms.PictureBox testCredentialsStatusImage;
         private System.Windows.Forms.Label errorLabel;
         protected System.Windows.Forms.Label label2;
         protected System.Windows.Forms.TextBox textBoxMyCitrixPassword;
         private System.Windows.Forms.LinkLabel authRubricLinkLabel;
-        private System.Windows.Forms.Label authRubricTextLabel;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel5;
+        private System.Windows.Forms.PictureBox pictureBoxStatus;
+        private System.Windows.Forms.Label labelStatus;
     }
 }

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.cs
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.cs
@@ -66,8 +66,8 @@ namespace XenAdmin.Dialogs.HealthCheck
                 healthCheckSettings.Status = HealthCheckStatus.Enabled;
             authenticated = healthCheckSettings.TryGetExistingTokens(pool.Connection, out authenticationToken, out diagnosticToken);
             authenticationRequired = !authenticated;
-            xsUserName = healthCheckSettings.GetSecretyInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET);
-            xsPassword = healthCheckSettings.GetSecretyInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET);
+            xsUserName = healthCheckSettings.GetSecretInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET);
+            xsPassword = healthCheckSettings.GetSecretInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET);
             InitializeComponent();
             PopulateControls();
             InitializeControls();
@@ -157,7 +157,7 @@ namespace XenAdmin.Dialogs.HealthCheck
                 return true;
             if (timeOfDayComboBox.SelectedIndex != healthCheckSettings.TimeOfDay)
                 return true;
-            if (authenticationToken != healthCheckSettings.GetSecretyInfo(pool.Connection, HealthCheckSettings.UPLOAD_TOKEN_SECRET))
+            if (authenticationToken != healthCheckSettings.GetSecretInfo(pool.Connection, HealthCheckSettings.UPLOAD_TOKEN_SECRET))
                 return true;
             if (textboxXSUserName.Text != xsUserName)
                 return true;

--- a/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
+++ b/XenAdmin/Dialogs/HealthCheck/HealthCheckSettingsDialog.resx
@@ -133,7 +133,7 @@
     <value>NoControl</value>
   </data>
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>31, 3</value>
+    <value>440, 3</value>
   </data>
   <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 25</value>
@@ -166,7 +166,7 @@
     <value>NoControl</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 3</value>
+    <value>521, 3</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 25</value>
@@ -192,6 +192,9 @@
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
@@ -200,6 +203,9 @@
   </data>
   <data name="decentGroupBox2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="decentGroupBox2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
   <data name="tableLayoutPanel4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -210,11 +216,11 @@
   <data name="tableLayoutPanel4.ColumnCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
+  <data name="frequencyLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="frequencyLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="frequencyLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="frequencyLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -223,22 +229,16 @@
     <value>NoControl</value>
   </data>
   <data name="frequencyLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 3</value>
-  </data>
-  <data name="frequencyLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>3, 7</value>
   </data>
   <data name="frequencyLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 29</value>
+    <value>65, 15</value>
   </data>
   <data name="frequencyLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="frequencyLabel.Text" xml:space="preserve">
     <value>&amp;Frequency:</value>
-  </data>
-  <data name="frequencyLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;frequencyLabel.Name" xml:space="preserve">
     <value>frequencyLabel</value>
@@ -256,13 +256,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="frequencyNumericBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>97, 6</value>
+    <value>103, 3</value>
   </data>
   <data name="frequencyNumericBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>54, 23</value>
   </data>
   <data name="frequencyNumericBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;frequencyNumericBox.Name" xml:space="preserve">
     <value>frequencyNumericBox</value>
@@ -276,11 +276,11 @@
   <data name="&gt;&gt;frequencyNumericBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="weeksLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="weeksLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="weeksLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="weeksLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -289,22 +289,16 @@
     <value>NoControl</value>
   </data>
   <data name="weeksLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 3</value>
-  </data>
-  <data name="weeksLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>163, 7</value>
   </data>
   <data name="weeksLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>437, 29</value>
+    <value>39, 15</value>
   </data>
   <data name="weeksLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
+    <value>2</value>
   </data>
   <data name="weeksLabel.Text" xml:space="preserve">
     <value>weeks</value>
-  </data>
-  <data name="weeksLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;weeksLabel.Name" xml:space="preserve">
     <value>weeksLabel</value>
@@ -318,11 +312,11 @@
   <data name="&gt;&gt;weeksLabel.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="dayOfweekLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="dayOfweekLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="dayOfweekLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="dayOfweekLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -331,22 +325,16 @@
     <value>NoControl</value>
   </data>
   <data name="dayOfweekLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 61</value>
-  </data>
-  <data name="dayOfweekLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>3, 65</value>
   </data>
   <data name="dayOfweekLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 29</value>
+    <value>94, 15</value>
   </data>
   <data name="dayOfweekLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="dayOfweekLabel.Text" xml:space="preserve">
     <value>&amp;Day of the week:</value>
-  </data>
-  <data name="dayOfweekLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;dayOfweekLabel.Name" xml:space="preserve">
     <value>dayOfweekLabel</value>
@@ -360,11 +348,11 @@
   <data name="&gt;&gt;dayOfweekLabel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="timeOfDayLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="timeOfDayLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="timeOfDayLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="timeOfDayLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -373,22 +361,16 @@
     <value>NoControl</value>
   </data>
   <data name="timeOfDayLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 32</value>
-  </data>
-  <data name="timeOfDayLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+    <value>3, 36</value>
   </data>
   <data name="timeOfDayLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 29</value>
+    <value>92, 15</value>
   </data>
   <data name="timeOfDayLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="timeOfDayLabel.Text" xml:space="preserve">
     <value>&amp;Time of the day:</value>
-  </data>
-  <data name="timeOfDayLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;timeOfDayLabel.Name" xml:space="preserve">
     <value>timeOfDayLabel</value>
@@ -409,13 +391,13 @@
     <value>15</value>
   </data>
   <data name="timeOfDayComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>97, 35</value>
+    <value>103, 32</value>
   </data>
   <data name="timeOfDayComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 23</value>
   </data>
   <data name="timeOfDayComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;timeOfDayComboBox.Name" xml:space="preserve">
     <value>timeOfDayComboBox</value>
@@ -433,13 +415,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="dayOfWeekComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>97, 64</value>
+    <value>103, 61</value>
   </data>
   <data name="dayOfWeekComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 23</value>
   </data>
   <data name="dayOfWeekComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;dayOfWeekComboBox.Name" xml:space="preserve">
     <value>dayOfWeekComboBox</value>
@@ -462,17 +444,14 @@
   <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 19</value>
   </data>
-  <data name="tableLayoutPanel4.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
-  </data>
   <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>591, 93</value>
+    <value>587, 87</value>
   </data>
   <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel4.Name" xml:space="preserve">
     <value>tableLayoutPanel4</value>
@@ -493,10 +472,16 @@
     <value>Segoe UI, 9pt, style=Bold</value>
   </data>
   <data name="decentGroupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 92</value>
+    <value>3, 77</value>
+  </data>
+  <data name="decentGroupBox2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 10, 3, 3</value>
+  </data>
+  <data name="decentGroupBox2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
   </data>
   <data name="decentGroupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>597, 115</value>
+    <value>593, 112</value>
   </data>
   <data name="decentGroupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -519,8 +504,8 @@
   <data name="decentGroupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="decentGroupBox1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
+  <data name="decentGroupBox1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -531,11 +516,11 @@
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -544,22 +529,19 @@
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 86</value>
+    <value>20, 78</value>
   </data>
   <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 29</value>
+    <value>63, 15</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>U&amp;sername:</value>
-  </data>
-  <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -573,11 +555,11 @@
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="label2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="label2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -586,22 +568,19 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 115</value>
+    <value>20, 107</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 29</value>
+    <value>60, 15</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>Pass&amp;word:</value>
-  </data>
-  <data name="label2.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -619,7 +598,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 118</value>
+    <value>89, 103</value>
   </data>
   <data name="textBoxMyCitrixPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -643,7 +622,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textBoxMyCitrixUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 89</value>
+    <value>89, 74</value>
   </data>
   <data name="textBoxMyCitrixUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -673,10 +652,10 @@
     <value>NoControl</value>
   </data>
   <data name="existingAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 39</value>
+    <value>3, 24</value>
   </data>
   <data name="existingAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>167, 19</value>
+    <value>168, 19</value>
   </data>
   <data name="existingAuthenticationRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -706,10 +685,10 @@
     <value>NoControl</value>
   </data>
   <data name="newAuthenticationRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 64</value>
+    <value>3, 49</value>
   </data>
   <data name="newAuthenticationRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>232, 19</value>
+    <value>233, 19</value>
   </data>
   <data name="newAuthenticationRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -732,17 +711,29 @@
   <data name="authRubricLinkLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="authRubricLinkLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="authRubricLinkLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="authRubricLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 6</value>
+    <value>3, 0</value>
+  </data>
+  <data name="authRubricLinkLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 6</value>
+  </data>
+  <data name="authRubricLinkLabel.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>585, 9999</value>
   </data>
   <data name="authRubricLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 15</value>
+    <value>581, 15</value>
   </data>
   <data name="authRubricLinkLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
+  </data>
+  <data name="authRubricLinkLabel.Text" xml:space="preserve">
+    <value>link label</value>
   </data>
   <data name="&gt;&gt;authRubricLinkLabel.Name" xml:space="preserve">
     <value>authRubricLinkLabel</value>
@@ -756,32 +747,104 @@
   <data name="&gt;&gt;authRubricLinkLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="authRubricTextLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="tableLayoutPanel5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="authRubricTextLabel.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="tableLayoutPanel5.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel5.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="pictureBoxStatus.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <data name="authRubricTextLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 21</value>
+  <data name="pictureBoxStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
-  <data name="authRubricTextLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 15</value>
+  <data name="pictureBoxStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
   </data>
-  <data name="authRubricTextLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="pictureBoxStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="&gt;&gt;authRubricTextLabel.Name" xml:space="preserve">
-    <value>authRubricTextLabel</value>
+  <data name="&gt;&gt;pictureBoxStatus.Name" xml:space="preserve">
+    <value>pictureBoxStatus</value>
   </data>
-  <data name="&gt;&gt;authRubricTextLabel.Type" xml:space="preserve">
+  <data name="&gt;&gt;pictureBoxStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxStatus.Parent" xml:space="preserve">
+    <value>tableLayoutPanel5</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxStatus.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="labelStatus.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelStatus.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="labelStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 4</value>
+  </data>
+  <data name="labelStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>467, 15</value>
+  </data>
+  <data name="labelStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelStatus.Text" xml:space="preserve">
+    <value>error</value>
+  </data>
+  <data name="&gt;&gt;labelStatus.Name" xml:space="preserve">
+    <value>labelStatus</value>
+  </data>
+  <data name="&gt;&gt;labelStatus.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;authRubricTextLabel.Parent" xml:space="preserve">
+  <data name="&gt;&gt;labelStatus.Parent" xml:space="preserve">
+    <value>tableLayoutPanel5</value>
+  </data>
+  <data name="&gt;&gt;labelStatus.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel5.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>89, 132</value>
+  </data>
+  <data name="tableLayoutPanel5.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>495, 24</value>
+  </data>
+  <data name="tableLayoutPanel5.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel5.Name" xml:space="preserve">
+    <value>tableLayoutPanel5</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel5.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;authRubricTextLabel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tableLayoutPanel5.ZOrder" xml:space="preserve">
     <value>7</value>
+  </data>
+  <data name="tableLayoutPanel5.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBoxStatus" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStatus" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -792,17 +855,14 @@
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 19</value>
   </data>
-  <data name="tableLayoutPanel2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 6, 0, 10</value>
-  </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>591, 154</value>
+    <value>587, 159</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -817,16 +877,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixPassword" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixUsername" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="existingAuthenticationRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="newAuthenticationRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="authRubricLinkLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="authRubricTextLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxMyCitrixUsername" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="existingAuthenticationRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="newAuthenticationRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="authRubricLinkLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="tableLayoutPanel5" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,30,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBox1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
   </data>
   <data name="decentGroupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 402</value>
+    <value>3, 390</value>
+  </data>
+  <data name="decentGroupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 5, 3, 3</value>
+  </data>
+  <data name="decentGroupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
   </data>
   <data name="decentGroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>597, 218</value>
+    <value>593, 184</value>
   </data>
   <data name="decentGroupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -859,13 +925,16 @@
     <value>NoControl</value>
   </data>
   <data name="rubricLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>3, 0</value>
   </data>
   <data name="rubricLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 3</value>
+    <value>3, 0, 3, 10</value>
+  </data>
+  <data name="rubricLabel.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>585, 9999</value>
   </data>
   <data name="rubricLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>603, 30</value>
+    <value>585, 30</value>
   </data>
   <data name="rubricLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -885,89 +954,14 @@
   <data name="&gt;&gt;rubricLabel.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="PolicyStatementLinkLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="flowLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="PolicyStatementLinkLabel.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="PolicyStatementLinkLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="PolicyStatementLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 41</value>
-  </data>
-  <data name="PolicyStatementLinkLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 0</value>
-  </data>
-  <data name="PolicyStatementLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 15</value>
-  </data>
-  <data name="PolicyStatementLinkLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="PolicyStatementLinkLabel.Text" xml:space="preserve">
-    <value>Privacy statement</value>
-  </data>
-  <data name="&gt;&gt;PolicyStatementLinkLabel.Name" xml:space="preserve">
-    <value>PolicyStatementLinkLabel</value>
-  </data>
-  <data name="&gt;&gt;PolicyStatementLinkLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PolicyStatementLinkLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;PolicyStatementLinkLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="m_ctrlError.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="m_ctrlError.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="m_ctrlError.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="m_ctrlError.Error" xml:space="preserve">
-    <value />
-  </data>
-  <data name="m_ctrlError.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="m_ctrlError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 623</value>
-  </data>
-  <data name="m_ctrlError.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
-  </data>
-  <data name="m_ctrlError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>407, 22</value>
-  </data>
-  <data name="m_ctrlError.TabIndex" type="System.Int32, mscorlib">
-    <value>27</value>
-  </data>
-  <data name="m_ctrlError.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;m_ctrlError.Name" xml:space="preserve">
-    <value>m_ctrlError</value>
-  </data>
-  <data name="&gt;&gt;m_ctrlError.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.Common.PasswordFailure, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;m_ctrlError.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;m_ctrlError.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="flowLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left, Right</value>
   </data>
   <data name="flowLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="flowLayoutPanel1.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
     <value>RightToLeft</value>
@@ -976,16 +970,16 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>421, 627</value>
+    <value>0, 577</value>
   </data>
   <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 36</value>
+    <value>599, 31</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>7</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -997,7 +991,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="enrollmentCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1009,16 +1003,16 @@
     <value>NoControl</value>
   </data>
   <data name="enrollmentCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 59</value>
+    <value>3, 43</value>
   </data>
   <data name="enrollmentCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 4, 0, 4</value>
+    <value>3, 2, 10, 0</value>
   </data>
   <data name="enrollmentCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 27</value>
+    <value>152, 21</value>
   </data>
   <data name="enrollmentCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="enrollmentCheckBox.Text" xml:space="preserve">
     <value>&amp;Enable Health Check</value>
@@ -1033,7 +1027,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;enrollmentCheckBox.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -1053,11 +1047,11 @@
   <data name="tableLayoutPanel3.ColumnCount" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
+  <data name="errorLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
   <data name="errorLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="errorLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="errorLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -1066,13 +1060,10 @@
     <value>NoControl</value>
   </data>
   <data name="errorLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>213, 138</value>
-  </data>
-  <data name="errorLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
+    <value>227, 137</value>
   </data>
   <data name="errorLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>378, 20</value>
+    <value>357, 15</value>
   </data>
   <data name="errorLabel.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -1102,10 +1093,7 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsStatusImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>194, 138</value>
-  </data>
-  <data name="testCredentialsStatusImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 5, 3, 3</value>
+    <value>205, 136</value>
   </data>
   <data name="testCredentialsStatusImage.Size" type="System.Drawing.Size, System.Drawing">
     <value>16, 16</value>
@@ -1141,13 +1129,16 @@
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 6</value>
+    <value>3, 0</value>
   </data>
   <data name="label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 4</value>
+    <value>3, 0, 3, 6</value>
+  </data>
+  <data name="label3.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>585, 9999</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>591, 15</value>
+    <value>581, 15</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1170,11 +1161,11 @@
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="label4.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="label4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="label4.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -1183,22 +1174,19 @@
     <value>NoControl</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 75</value>
+    <value>20, 78</value>
   </data>
   <data name="label4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 29</value>
+    <value>63, 15</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="label4.Text" xml:space="preserve">
     <value>&amp;Username:</value>
-  </data>
-  <data name="label4.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;label4.Name" xml:space="preserve">
     <value>label4</value>
@@ -1212,11 +1200,11 @@
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="label5.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="label5.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -1225,22 +1213,19 @@
     <value>NoControl</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 104</value>
+    <value>20, 107</value>
   </data>
   <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>20, 0, 3, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 29</value>
+    <value>60, 15</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>&amp;Password:</value>
-  </data>
-  <data name="label5.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;label5.Name" xml:space="preserve">
     <value>label5</value>
@@ -1258,7 +1243,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 107</value>
+    <value>89, 103</value>
   </data>
   <data name="textboxXSPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1282,7 +1267,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="textboxXSUserName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 78</value>
+    <value>89, 74</value>
   </data>
   <data name="textboxXSUserName.Size" type="System.Drawing.Size, System.Drawing">
     <value>300, 23</value>
@@ -1315,7 +1300,7 @@
     <value>NoControl</value>
   </data>
   <data name="currentXsCredentialsRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 28</value>
+    <value>3, 24</value>
   </data>
   <data name="currentXsCredentialsRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>231, 19</value>
@@ -1348,7 +1333,7 @@
     <value>NoControl</value>
   </data>
   <data name="newXsCredentialsRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 53</value>
+    <value>3, 49</value>
   </data>
   <data name="newXsCredentialsRadioButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>152, 19</value>
@@ -1371,9 +1356,6 @@
   <data name="&gt;&gt;newXsCredentialsRadioButton.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="testCredentialsButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="testCredentialsButton.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -1381,13 +1363,10 @@
     <value>NoControl</value>
   </data>
   <data name="testCredentialsButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 133</value>
-  </data>
-  <data name="testCredentialsButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
+    <value>89, 132</value>
   </data>
   <data name="testCredentialsButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 25</value>
+    <value>110, 25</value>
   </data>
   <data name="testCredentialsButton.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1416,17 +1395,14 @@
   <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 19</value>
   </data>
-  <data name="tableLayoutPanel3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 6, 0, 3</value>
-  </data>
   <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>591, 161</value>
+    <value>587, 160</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Name" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -1441,16 +1417,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="errorLabel" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="testCredentialsStatusImage" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textboxXSPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="textboxXSUserName" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="currentXsCredentialsRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="newXsCredentialsRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="testCredentialsButton" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,100,AutoSize,50,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="errorLabel" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="testCredentialsStatusImage" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textboxXSPassword" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="textboxXSUserName" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="currentXsCredentialsRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="newXsCredentialsRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="testCredentialsButton" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt, style=Bold</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 213</value>
+    <value>3, 197</value>
+  </data>
+  <data name="decentGroupBoxXSCredentials.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 5, 3, 3</value>
+  </data>
+  <data name="decentGroupBoxXSCredentials.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
   </data>
   <data name="decentGroupBoxXSCredentials.Size" type="System.Drawing.Size, System.Drawing">
-    <value>597, 183</value>
+    <value>593, 185</value>
   </data>
   <data name="decentGroupBoxXSCredentials.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1468,28 +1450,61 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;decentGroupBoxXSCredentials.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>5</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>161, 46</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 15</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="PolicyStatementLinkLabel.Text" xml:space="preserve">
+    <value>Privacy statement</value>
+  </data>
+  <data name="&gt;&gt;PolicyStatementLinkLabel.Name" xml:space="preserve">
+    <value>PolicyStatementLinkLabel</value>
+  </data>
+  <data name="&gt;&gt;PolicyStatementLinkLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PolicyStatementLinkLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;PolicyStatementLinkLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+    <value>Top</value>
   </data>
   <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="tableLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
+    <value>10, 10</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>6</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>619, 671</value>
+    <value>599, 608</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -1504,7 +1519,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="decentGroupBox2" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="decentGroupBox1" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="rubricLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="PolicyStatementLinkLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="m_ctrlError" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="flowLayoutPanel1" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="enrollmentCheckBox" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="decentGroupBoxXSCredentials" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="decentGroupBox2" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="decentGroupBox1" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="rubricLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="flowLayoutPanel1" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="enrollmentCheckBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="decentGroupBoxXSCredentials" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="PolicyStatementLinkLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -1512,14 +1527,23 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>619, 671</value>
+    <value>619, 641</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>520, 490</value>
+    <value>635, 600</value>
+  </data>
+  <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 10, 10, 10</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Health Check Enrollment</value>

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -992,8 +992,8 @@ namespace XenAdmin
                 return;
             var newHealthCheckSSettings = pool.HealthCheckSettings();
             new TransferHealthCheckSettingsAction(pool, newHealthCheckSSettings,
-                newHealthCheckSSettings.GetSecretyInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET),
-                newHealthCheckSSettings.GetSecretyInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET), true).RunAsync();
+                newHealthCheckSSettings.GetSecretInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_USER_SECRET),
+                newHealthCheckSSettings.GetSecretInfo(pool.Connection, HealthCheckSettings.UPLOAD_CREDENTIAL_PASSWORD_SECRET), true).RunAsync();
         }
 
         private static bool SameProductBrand(Host host)

--- a/XenModel/Actions/HealthCheck/GetHealthCheckAnalysisResultAction.cs
+++ b/XenModel/Actions/HealthCheck/GetHealthCheckAnalysisResultAction.cs
@@ -71,7 +71,7 @@ namespace XenAdmin.Actions
             {
                 var healthCheckSettings = Pool.HealthCheckSettings();
 
-                var diagnosticToken = healthCheckSettings.GetSecretyInfo(Session, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET);
+                var diagnosticToken = healthCheckSettings.GetSecretInfo(Session, HealthCheckSettings.DIAGNOSTIC_TOKEN_SECRET);
                 if (string.IsNullOrEmpty(diagnosticToken))
                 {
                     log.DebugFormat("Cannot get the diagnostic result for {0}, because couldn't retrieve the diagnostic token", Pool.Name());

--- a/XenModel/HealthCheckSettings.cs
+++ b/XenModel/HealthCheckSettings.cs
@@ -298,7 +298,7 @@ namespace XenAdmin.Model
 
         #endregion
 
-        public string GetSecretyInfo(Session session, string secretType)
+        public string GetSecretInfo(Session session, string secretType)
         {
             string UUID = string.Empty;
             switch (secretType)
@@ -334,11 +334,11 @@ namespace XenAdmin.Model
             }
         }
 
-        public string GetSecretyInfo(IXenConnection connection, string secretType)
+        public string GetSecretInfo(IXenConnection connection, string secretType)
         {
             if (connection == null)
                 return null;
-            return GetSecretyInfo(connection.Session, secretType);
+            return GetSecretInfo(connection.Session, secretType);
         }
 
         public bool TryGetExistingTokens(IXenConnection connection, out string uploadToken, out string diagnosticToken)
@@ -348,8 +348,8 @@ namespace XenAdmin.Model
             if (connection == null)
                 return false;
 
-            uploadToken = GetSecretyInfo(connection, UPLOAD_TOKEN_SECRET);
-            diagnosticToken = GetSecretyInfo(connection, DIAGNOSTIC_TOKEN_SECRET);
+            uploadToken = GetSecretInfo(connection, UPLOAD_TOKEN_SECRET);
+            diagnosticToken = GetSecretInfo(connection, DIAGNOSTIC_TOKEN_SECRET);
 
             if (!String.IsNullOrEmpty(uploadToken) && !String.IsNullOrEmpty(diagnosticToken))
                 return true;
@@ -369,8 +369,8 @@ namespace XenAdmin.Model
                 if (poolOfOne != null)
                 {
                     var healthCheckSettings = poolOfOne.HealthCheckSettings();
-                    uploadToken = healthCheckSettings.GetSecretyInfo(connection, UPLOAD_TOKEN_SECRET);
-                    diagnosticToken = healthCheckSettings.GetSecretyInfo(connection, DIAGNOSTIC_TOKEN_SECRET);
+                    uploadToken = healthCheckSettings.GetSecretInfo(connection, UPLOAD_TOKEN_SECRET);
+                    diagnosticToken = healthCheckSettings.GetSecretInfo(connection, DIAGNOSTIC_TOKEN_SECRET);
                     if (!String.IsNullOrEmpty(uploadToken) && !String.IsNullOrEmpty(diagnosticToken))
                         return true;
                 }


### PR DESCRIPTION
- Typo.
- Added controls to display the error in case authentication fails.
- Use the same control (LinkLabel) to show the rubric either when new authentication is needed or an existing one can be used.
- Moved privacy policy statement next to the checkbox because it looked crammed.

Commits best reviewed separately. It's also recommended to check out the code and quickly run it due to the inherent difficulty of diffing designer changes.