### PR TITLE
CA-353524: Full copy of VM on the same SR is allowed.

### DIFF
--- a/XenAdmin/Controls/PoolHostPicker.cs
+++ b/XenAdmin/Controls/PoolHostPicker.cs
@@ -447,7 +447,7 @@ namespace XenAdmin.Controls
             {
                 foreach (SR sr in TheHost.Connection.Cache.SRs)
                 {
-                    if (sr.CanBeSeenFrom(TheHost) && sr.CanCreateVmOn())
+                    if (sr.CanBeSeenFrom(TheHost) && sr.SupportsVdiCreate() && !sr.IsBroken(false) && !sr.IsFull())
                         return true;
                 }
             }

--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -44,7 +44,7 @@ namespace XenAdmin.Controls
     public class SrPicker : CustomTreeView
     {
         // Migrate is the live VDI move operation
-        public enum SRPickerType { VM, InstallFromTemplate, MoveOrCopy, Migrate, LunPerVDI }
+        public enum SRPickerType { VM, InstallFromTemplate, Move, Copy, Migrate, LunPerVDI }
 
         #region Private fields
 

--- a/XenAdmin/Dialogs/CopyVMDialog.cs
+++ b/XenAdmin/Dialogs/CopyVMDialog.cs
@@ -99,7 +99,7 @@ namespace XenAdmin.Dialogs
                 where vdi != null
                 select vdi).ToArray();
 
-            srPicker1.PopulateAsync(SrPicker.SRPickerType.MoveOrCopy, _vm.Connection,
+            srPicker1.PopulateAsync(SrPicker.SRPickerType.Copy, _vm.Connection,
                 _vm.Home(), null, vdis);
         }
 

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
@@ -74,7 +74,7 @@ namespace XenAdmin.Dialogs
 
         protected SR SelectedSR => srPicker1.SR;
 
-        protected virtual SrPicker.SRPickerType SrPickerType => SrPicker.SRPickerType.MoveOrCopy;
+        protected virtual SrPicker.SRPickerType SrPickerType => SrPicker.SRPickerType.Move;
 
         private void UpdateButtons()
         {

--- a/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
+++ b/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
@@ -59,7 +59,7 @@ namespace XenAdmin.Dialogs.VMDialogs
                 where vdi != null
                 select vdi).ToArray();
 
-            srPicker1.PopulateAsync(SrPicker.SRPickerType.MoveOrCopy, vm.Connection,
+            srPicker1.PopulateAsync(SrPicker.SRPickerType.Move, vm.Connection,
                 vm.Home(), null, vdis);
         }
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.cs
@@ -134,7 +134,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                 where vdi != null
                 select vdi).ToArray();
 
-            srPicker1.PopulateAsync(SrPicker.SRPickerType.MoveOrCopy, TheVM.Connection,
+            srPicker1.PopulateAsync(SrPicker.SRPickerType.Copy, TheVM.Connection,
                 TheVM.Home(), null, vdis);
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
@@ -233,7 +233,8 @@ namespace XenAdmin.Wizards.NewVMWizard
 
             foreach (SR sr in connection.Cache.SRs)
             {
-                if (sr.CanCreateVmOn() && sr.CanBeSeenFrom(affinity) && sr.VdiCreationCanProceed(diskSize))
+                if (sr.SupportsVdiCreate() && !sr.IsBroken(false) && !sr.IsFull() &&
+                    sr.CanBeSeenFrom(affinity) && sr.VdiCreationCanProceed(diskSize))
                 {
                     if (suggestedSr != null || defaultSr != null)
                     {

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -292,7 +292,7 @@ namespace XenAdmin.Core
         {
             foreach (SR sr in connection.Cache.SRs)
             {
-                if (sr.content_type != XenAPI.SR.Content_Type_ISO && sr.shared && sr.CanCreateVmOn())
+                if (sr.shared && sr.SupportsVdiCreate() && !sr.IsBroken(false) && !sr.IsFull())
                     return true;
             }
             return false;

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -357,14 +357,6 @@ namespace XenAPI
             return physical_size - physical_utilisation;
         }
 
-        public virtual bool ShowInVDISRList(bool showHiddenVMs)
-        {
-            if (content_type == Content_Type_ISO)
-                return false;
-            return Show(showHiddenVMs);
-
-        }
-
         public bool IsDetached()
         {
             // SR is detached when it has no PBDs or when all its PBDs are unplugged
@@ -451,18 +443,6 @@ namespace XenAPI
             Pool pool = Helpers.GetPoolOfOne(sr.Connection);
             return pool != null && pool.default_SR != null && pool.default_SR.opaque_ref == sr.opaque_ref;
         }
-
-        /// <summary>
-        /// Returns true if a new VM may be created on this SR: the SR supports VDI_CREATE, has the right number of PBDs, and is not full.
-        /// </summary>
-        /// <returns></returns>
-        public bool CanCreateVmOn()
-        {
-            System.Diagnostics.Trace.Assert(Connection != null, "Connection must not be null");
-
-            return SupportsVdiCreate() && !IsBroken(false) && !IsFull();
-        }
-
 
         /// <summary>
         /// Whether the underlying SR backend supports VDI_CREATE. Will return true even if the SR is full.


### PR DESCRIPTION
Moving and copying a VM should be treated differently, hence we need a different SrPickerItem subclass for each operation. Minor logic simplifications: I removed the methods ShowInVDISRList and CanCreateVmOn because in an occasion or two they were causing duplication of checks (this happens with other SR extension methods too, but it's out of scope to touch them at this point).