### PR TITLE
The Healthcheck service does not need any direct references to the XmlRpc dll

### DIFF
--- a/XenServerHealthCheck/XenServerHealthCheck.csproj
+++ b/XenServerHealthCheck/XenServerHealthCheck.csproj
@@ -36,9 +36,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.1, Culture=neutral, PublicKeyToken=683ddba221ac0742, processorArchitecture=MSIL">
-      <HintPath>..\packages\CookComputing.XmlRpcV2.dll</HintPath>
-    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=d247b8b0ac7959e9, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>


### PR DESCRIPTION
The dll CookComputing.XmlRpcV2 is copied over anyway because it is a dependency of XenModel.