### PR TITLE
CA-279581: Prevent panel headers from overlapping scrollbar

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.Designer.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.Designer.cs
@@ -169,6 +169,7 @@ namespace XenAdmin.TabPages
             this.panel2.Controls.Add(this.panelCertificate);
             this.panel2.Controls.Add(this.panelGeneral);
             this.panel2.Name = "panel2";
+            this.panel2.Paint += new System.Windows.Forms.PaintEventHandler(this.panel2_Paint);
             // 
             // panelReadCaching
             // 

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1944,8 +1944,9 @@ namespace XenAdmin.TabPages
         }
 
         private void panel2_Paint(object sender, PaintEventArgs e)
-        {
-            panel2.AutoScroll = sections.Sum(s => s.Height) > panel2.Height;
+        {   
+            //Force scrollbar to be repainted to avoid occasional pixel glitch.
+            panel2.AutoScroll = sections.Sum(s => s?.Parent.Height ?? s.Height) > panel2.ClientRectangle.Height;
         }
 
         #endregion

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1943,6 +1943,11 @@ namespace XenAdmin.TabPages
             StartPutty( "env docker logs --tail=50 --follow --timestamps");
         }
 
+        private void panel2_Paint(object sender, PaintEventArgs e)
+        {
+            panel2.AutoScroll = sections.Sum(s => s.Height) > panel2.Height;
+        }
+
         #endregion
 
         private void StartPutty(string dockerCmd)

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1946,7 +1946,7 @@ namespace XenAdmin.TabPages
         private void panel2_Paint(object sender, PaintEventArgs e)
         {   
             //Force scrollbar to be repainted to avoid occasional pixel glitch.
-            panel2.AutoScroll = sections.Sum(s => s?.Parent.Height ?? s.Height) > panel2.ClientRectangle.Height;
+            panel2.AutoScroll = sections.Sum(s => s.Parent?.Height ?? s.Height) > panel2.ClientRectangle.Height;
         }
 
         #endregion


### PR DESCRIPTION
Because of this, the scrollbar is partially visible until these pixels are refreshed manually (either by resizing the window, moving to a different page, or by interacting with controls that occupy the same space.

In order to avoid this, the `AutoScroll` property is updated programmatically whenever the `panel2`'s `Paint` event is fired.