### PR TITLE
CA-350819: Add support for passwordless certificates

### DIFF
--- a/XenAdmin/Wizards/ExportWizard/ExportOptionsPage.cs
+++ b/XenAdmin/Wizards/ExportWizard/ExportOptionsPage.cs
@@ -170,7 +170,7 @@ namespace XenAdmin.Wizards.ExportWizard
 				m_checkBoxSign.Checked = true;
 
 		    m_ctrlErrorCert.HideError();
-			m_buttonValidate.Enabled = !string.IsNullOrEmpty(m_textBoxCertificate.Text) && !string.IsNullOrEmpty(m_textBoxPrivateKeyPwd.Text);
+			m_buttonValidate.Enabled = !string.IsNullOrEmpty(m_textBoxCertificate.Text) && m_textBoxPrivateKeyPwd.Text != null;
 			m_pictureBoxTickValidate.Visible = false;
 			m_isSignatureOk = false;
 			SetButtonNextEnabled(m_isEncryptionOk && m_isSignatureOk);
@@ -266,7 +266,7 @@ namespace XenAdmin.Wizards.ExportWizard
 		{
 			if (m_checkBoxManifest.Checked && m_checkBoxSign.Checked)
 			{
-				if (string.IsNullOrEmpty(m_textBoxCertificate.Text) || string.IsNullOrEmpty(m_textBoxPrivateKeyPwd.Text)
+				if (string.IsNullOrEmpty(m_textBoxCertificate.Text) || m_textBoxPrivateKeyPwd.Text == null
 					|| !m_ctrlErrorCert.PerformCheck(CheckCertificatePathValid, CheckCertificatePathExists, CheckSignPasswordValid, CheckCertificateValid))
 				{
 					m_pictureBoxTickValidate.Visible = false;


### PR DESCRIPTION

### Certificates:
After having removed the restriction for non-empty passwords, the certificate validation still works.

Tested with the following combinations:


.pem | .pfx | Correct Password | Incorrect Password | Empty Password
-- | -- | -- | -- | --
NO password | NO password | N/A | ✅ As expected | ✅ As expected
WITH password | NO password | N/A | ✅ As expected | ✅ As expected
NO password | WITH password | ✅ As expected | ✅ As expected | ✅ As expected
WITH password (different) | WITH password (different) | ✅ As expected | ✅ As expected | ✅ As expected
WITH password(same) | WITH password    (same) | ✅ As expected | ✅ As expected | ✅ As expected


.pem was generated with:

```openssl req -x509 -newkey rsa:2048 [-nodes] -sha256 -days 29 -keyout key29days.pem -out cert29days.pem```

.pfx was generated with:

`openssl pkcs12 -export -out key29days.pfx -inkey key29days.pem -in cert29days.pem -CSP "Microsoft Enhanced RSA and AES Cryptographic Provider"`

**n.b.:** N/A in this context means that a "correct password" string cannot be tested, as any string is incorrect. This still means that the behavior is "As expected"