### PR TITLE
CP-33153: Added friendly title and description for GFS2_CAPACITY alert. Corrected scan action description.

### DIFF
--- a/XenAdmin/Alerts/Types/MessageAlert.cs
+++ b/XenAdmin/Alerts/Types/MessageAlert.cs
@@ -114,7 +114,7 @@ namespace XenAdmin.Alerts
                         }
                         break;
 
-                    // applies to is hosts, vms and pools where only the name is required
+                    // applies to hosts, vms and pools where only the name is required
                     case Message.MessageType.HA_HEARTBEAT_APPROACHING_TIMEOUT:
                     case Message.MessageType.HA_HOST_FAILED:
                     case Message.MessageType.HA_HOST_WAS_FENCED:
@@ -240,6 +240,11 @@ namespace XenAdmin.Alerts
                         VMSS vmss = Helpers.XenObjectFromMessage(Message) as VMSS;
                         var policyAlertVMSS = new PolicyAlert(Message.priority, Message.name, Message.timestamp, Message.body, (vmss == null) ? "" : vmss.Name());
                         return policyAlertVMSS.Text;
+
+                    case Message.MessageType.unknown when Message.name == "GFS2_CAPACITY":
+                        if (XenObject != null)
+                            return string.Format(Message.FriendlyBody(Message.name), XenObject.Name());
+                        break;
                 }
 
                 return Message.body;
@@ -407,6 +412,9 @@ namespace XenAdmin.Alerts
         {
             get
             {
+                if (Message.name == "GFS2_CAPACITY")
+                    return Message.FriendlyName(Message.name);
+
                 string title = Message.FriendlyName(Message.MessageTypeString());
                 if (string.IsNullOrEmpty(title))
                     title = Message.name;

--- a/XenModel/Actions/SR/SrRefreshAction.cs
+++ b/XenModel/Actions/SR/SrRefreshAction.cs
@@ -44,7 +44,7 @@ namespace XenAdmin.Actions
 
         protected override void Run()
         {
-            Description = Messages.SR_REFRESH_ACTION_DESC;
+            Description = string.Format(Messages.SR_REFRESH_ACTION_DESC, SR.NameWithoutHost());
             XenAPI.SR.scan(Session, SR.opaque_ref);
             Description = Messages.COMPLETED;
         }

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -3690,6 +3690,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Space utilization on SR &apos;{0}&apos; has exceeded 80%..
+        /// </summary>
+        public static string Message_body_gfs2_capacity {
+            get {
+                return ResourceManager.GetString("Message.body-gfs2_capacity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A grace license was issued for {0}. This was because the license server could not be reached, it is an out-of-date version, or because the host has recently been upgraded..
         /// </summary>
         public static string Message_body_grace_license {
@@ -4505,6 +4514,15 @@ namespace XenAdmin {
         public static string Message_name_extauth_init_in_host_failed {
             get {
                 return ResourceManager.GetString("Message.name-extauth_init_in_host_failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Storage repository low on space.
+        /// </summary>
+        public static string Message_name_gfs2_capacity {
+            get {
+                return ResourceManager.GetString("Message.name-gfs2_capacity", resourceCulture);
             }
         }
         

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1001,6 +1001,9 @@
 
 {1}</value>
   </data>
+  <data name="Message.body-gfs2_capacity" xml:space="preserve">
+    <value>Space utilization on SR '{0}' has exceeded 80%.</value>
+  </data>
   <data name="Message.body-grace_license" xml:space="preserve">
     <value>A grace license was issued for {0}. This was because the license server could not be reached, it is an out-of-date version, or because the host has recently been upgraded.</value>
   </data>
@@ -1228,6 +1231,9 @@
   </data>
   <data name="Message.name-extauth_init_in_host_failed" xml:space="preserve">
     <value>Active Directory authorization is not available</value>
+  </data>
+  <data name="Message.name-gfs2_capacity" xml:space="preserve">
+    <value>Storage repository low on space</value>
   </data>
   <data name="Message.name-grace_license" xml:space="preserve">
     <value>Grace license issued.</value>


### PR DESCRIPTION
The handling of this alert is a bit unorthodox because it is not listed among the known Message types since it is coming from a xapi plugin and the API is not obliged to know about it.