### PR TITLE
CA-339353: Fixed broken SrProbeAction when the logged in user is not local root

### DIFF
--- a/XenModel/Actions/AsyncAction.cs
+++ b/XenModel/Actions/AsyncAction.cs
@@ -266,22 +266,9 @@ namespace XenAdmin.Actions
             }
         }
 
-        public void PollToCompletion(int start, int finish)
+        public void PollToCompletion(double start = 0, double finish = 100)
         {
             new TaskPoller(this, start, finish).PollToCompletion();
-        }
-
-        public void PollToCompletion(double start, double finish)
-        {
-            PollToCompletion((int)start, (int)finish);
-        }
-
-        /// <summary>
-        /// Equivalent to PollToCompletion(0, 100).
-        /// </summary>
-        public void PollToCompletion()
-        {
-            PollToCompletion(0, 100);
         }
 
         /// <summary>

--- a/XenModel/Actions/Host/RestartToolstackAction.cs
+++ b/XenModel/Actions/Host/RestartToolstackAction.cs
@@ -49,7 +49,7 @@ namespace XenAdmin.Actions
 
             Description = string.Format(Messages.ACTION_TOOLSTACK_RESTARTING_ON, Host.Name().Ellipsise(30));
             RelatedTask = Host.async_restart_agent(session, Host.opaque_ref);
-            PollToCompletion(0, 100);
+            PollToCompletion();
 
             //call interrupt so we can reconnect afterwards
             if (Helpers.HostIsMaster(Host))

--- a/XenModel/Actions/PVS/PvsProxyCreateAction.cs
+++ b/XenModel/Actions/PVS/PvsProxyCreateAction.cs
@@ -58,7 +58,7 @@ namespace XenAdmin.Actions
         {
             Description = Messages.ENABLING;
             RelatedTask = PVS_proxy.async_create(Session, site.opaque_ref, vif.opaque_ref);         
-            PollToCompletion(0, 100);
+            PollToCompletion();
             Description = Messages.ENABLED;
         }
     }

--- a/XenModel/Actions/PVS/PvsProxyDestroyAction.cs
+++ b/XenModel/Actions/PVS/PvsProxyDestroyAction.cs
@@ -56,7 +56,7 @@ namespace XenAdmin.Actions
         {
             Description = Messages.DISABLING;
             RelatedTask = PVS_proxy.async_destroy(Session, proxy.opaque_ref);
-            PollToCompletion(0, 100);
+            PollToCompletion();
             Description = Messages.DISABLED;
         }
     }

--- a/XenModel/Actions/Pool_Patch/RemovePatchAction.cs
+++ b/XenModel/Actions/Pool_Patch/RemovePatchAction.cs
@@ -56,7 +56,7 @@ namespace XenAdmin.Actions
             try
             {
                 RelatedTask = Pool_patch.async_destroy(Session, patch.opaque_ref);
-                PollToCompletion(0, 100);
+                PollToCompletion();
             }
             catch (Failure f)
             {

--- a/XenModel/Actions/SR/SrProbeAction.cs
+++ b/XenModel/Actions/SR/SrProbeAction.cs
@@ -37,7 +37,7 @@ using XenAdmin.Core;
 
 namespace XenAdmin.Actions
 {
-    public class SrProbeAction : PureAsyncAction
+    public class SrProbeAction : AsyncAction
     {
         private readonly Host host;
         private readonly Dictionary<string, string> dconf;
@@ -81,6 +81,20 @@ namespace XenAdmin.Actions
             Description = string.Format(Messages.ACTION_SR_SCANNING, SR.getFriendlyTypeName(srType), target);
 
             this.smconf = smconf ?? new Dictionary<string, string>();
+
+            #region RBAC Dependencies
+
+            if (SrType == SR.SRTypes.gfs2)
+            {
+                ApiMethodsToRoleCheck.Add("sr.probe_ext");
+            }
+            else
+            {
+                ApiMethodsToRoleCheck.Add("sr.probe");
+                ApiMethodsToRoleCheck.AddRange(Role.CommonTaskApiList);
+            }
+
+            #endregion
         }
 
         protected override void Run()

--- a/XenModel/Actions/VM/VMShutdownAction.cs
+++ b/XenModel/Actions/VM/VMShutdownAction.cs
@@ -59,7 +59,7 @@ namespace XenAdmin.Actions.VMActions
             this.Description = Messages.ACTION_VM_SHUTTING_DOWN;
 
             RelatedTask = VM.async_clean_shutdown(Session, VM.opaque_ref);
-            PollToCompletion(0, 100);
+            PollToCompletion();
             this.Description = Messages.ACTION_VM_SHUT_DOWN;
         }
     }
@@ -76,7 +76,7 @@ namespace XenAdmin.Actions.VMActions
             this.Description = Messages.ACTION_VM_SHUTTING_DOWN;
 
             RelatedTask = VM.async_hard_shutdown(Session, VM.opaque_ref);
-            PollToCompletion(0, 100);
+            PollToCompletion();
 
             this.Description = Messages.ACTION_VM_SHUT_DOWN;
         }

--- a/XenModel/Actions/VM/VMSuspendAction.cs
+++ b/XenModel/Actions/VM/VMSuspendAction.cs
@@ -46,7 +46,7 @@ namespace XenAdmin.Actions.VMActions
         {
             this.Description = Messages.ACTION_VM_SUSPENDING;
             RelatedTask = VM.async_suspend(Session, VM.opaque_ref);
-            PollToCompletion(0, 100);
+            PollToCompletion();
             this.Description = Messages.ACTION_VM_SUSPENDED;
         }
     }


### PR DESCRIPTION
- CA-339353: SrProbeAction should run its RBAC checks explicitly instead of inheriting from PureAsyncAction. The fix for CA-337280 moved the parsing of the probe result in the Run body of the action, causing it to fail when the dry-run for the RBAC checks is performed.
- Minor modifications to task polling: Consolidated Action.PollToCompletion overloads, among others, to reduce precision loss.
Logging the environment's stack trace is not very useful in the case of an API failure. Log the task's opaque_ref so it's easier to trace errors in the server side logs.