### PR TITLE
Some refactoring around Commands to improve calculation efficiency

### DIFF
--- a/XenAdmin/Commands/AddHostCommand.cs
+++ b/XenAdmin/Commands/AddHostCommand.cs
@@ -70,7 +70,7 @@ namespace XenAdmin.Commands
         public AddHostCommand(IMainWindow mainWindow, Control parent)
             : base(mainWindow)
         {
-            SetParent(parent);
+            Parent = parent;
         }
 
         protected override void ExecuteCore(SelectedItemCollection selection)
@@ -91,29 +91,10 @@ namespace XenAdmin.Commands
             MainWindowCommandInterface.TrySelectNewObjectInTree(conn, true, true, true);
         }
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._000_AddApplicationServer_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._000_AddApplicationServer_h32bit_16;
 
-        public override Image ToolBarImage
-        {
-            get
-            {
-                
-                return Images.StaticImages._000_AddApplicationServer_h32bit_24;
-            }
-        }
+        public override Image ToolBarImage => Images.StaticImages._000_AddApplicationServer_h32bit_24;
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_ADD_HOST;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_ADD_HOST;
     }
 }

--- a/XenAdmin/Commands/AddHostToPoolCommand.cs
+++ b/XenAdmin/Commands/AddHostToPoolCommand.cs
@@ -30,7 +30,6 @@
  */
 
 using System.Collections.Generic;
-using System.Drawing;
 using System.Windows.Forms;
 using XenAdmin.Actions;
 using XenAdmin.Core;
@@ -86,10 +85,18 @@ namespace XenAdmin.Commands
                 return;
             }
 
-            if (_confirm && !ShowConfirmationDialog())
+            if (_confirm)
             {
-                // Bail out if the user doesn't want to continue.
-                return;
+                var msg = _hosts.Count > 1
+                    ? string.Format(Messages.MAINWINDOW_CONFIRM_MOVE_TO_POOL_MULTIPLE, _pool.Name().Ellipsise(500))
+                    : string.Format(Messages.MAINWINDOW_CONFIRM_MOVE_TO_POOL, _hosts[0].Name().Ellipsise(500), _pool.Name().Ellipsise(500));
+
+                using (var dialog = new WarningDialog(msg, ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo)
+                    {WindowTitle = Messages.POOLCREATE_ADDING})
+                {
+                    if (dialog.ShowDialog(Parent ?? Program.MainWindow) == DialogResult.No)
+                        return;
+                }
             }
 
             if (!Helpers.IsConnected(_pool))
@@ -176,30 +183,6 @@ namespace XenAdmin.Commands
                 return true;
             }
             return false;
-        }
-
-        protected override string ConfirmationDialogText
-        {
-            get
-            {
-                if (_hosts.Count == 1)
-                {
-                    return string.Format(Messages.MAINWINDOW_CONFIRM_MOVE_TO_POOL, _hosts[0].Name().Ellipsise(500), _pool.Name().Ellipsise(500));
-                }
-                else if (_hosts.Count > 1)
-                {
-                    return string.Format(Messages.MAINWINDOW_CONFIRM_MOVE_TO_POOL_MULTIPLE, _pool.Name().Ellipsise(500));
-                }
-                return null;
-            }
-        }
-
-        protected override string ConfirmationDialogTitle
-        {
-            get
-            {
-                return Messages.POOLCREATE_ADDING;
-            }
         }
 
         public static PoolAbstractAction.AdUserAndPassword GetAdPrompt(Host poolMaster)

--- a/XenAdmin/Commands/ApplyLicenseEditionCommand.cs
+++ b/XenAdmin/Commands/ApplyLicenseEditionCommand.cs
@@ -32,7 +32,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.Windows.Forms;
 using XenAdmin.Actions;
 using XenAdmin.Dialogs;
@@ -66,7 +65,7 @@ namespace XenAdmin.Commands
             this.xos = xos;
             _licenseServerAddress = licenseServerAddress;
             _licenseServerPort = licenseServerPort;
-            SetParent(parent);
+            Parent = parent;
         }
 
         protected override void ExecuteCore(SelectedItemCollection selection)

--- a/XenAdmin/Commands/Command.cs
+++ b/XenAdmin/Commands/Command.cs
@@ -278,7 +278,7 @@ namespace XenAdmin.Commands
         protected virtual string ConfirmationDialogText => null;
 
         /// <summary>
-        /// Gets the help id for the confirmatin dialog.
+        /// Gets the help id for the confirmation dialog.
         /// </summary>
         protected virtual string ConfirmationDialogHelpId => null;
 
@@ -292,7 +292,7 @@ namespace XenAdmin.Commands
         /// Shows a confirmation dialog.
         /// </summary>
         /// <returns>True if the user clicked Yes.</returns>
-        protected bool ShowConfirmationDialog()
+        private bool ShowConfirmationDialog()
         {
             if (Program.RunInAutomatedTestMode)
                 return true;

--- a/XenAdmin/Commands/Command.cs
+++ b/XenAdmin/Commands/Command.cs
@@ -187,58 +187,37 @@ namespace XenAdmin.Commands
         /// <summary>
         /// Gets the text for a menu item which launches this Command.
         /// </summary>
-        public virtual string MenuText
-        {
-            get { return null; }
-        }
+        public virtual string MenuText => null;
 
         /// <summary>
         /// Gets the text for a context menu item which launches this Command.
         /// </summary>
-        public virtual string ContextMenuText
-        {
-            get { return null; }
-        }
+        public virtual string ContextMenuText => null;
 
         /// <summary>
         /// Gets the image for a menu item which launches this Command.
         /// </summary>
-        public virtual Image MenuImage
-        {
-            get { return null; }
-        }
+        public virtual Image MenuImage => null;
 
         /// <summary>
         /// Gets the image for a context menu item which launches this Command.
         /// </summary>
-        public virtual Image ContextMenuImage
-        {
-            get { return null; }
-        }
+        public virtual Image ContextMenuImage => null;
 
         /// <summary>
         /// Gets the text for the toolbar button which launches this Command.
         /// </summary>
-        public virtual string ToolBarText
-        {
-            get { return null; }
-        }
+        public virtual string ToolBarText => null;
 
         /// <summary>
         /// Gets the image for a toolbar button which launches this Command.
         /// </summary>
-        public virtual Image ToolBarImage
-        {
-            get { return null; }
-        }
+        public virtual Image ToolBarImage => null;
 
         /// <summary>
         /// Gets the text for a button which launches this Command.
         /// </summary>
-        public virtual string ButtonText
-        {
-            get { return null; }
-        }
+        public virtual string ButtonText => null;
 
         /// <summary>
         /// Gets the tool tip text. By default this is the can't execute reason if execution is not possible and
@@ -285,26 +264,17 @@ namespace XenAdmin.Commands
         /// <summary>
         /// Gets the tool tip text when the command is able to run. Null by default.
         /// </summary>
-        protected virtual string EnabledToolTipText
-        {
-            get { return null; }
-        }
+        protected virtual string EnabledToolTipText => null;
 
         /// <summary>
         /// Gets the shortcut key display string. This is only used if this Command is used on the main menu.
         /// </summary>
-        public virtual string ShortcutKeyDisplayString
-        {
-            get { return null; }
-        }
+        public virtual string ShortcutKeyDisplayString => null;
 
         /// <summary>
         /// Gets the shortcut keys. This is only used if this Command is used on the main menu.
         /// </summary>
-        public virtual Keys ShortcutKeys
-        {
-            get { return Keys.None; }
-        }
+        public virtual Keys ShortcutKeys => Keys.None;
 
         /// <summary>
         /// Gets a value indicating whether a confirmation dialog should be shown.
@@ -415,31 +385,19 @@ namespace XenAdmin.Commands
         /// <summary>
         /// Gets the main window to be used by the Command.
         /// </summary>
-        public IMainWindow MainWindowCommandInterface
-        {
-            get { return _mainWindow; }
-        }
+        public IMainWindow MainWindowCommandInterface => _mainWindow;
+
 
         /// <summary>
-        /// Sets the parent for any dialogs. If not called, then the main window is used.
-        /// </summary>
-        /// <param name="parent">The parent.</param>
-        public void SetParent(Control parent)
-        {
-            _parent = parent;
-        }
-
-        /// <summary>
-        /// Gets the parent for any dialogs. If SetParent() hasn't been called then the MainWindow is returned.
+        /// Gets or sets the parent control for any dialogs launched during the
+        /// execution of the command. Defaults to the MainWindow Form.
         /// </summary>
         public Control Parent
         {
-            get
-            {
-                return _parent ?? _mainWindow.Form;
-            }
+            get => _parent ?? _mainWindow?.Form;
+            set => _parent = value;
         }
-        
+
         /// <summary>
         /// Runs the specified <see cref="AsyncAction"/>s such that they are synchronous per connection but asynchronous across connections.
         /// </summary>

--- a/XenAdmin/Commands/Command.cs
+++ b/XenAdmin/Commands/Command.cs
@@ -206,43 +206,24 @@ namespace XenAdmin.Commands
         public virtual string ButtonText => null;
 
         /// <summary>
-        /// Gets the tool tip text. By default this is the can't execute reason if execution is not possible and
-        /// blank if it can. Override EnabledToolTipText to provide a descriptive tooltip when the command is enabled.
+        /// Gets the tool tip text when execution is not possible. This is the
+        /// can't execute reason for single selection, and null otherwise.
         /// </summary>
-        public virtual string ToolTipText
+        public virtual string DisabledToolTipText
         {
-            get 
+            get
             {
-                if (CanExecute())
-                    return EnabledToolTipText;
-
-                return DisabledToolTipText;  
-            }
-        }
-
-        /// <summary>
-        /// Gets the tool tip text when the command is not able to run. CantExectuteReason for single items,
-        /// null for multiple.
-        /// </summary>
-        protected virtual string DisabledToolTipText
-        {
-            get 
-            {
-                var reasons = GetCantExecuteReasons();
-                // It's necessary to double check that we have one reason which matches up with a single selection
-                // as CanExecuteCore and GetCantExecuteReasons aren't required to match up.
-                if (reasons.Count == 1 && GetSelection().Count == 1)
+                var selection = GetSelection();
+                if (selection.Count == 1)
                 {
-                    foreach (string s in reasons.Values)
-                    {
-                        if (s.Equals(Messages.UNKNOWN))
-                        {
-                            //This is the default, and not a useful tooltip
-                            return null;
-                        }
-                        return s;
-                    }
+                    var item = selection[0];
+                    if (item?.XenObject == null)
+                        return null;
+
+                    string reason = GetCantExecuteReasonCore(item.XenObject);
+                    return reason == Messages.UNKNOWN ? null : reason;
                 }
+
                 return null;
             }
         }
@@ -250,7 +231,7 @@ namespace XenAdmin.Commands
         /// <summary>
         /// Gets the tool tip text when the command is able to run. Null by default.
         /// </summary>
-        protected virtual string EnabledToolTipText => null;
+        public virtual string EnabledToolTipText => null;
 
         /// <summary>
         /// Gets the shortcut key display string. This is only used if this Command is used on the main menu.

--- a/XenAdmin/Commands/Command.cs
+++ b/XenAdmin/Commands/Command.cs
@@ -113,20 +113,6 @@ namespace XenAdmin.Commands
         }
 
         /// <summary>
-        /// Gets a list of <see cref="SelectedItem"/>s from the specified <see cref="IXenObject"/>s.
-        /// </summary>
-        protected static IEnumerable<SelectedItem> ConvertToSelection<T>(IEnumerable<T> xenObjects) where T : IXenObject
-        {
-            Util.ThrowIfParameterNull(xenObjects, "selection");
-            List<SelectedItem> selection = new List<SelectedItem>();
-            foreach (T xenObject in xenObjects)
-            {
-                selection.Add(new SelectedItem(xenObject));
-            }
-            return selection;
-        }
-
-        /// <summary>
         /// Gets the current selection context for the Command.
         /// </summary>
         public SelectedItemCollection GetSelection()

--- a/XenAdmin/Commands/Controls/AssignVMGroupToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/AssignVMGroupToolStripMenuItem.cs
@@ -35,9 +35,9 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using XenAdmin.Core;
-using XenAPI;
 using XenAdmin.Dialogs;
-using System.Drawing;
+using XenAPI;
+
 
 namespace XenAdmin.Commands
 {
@@ -153,7 +153,7 @@ namespace XenAdmin.Commands
                 get { return (String.IsNullOrEmpty(_menuText) ? _group.Name() : _menuText).Ellipsise(30); }
             }
 
-            protected override string EnabledToolTipText
+            public override string EnabledToolTipText
             {
                 get { return _group.Name(); }
             }

--- a/XenAdmin/Commands/Controls/CommandButton.cs
+++ b/XenAdmin/Commands/Controls/CommandButton.cs
@@ -76,17 +76,16 @@ namespace XenAdmin.Commands
 
         private new void Update()
         {
+            Enabled = _command != null && _command.CanExecute();
             base.Enabled = DesignMode || Enabled;
 
             if (_command != null)
             {
                 if (_command.ButtonText != null)
-                {
                     Text = _command.ButtonText;
-                }
 
                 if (Parent is ToolTipContainer ttContainer)
-                    ttContainer.SetToolTip(_command.ToolTipText);
+                    ttContainer.SetToolTip(Enabled ? _command.EnabledToolTipText : _command.DisabledToolTipText);
             }
         }
 
@@ -111,13 +110,7 @@ namespace XenAdmin.Commands
 
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new bool Enabled
-        {
-            get
-            {
-                return _command != null && _command.CanExecute();
-            }
-        }
+        public new bool Enabled { get; private set; }
 
         /// <summary>
         /// Sets the <see cref="SelectionBroadcaster"/> that should be listened to for selection changes.

--- a/XenAdmin/Commands/Controls/CommandToolStripButton.cs
+++ b/XenAdmin/Commands/Controls/CommandToolStripButton.cs
@@ -98,22 +98,19 @@ namespace XenAdmin.Commands
 
         private void Update()
         {
+            Enabled = _command != null && _command.CanExecute();
             base.Enabled = DesignMode || Enabled;
 
             if (_command != null)
             {
                 if (_command.ToolBarText != null)
-                {
                     Text = _command.ToolBarText;
-                }
 
                 if (_command.ToolBarImage != null)
-                {
                     Image = _command.ToolBarImage;
-                }
 
                 //null is allowed (CA-147657)
-                ToolTipText = _command.ToolTipText;
+                ToolTipText = Enabled ? _command.EnabledToolTipText : _command.DisabledToolTipText;
             }
         }
 
@@ -138,13 +135,7 @@ namespace XenAdmin.Commands
 
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new bool Enabled
-        {
-            get
-            {
-                return _command != null && _command.CanExecute();
-            }
-        }
+        public new bool Enabled { get; private set; }
 
         /// <summary>
         /// Sets the <see cref="SelectionBroadcaster"/> that should be listened to for selection changes.

--- a/XenAdmin/Commands/Controls/CommandToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/CommandToolStripMenuItem.cs
@@ -156,6 +156,7 @@ namespace XenAdmin.Commands
 
         protected virtual void Update()
         {
+            Enabled = _command != null && _command.CanExecute();
             base.Enabled = DesignMode || Enabled;
 
             if (_command != null)
@@ -178,7 +179,8 @@ namespace XenAdmin.Commands
                     Image = _command.MenuImage;
                 }
 
-                ToolTipText = _command.ToolTipText; // null ToolTip is allowed (CA-47310)
+                // null ToolTip is allowed (CA-47310)
+                ToolTipText = Enabled ? _command.EnabledToolTipText : _command.DisabledToolTipText;
 
                 if (_command.ShortcutKeyDisplayString != null)
                 {
@@ -229,13 +231,7 @@ namespace XenAdmin.Commands
 
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new bool Enabled
-        {
-            get
-            {
-                return _command != null && _command.CanExecute();
-            }
-        }
+        public new bool Enabled { get; private set; }
 
         /// <summary>
         /// Gets or sets the <see cref="SelectionBroadcaster"/> that should be listened to for selection changes.

--- a/XenAdmin/Commands/DeleteVMCommand.cs
+++ b/XenAdmin/Commands/DeleteVMCommand.cs
@@ -85,7 +85,7 @@ namespace XenAdmin.Commands
 
                 if (cantExecuteReasons.Count > 0)
                 {
-                    errorDialog = new CommandErrorDialog(ErrorDialogTitle, ErrorDialogText, GetCantExecuteReasons());
+                    errorDialog = new CommandErrorDialog(ErrorDialogTitle, ErrorDialogText, cantExecuteReasons);
                 }
 
                 List<AsyncAction> actions = new List<AsyncAction>();

--- a/XenAdmin/Commands/DestroySRCommand.cs
+++ b/XenAdmin/Commands/DestroySRCommand.cs
@@ -30,6 +30,7 @@
  */
 
 using System.Collections.Generic;
+using System.Linq;
 using XenAdmin.Actions;
 using XenAdmin.Core;
 using XenAPI;
@@ -51,18 +52,18 @@ namespace XenAdmin.Commands
         {
         }
 
-        public DestroySRCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selection)
-            : base(mainWindow, selection)
+        public DestroySRCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selectedItems)
+            : base(mainWindow, selectedItems)
         {
         }
 
-        public DestroySRCommand(IMainWindow mainWindow, SR selection)
-            : base(mainWindow, selection)
+        public DestroySRCommand(IMainWindow mainWindow, SR sr)
+            : base(mainWindow, sr)
         {
         }
 
-        public DestroySRCommand(IMainWindow mainWindow, IEnumerable<SR> selection)
-            : base(mainWindow, ConvertToSelection(selection))
+        public DestroySRCommand(IMainWindow mainWindow, IEnumerable<SR> srs)
+            : base(mainWindow, srs.Select(s => new SelectedItem(s)).ToList())
         {
         }
 
@@ -90,21 +91,9 @@ namespace XenAdmin.Commands
         /// <summary>
         /// Gets the text for a menu item which launches this Command.
         /// </summary>
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_DESTROY_SR;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_DESTROY_SR;
 
-        protected override bool ConfirmationRequired
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationRequired => true;
 
         protected override string ConfirmationDialogText
         {
@@ -163,20 +152,8 @@ namespace XenAdmin.Commands
             return base.GetCantExecuteReasonCore(item);
         }
 
-        protected override string ConfirmationDialogYesButtonLabel
-        {
-            get
-            {
-                return Messages.MESSAGEBOX_DESTROY_SR_YES_BUTTON_LABEL;
-            }
-        }
+        protected override string ConfirmationDialogYesButtonLabel => Messages.MESSAGEBOX_DESTROY_SR_YES_BUTTON_LABEL;
 
-        protected override bool ConfirmationDialogNoButtonSelected
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationDialogNoButtonSelected => true;
     }
 }

--- a/XenAdmin/Commands/InstallToolsCommand.cs
+++ b/XenAdmin/Commands/InstallToolsCommand.cs
@@ -62,7 +62,7 @@ namespace XenAdmin.Commands
         }
 
         public InstallToolsCommand(IMainWindow mainWindow, IEnumerable<VM> vms)
-            : this(mainWindow, ConvertToSelection(vms))
+            : this(mainWindow, vms.Select(v => new SelectedItem(v)).ToList())
         {
         }
 

--- a/XenAdmin/Commands/InstallToolsCommand.cs
+++ b/XenAdmin/Commands/InstallToolsCommand.cs
@@ -36,7 +36,6 @@ using XenAdmin.Actions;
 using XenAdmin.Core;
 using System.Windows.Forms;
 using XenAdmin.Dialogs;
-using System.Drawing;
 using System.Linq;
 
 
@@ -76,7 +75,7 @@ namespace XenAdmin.Commands
         public InstallToolsCommand(IMainWindow mainWindow, VM vm, Control parent)
             : base(mainWindow, vm)
         {
-            SetParent(parent);
+            Parent = parent;
         }
 
         public InstallToolsCommand(IMainWindow mainWindow, VM vm)

--- a/XenAdmin/Commands/NewFolderCommand.cs
+++ b/XenAdmin/Commands/NewFolderCommand.cs
@@ -70,7 +70,7 @@ namespace XenAdmin.Commands
         public NewFolderCommand(IMainWindow mainWindow, Folder folder, Control parent)
             : base(mainWindow, folder)
         {
-            SetParent(parent);
+            Parent = parent;
         }
 
         private void Execute(Folder folder, IWin32Window ownerWindow)
@@ -173,21 +173,9 @@ namespace XenAdmin.Commands
             return false;
         }
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.NEW_FOLDER;
-            }
-        }
+        public override string MenuText => Messages.NEW_FOLDER;
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._000_Folder_open_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._000_Folder_open_h32bit_16;
 
         protected override string GetCantExecuteReasonCore(IXenObject item)
         {

--- a/XenAdmin/Commands/RebootCommand.cs
+++ b/XenAdmin/Commands/RebootCommand.cs
@@ -29,13 +29,9 @@
  * SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using XenAPI;
-using XenAdmin.Properties;
 using System.Drawing;
 using System.Collections.ObjectModel;
+using XenAPI;
 
 
 namespace XenAdmin.Commands
@@ -72,7 +68,7 @@ namespace XenAdmin.Commands
             }
         }
 
-        protected override string EnabledToolTipText
+        public override string EnabledToolTipText
         {
             get
             {
@@ -91,12 +87,6 @@ namespace XenAdmin.Commands
             return new RebootVMCommand(MainWindowCommandInterface, selection).CanExecute() || new RebootHostCommand(MainWindowCommandInterface, selection).CanExecute();
         }
 
-        public override Image ToolBarImage
-        {
-            get
-            {
-                return Images.StaticImages._001_Reboot_h32bit_24;
-            }
-        }
+        public override Image ToolBarImage => Images.StaticImages._001_Reboot_h32bit_24;
     }
 }

--- a/XenAdmin/Commands/RebootHostCommand.cs
+++ b/XenAdmin/Commands/RebootHostCommand.cs
@@ -34,7 +34,6 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using XenAdmin.Actions;
-using XenAdmin.Properties;
 using XenAPI;
 using XenAdmin.Dialogs;
 
@@ -62,7 +61,7 @@ namespace XenAdmin.Commands
         public RebootHostCommand(IMainWindow mainWindow, Host host, Control parent)
             : base(mainWindow, host)
         {
-            SetParent(parent);
+            Parent = parent;
         }
 
         protected override void ExecuteCore(SelectedItemCollection selection)
@@ -100,21 +99,9 @@ namespace XenAdmin.Commands
             return false;
         }
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._001_Reboot_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._001_Reboot_h32bit_16;
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_REBOOT;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_REBOOT;
 
         protected override string ConfirmationDialogText
         {
@@ -150,13 +137,7 @@ namespace XenAdmin.Commands
             }
         }
 
-        protected override bool ConfirmationRequired
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationRequired => true;
 
         protected override string ConfirmationDialogTitle
         {
@@ -197,28 +178,10 @@ namespace XenAdmin.Commands
             return base.GetCantExecuteReasonCore(item);
         }
 
-        public override string ContextMenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_REBOOT_HOST_CONTEXT_MENU;
-            }
-        }
+        public override string ContextMenuText => Messages.MAINWINDOW_REBOOT_HOST_CONTEXT_MENU;
 
-        protected override string ConfirmationDialogYesButtonLabel
-        {
-            get
-            {
-                return Messages.CONFIRM_REBOOT_SERVER_YES_BUTTON_LABEL;
-            }
-        }
+        protected override string ConfirmationDialogYesButtonLabel => Messages.CONFIRM_REBOOT_SERVER_YES_BUTTON_LABEL;
 
-        protected override bool ConfirmationDialogNoButtonSelected
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationDialogNoButtonSelected => true;
     }
 }

--- a/XenAdmin/Commands/RemoveHostFromPoolCommand.cs
+++ b/XenAdmin/Commands/RemoveHostFromPoolCommand.cs
@@ -66,7 +66,7 @@ namespace XenAdmin.Commands
         }
 
         public RemoveHostFromPoolCommand(IMainWindow mainWindow, IEnumerable<Host> hosts)
-            : base(mainWindow, ConvertToSelection<Host>(hosts))
+            : base(mainWindow, hosts.Select(h => new SelectedItem(h)).ToList())
         {
         }
 

--- a/XenAdmin/Commands/RepairSRCommand.cs
+++ b/XenAdmin/Commands/RepairSRCommand.cs
@@ -29,16 +29,12 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
-using System.Text;
-using XenAdmin.Core;
-using XenAPI;
-using System.Windows.Forms;
-using XenAdmin.Dialogs;
-using XenAdmin.Properties;
 using System.Drawing;
-using System.Collections.ObjectModel;
+using System.Linq;
+using XenAdmin.Core;
+using XenAdmin.Dialogs;
+using XenAPI;
 
 
 namespace XenAdmin.Commands
@@ -66,8 +62,8 @@ namespace XenAdmin.Commands
         {
         }
 
-        public RepairSRCommand(IMainWindow mainWindow, IEnumerable<SR> selection)
-            : base(mainWindow, ConvertToSelection<SR>(selection))
+        public RepairSRCommand(IMainWindow mainWindow, IEnumerable<SR> srs)
+            : base(mainWindow, srs.Select(s => new SelectedItem(s)).ToList())
         {
         }
 
@@ -94,28 +90,10 @@ namespace XenAdmin.Commands
             return sr != null && sr.HasPBDs() && (sr.IsBroken() || !sr.MultipathAOK()) && !HelpersGUI.GetActionInProgress(sr) && sr.CanRepairAfterUpgradeFromLegacySL();
         }
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._000_StorageBroken_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._000_StorageBroken_h32bit_16;
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_REPAIR_SR;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_REPAIR_SR;
 
-        public override string ContextMenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_REPAIR_SR_CONTEXT_MENU;
-            }
-        }
+        public override string ContextMenuText => Messages.MAINWINDOW_REPAIR_SR_CONTEXT_MENU;
     }
 }

--- a/XenAdmin/Commands/ResumeVMCommand.cs
+++ b/XenAdmin/Commands/ResumeVMCommand.cs
@@ -35,8 +35,6 @@ using System.Drawing;
 using System.Windows.Forms;
 using XenAdmin.Actions;
 using XenAdmin.Core;
-using XenAdmin.Network;
-using XenAdmin.Properties;
 using XenAPI;
 using XenAdmin.Dialogs;
 using XenAdmin.Actions.VMActions;
@@ -92,53 +90,17 @@ namespace XenAdmin.Commands
             return false;
         }
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_RESUME;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_RESUME;
 
-        public override string ContextMenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_RESUME_CONTEXT_MENU;
-            }
-        }
+        public override string ContextMenuText => Messages.MAINWINDOW_RESUME_CONTEXT_MENU;
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._000_Resumed_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._000_Resumed_h32bit_16;
 
-        public override Image ToolBarImage
-        {
-            get
-            {
-                return Images.StaticImages._000_Resumed_h32bit_24;
-            }
-        }
+        public override Image ToolBarImage => Images.StaticImages._000_Resumed_h32bit_24;
 
-        protected override string EnabledToolTipText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TOOLBAR_RESUMEVM;
-            }
-        }
+        public override string EnabledToolTipText => Messages.MAINWINDOW_TOOLBAR_RESUMEVM;
 
-        public override string ToolBarText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TOOLBAR_RESUME;
-            }
-        }
+        public override string ToolBarText => Messages.MAINWINDOW_TOOLBAR_RESUME;
 
         protected override CommandErrorDialog GetErrorDialogCore(IDictionary<IXenObject, string> cantExecuteReasons)
         {
@@ -152,21 +114,9 @@ namespace XenAdmin.Commands
             return null;
         }
 
-        public override string ShortcutKeyDisplayString
-        {
-            get
-            {
-                return Messages.MAINWINDOW_CTRL_Y;
-            }
-        }
+        public override string ShortcutKeyDisplayString => Messages.MAINWINDOW_CTRL_Y;
 
-        public override Keys ShortcutKeys
-        {
-            get
-            {
-                return Keys.Control | Keys.Y;
-            }
-        }
+        public override Keys ShortcutKeys => Keys.Control | Keys.Y;
 
         protected override string GetCantExecuteReasonCore(IXenObject item)
         {

--- a/XenAdmin/Commands/ShutDownCommand.cs
+++ b/XenAdmin/Commands/ShutDownCommand.cs
@@ -29,17 +29,10 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
-using System.Text;
-using XenAPI;
-using XenAdmin.Core;
-using System.Drawing;
-using XenAdmin.Network;
-using XenAdmin.Actions;
-using System.Windows.Forms;
 using System.Collections.ObjectModel;
-using XenAdmin.Properties;
+using System.Drawing;
+using XenAPI;
 
 
 namespace XenAdmin.Commands
@@ -86,15 +79,9 @@ namespace XenAdmin.Commands
             return new ShutDownVMCommand(MainWindowCommandInterface, selection).CanExecute() || new ShutDownHostCommand(MainWindowCommandInterface, selection).CanExecute();
         }
 
-        public override Image ToolBarImage
-        {
-            get
-            {
-                return Images.StaticImages._001_ShutDown_h32bit_24;
-            }
-        }
+        public override Image ToolBarImage => Images.StaticImages._001_ShutDown_h32bit_24;
 
-        protected override string EnabledToolTipText
+        public override string EnabledToolTipText
         {
             get
             {
@@ -107,12 +94,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        public override string ToolBarText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TOOLBAR_SHUTDOWN;
-            }
-        }
+        public override string ToolBarText => Messages.MAINWINDOW_TOOLBAR_SHUTDOWN;
     }
 }

--- a/XenAdmin/Commands/ShutDownHostCommand.cs
+++ b/XenAdmin/Commands/ShutDownHostCommand.cs
@@ -35,7 +35,6 @@ using System.Linq;
 using System.Windows.Forms;
 using XenAdmin.Actions;
 using XenAdmin.Core;
-using XenAdmin.Properties;
 using XenAPI;
 using XenAdmin.Dialogs;
 using System.Text;
@@ -64,7 +63,7 @@ namespace XenAdmin.Commands
         public ShutDownHostCommand(IMainWindow mainWindow, Host host, Control parent)
             : base(mainWindow, host)
         {
-            SetParent(parent);
+            Parent = parent;
         }
 
         protected override void ExecuteCore(SelectedItemCollection selection)
@@ -90,29 +89,11 @@ namespace XenAdmin.Commands
             return host != null && host.IsLive() && !HelpersGUI.HasActiveHostAction(host) ;
         }
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_SHUTDOWN;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_SHUTDOWN;
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._001_ShutDown_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._001_ShutDown_h32bit_16;
 
-        protected override bool ConfirmationRequired
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationRequired => true;
 
         protected override string ConfirmationDialogTitle
         {
@@ -216,20 +197,8 @@ namespace XenAdmin.Commands
             return base.GetCantExecuteReasonCore(item);
         }
 
-        protected override string ConfirmationDialogYesButtonLabel
-        {
-            get
-            {
-                return Messages.CONFIRM_SHUTDOWN_SERVER_YES_BUTTON_LABEL;
-            }
-        }
+        protected override string ConfirmationDialogYesButtonLabel => Messages.CONFIRM_SHUTDOWN_SERVER_YES_BUTTON_LABEL;
 
-        protected override bool ConfirmationDialogNoButtonSelected
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationDialogNoButtonSelected => true;
     }
 }

--- a/XenAdmin/Commands/StartVMCommand.cs
+++ b/XenAdmin/Commands/StartVMCommand.cs
@@ -29,19 +29,16 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
-using System.Text;
-using XenAdmin.Actions;
-using XenAdmin.Core;
-using XenAPI;
-using XenAdmin.Network;
+using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Windows.Forms;
-using System.Collections.ObjectModel;
-using XenAdmin.Properties;
-using XenAdmin.Dialogs;
 using XenAdmin.Actions.VMActions;
+using XenAdmin.Actions;
+using XenAdmin.Core;
+using XenAdmin.Dialogs;
+using XenAdmin.Network;
+using XenAPI;
 
 
 namespace XenAdmin.Commands
@@ -136,53 +133,17 @@ namespace XenAdmin.Commands
             return Helpers.EnabledTargetExists(host, connection);
         }
 
-        protected override string EnabledToolTipText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TOOLBAR_STARTVM;
-            }
-        }
+        public override string EnabledToolTipText => Messages.MAINWINDOW_TOOLBAR_STARTVM;
 
-        public override Image ToolBarImage
-        {
-            get
-            {
-                return Images.StaticImages._001_PowerOn_h32bit_24;
-            }
-        }
+        public override Image ToolBarImage => Images.StaticImages._001_PowerOn_h32bit_24;
 
-        public override string ToolBarText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TOOLBAR_START;
-            }
-        }
+        public override string ToolBarText => Messages.MAINWINDOW_TOOLBAR_START;
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._001_PowerOn_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._001_PowerOn_h32bit_16;
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_START;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_START;
 
-        public override string ContextMenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_START_CONTEXT_MENU;
-            }
-        }
+        public override string ContextMenuText => Messages.MAINWINDOW_START_CONTEXT_MENU;
 
         protected override CommandErrorDialog GetErrorDialogCore(IDictionary<IXenObject, string> cantExecuteReasons)
         {
@@ -191,21 +152,9 @@ namespace XenAdmin.Commands
             return null;
         }
 
-        public override Keys ShortcutKeys
-        {
-            get
-            {
-                return Keys.Control | Keys.B;
-            }
-        }
+        public override Keys ShortcutKeys => Keys.Control | Keys.B;
 
-        public override string ShortcutKeyDisplayString
-        {
-            get
-            {
-                return Messages.MAINWINDOW_CTRL_B;
-            }
-        }
+        public override string ShortcutKeyDisplayString => Messages.MAINWINDOW_CTRL_B;
 
         protected override AsyncAction BuildAction(VM vm)
         {

--- a/XenAdmin/Commands/SuspendVMCommand.cs
+++ b/XenAdmin/Commands/SuspendVMCommand.cs
@@ -33,10 +33,9 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using XenAdmin.Actions;
-using XenAdmin.Properties;
-using XenAPI;
-using XenAdmin.Dialogs;
 using XenAdmin.Actions.VMActions;
+using XenAdmin.Dialogs;
+using XenAPI;
 
 
 namespace XenAdmin.Commands
@@ -83,53 +82,17 @@ namespace XenAdmin.Commands
             RunAction(vms, Messages.ACTION_VMS_SUSPENDING_TITLE, Messages.ACTION_VMS_SUSPENDING_TITLE, Messages.ACTION_VM_SUSPENDED, null);
         }
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_SUSPEND;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_SUSPEND;
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return Images.StaticImages._000_paused_h32bit_16;
-            }
-        }
+        public override Image MenuImage => Images.StaticImages._000_paused_h32bit_16;
 
-        public override Image ToolBarImage
-        {
-            get
-            {
-                return Images.StaticImages._000_Paused_h32bit_24;
-            }
-        }
+        public override Image ToolBarImage => Images.StaticImages._000_Paused_h32bit_24;
 
-        public override string ToolBarText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TOOLBAR_SUSPEND;
-            }
-        }
+        public override string ToolBarText => Messages.MAINWINDOW_TOOLBAR_SUSPEND;
 
-        protected override string EnabledToolTipText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TOOLBAR_SUSPENDVM;
-            }
-        }
+        public override string EnabledToolTipText => Messages.MAINWINDOW_TOOLBAR_SUSPENDVM;
 
-        protected override bool ConfirmationRequired
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationRequired => true;
 
         protected override string ConfirmationDialogTitle
         {
@@ -157,10 +120,7 @@ namespace XenAdmin.Commands
             }
         }
 
-        protected override string ConfirmationDialogHelpId
-        {
-            get { return "WarningVmLifeCycleSuspend"; }
-        }
+        protected override string ConfirmationDialogHelpId => "WarningVmLifeCycleSuspend";
 
         protected override CommandErrorDialog GetErrorDialogCore(IDictionary<IXenObject, string> cantExecuteReasons)
         {
@@ -174,21 +134,9 @@ namespace XenAdmin.Commands
             return null;
         }
 
-        public override Keys ShortcutKeys
-        {
-            get
-            {
-                return Keys.Control | Keys.Y;
-            }
-        }
+        public override Keys ShortcutKeys => Keys.Control | Keys.Y;
 
-        public override string ShortcutKeyDisplayString
-        {
-            get
-            {
-                return Messages.MAINWINDOW_CTRL_Y;
-            }
-        }
+        public override string ShortcutKeyDisplayString => Messages.MAINWINDOW_CTRL_Y;
 
         protected override string GetCantExecuteReasonCore(IXenObject item)
         {

--- a/XenAdmin/Commands/TrimSRCommand.cs
+++ b/XenAdmin/Commands/TrimSRCommand.cs
@@ -32,7 +32,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using XenAdmin.Actions;
-using XenAdmin.Core;
 using XenAPI;
 
 
@@ -78,61 +77,40 @@ namespace XenAdmin.Commands
             return sr != null && sr.SupportsTrim() && sr.GetFirstAttachedStorageHost() != null;
         }
 
-        public override string MenuText
-        {
-            get
-            {
-                return Messages.MAINWINDOW_TRIM_SR;
-            }
-        }
+        public override string MenuText => Messages.MAINWINDOW_TRIM_SR;
 
         protected override string GetCantExecuteReasonCore(IXenObject item)
         {
-            SR sr = item as SR;
-            if (sr != null && !sr.SupportsTrim())
+            if (item is SR sr && !sr.SupportsTrim())
             {
                 return Messages.TOOLTIP_SR_TRIM_UNSUPPORTED;
             }
             return base.GetCantExecuteReasonCore(item);
         }
 
-        /// <summary>
-        /// Gets the tool tip text when the command is not able to run. 
-        /// If multiple items and Trim is not supported on all, then return this reason.
-        /// Otherwise, the default behaviour: CantExectuteReason for single items, null for multiple.
-        /// </summary>
-        protected override string DisabledToolTipText
+        public override string DisabledToolTipText
         {
             get
             {
                 var selection = GetSelection();
-                var allUnsuported = selection.Count > 1 && selection.Select(item => item.XenObject as SR).All(sr => sr != null && !sr.SupportsTrim());
-                return allUnsuported ? Messages.TOOLTIP_SR_TRIM_UNSUPPORTED_MULTIPLE : base.DisabledToolTipText;
+
+                var unsupportedCount = selection.Count(i => i.XenObject is SR sr && !sr.SupportsTrim());
+                if (unsupportedCount == selection.Count)
+                {
+                    if (unsupportedCount > 1)
+                        return Messages.TOOLTIP_SR_TRIM_UNSUPPORTED_MULTIPLE;
+                    if (unsupportedCount == 1)
+                        return Messages.TOOLTIP_SR_TRIM_UNSUPPORTED;
+                }
+
+                return null;
             }
         }
 
-        protected override bool ConfirmationRequired
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override bool ConfirmationRequired => true;
 
-        protected override string ConfirmationDialogTitle
-        {
-            get
-            {
-                return Messages.CONFIRM_TRIM_SR_TITLE;
-            }
-        }
+        protected override string ConfirmationDialogTitle => Messages.CONFIRM_TRIM_SR_TITLE;
 
-        protected override string ConfirmationDialogText
-        {
-            get
-            {
-                return Messages.CONFIRM_TRIM_SR;
-            }
-        }
+        protected override string ConfirmationDialogText => Messages.CONFIRM_TRIM_SR;
     }
 }

--- a/XenAdmin/Commands/VMLifeCycleCommand.cs
+++ b/XenAdmin/Commands/VMLifeCycleCommand.cs
@@ -29,17 +29,11 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using XenAPI;
 using XenAdmin.Actions;
 using System.Windows.Forms;
-using XenAdmin.Network;
-using System.Collections.ObjectModel;
-using XenAdmin.Core;
-using System.Threading;
-using XenAdmin.Actions.VMActions;
+
 
 namespace XenAdmin.Commands
 {
@@ -66,7 +60,7 @@ namespace XenAdmin.Commands
         protected VMLifeCycleCommand(IMainWindow mainWindow, VM vm, Control parent)
             : base(mainWindow, new SelectedItem(vm))
         {
-            SetParent(parent);
+            Parent = parent;
         }
 
         protected abstract bool CanExecute(VM vm);

--- a/XenAdmin/Plugins/Features/MenuItemFeatureCommand.cs
+++ b/XenAdmin/Plugins/Features/MenuItemFeatureCommand.cs
@@ -29,19 +29,15 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Drawing;
 using XenAPI;
 using XenAdmin.Actions;
 using XenAdmin.Model;
-using XenAdmin.Network;
-using XenAdmin.Core;
 using XenAdmin.XenSearch;
 using System.Windows.Forms;
-using System.Diagnostics;
 using XenAdmin.Commands;
+
 
 namespace XenAdmin.Plugins
 {
@@ -224,12 +220,8 @@ namespace XenAdmin.Plugins
             }
         }
 
-        public override string ToolTipText
-        {
-            get
-            {
-                return _menuItemFeature.Tooltip ?? string.Empty;
-            }
-        }
+        public override string EnabledToolTipText => _menuItemFeature.Tooltip;
+
+        public override string DisabledToolTipText => _menuItemFeature.Tooltip;
     }
 }

--- a/XenAdmin/Plugins/Features/ParentMenuItemFeatureCommand.cs
+++ b/XenAdmin/Plugins/Features/ParentMenuItemFeatureCommand.cs
@@ -29,14 +29,12 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
-using System.Text;
-using XenAPI;
 using System.Drawing;
-using System.Collections.ObjectModel;
 using XenAdmin.XenSearch;
 using XenAdmin.Commands;
+using XenAPI;
+
 
 namespace XenAdmin.Plugins
 {
@@ -72,28 +70,12 @@ namespace XenAdmin.Plugins
             return false;
         }
 
-        public override string MenuText
-        {
-            get
-            {
-                return _owner.ToString();
-            }
-        }
+        public override string MenuText => _owner.ToString();
 
-        public override Image MenuImage
-        {
-            get
-            {
-                return _owner.Icon;
-            }
-        }
+        public override Image MenuImage => _owner.Icon;
 
-        public override string ToolTipText
-        {
-            get
-            {
-                return _owner.Tooltip ?? string.Empty;
-            }
-        }
+        public override string EnabledToolTipText => _owner.Tooltip;
+
+        public override string DisabledToolTipText => _owner.Tooltip;
     }
 }

--- a/XenAdmin/TabPages/SrStoragePage.Designer.cs
+++ b/XenAdmin/TabPages/SrStoragePage.Designer.cs
@@ -29,7 +29,7 @@ namespace XenAdmin.TabPages
             this.editVirtualDiskToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.TitleLabel = new System.Windows.Forms.Label();
             this.RemoveButtonContainer = new XenAdmin.Controls.ToolTipContainer();
-            this.RemoveButton = new System.Windows.Forms.Button();
+            this.RemoveButton = new XenAdmin.Commands.CommandButton();
             this.EditButtonContainer = new XenAdmin.Controls.ToolTipContainer();
             this.EditButton = new System.Windows.Forms.Button();
             this.addVirtualDiskButton = new System.Windows.Forms.Button();
@@ -38,7 +38,7 @@ namespace XenAdmin.TabPages
             this.toolTipContainerRescan = new XenAdmin.Controls.ToolTipContainer();
             this.buttonRescan = new System.Windows.Forms.Button();
             this.toolTipContainerMove = new XenAdmin.Controls.ToolTipContainer();
-            this.buttonMove = new System.Windows.Forms.Button();
+            this.buttonMove = new XenAdmin.Commands.CommandButton();
             this.dataGridViewVDIs = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
             this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnVolume = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -130,7 +130,6 @@ namespace XenAdmin.TabPages
             resources.ApplyResources(this.RemoveButton, "RemoveButton");
             this.RemoveButton.Name = "RemoveButton";
             this.RemoveButton.UseVisualStyleBackColor = true;
-            this.RemoveButton.Click += new System.EventHandler(this.RemoveButton_Click);
             // 
             // EditButtonContainer
             // 
@@ -191,7 +190,6 @@ namespace XenAdmin.TabPages
             resources.ApplyResources(this.buttonMove, "buttonMove");
             this.buttonMove.Name = "buttonMove";
             this.buttonMove.UseVisualStyleBackColor = true;
-            this.buttonMove.Click += new System.EventHandler(this.buttonMove_Click);
             // 
             // dataGridViewVDIs
             // 
@@ -298,13 +296,13 @@ namespace XenAdmin.TabPages
         private XenAdmin.Controls.ToolTipContainer EditButtonContainer;
         private System.Windows.Forms.Button EditButton;
         private XenAdmin.Controls.ToolTipContainer RemoveButtonContainer;
-        private System.Windows.Forms.Button RemoveButton;
+        private XenAdmin.Commands.CommandButton RemoveButton;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.Button buttonRescan;
         private XenAdmin.Controls.ToolTipContainer toolTipContainerRescan;
         private XenAdmin.Controls.ToolTipContainer toolTipContainerMove;
-        private System.Windows.Forms.Button buttonMove;
+        private XenAdmin.Commands.CommandButton buttonMove;
         private System.Windows.Forms.ToolStripMenuItem moveVirtualDiskToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private XenAdmin.Controls.DataGridViewEx.DataGridViewEx dataGridViewVDIs;

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -34672,7 +34672,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot reclaim freed space, because the SR is detached..
+        ///   Looks up a localized string similar to Cannot reclaim freed space because the SR is detached..
         /// </summary>
         public static string SR_TRIM_NO_STORAGE_HOST_ERROR {
             get {
@@ -36116,7 +36116,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reclaiming freed space not supported on this SR.
+        ///   Looks up a localized string similar to Reclaiming freed space is not supported on this SR.
         /// </summary>
         public static string TOOLTIP_SR_TRIM_UNSUPPORTED {
             get {
@@ -36125,7 +36125,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reclaiming freed space not supported on these SRs.
+        ///   Looks up a localized string similar to Reclaiming freed space is not supported on these SRs.
         /// </summary>
         public static string TOOLTIP_SR_TRIM_UNSUPPORTED_MULTIPLE {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12055,7 +12055,7 @@ The upper limit: SR size / {2}</value>
     <value>{0} used of {1} total ({2} allocated)</value>
   </data>
   <data name="SR_TRIM_NO_STORAGE_HOST_ERROR" xml:space="preserve">
-    <value>Cannot reclaim freed space, because the SR is detached.</value>
+    <value>Cannot reclaim freed space because the SR is detached.</value>
   </data>
   <data name="SR_UNABLE_TO_CONNECT_TO_SCSI_TARGET" xml:space="preserve">
     <value>Unable to connect to iSCSI target</value>
@@ -12489,10 +12489,10 @@ Refer to the "[XenServer product] Administrator's Guide" for instructions on how
     <value>This network cannot be removed because it is a physical device</value>
   </data>
   <data name="TOOLTIP_SR_TRIM_UNSUPPORTED" xml:space="preserve">
-    <value>Reclaiming freed space not supported on this SR</value>
+    <value>Reclaiming freed space is not supported on this SR</value>
   </data>
   <data name="TOOLTIP_SR_TRIM_UNSUPPORTED_MULTIPLE" xml:space="preserve">
-    <value>Reclaiming freed space not supported on these SRs</value>
+    <value>Reclaiming freed space is not supported on these SRs</value>
   </data>
   <data name="TREESEARCHBOX_DROPDOWN_TOOLTIP" xml:space="preserve">
     <value>Views and Saved Searches</value>


### PR DESCRIPTION
Please review commits separately and with whitespace disabled.

The actual change making the difference in the calculations is the commit with the tooltip refactoring. As an example, I counted the times the method StartVMCommand.CanExecute(VM vm) is hit before and after this change. Previously, on VM selection and on cache update the method was hit 13 and 7 times respectively, after the change these numbers have gone down to 4 and 2. (Ideally we'd like them both to be 1, however this won't be possible unless we combine the CanExecute() and GetCantExecuteReasons() to one method CanExecute(out reasons), which is a big and scary change best left for later).