### PR TITLE
CA-343956: Corrected action performed by the Attach Disk context menu…

### DIFF
--- a/XenAdmin/Dialogs/AttachDiskDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AttachDiskDialog.Designer.cs
@@ -97,6 +97,7 @@ namespace XenAdmin.Dialogs
             this.Controls.Add(this.DiskListTreeView);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.Name = "AttachDiskDialog";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.AttachDiskDialog_FormClosing);
             this.readonlyCheckboxToolTipContainer.ResumeLayout(false);
             this.readonlyCheckboxToolTipContainer.PerformLayout();

--- a/XenAdmin/Dialogs/AttachDiskDialog.resx
+++ b/XenAdmin/Dialogs/AttachDiskDialog.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="DiskListTreeView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="DiskListTreeView.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="DiskListTreeView.IntegralHeight" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -136,7 +136,7 @@
     <value>12, 28</value>
   </data>
   <data name="DiskListTreeView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>365, 145</value>
+    <value>438, 205</value>
   </data>
   <data name="DiskListTreeView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -153,11 +153,11 @@
   <data name="&gt;&gt;DiskListTreeView.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="ReadOnlyCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
   <data name="ReadOnlyCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="ReadOnlyCheckBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="ReadOnlyCheckBox.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -178,7 +178,7 @@
     <value>ReadOnlyCheckBox</value>
   </data>
   <data name="&gt;&gt;ReadOnlyCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ReadOnlyCheckBox.Parent" xml:space="preserve">
     <value>readonlyCheckboxToolTipContainer</value>
@@ -193,7 +193,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="OkBtn.Location" type="System.Drawing.Point, System.Drawing">
-    <value>221, 179</value>
+    <value>294, 239</value>
   </data>
   <data name="OkBtn.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -208,7 +208,7 @@
     <value>OkBtn</value>
   </data>
   <data name="&gt;&gt;OkBtn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;OkBtn.Parent" xml:space="preserve">
     <value>$this</value>
@@ -223,7 +223,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="CancelBtn.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 179</value>
+    <value>375, 239</value>
   </data>
   <data name="CancelBtn.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -238,7 +238,7 @@
     <value>CancelBtn</value>
   </data>
   <data name="&gt;&gt;CancelBtn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CancelBtn.Parent" xml:space="preserve">
     <value>$this</value>
@@ -271,7 +271,7 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -292,10 +292,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="readonlyCheckboxToolTipContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 180</value>
+    <value>12, 243</value>
   </data>
   <data name="readonlyCheckboxToolTipContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 22</value>
+    <value>129, 19</value>
   </data>
   <data name="readonlyCheckboxToolTipContainer.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -312,14 +312,14 @@
   <data name="&gt;&gt;readonlyCheckboxToolTipContainer.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>391, 221</value>
+    <value>464, 281</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/TabPages/VMStoragePage.cs
+++ b/XenAdmin/TabPages/VMStoragePage.cs
@@ -447,7 +447,7 @@ namespace XenAdmin.TabPages
         private void toolStripMenuItemAttach_Click(object sender, EventArgs e)
         {
             if (AttachButton.Visible && AttachButton.Enabled)
-                AddButton.PerformClick();
+                AttachButton.PerformClick();
             UpdateButtons();
         }
 


### PR DESCRIPTION
... item. Show grip on the Attach Disk dialog. The dialog is launched non-modally, hence showing the grip automatically has no effect. Also, made the dialog slightly bigger.