### PR TITLE
CA-352455 + issue with action description while polling task

### DIFF
--- a/XenModel/Actions/AsyncAction.cs
+++ b/XenModel/Actions/AsyncAction.cs
@@ -141,7 +141,7 @@ namespace XenAdmin.Actions
         /// <summary>
         /// Prepare the action's task for exit by removing the XenCenterUUID.
         /// A call here just before exit will mean that the task will get picked 
-        /// up as a meddling action on restart of xencenter, and thus reappear in the log.
+        /// up as a meddling action on restart of xencenter, and thus reappear in the EventsTab.
         /// </summary>
         public void PrepareForLogReloadAfterRestart()
         {
@@ -269,6 +269,9 @@ namespace XenAdmin.Actions
 
         public void PollToCompletion(double start = 0, double finish = 100, bool suppressFailures = false)
         {
+            if (RelatedTask == null)
+                return;
+
             try
             {
                 DateTime startTime = DateTime.Now;
@@ -342,8 +345,7 @@ namespace XenAdmin.Actions
                 Session = session;
             }
 
-            Tick((int)(start + task.progress * (finish - start)),
-                task.Description() == "" ? Description : task.Description());
+            PercentComplete = (int)(start + task.progress * (finish - start));
 
             switch (task.status)
             {

--- a/XenModel/Actions/AsyncAction.cs
+++ b/XenModel/Actions/AsyncAction.cs
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Xml;
 using XenAdmin.Core;
 using XenAdmin.Network;
 using XenAPI;
@@ -366,9 +367,15 @@ namespace XenAdmin.Actions
                     log.InfoFormat("Task {0} finished successfully", RelatedTask.opaque_ref);
                     if (task.result != "") // Work around CA-6597
                     {
-                        Match m = Regex.Match(task.result, "<value>(.*)</value>");
-                        if (m.Success)
-                            Result = m.Groups[1].Value;
+                        var doc = new XmlDocument();
+                        doc.LoadXml(task.result);
+                        var nodes = doc.GetElementsByTagName("value");
+
+                        foreach (XmlNode node in nodes)
+                        {
+                            Result = node.InnerText;
+                            break;
+                        }
                     }
                     return true;
 

--- a/XenModel/Actions/Host/HostBackupRestoreAction.cs
+++ b/XenModel/Actions/Host/HostBackupRestoreAction.cs
@@ -81,6 +81,7 @@ namespace XenAdmin.Actions
                 switch (type)
                 {
                     case HostBackupRestoreType.backup:
+                        Description = string.Format(Messages.BACKINGUP_HOST, Host.Name());
                         RelatedTask = Task.create(Session, "get_host_backup_task", Host.address);
                         log.DebugFormat("HTTP GETTING file from {0} to {1}", Host.address, filename);
 

--- a/XenModel/Actions/Host/SingleHostStatusAction.cs
+++ b/XenModel/Actions/Host/SingleHostStatusAction.cs
@@ -60,6 +60,7 @@ namespace XenAdmin.Actions
 
         protected override void Run()
         {
+            Description = string.Format(Messages.ACTION_SYSTEM_STATUS_COMPILING, Helpers.GetName(host));
             Status = ReportStatus.compiling;
 
             string hostname = Helpers.GetName(host);

--- a/XenModel/Actions/VM/ExportVmAction.cs
+++ b/XenModel/Actions/VM/ExportVmAction.cs
@@ -98,9 +98,7 @@ namespace XenAdmin.Actions
             SafeToExit = false;
             Description = Messages.ACTION_EXPORT_DESCRIPTION_IN_PROGRESS;
 
-            RelatedTask = XenAPI.Task.create(Session,
-                string.Format(Messages.ACTION_EXPORT_TASK_NAME, VM.Name()),
-                string.Format(Messages.ACTION_EXPORT_TASK_DESCRIPTION, VM.Name()));
+            RelatedTask = Task.create(Session, "export", $"Exporting {VM.Name()} to backup file");
 
             UriBuilder uriBuilder = new UriBuilder(this.Session.Url);
             uriBuilder.Path = "export";

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -1204,15 +1204,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exporting {0} to backup file.
-        /// </summary>
-        public static string ACTION_EXPORT_TASK_DESCRIPTION {
-            get {
-                return ResourceManager.GetString("ACTION_EXPORT_TASK_DESCRIPTION", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Exporting {0}.
         /// </summary>
         public static string ACTION_EXPORT_TASK_NAME {
@@ -3675,24 +3666,6 @@ namespace XenAdmin {
         public static string ACTION_WLB_REPORT_SUCCESSFUL {
             get {
                 return ResourceManager.GetString("ACTION_WLB_REPORT_SUCCESSFUL", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Downloading WLB report {0}.
-        /// </summary>
-        public static string ACTION_WLB_REPORT_TASK_DESCRIPTION {
-            get {
-                return ResourceManager.GetString("ACTION_WLB_REPORT_TASK_DESCRIPTION", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Downloading WLB report {0}.
-        /// </summary>
-        public static string ACTION_WLB_REPORT_TASK_NAME {
-            get {
-                return ResourceManager.GetString("ACTION_WLB_REPORT_TASK_NAME", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -498,9 +498,6 @@
   <data name="ACTION_EXPORT_POOL_RESOURCE_LIST_FROM_X" xml:space="preserve">
     <value>Exporting pool resource list from '{0}'</value>
   </data>
-  <data name="ACTION_EXPORT_TASK_DESCRIPTION" xml:space="preserve">
-    <value>Exporting {0} to backup file</value>
-  </data>
   <data name="ACTION_EXPORT_TASK_NAME" xml:space="preserve">
     <value>Exporting {0}</value>
   </data>
@@ -1322,12 +1319,6 @@
   </data>
   <data name="ACTION_WLB_REPORT_SUCCESSFUL" xml:space="preserve">
     <value>Downloaded</value>
-  </data>
-  <data name="ACTION_WLB_REPORT_TASK_DESCRIPTION" xml:space="preserve">
-    <value>Downloading WLB report {0}</value>
-  </data>
-  <data name="ACTION_WLB_REPORT_TASK_NAME" xml:space="preserve">
-    <value>Downloading WLB report {0}</value>
   </data>
   <data name="ACTIVATE" xml:space="preserve">
     <value>A&amp;ctivate</value>

--- a/XenModel/WLB/WlbReportAction.cs
+++ b/XenModel/WLB/WlbReportAction.cs
@@ -79,9 +79,7 @@ namespace XenAdmin.Actions.Wlb
         {
             Description = Messages.ACTION_WLB_REPORT_DOWNLOADING;
 
-            RelatedTask = XenAPI.Task.create(Session,
-                string.Format(Messages.ACTION_WLB_REPORT_TASK_NAME, reportName),
-                string.Format(Messages.ACTION_WLB_REPORT_TASK_DESCRIPTION, reportName));
+            RelatedTask = Task.create(Session, "wlb_report", $"Downloading WLB report {reportName}");
 
             UriBuilder uriBuilder = new UriBuilder(Session.Url);
             uriBuilder.Path = "wlb_report";

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -538,16 +538,6 @@ namespace XenAPI
             XmlDocument doc = new XmlDocument();
             doc.LoadXml(xml);
 
-            // If we've got this from an async task result, then it will be wrapped
-            // in a <value> element.  Parse the contents instead.
-            foreach (XmlNode node in doc.GetElementsByTagName("value"))
-            {
-                xml = node.InnerText;
-                doc = new XmlDocument();
-                doc.LoadXml(xml);
-                break;
-            }
-
             foreach (XmlNode node in doc.GetElementsByTagName("SR"))
             {
                 string uuid = "";


### PR DESCRIPTION
- CA-352455: Parse the task result as xml document instead of using a regex.
- Do not use the task description as the AsyncAction description because in most cases it is not localised. Also, do not poll if the RelatedTask is null.