### PR TITLE
ignore 'vim.exe.stackdump'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ ServiceFabricBackup/
 
 .vs
 .vscode
+
+vim.exe.stackdump


### PR DESCRIPTION
On my setup (Windows 10) this file results from attempting to modify my last commit with `git commit --amend`. Cygwin and Git Bash work fine of course. However I'd prefer to ensure that the file doesn't accidentally make it into commits.