### PR TITLE
DelegatedAsyncAction should only be used for simple API calls, hence …

### DIFF
--- a/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMOperationToolStripMenuItem.cs
@@ -37,6 +37,7 @@ using XenAdmin.Controls;
 using XenAPI;
 using XenAdmin.Core;
 using XenAdmin.Actions;
+using XenAdmin.Actions.Wlb;
 using XenAdmin.Network;
 
 

--- a/XenAdmin/Controls/Wlb/WlbOptimizePool.cs
+++ b/XenAdmin/Controls/Wlb/WlbOptimizePool.cs
@@ -580,11 +580,11 @@ namespace XenAdmin.Controls.Wlb
                             this.applyButton.Text = Messages.WLB_OPT_OPTIMIZING;
                             EnableControls(false, false);
                         }
-                        else if (action == null || (action != null && action.GetType() != typeof(WlbRetrieveRecommendationAction)))
+                        else if (action as WlbRetrieveRecommendationsAction == null)
                         {
                             this.applyButton.Text = Messages.WLB_OPT_APPLY_RECOMMENDATIONS;
                             // retrieve recommendations, and load optimize pool listview properly
-                            WlbRetrieveRecommendationAction optAction = new WlbRetrieveRecommendationAction(_pool);
+                            var optAction = new WlbRetrieveRecommendationsAction(_pool);
                             optAction.Completed += this.OptRecRetrieveAction_Completed;
                             optAction.RunAsync();
                         }
@@ -623,10 +623,10 @@ namespace XenAdmin.Controls.Wlb
             {
                 action.Completed -= OptRecRetrieveAction_Completed;
 
-                if (action is WlbRetrieveRecommendationAction)
+                if (action is WlbRetrieveRecommendationsAction thisAction)
                 {
-                    WlbRetrieveRecommendationAction thisAction = (WlbRetrieveRecommendationAction)action;
-                    _recommendations = thisAction.WLBOptPoolRecommendations;
+                    _recommendations = thisAction.Recommendations;
+                    
                     if (_recommendations != null && IsGoodRecommendation(_recommendations) && _xenObject.Connection == action.Connection)
                     {
                         Program.Invoke(this, delegate()

--- a/XenAdmin/Core/HelpersGUI.cs
+++ b/XenAdmin/Core/HelpersGUI.cs
@@ -228,15 +228,13 @@ namespace XenAdmin.Core
             Program.AssertOnEventThread();
             foreach (ActionBase action in ConnectionsManager.History)
             {
-                if (action.IsCompleted)
+                if (action.IsCompleted || action.Connection != connection)
                     continue;
 
-                WlbOptimizePoolAction optAction = action as WlbOptimizePoolAction;
-                if (optAction != null && optAction.Connection == connection)
+                if (action is WlbOptimizePoolAction optAction)
                     return optAction;
 
-                WlbRetrieveRecommendationAction optRecAction = action as WlbRetrieveRecommendationAction;
-                if (optRecAction != null && optRecAction.Connection == connection)
+                if (action is WlbRetrieveRecommendationsAction optRecAction)
                     return optRecAction;
             }
             return null;

--- a/XenModel/Actions/DelegatedAsyncAction.cs
+++ b/XenModel/Actions/DelegatedAsyncAction.cs
@@ -44,11 +44,7 @@ namespace XenAdmin.Actions
     public class DelegatedAsyncAction : AsyncAction
     {
         private readonly Action<Session> invoker;
-        private readonly Func<Session, object> function;
         private readonly string endDescription;
-
-        //TODO: this should move to AsyncAction and replace Result really
-        public object ResultObject { get; private set; }
 
         public DelegatedAsyncAction(IXenConnection connection, string title, string startDescription, string endDescription,
             Action<Session> invoker, params string[] rbacMethods)
@@ -65,28 +61,10 @@ namespace XenAdmin.Actions
             ApiMethodsToRoleCheck = new RbacMethodList(rbacMethods);
         }
 
-        public DelegatedAsyncAction(IXenConnection connection, string title, string startDescription, string endDescription,
-            Func<Session, object> function, params string[] rbacMethods)
-            : this(connection, title, startDescription, endDescription, function, false, rbacMethods)
-        {
-        }
-
-        public DelegatedAsyncAction(IXenConnection connection, string title, string startDescription, string endDescription,
-            Func<Session, object> function, bool suppressHistory, params string[] rbacMethods)
-            : base(connection, title, startDescription, suppressHistory)
-        {
-            this.endDescription = endDescription;
-            this.function = function;
-            ApiMethodsToRoleCheck = new RbacMethodList(rbacMethods);
-        }
-
-
         protected override void Run()
         {
             if (invoker != null)
                 invoker(Session);
-            else if (function != null)
-                ResultObject = function(Session);
 
             Description = endDescription;
         }

--- a/XenModel/Actions/WLB/WlbEvacuateRecommendationsAction.cs
+++ b/XenModel/Actions/WLB/WlbEvacuateRecommendationsAction.cs
@@ -1,0 +1,88 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using XenAdmin.Core;
+using XenAdmin.Wlb;
+using XenAPI;
+
+
+namespace XenAdmin.Actions.Wlb
+{
+    public class WlbEvacuateRecommendationsAction : AsyncAction
+    {
+        public WlbEvacuateRecommendationsAction(Host host)
+            : base(host.Connection, string.Format(Messages.WLB_RETRIEVING_EVACUATE_RECOMMENDATIONS, host.Name()), true)
+        {
+            Host = host;
+        }
+
+        public Dictionary<XenRef<VM>, string[]> CantEvacuateReasons = new Dictionary<XenRef<VM>, string[]>();
+
+        protected override void Run()
+        {
+            Description = Messages.SCANNING_VMS;
+
+            if (Helpers.WlbEnabled(Connection))
+                CantEvacuateReasons = Host.retrieve_wlb_evacuate_recommendations(Session, Host.opaque_ref);
+
+            if (CantEvacuateReasons == null || CantEvacuateReasons.Count == 0 || !ValidRecommendation(CantEvacuateReasons))
+                CantEvacuateReasons = Host.get_vms_which_prevent_evacuation(Session, Host.opaque_ref);
+
+            Description = Messages.COMPLETED;
+        }
+
+        private bool ValidRecommendation(Dictionary<XenRef<VM>, string[]> reasons)
+        {
+            List<Host> controlDomain = new List<Host>();
+
+            foreach (KeyValuePair<XenRef<VM>, string[]> kvp in reasons)
+            {
+                if (Connection.Resolve(kvp.Key).is_control_domain)
+                    controlDomain.Add(Connection.Cache.Find_By_Uuid<Host>(kvp.Value[(int)RecProperties.ToHost]));
+            }
+
+            foreach (KeyValuePair<XenRef<VM>, string[]> kvp in reasons)
+            {
+                if (kvp.Value[0].Trim().ToLower() == "wlb")
+                {
+                    Host toHost = Connection.Cache.Find_By_Uuid<Host>(kvp.Value[(int)RecProperties.ToHost]);
+                    if (!Connection.Resolve(kvp.Key).is_control_domain && !toHost.IsLive() && !controlDomain.Contains(toHost))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/XenModel/Actions/WLB/WlbRetrieveVmRecommendationsAction.cs
+++ b/XenModel/Actions/WLB/WlbRetrieveVmRecommendationsAction.cs
@@ -29,21 +29,17 @@
  * SUCH DAMAGE.
  */
 
-using System;
 using System.Collections.Generic;
 using XenAdmin.Core;
 using XenAdmin.Network;
 using XenAPI;
 
-namespace XenAdmin.Actions
+
+namespace XenAdmin.Actions.Wlb
 {
     public class WlbRetrieveVmRecommendationsAction: AsyncAction
     {
-        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
         private readonly List<VM> vms;
-        private readonly Dictionary<VM, Dictionary<XenRef<Host>, string[]>> recommendations = new Dictionary<VM, Dictionary<XenRef<Host>, string[]>>();
-        private bool isError;
 
         public WlbRetrieveVmRecommendationsAction(IXenConnection connection, List<VM> vms)
             : base(connection, Messages.WLB_RETRIEVING_VM_RECOMMENDATIONS, true)
@@ -54,36 +50,11 @@ namespace XenAdmin.Actions
 
         protected override void Run()
         {
-            if (vms.Count == 0)
-            {
-                isError = true;
-                return;
-            }
-
-            if (Helpers.WlbEnabled(vms[0].Connection))
-            {
-                try
-                {
-                    foreach (var vm in vms)
-                    {
-                        recommendations[vm] = VM.retrieve_wlb_recommendations(Session, vm.opaque_ref);
-                    }
-                }
-                catch (Exception e)
-                {
-                    log.Error("Error getting WLB recommendations", e);
-                    isError = true;
-                }
-            }
-            else
-            {
-                isError = true;
-            }
+            if (Helpers.WlbEnabled(Connection))
+                foreach (var vm in vms)
+                    Recommendations[vm] = VM.retrieve_wlb_recommendations(Session, vm.opaque_ref);
         }
 
-        public Dictionary<VM, Dictionary<XenRef<Host>, string[]>> Recommendations
-        {
-            get { return isError ? null : recommendations; }
-        }
+        public readonly Dictionary<VM, Dictionary<XenRef<Host>, string[]>> Recommendations = new Dictionary<VM, Dictionary<XenRef<Host>, string[]>>();
     }
 }

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -22572,15 +22572,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Maintenance Mode.
-        /// </summary>
-        public static string MAINTENANCE_MODE {
-            get {
-                return ResourceManager.GetString("MAINTENANCE_MODE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &amp;Add....
         /// </summary>
         public static string MAINWINDOW_ADD_HOST {
@@ -41787,6 +41778,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Retrieving WLB recommendations on VMs to migrate from server {0}.
+        /// </summary>
+        public static string WLB_RETRIEVING_EVACUATE_RECOMMENDATIONS {
+            get {
+                return ResourceManager.GetString("WLB_RETRIEVING_EVACUATE_RECOMMENDATIONS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Retrieving WLB recommendations for pool {0}.
         /// </summary>
         public static string WLB_RETRIEVING_RECOMMENDATIONS {
@@ -41796,7 +41796,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Retrieving WLB recommendations .
+        ///   Looks up a localized string similar to Retrieving WLB recommendations.
         /// </summary>
         public static string WLB_RETRIEVING_VM_RECOMMENDATIONS {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7840,9 +7840,6 @@ Size: {3}</value>
   <data name="MAIL_LANGUAGE_JAPANESE_NAME" xml:space="preserve">
     <value>Japanese (Japan)</value>
   </data>
-  <data name="MAINTENANCE_MODE" xml:space="preserve">
-    <value>Maintenance Mode</value>
-  </data>
   <data name="MAINWINDOW_ADD_HOST" xml:space="preserve">
     <value>&amp;Add...</value>
   </data>
@@ -14439,11 +14436,14 @@ Would you like to adjust the current Optimization Mode to match the schedule?</v
   <data name="WLB_RETRIEVING_CONFIGURATION" xml:space="preserve">
     <value>Retrieving WLB Configuration</value>
   </data>
+  <data name="WLB_RETRIEVING_EVACUATE_RECOMMENDATIONS" xml:space="preserve">
+    <value>Retrieving WLB recommendations on VMs to migrate from server {0}</value>
+  </data>
   <data name="WLB_RETRIEVING_RECOMMENDATIONS" xml:space="preserve">
     <value>Retrieving WLB recommendations for pool {0}</value>
   </data>
   <data name="WLB_RETRIEVING_VM_RECOMMENDATIONS" xml:space="preserve">
-    <value>Retrieving WLB recommendations </value>
+    <value>Retrieving WLB recommendations</value>
   </data>
   <data name="WLB_SAVING_SETTINGS" xml:space="preserve">
     <value>Saving Workload Balancing settings</value>

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Actions\VM\VMCrossPoolMigrateAction.cs" />
     <Compile Include="Actions\VM\VMSnapshotCreateAction.cs" />
     <Compile Include="Actions\VM\VMStartAction.cs" />
+    <Compile Include="Actions\WLB\WlbEvacuateRecommendationsAction.cs" />
     <Compile Include="Actions\WLB\WlbRetrieveVmRecommendationsAction.cs" />
     <Compile Include="Actions\XCM\ActivateConversionVpxAction.cs" />
     <Compile Include="Actions\ZipStatusReportAction.cs" />
@@ -327,7 +328,7 @@
     <Compile Include="Actions\WLB\EnableWLBAction.cs" />
     <Compile Include="Actions\WLB\InitializeWLBAction.cs" />
     <Compile Include="Actions\WLB\SendWlbConfigurationAction.cs" />
-    <Compile Include="Actions\WLB\WlbRetrieveRecommendationAction.cs" />
+    <Compile Include="Actions\WLB\WlbRetrieveRecommendationsAction.cs" />
     <Compile Include="Alerts\PerfmonDefinition.cs" />
     <Compile Include="Alerts\PerfmonOptionsDefinition.cs" />
     <Compile Include="InvisibleMessages.Designer.cs">


### PR DESCRIPTION
…created new class for retrieving WLB host evacuation recommendations. This allows removal of DelegatedAsyncAction.ResultObject, which might lead to complicated implementations. Also: some refactoring of the other WLB retrieve recommendations actions.