### PR TITLE
Bad application of the code reusability principle in VMDestroyAction.

### DIFF
--- a/XenModel/Actions/AsyncAction.cs
+++ b/XenModel/Actions/AsyncAction.cs
@@ -335,33 +335,6 @@ namespace XenAdmin.Actions
             }
         }
 
-        protected static void BestEffort(ref Exception caught, bool expectDisruption, Action func)
-        {
-            try
-            {
-                func();
-            }
-            catch (Exception exn)
-            {
-                if (expectDisruption &&
-                    exn is WebException && ((WebException)exn).Status == WebExceptionStatus.KeepAliveFailure)  // ignore keep-alive failures if disruption is expected
-                {
-                    return;
-                }
-
-                log.Error(exn, exn);
-                if (caught == null)
-                {
-                    caught = exn;
-                }
-            }
-        }
-
-        protected void BestEffort(ref Exception caught, Action func)
-        {
-            BestEffort(ref caught, Connection != null && Connection.ExpectDisruption, func);
-        }
-
         protected void AddCommonAPIMethodsToRoleCheck()
         {
             ApiMethodsToRoleCheck.AddRange(Role.CommonTaskApiList);


### PR DESCRIPTION
Destroying a VM does not disrupt the connection, hence the use of the BestEffort method is not warranted. After this correction, BestEffort is only used in the DestroyedBondAction, hence I removed it completely and replaced it with simpler exception handling in the latter class's Run method.