### PR TITLE
CA-343781 + 3rd party library references + redundant exception

### DIFF
--- a/CFUValidator/CFUValidator.csproj
+++ b/CFUValidator/CFUValidator.csproj
@@ -50,8 +50,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Moq, Version=4.5.3.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/XenAdmin/Network/XenConnectionUI.cs
+++ b/XenAdmin/Network/XenConnectionUI.cs
@@ -133,20 +133,6 @@ namespace XenAdmin.Network
 
         private static void ShowConnectingDialogError(Form owner, IXenConnection connection, Exception error)
         {
-            if (error is ExpressRestriction e)
-            {
-                using (var dialog = new WarningDialog(string.Format(
-                    Messages.CONNECTION_RESTRICTED_MESSAGE_LONG, e.HostName, e.ExistingHostName))
-                {
-                    ShowLinkLabel = true,
-                    LinkText = InvisibleMessages.HTTP_LICENSES,
-                    LinkData = InvisibleMessages.HTTP_LICENSES
-                })
-                    dialog.ShowDialog(owner);
-                
-                return;
-            }
-
             if (error is Failure f)
             {
                 if (f.ErrorDescription[0] == Failure.HOST_IS_SLAVE)

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -69,6 +69,7 @@ namespace XenAdmin.TabPages
         {
             InitializeComponent();
             spinner.SuccessImage = SystemIcons.Information.ToBitmap();
+            spinner.FailureImage = Images.StaticImages._000_error_h32bit_32;
             tableLayoutPanel1.Visible = false;
             toolStripSplitButtonDismiss.DefaultItem = dismissAllToolStripMenuItem;
             toolStripSplitButtonDismiss.Text = dismissAllToolStripMenuItem.Text;
@@ -193,6 +194,7 @@ namespace XenAdmin.TabPages
                     else
                     {
                         spinner.ShowFailureImage();
+                        tableLayoutPanel3.Visible = true;
                         labelProgress.Text = string.IsNullOrEmpty(errorMessage)
                                                  ? Messages.AVAILABLE_UPDATES_NOT_FOUND
                                                  : errorMessage;

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -59,12 +59,10 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiscUtils, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="DiscUtils, Version=0.8.0.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\DiscUtils.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ReportViewer.WinForms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/XenAdminTests/XenAdminTests.csproj
+++ b/XenAdminTests/XenAdminTests.csproj
@@ -35,24 +35,19 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CookComputing.XmlRpcV2, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.1, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\CookComputing.XmlRpcV2.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.5.3.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Newtonsoft.Json.CH, Version=10.0.2.1, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.CH.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/XenCenterLib/XenCenterLib.csproj
+++ b/XenCenterLib/XenCenterLib.csproj
@@ -36,16 +36,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.85.4.403, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.85.4.404, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="Ionic.Zip, Version=1.9.1.8, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Ionic.Zip, Version=1.9.1.8, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\Ionic.Zip.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/XenModel/InvisibleMessages.Designer.cs
+++ b/XenModel/InvisibleMessages.Designer.cs
@@ -115,15 +115,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to www.citrix.com/xenserverenterprise.
-        /// </summary>
-        public static string HTTP_LICENSES {
-            get {
-                return ResourceManager.GetString("HTTP_LICENSES", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to http://support.citrix.com/article/CTX141433.
         /// </summary>
         public static string ISL_DEPRECATION_URL {

--- a/XenModel/InvisibleMessages.resx
+++ b/XenModel/InvisibleMessages.resx
@@ -126,9 +126,6 @@
   <data name="HOMEPAGE_FILENAME" xml:space="preserve">
     <value>HomePage.mht</value>
   </data>
-  <data name="HTTP_LICENSES" xml:space="preserve">
-    <value>www.citrix.com/xenserverenterprise</value>
-  </data>
   <data name="ISL_DEPRECATION_URL" xml:space="preserve">
     <value>http://support.citrix.com/article/CTX141433</value>
   </data>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8909,35 +8909,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connection to Server {0} restricted because a connection already exists to another XE Express Server ({1}).
-        /// </summary>
-        public static string CONNECTION_RESTRICTED_MESSAGE {
-            get {
-                return ResourceManager.GetString("CONNECTION_RESTRICTED_MESSAGE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Connection to server {0} restricted - a connection to a [Citrix XenServer] Express Edition server ({1}) already exists.
-        ///
-        ///You can only connect to a single [Citrix XenServer] Express Edition server at a time. To find out how to upgrade your license, follow the link below..
-        /// </summary>
-        public static string CONNECTION_RESTRICTED_MESSAGE_LONG {
-            get {
-                return ResourceManager.GetString("CONNECTION_RESTRICTED_MESSAGE_LONG", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot connect to {0} due to license restrictions on the server.
-        /// </summary>
-        public static string CONNECTION_RESTRICTED_NOTICE_TITLE {
-            get {
-                return ResourceManager.GetString("CONNECTION_RESTRICTED_NOTICE_TITLE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Connection to {0}: trying to find pool at {1}.
         /// </summary>
         public static string CONNECTION_RETRYING_SLAVE {
@@ -22045,15 +22016,6 @@ namespace XenAdmin {
         public static string LICENSE_REGULAR_GRACE_TOOLTIP {
             get {
                 return ResourceManager.GetString("LICENSE_REGULAR_GRACE_TOOLTIP", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to License Restriction: Could not connect to {0}, a server with an XE Express License already exists ({1}).
-        /// </summary>
-        public static string LICENSE_RESTRICTION_MESSAGE {
-            get {
-                return ResourceManager.GetString("LICENSE_RESTRICTION_MESSAGE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3214,18 +3214,6 @@ Would you like to carry out the operation at this time?</value>
   <data name="CONNECTION_REFUSED_TITLE" xml:space="preserve">
     <value>Refused connection to {0}</value>
   </data>
-  <data name="CONNECTION_RESTRICTED_MESSAGE" xml:space="preserve">
-    <value>Connection to Server {0} restricted because a connection already exists to another XE Express Server ({1})</value>
-  </data>
-  <data name="CONNECTION_RESTRICTED_MESSAGE_LONG" xml:space="preserve">
-    <value>Connection to server {0} restricted - a connection to a [Citrix XenServer] Express Edition server ({1}) already exists.
-
-You can only connect to a single [Citrix XenServer] Express Edition server at a time. To find out how to upgrade your license, follow the link below.</value>
-  </data>
-  <data name="CONNECTION_RESTRICTED_NOTICE_TITLE" xml:space="preserve">
-    <value>Cannot connect to {0} due to license restrictions on the server</value>
-    <comment>Title of notice shown when connection to a host is restricted by license</comment>
-  </data>
   <data name="CONNECTION_RETRYING_SLAVE" xml:space="preserve">
     <value>Connection to {0}: trying to find pool at {1}</value>
   </data>
@@ -7659,9 +7647,6 @@ SR UUID: {1}</value>
   </data>
   <data name="LICENSE_REGULAR_GRACE_TOOLTIP" xml:space="preserve">
     <value>The license server {0} could not be reached. You have until {1} to reconnect to the license server.</value>
-  </data>
-  <data name="LICENSE_RESTRICTION_MESSAGE" xml:space="preserve">
-    <value>License Restriction: Could not connect to {0}, a server with an XE Express License already exists ({1})</value>
   </data>
   <data name="LICENSE_SA_EXPIRED" xml:space="preserve">
     <value>Your support and maintenance has expired</value>

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -1399,7 +1399,7 @@ namespace XenAdmin.Network
         {
             if (task != connectTask)
             {
-                // We've been superceded by a newer ConnectTask. Exit silently without firing events.
+                // We've been superseded by a newer ConnectTask. Exit silently without firing events.
                 // Can happen when user disconnects while sync is taking place, then reconnects
                 // (creating a new _connectTask) before the sync is complete.
             }
@@ -1410,21 +1410,7 @@ namespace XenAdmin.Network
                 connectTask = null;
                 HandleConnectionTermination();
 
-                if (error is ExpressRestriction)
-                {
-                    EndConnect(true, task, false);
-
-                    ExpressRestriction e = (ExpressRestriction)error;
-                    // This can happen when the user attempts to connect to a second XE Express host from the UI
-                    string msg = string.Format(Messages.CONNECTION_RESTRICTED_MESSAGE, e.HostName, e.ExistingHostName);
-                    log.Info($"Connection to Server {e.HostName} restricted because a connection already exists to another XE Express Server ({e.ExistingHostName})");
-                    string title = string.Format(Messages.CONNECTION_RESTRICTED_NOTICE_TITLE, e.HostName);
-                    ActionBase action = new ActionBase(title, msg, false, true, msg);
-                    SetPoolAndHostInAction(action, pool, PoolOpaqueRef);
-
-                    OnConnectionResult(false, Messages.CONNECTION_RESTRICTED_MESSAGE, error);
-                }
-                else if (error is ServerNotSupported)
+                if (error is ServerNotSupported)
                 {
                     EndConnect(true, task, false);
                     log.Info(error.Message);
@@ -2016,27 +2002,6 @@ namespace XenAdmin.Network
 
 
         #endregion
-    }
-
-
-    public class ExpressRestriction : DisconnectionException
-    {
-        public readonly string HostName;
-        public readonly string ExistingHostName;
-
-        public ExpressRestriction(string HostName, string ExistingHostName)
-        {
-            this.HostName = HostName;
-            this.ExistingHostName = ExistingHostName;
-        }
-
-        public override string Message
-        {
-            get
-            {
-                return string.Format(Messages.LICENSE_RESTRICTION_MESSAGE, HostName, ExistingHostName);
-            }
-        }
     }
 
     public class ServerNotSupported : DisconnectionException

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -36,16 +36,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CookComputing.XmlRpcV2, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.1, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\CookComputing.XmlRpcV2.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Newtonsoft.Json.CH, Version=10.0.2.1, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.CH.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/XenOvfApi/XenOvfApi.csproj
+++ b/XenOvfApi/XenOvfApi.csproj
@@ -38,8 +38,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/XenOvfTransport/XenOvfTransport.csproj
+++ b/XenOvfTransport/XenOvfTransport.csproj
@@ -36,8 +36,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="DiscUtils, Version=0.8.0.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscUtils.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
@@ -46,10 +48,6 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Xml" />
-    <Reference Include="DiscUtils, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\DiscUtils.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DiskStream.cs" />

--- a/XenServerHealthCheck/XenServerHealthCheck.csproj
+++ b/XenServerHealthCheck/XenServerHealthCheck.csproj
@@ -36,12 +36,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CookComputing.XmlRpcV2, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.1, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\CookComputing.XmlRpcV2.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/packages/DOTNET_BUILD_LOCATION
+++ b/packages/DOTNET_BUILD_LOCATION
@@ -1,1 +1,1 @@
-xc-local-release/dotnet-packages/master/33
+xc-local-release/dotnet-packages/master/34


### PR DESCRIPTION
1. Fixed 3rd library references in project files (ported from release/stockholm/UPD-624).
2. CA-343781: Fixed error visibility on updates page (ported from release/stockholm/UPD-624).
3. Removed old exception.

1 and 2 do not need review if https://github.com/xenserver/xenadmin/pull/2727 is done first.