### PR TITLE
Update DEFAULT_NUM_VBDS_ALLOWED to 255

### DIFF
--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -56,7 +56,7 @@ namespace XenAPI
         // or different XenServer versions.
         private const int DEFAULT_NUM_VCPUS_ALLOWED = 16;
         private const int DEFAULT_NUM_VIFS_ALLOWED = 7;
-        private const int DEFAULT_NUM_VBDS_ALLOWED = 16;
+        private const int DEFAULT_NUM_VBDS_ALLOWED = 255;
         public const long DEFAULT_MEM_ALLOWED = 1 * Util.BINARY_TERA;
         public const int DEFAULT_CORES_PER_SOCKET = 1;
         public const long MAX_SOCKETS = 16;  // current hard limit in Xen: CA-198276


### PR DESCRIPTION
All currently supported versions of the product support 255 VBDs,
see https://docs.citrix.com/en-us/xenserver/7-0/downloads/config-limits.pdf

When a VM is imported through XCM it may not have recommendations,
and XenCenter falls back to the default, which is 16.
Then adding another disk shows an error that the maximum number of disks was reached,
which contradicts our support statement of 255 disks.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>