### PR TITLE
CP-36122: Warn the user about inhomogeneous certificate verification …

### DIFF
--- a/XenAdmin/Commands/AddHostToPoolCommand.cs
+++ b/XenAdmin/Commands/AddHostToPoolCommand.cs
@@ -99,7 +99,7 @@ namespace XenAdmin.Commands
                 }
             }
 
-            if (!Helpers.IsConnected(_pool))
+            if (_pool == null || _pool.Connection == null || !_pool.Connection.IsConnected)
             {
                 string message = _hosts.Count == 1
                                      ? string.Format(Messages.ADD_HOST_TO_POOL_DISCONNECTED_POOL,

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -30911,6 +30911,42 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Certificate verification is enabled on master, but not on this server. To create the pool, first enable certificate verification on the server..
+        /// </summary>
+        public static string POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_MASTER {
+            get {
+                return ResourceManager.GetString("POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_MASTER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate verification is enabled on this server, but not on master. To create the pool, first enable certificate verification on master..
+        /// </summary>
+        public static string POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_MASTER_JOINER {
+            get {
+                return ResourceManager.GetString("POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_MASTER_JOINER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate verification is enabled on the pool, but not on this server. To add the server to the pool, first enable certificate verification on the server..
+        /// </summary>
+        public static string POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_POOL {
+            get {
+                return ResourceManager.GetString("POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_POOL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate verification is enabled on this server, but not on the pool. To add the server to the pool, first enable certificate verification on the pool..
+        /// </summary>
+        public static string POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_POOL_JOINER {
+            get {
+                return ResourceManager.GetString("POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_POOL_JOINER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HA is enabled on the pool.
         /// </summary>
         public static string POOL_JOIN_FORBIDDEN_BY_HA {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10739,6 +10739,18 @@ Please reconnect the host and try again</value>
   <data name="POOL_IS_PARTIALLY_LICENSED" xml:space="preserve">
     <value>The pool is partially licensed</value>
   </data>
+  <data name="POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_MASTER" xml:space="preserve">
+    <value>Certificate verification is enabled on master, but not on this server. To create the pool, first enable certificate verification on the server.</value>
+  </data>
+  <data name="POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_MASTER_JOINER" xml:space="preserve">
+    <value>Certificate verification is enabled on this server, but not on master. To create the pool, first enable certificate verification on master.</value>
+  </data>
+  <data name="POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_POOL" xml:space="preserve">
+    <value>Certificate verification is enabled on the pool, but not on this server. To add the server to the pool, first enable certificate verification on the server.</value>
+  </data>
+  <data name="POOL_JOIN_CERTIFICATE_CHECKING_ONLY_ON_POOL_JOINER" xml:space="preserve">
+    <value>Certificate verification is enabled on this server, but not on the pool. To add the server to the pool, first enable certificate verification on the pool.</value>
+  </data>
   <data name="POOL_JOIN_FORBIDDEN_BY_HA" xml:space="preserve">
     <value>HA is enabled on the pool</value>
   </data>

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -273,21 +273,6 @@ namespace XenAdmin.Core
             return o == null ? "" : o.Name();
         }
 
-        public static bool IsConnected(IXenConnection connection)
-        {
-            return (connection != null && connection.IsConnected);
-        }
-
-        public static bool IsConnected(Pool pool)
-        {
-            return (pool != null && IsConnected(pool.Connection));
-        }
-
-        public static bool IsConnected(Host host)
-        {
-            return (host != null && IsConnected(host.Connection));
-        }
-
         public static bool HasFullyConnectedSharedStorage(IXenConnection connection)
         {
             foreach (SR sr in connection.Cache.SRs)


### PR DESCRIPTION
…when creating/joining a pool. Also, removed methods that were obscuring unnecessarily the contained logic (to the extent that a comment was necessary to explain it).

I've added two sets of messages because the one is used on the NewPool dialog, and the other when adding/drag-and-dropping a server to a pool.