### PR TITLE
CP-34231: Replace negative language with `coordinator`

### DIFF
--- a/XenAdmin/Dialogs/EvacuateHostDialog.resx
+++ b/XenAdmin/Dialogs/EvacuateHostDialog.resx
@@ -322,7 +322,7 @@
     <value>0</value>
   </data>
   <data name="labelMasterBlurb.Text" xml:space="preserve">
-    <value>This server is the pool master. Entering maintenance mode will nominate a new master for the pool. {0} will temporarily lose its connection to the pool.</value>
+    <value>This server is the pool coordinator. Entering maintenance mode will nominate a new master for the pool. {0} will temporarily lose its connection to the pool.</value>
   </data>
   <data name="&gt;&gt;labelMasterBlurb.Name" xml:space="preserve">
     <value>labelMasterBlurb</value>
@@ -358,7 +358,7 @@
     <value>1</value>
   </data>
   <data name="NewMasterLabel.Text" xml:space="preserve">
-    <value>&amp;New master:</value>
+    <value>&amp;New coordinator:</value>
   </data>
   <data name="&gt;&gt;NewMasterLabel.Name" xml:space="preserve">
     <value>NewMasterLabel</value>

--- a/XenAdmin/Dialogs/NewPoolDialog.resx
+++ b/XenAdmin/Dialogs/NewPoolDialog.resx
@@ -457,7 +457,7 @@
     <value>0</value>
   </data>
   <data name="labelMaster.Text" xml:space="preserve">
-    <value>&amp;Coordinator:</value>
+    <value>C&amp;oordinator:</value>
   </data>
   <data name="labelMaster.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>

--- a/XenAdmin/Dialogs/NewPoolDialog.resx
+++ b/XenAdmin/Dialogs/NewPoolDialog.resx
@@ -457,7 +457,7 @@
     <value>0</value>
   </data>
   <data name="labelMaster.Text" xml:space="preserve">
-    <value>&amp;Master:</value>
+    <value>&amp;Coordinator:</value>
   </data>
   <data name="labelMaster.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>

--- a/XenAdmin/Wizards/HAWizard_Pages/HAFinishPage.resx
+++ b/XenAdmin/Wizards/HAWizard_Pages/HAFinishPage.resx
@@ -547,7 +547,7 @@
     <value>3</value>
   </data>
   <data name="labelNoVmsProtected.Text" xml:space="preserve">
-    <value>No virtual machines are protected. This configuration will protect the pool master, but none of your services.</value>
+    <value>No virtual machines are protected. This configuration will protect the pool coordinator, but none of your services.</value>
   </data>
   <data name="labelNoVmsProtected.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -3834,7 +3834,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Server &apos;{0}&apos; is now the master of pool &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Server &apos;{0}&apos; is now the coordinator of pool &apos;{1}&apos;..
         /// </summary>
         public static string Message_body_pool_master_transition {
             get {
@@ -4626,7 +4626,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pool master changed.
+        ///   Looks up a localized string similar to Pool cooordinator changed.
         /// </summary>
         public static string Message_name_pool_master_transition {
             get {

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1086,7 +1086,7 @@
     <value>A storage repository could not be attached when server '{0}' started.</value>
   </data>
   <data name="Message.body-pool_master_transition" xml:space="preserve">
-    <value>Server '{0}' is now the master of pool '{1}'.</value>
+    <value>Server '{0}' is now the coordinator of pool '{1}'.</value>
   </data>
   <data name="Message.body-vbd_qos_failed" xml:space="preserve">
     <value>Quality of Service settings for disk '{0}' on virtual machine '{1}' could not be obeyed.</value>
@@ -1305,7 +1305,7 @@
     <value>Failed to attach storage on server start</value>
   </data>
   <data name="Message.name-pool_master_transition" xml:space="preserve">
-    <value>Pool master changed</value>
+    <value>Pool cooordinator changed</value>
   </data>
   <data name="Message.name-vbd_qos_failed" xml:space="preserve">
     <value>VM Disk QoS Failed</value>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -6067,7 +6067,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find the bond master in {0}&apos;s cache..
+        ///   Looks up a localized string similar to Could not find the bond interface in {0}&apos;s cache..
         /// </summary>
         public static string BOND_MASTER_GONE {
             get {
@@ -8795,7 +8795,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Looking for master for {0} on {1}....
+        ///   Looks up a localized string similar to Looking for coordinator for {0} on {1}....
         /// </summary>
         public static string CONNECTION_FINDING_MASTER_DESCRIPTION {
             get {
@@ -8804,7 +8804,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Looking for master for {0}.
+        ///   Looks up a localized string similar to Looking for coordinator for {0}.
         /// </summary>
         public static string CONNECTION_FINDING_MASTER_TITLE {
             get {
@@ -8831,7 +8831,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lost connection to {0}. Will search for a new pool master in {1} seconds..
+        ///   Looks up a localized string similar to Lost connection to {0}. Will search for a new pool coordinator in {1} seconds..
         /// </summary>
         public static string CONNECTION_LOST_NOTICE_MASTER_IN_X_SECONDS {
             get {
@@ -8876,7 +8876,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connection to {0}: redirecting to the pool master at {1}.
+        ///   Looks up a localized string similar to Connection to {0}: redirecting to the pool coordinator at {1}.
         /// </summary>
         public static string CONNECTION_REDIRECTING {
             get {
@@ -11093,7 +11093,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Creating new pool &apos;{0}&apos; with master &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Creating new pool &apos;{0}&apos; with coordinator &apos;{1}&apos;.
         /// </summary>
         public static string CREATING_NAMED_POOL_WITH_MASTER {
             get {
@@ -15741,7 +15741,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot nominate a new master while the pool is in the process of creating a cluster..
+        ///   Looks up a localized string similar to You cannot nominate a new coordinator while the pool is in the process of creating a cluster..
         /// </summary>
         public static string EVACUATE_HOST_CLUSER_CREATING {
             get {
@@ -15768,7 +15768,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot nominate a new master while HA is being disabled on the pool..
+        ///   Looks up a localized string similar to You cannot nominate a new coordinator while HA is being disabled on the pool..
         /// </summary>
         public static string EVACUATE_HOST_HA_DISABLING {
             get {
@@ -15777,7 +15777,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot nominate a new master while HA is being enabled on the pool..
+        ///   Looks up a localized string similar to You cannot nominate a new coordinator while HA is being enabled on the pool..
         /// </summary>
         public static string EVACUATE_HOST_HA_ENABLING {
             get {
@@ -15894,7 +15894,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User canceled. Master needs to be upgraded first..
+        ///   Looks up a localized string similar to User canceled. Coordinator needs to be upgraded first..
         /// </summary>
         public static string EXCEPTION_USER_CANCELLED_MASTER {
             get {
@@ -17995,7 +17995,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Server &apos;{0}&apos; cannot be placed in Maintenance Mode because it is the master of an HA-enabled pool..
+        ///   Looks up a localized string similar to Server &apos;{0}&apos; cannot be placed in Maintenance Mode because it is the coordinator of an HA-enabled pool..
         /// </summary>
         public static string HA_CANNOT_EVACUATE_MASTER {
             get {
@@ -19627,7 +19627,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nominated server {0} as new master.
+        ///   Looks up a localized string similar to Nominated server {0} as new coordinator.
         /// </summary>
         public static string HOSTACTION_TRANSITIONED_NEW_MASTER {
             get {
@@ -19636,7 +19636,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nominating server {0} as new master....
+        ///   Looks up a localized string similar to Nominating server {0} as new coordinator....
         /// </summary>
         public static string HOSTACTION_TRANSITIONING_NEW_MASTER {
             get {
@@ -23572,7 +23572,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Master.
+        ///   Looks up a localized string similar to Coordinator.
         /// </summary>
         public static string MASTER {
             get {
@@ -24157,7 +24157,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The pool Master will become a standalone server, are you sure you want to continue?.
+        ///   Looks up a localized string similar to The pool Coordinator will become a standalone server, are you sure you want to continue?.
         /// </summary>
         public static string MESSAGEBOX_POOL_DELETE {
             get {
@@ -24166,7 +24166,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot remove the master from the pool..
+        ///   Looks up a localized string similar to You cannot remove the coordinator from the pool..
         /// </summary>
         public static string MESSAGEBOX_POOL_MASTER_REMOVE {
             get {
@@ -25276,7 +25276,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to add the server &apos;{0}&apos; to a pool with a master that is configured to use AD authentication. All pool members must use the same authentication method.
+        ///   Looks up a localized string similar to You are attempting to add the server &apos;{0}&apos; to a pool with a coordinator that is configured to use AD authentication. All pool members must use the same authentication method.
         ///
         ///Do you want to enable AD authentication on your server and join it to the same domain as the pool?.
         /// </summary>
@@ -25287,7 +25287,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to add the following servers to a pool with a master that is configured to use AD authentication:
+        ///   Looks up a localized string similar to You are attempting to add the following servers to a pool with a coordinator that is configured to use AD authentication:
         ///
         ///{0}
         ///
@@ -25309,7 +25309,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to add the server &apos;{0}&apos; to a pool with a master that is using an older CPU.
+        ///   Looks up a localized string similar to You are attempting to add the server &apos;{0}&apos; to a pool with a coordinator that is using an older CPU.
         ///
         ///{1} can continue by rebooting the server and reducing its CPU to the level of the master. This will shut down any VMs running on the server. This feature is supported for CPU combinations listed in the {1} Hardware Compatibility List.
         ///
@@ -25322,11 +25322,11 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are attempting to add the following servers to a pool with a master that is using an older CPU:
+        ///   Looks up a localized string similar to You are attempting to add the following servers to a pool with a coordinator that is using an older CPU:
         ///
         ///{0}
         ///
-        ///{1} can continue by rebooting the servers and reducing their CPUs to the level of the master. This will shut down any VMs running on the servers. This feature is supported for CPU combinations listed in the {1} Hardware Compatibility List.
+        ///{1} can continue by rebooting the servers and reducing their CPUs to the level of the coordinator. This will shut down any VMs running on the servers. This feature is supported for CPU combinations listed in the {1} Hardware Compatibility List.
         ///
         ///Do you want to do this?.
         /// </summary>
@@ -25339,7 +25339,7 @@ namespace XenAdmin {
         /// <summary>
         ///   Looks up a localized string similar to You are attempting to add the server &apos;{0}&apos; to a licensed pool.
         ///
-        ///Do you want to apply the licensing from the master to this server?.
+        ///Do you want to apply the licensing from the coordinator to this server?.
         /// </summary>
         public static string NEW_POOL_LICENSE_MESSAGE {
             get {
@@ -25352,7 +25352,7 @@ namespace XenAdmin {
         ///
         ///{0}
         ///
-        ///Do you want to apply the licensing from the master to these servers?.
+        ///Do you want to apply the licensing from the coordinator to these servers?.
         /// </summary>
         public static string NEW_POOL_LICENSE_MESSAGE_MULTIPLE {
             get {
@@ -25649,7 +25649,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server&apos;s hardware is incompatible with the master&apos;s.
+        ///   Looks up a localized string similar to This server&apos;s hardware is incompatible with the coordinator&apos;s.
         /// </summary>
         public static string NEWPOOL_DIFF_HARDWARE {
             get {
@@ -25658,7 +25658,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server is a different version to the master.
+        ///   Looks up a localized string similar to This server is a different version to the coordinator.
         /// </summary>
         public static string NEWPOOL_DIFF_SERVER {
             get {
@@ -25667,7 +25667,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server has different updates from the master.
+        ///   Looks up a localized string similar to This server has different updates from the coordinator.
         /// </summary>
         public static string NEWPOOL_DIFFERENT_HOMOGENEOUS_UPDATES_FROM_MASTER {
             get {
@@ -25685,7 +25685,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server&apos;s network backend is different from the master&apos;s.
+        ///   Looks up a localized string similar to This server&apos;s network backend is different from the coordinator&apos;s.
         /// </summary>
         public static string NEWPOOL_DIFFERENT_NETWORK_BACKENDS {
             get {
@@ -25694,7 +25694,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server has a different Active Directory configuration to the master.
+        ///   Looks up a localized string similar to This server has a different Active Directory configuration to the coordinator.
         /// </summary>
         public static string NEWPOOL_DIFFERING_AD_CONFIG {
             get {
@@ -25739,7 +25739,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server is master of an existing pool.
+        ///   Looks up a localized string similar to This server is coordinator of an existing pool.
         /// </summary>
         public static string NEWPOOL_IS_A_POOL {
             get {
@@ -25757,7 +25757,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server does not have the same license as the pool master.
+        ///   Looks up a localized string similar to This server does not have the same license as the pool coordinator.
         /// </summary>
         public static string NEWPOOL_LICENSEMISMATCH {
             get {
@@ -25766,7 +25766,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This server&apos;s Linux pack installation state differs from that of the master.
+        ///   Looks up a localized string similar to This server&apos;s Linux pack installation state differs from that of the coordinator.
         /// </summary>
         public static string NEWPOOL_LINUXPACK {
             get {
@@ -25775,7 +25775,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The master is still connecting.
+        ///   Looks up a localized string similar to The coordinator is still connecting.
         /// </summary>
         public static string NEWPOOL_MASTER_CONNECTING {
             get {
@@ -25784,7 +25784,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The master is disconnected.
+        ///   Looks up a localized string similar to The coordinator is disconnected.
         /// </summary>
         public static string NEWPOOL_MASTER_DISCONNECTED {
             get {
@@ -25793,7 +25793,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your current role on the master is not authorized to add hosts to the master&apos;s pool.
+        ///   Looks up a localized string similar to Your current role on the coordinator is not authorized to add hosts to the coordinator&apos;s pool.
         /// </summary>
         public static string NEWPOOL_MASTER_ROLE {
             get {
@@ -27631,7 +27631,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is no server eligible to become the master of your new pool.
+        ///   Looks up a localized string similar to There is no server eligible to become the coordinator of your new pool.
         /// </summary>
         public static string NO_ELIGIBLE_MASTER {
             get {
@@ -29034,7 +29034,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restart these servers in this order (master always first):.
+        ///   Looks up a localized string similar to Restart these servers in this order (coordinator always first):.
         /// </summary>
         public static string PATCHINGWIZARD_MODEPAGE_RESTARTSERVERS {
             get {
@@ -29052,7 +29052,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restart toolstack on these servers in this order (master always first):.
+        ///   Looks up a localized string similar to Restart toolstack on these servers in this order (coordinator always first):.
         /// </summary>
         public static string PATCHINGWIZARD_MODEPAGE_RESTARTXAPI {
             get {
@@ -29413,7 +29413,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot install updates on this host because the master is running a version higher than {0}.
+        ///   Looks up a localized string similar to Cannot install updates on this host because the coordinator is running a version higher than {0}.
         /// </summary>
         public static string PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_UPDATE_MASTER_POST_7_0 {
             get {
@@ -30492,7 +30492,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pool master.
+        ///   Looks up a localized string similar to Pool coordinator.
         /// </summary>
         public static string POOL_MASTER {
             get {
@@ -30501,7 +30501,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find the pool master in {0}&apos;s cache..
+        ///   Looks up a localized string similar to Could not find the pool coordinator in {0}&apos;s cache..
         /// </summary>
         public static string POOL_MASTER_GONE {
             get {
@@ -30830,7 +30830,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: The master needs to be rebooted first.
+        ///   Looks up a localized string similar to {0}: The coordinator needs to be rebooted first.
         /// </summary>
         public static string PROBLEM_MASTER_PENDING_RESTART_HOST {
             get {
@@ -30839,7 +30839,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: This update requires the master to be rebooted first.
+        ///   Looks up a localized string similar to {0}: This update requires the coordinator to be rebooted first.
         /// </summary>
         public static string PROBLEM_MASTER_PENDING_RESTART_HOST_THIS_UPDATE {
             get {
@@ -30848,7 +30848,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: Toolstack on master needs to be restarted first.
+        ///   Looks up a localized string similar to {0}: Toolstack on coordinator needs to be restarted first.
         /// </summary>
         public static string PROBLEM_MASTER_PENDING_RESTART_TOOLSTACK {
             get {
@@ -30857,7 +30857,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: This update requires the toolstack on master to be restarted first.
+        ///   Looks up a localized string similar to {0}: This update requires the toolstack on coordinator to be restarted first.
         /// </summary>
         public static string PROBLEM_MASTER_PENDING_RESTART_TOOLSTACK_THIS_UPDATE {
             get {
@@ -32845,7 +32845,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot nominate a new master while a pool secret rotation is in progress..
+        ///   Looks up a localized string similar to You cannot nominate a new coordinator while a pool secret rotation is in progress..
         /// </summary>
         public static string ROTATE_POOL_SECRET_PENDING_NEW_MASTER {
             get {
@@ -33486,7 +33486,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The current time on the pool master is: {0}.
+        ///   Looks up a localized string similar to The current time on the pool coordinator is: {0}.
         /// </summary>
         public static string SERVER_TIME {
             get {
@@ -33900,7 +33900,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} are pool masters. It is strongly recommended to nominate a new master for each affected pool before proceeding..
+        ///   Looks up a localized string similar to {0} are pool coordinators. It is strongly recommended to nominate a new coordinator for each affected pool before proceeding..
         /// </summary>
         public static string SHUT_DOWN_POOL_MASTER_MULTIPLE {
             get {
@@ -33909,7 +33909,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is the pool master. It is strongly recommended to nominate a new master for the pool before proceeding..
+        ///   Looks up a localized string similar to {0} is the pool coordinator. It is strongly recommended to nominate a new coordinator for the pool before proceeding..
         /// </summary>
         public static string SHUT_DOWN_POOL_MASTER_SINGLE {
             get {
@@ -34044,8 +34044,8 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Server &apos;{0}&apos; is in a pool.  To connect to a pool, you must connect to the pool master.
-        ///Do you want to connect to the pool master &apos;{1}&apos;?.
+        ///   Looks up a localized string similar to Server &apos;{0}&apos; is in a pool.  To connect to a pool, you must connect to the pool coordinator.
+        ///Do you want to connect to the pool coordinator &apos;{1}&apos;?.
         /// </summary>
         public static string SLAVE_CONNECTION_ERROR {
             get {
@@ -37471,7 +37471,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Upgrade pool master &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Upgrade pool coordinator &apos;{0}&apos;.
         /// </summary>
         public static string UPGRADE_POOL_MASTER {
             get {
@@ -39509,7 +39509,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pool master unreachable.
+        ///   Looks up a localized string similar to Pool coordinator unreachable.
         /// </summary>
         public static string VMSS_HOST_NOT_LIVE {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2218,7 +2218,7 @@ Deleting this bond will disrupt traffic through the secondary interface on the b
     <value>Could not find the bond in {0}'s cache.</value>
   </data>
   <data name="BOND_MASTER_GONE" xml:space="preserve">
-    <value>Could not find the bond master in {0}'s cache.</value>
+    <value>Could not find the bond interface in {0}'s cache.</value>
   </data>
   <data name="BOOTORDER" xml:space="preserve">
     <value>Boot order: {0}</value>
@@ -3173,10 +3173,10 @@ Would you like to carry out the operation at this time?</value>
     <value>Failed to connect to {0}</value>
   </data>
   <data name="CONNECTION_FINDING_MASTER_DESCRIPTION" xml:space="preserve">
-    <value>Looking for master for {0} on {1}...</value>
+    <value>Looking for coordinator for {0} on {1}...</value>
   </data>
   <data name="CONNECTION_FINDING_MASTER_TITLE" xml:space="preserve">
-    <value>Looking for master for {0}</value>
+    <value>Looking for coordinator for {0}</value>
   </data>
   <data name="CONNECTION_GENERAL_TAB_TITLE" xml:space="preserve">
     <value>Connection General Properties</value>
@@ -3185,7 +3185,7 @@ Would you like to carry out the operation at this time?</value>
     <value>Could not contact server</value>
   </data>
   <data name="CONNECTION_LOST_NOTICE_MASTER_IN_X_SECONDS" xml:space="preserve">
-    <value>Lost connection to {0}. Will search for a new pool master in {1} seconds.</value>
+    <value>Lost connection to {0}. Will search for a new pool coordinator in {1} seconds.</value>
   </data>
   <data name="CONNECTION_LOST_NOTICE_TITLE" xml:space="preserve">
     <value>Lost connection to {0}</value>
@@ -3200,7 +3200,7 @@ Would you like to carry out the operation at this time?</value>
     <value>Connected to {0}</value>
   </data>
   <data name="CONNECTION_REDIRECTING" xml:space="preserve">
-    <value>Connection to {0}: redirecting to the pool master at {1}</value>
+    <value>Connection to {0}: redirecting to the pool coordinator at {1}</value>
   </data>
   <data name="CONNECTION_REFUSED" xml:space="preserve">
     <value>The connection was refused.</value>
@@ -3956,7 +3956,7 @@ For optimal performance and reliability during VM migration, ensure that the net
     <value>Calculating checksum for file '{0}'...</value>
   </data>
   <data name="CREATING_NAMED_POOL_WITH_MASTER" xml:space="preserve">
-    <value>Creating new pool '{0}' with master '{1}'</value>
+    <value>Creating new pool '{0}' with coordinator '{1}'</value>
   </data>
   <data name="CREATING_NEW_FOLDER" xml:space="preserve">
     <value>Creating new folder...</value>
@@ -5526,13 +5526,13 @@ Would you like to eject these ISOs before continuing?</value>
     <value>{0} Eject the CD</value>
   </data>
   <data name="EVACUATE_HOST_CLUSER_CREATING" xml:space="preserve">
-    <value>You cannot nominate a new master while the pool is in the process of creating a cluster.</value>
+    <value>You cannot nominate a new coordinator while the pool is in the process of creating a cluster.</value>
   </data>
   <data name="EVACUATE_HOST_HA_DISABLING" xml:space="preserve">
-    <value>You cannot nominate a new master while HA is being disabled on the pool.</value>
+    <value>You cannot nominate a new coordinator while HA is being disabled on the pool.</value>
   </data>
   <data name="EVACUATE_HOST_HA_ENABLING" xml:space="preserve">
-    <value>You cannot nominate a new master while HA is being enabled on the pool.</value>
+    <value>You cannot nominate a new coordinator while HA is being enabled on the pool.</value>
   </data>
   <data name="EVACUATE_HOST_INSTALL_MGMNT_PROMPT" xml:space="preserve">
     <value>{0} Install Management Agent</value>
@@ -5571,7 +5571,7 @@ Would you like to eject these ISOs before continuing?</value>
     <value>Canceled</value>
   </data>
   <data name="EXCEPTION_USER_CANCELLED_MASTER" xml:space="preserve">
-    <value>User canceled. Master needs to be upgraded first.</value>
+    <value>User canceled. Coordinator needs to be upgraded first.</value>
   </data>
   <data name="EXIT_MAINTENANCE_MODE" xml:space="preserve">
     <value>Exit &amp;Maintenance Mode</value>
@@ -6294,7 +6294,7 @@ not currently live:
 {0}</value>
   </data>
   <data name="HA_CANNOT_EVACUATE_MASTER" xml:space="preserve">
-    <value>Server '{0}' cannot be placed in Maintenance Mode because it is the master of an HA-enabled pool.</value>
+    <value>Server '{0}' cannot be placed in Maintenance Mode because it is the coordinator of an HA-enabled pool.</value>
   </data>
   <data name="HA_CHECK_DESCRIPTION" xml:space="preserve">
     <value>HA and WLB check</value>
@@ -6677,10 +6677,10 @@ Click Configure HA to alter the settings displayed below.</value>
     <value>Preparing to shut down server: shutting down {0} ({1} of {2})</value>
   </data>
   <data name="HOSTACTION_TRANSITIONED_NEW_MASTER" xml:space="preserve">
-    <value>Nominated server {0} as new master</value>
+    <value>Nominated server {0} as new coordinator</value>
   </data>
   <data name="HOSTACTION_TRANSITIONING_NEW_MASTER" xml:space="preserve">
-    <value>Nominating server {0} as new master...</value>
+    <value>Nominating server {0} as new coordinator...</value>
   </data>
   <data name="HOST_ACTION_IN_PROGRESS" xml:space="preserve">
     <value>This server has an operation in progress.</value>
@@ -8174,7 +8174,7 @@ This will permanently delete and reinitialize all local storage on the servers. 
     <value>Subscription Advantage required</value>
   </data>
   <data name="MASTER" xml:space="preserve">
-    <value>Master</value>
+    <value>Coordinator</value>
   </data>
   <data name="MAX" xml:space="preserve">
     <value>Max</value>
@@ -8384,10 +8384,10 @@ This action is final and unrecoverable.</value>
     <value>Writing password information failed: {0}</value>
   </data>
   <data name="MESSAGEBOX_POOL_DELETE" xml:space="preserve">
-    <value>The pool Master will become a standalone server, are you sure you want to continue?</value>
+    <value>The pool Coordinator will become a standalone server, are you sure you want to continue?</value>
   </data>
   <data name="MESSAGEBOX_POOL_MASTER_REMOVE" xml:space="preserve">
-    <value>You cannot remove the master from the pool.</value>
+    <value>You cannot remove the coordinator from the pool.</value>
   </data>
   <data name="MESSAGEBOX_PROGRAM_UNEXPECTED" xml:space="preserve">
     <value>[{0}] There has been an unexpected error. Technical details about this error have been saved to the following file. Please send this to your support representative.
@@ -8755,22 +8755,22 @@ You should only proceed if you have verified that these settings are correct.</v
     <value>Clustering is enabled on this server.</value>
   </data>
   <data name="NEWPOOL_DIFFERENT_HOMOGENEOUS_UPDATES_FROM_MASTER" xml:space="preserve">
-    <value>This server has different updates from the master</value>
+    <value>This server has different updates from the coordinator</value>
   </data>
   <data name="NEWPOOL_DIFFERENT_HOMOGENEOUS_UPDATES_FROM_POOL" xml:space="preserve">
     <value>This server has different updates from servers already in the pool</value>
   </data>
   <data name="NEWPOOL_DIFFERENT_NETWORK_BACKENDS" xml:space="preserve">
-    <value>This server's network backend is different from the master's</value>
+    <value>This server's network backend is different from the coordinator's</value>
   </data>
   <data name="NEWPOOL_DIFFERING_AD_CONFIG" xml:space="preserve">
-    <value>This server has a different Active Directory configuration to the master</value>
+    <value>This server has a different Active Directory configuration to the coordinator</value>
   </data>
   <data name="NEWPOOL_DIFF_HARDWARE" xml:space="preserve">
-    <value>This server's hardware is incompatible with the master's</value>
+    <value>This server's hardware is incompatible with the coordinator's</value>
   </data>
   <data name="NEWPOOL_DIFF_SERVER" xml:space="preserve">
-    <value>This server is a different version to the master</value>
+    <value>This server is a different version to the coordinator</value>
   </data>
   <data name="NEWPOOL_HAS_RUNNING_VMS" xml:space="preserve">
     <value>This server has running VMs</value>
@@ -8785,25 +8785,25 @@ You should only proceed if you have verified that these settings are correct.</v
     <value>This server needs to have one (and only one) IP address on the network that will be used for clustering.</value>
   </data>
   <data name="NEWPOOL_IS_A_POOL" xml:space="preserve">
-    <value>This server is master of an existing pool</value>
+    <value>This server is coordinator of an existing pool</value>
   </data>
   <data name="NEWPOOL_LICENSED_HOST_UNLICENSED_MASTER" xml:space="preserve">
     <value>You cannot add a licensed server to an unlicensed pool</value>
   </data>
   <data name="NEWPOOL_LICENSEMISMATCH" xml:space="preserve">
-    <value>This server does not have the same license as the pool master</value>
+    <value>This server does not have the same license as the pool coordinator</value>
   </data>
   <data name="NEWPOOL_LINUXPACK" xml:space="preserve">
-    <value>This server's Linux pack installation state differs from that of the master</value>
+    <value>This server's Linux pack installation state differs from that of the coordinator</value>
   </data>
   <data name="NEWPOOL_MASTER_CONNECTING" xml:space="preserve">
-    <value>The master is still connecting</value>
+    <value>The coordinator is still connecting</value>
   </data>
   <data name="NEWPOOL_MASTER_DISCONNECTED" xml:space="preserve">
-    <value>The master is disconnected</value>
+    <value>The coordinator is disconnected</value>
   </data>
   <data name="NEWPOOL_MASTER_ROLE" xml:space="preserve">
-    <value>Your current role on the master is not authorized to add hosts to the master's pool</value>
+    <value>Your current role on the coordinator is not authorized to add hosts to the coordinator's pool</value>
   </data>
   <data name="NEWPOOL_MAX_NUMBER_HOST_REACHED" xml:space="preserve">
     <value>The pool has already reached the maximum number of servers allowed by your license</value>
@@ -9436,44 +9436,44 @@ Once the VM has restarted click the Install {0} menu item once again.</value>
     <value>&amp;New Policy...</value>
   </data>
   <data name="NEW_POOL_AD_MESSAGE" xml:space="preserve">
-    <value>You are attempting to add the server '{0}' to a pool with a master that is configured to use AD authentication. All pool members must use the same authentication method.
+    <value>You are attempting to add the server '{0}' to a pool with a coordinator that is configured to use AD authentication. All pool members must use the same authentication method.
 
 Do you want to enable AD authentication on your server and join it to the same domain as the pool?</value>
   </data>
   <data name="NEW_POOL_AD_MESSAGE_MULTIPLE" xml:space="preserve">
-    <value>You are attempting to add the following servers to a pool with a master that is configured to use AD authentication:
+    <value>You are attempting to add the following servers to a pool with a coordinator that is configured to use AD authentication:
 
 {0}
 
 All pool members must use the same authentication method. Do you want to enable AD authentication on these servers and join them to the same domain as the pool?</value>
   </data>
   <data name="NEW_POOL_CPU_MASKING_MESSAGE" xml:space="preserve">
-    <value>You are attempting to add the server '{0}' to a pool with a master that is using an older CPU.
+    <value>You are attempting to add the server '{0}' to a pool with a coordinator that is using an older CPU.
 
-{1} can continue by rebooting the server and reducing its CPU to the level of the master. This will shut down any VMs running on the server. This feature is supported for CPU combinations listed in the {1} Hardware Compatibility List.
+{1} can continue by rebooting the server and reducing its CPU to the level of the coordinator. This will shut down any VMs running on the server. This feature is supported for CPU combinations listed in the {1} Hardware Compatibility List.
 
 Do you want to do this?</value>
   </data>
   <data name="NEW_POOL_CPU_MASKING_MESSAGE_MULTIPLE" xml:space="preserve">
-    <value>You are attempting to add the following servers to a pool with a master that is using an older CPU:
+    <value>You are attempting to add the following servers to a pool with a coordinator that is using an older CPU:
 
 {0}
 
-{1} can continue by rebooting the servers and reducing their CPUs to the level of the master. This will shut down any VMs running on the servers. This feature is supported for CPU combinations listed in the {1} Hardware Compatibility List.
+{1} can continue by rebooting the servers and reducing their CPUs to the level of the coordinator. This will shut down any VMs running on the servers. This feature is supported for CPU combinations listed in the {1} Hardware Compatibility List.
 
 Do you want to do this?</value>
   </data>
   <data name="NEW_POOL_LICENSE_MESSAGE" xml:space="preserve">
     <value>You are attempting to add the server '{0}' to a licensed pool.
 
-Do you want to apply the licensing from the master to this server?</value>
+Do you want to apply the licensing from the coordinator to this server?</value>
   </data>
   <data name="NEW_POOL_LICENSE_MESSAGE_MULTIPLE" xml:space="preserve">
     <value>You are attempting to add the following servers to a licensed pool.
 
 {0}
 
-Do you want to apply the licensing from the master to these servers?</value>
+Do you want to apply the licensing from the coordinator to these servers?</value>
   </data>
   <data name="NEW_POOL_SUPP_PACK" xml:space="preserve">
     <value>The following supplemental pack should be installed on all servers in a pool, but currently is not:
@@ -9797,7 +9797,7 @@ It is strongly recommended that you Cancel and apply the latest version of the p
     <value>This VM does not have any disks.</value>
   </data>
   <data name="NO_ELIGIBLE_MASTER" xml:space="preserve">
-    <value>There is no server eligible to become the master of your new pool</value>
+    <value>There is no server eligible to become the coordinator of your new pool</value>
   </data>
   <data name="NO_GPU_IN_POOL" xml:space="preserve">
     <value>GPU configuration and monitoring is disabled, because there are no GPUs available in this pool.</value>
@@ -10009,13 +10009,13 @@ This will cancel the update process and may leave your system in an unstable sta
     <value>No action required</value>
   </data>
   <data name="PATCHINGWIZARD_MODEPAGE_RESTARTSERVERS" xml:space="preserve">
-    <value>Restart these servers in this order (master always first):</value>
+    <value>Restart these servers in this order (coordinator always first):</value>
   </data>
   <data name="PATCHINGWIZARD_MODEPAGE_RESTARTVMS" xml:space="preserve">
     <value>Restart these VMs:</value>
   </data>
   <data name="PATCHINGWIZARD_MODEPAGE_RESTARTXAPI" xml:space="preserve">
-    <value>Restart toolstack on these servers in this order (master always first):</value>
+    <value>Restart toolstack on these servers in this order (coordinator always first):</value>
   </data>
   <data name="PATCHINGWIZARD_MODEPAGE_TEXT" xml:space="preserve">
     <value>Update Mode</value>
@@ -10135,7 +10135,7 @@ This will cancel the update process and may leave your system in an unstable sta
     <value>Automated updates are not supported on partially upgraded {0} pools</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_CANNOT_INSTALL_UPDATE_MASTER_POST_7_0" xml:space="preserve">
-    <value>Cannot install updates on this host because the master is running a version higher than {0}</value>
+    <value>Cannot install updates on this host because the coordinator is running a version higher than {0}</value>
   </data>
   <data name="PATCHINGWIZARD_SELECTSERVERPAGE_HOST_UNLICENSED" xml:space="preserve">
     <value>Subscription Advantage required</value>
@@ -10596,10 +10596,10 @@ Please reconnect the host and try again</value>
     <value>Pool License</value>
   </data>
   <data name="POOL_MASTER" xml:space="preserve">
-    <value>Pool master</value>
+    <value>Pool coordinator</value>
   </data>
   <data name="POOL_MASTER_GONE" xml:space="preserve">
-    <value>Could not find the pool master in {0}'s cache.</value>
+    <value>Could not find the pool coordinator in {0}'s cache.</value>
   </data>
   <data name="POOL_NAME_EMPTY" xml:space="preserve">
     <value>Pool name cannot be empty</value>
@@ -10694,16 +10694,16 @@ Are you sure you want to continue?</value>
     <value>Duplicate MAC address</value>
   </data>
   <data name="PROBLEM_MASTER_PENDING_RESTART_HOST" xml:space="preserve">
-    <value>{0}: The master needs to be rebooted first</value>
+    <value>{0}: The coordinator needs to be rebooted first</value>
   </data>
   <data name="PROBLEM_MASTER_PENDING_RESTART_HOST_THIS_UPDATE" xml:space="preserve">
-    <value>{0}: This update requires the master to be rebooted first</value>
+    <value>{0}: This update requires the coordinator to be rebooted first</value>
   </data>
   <data name="PROBLEM_MASTER_PENDING_RESTART_TOOLSTACK" xml:space="preserve">
-    <value>{0}: Toolstack on master needs to be restarted first</value>
+    <value>{0}: Toolstack on coordinator needs to be restarted first</value>
   </data>
   <data name="PROBLEM_MASTER_PENDING_RESTART_TOOLSTACK_THIS_UPDATE" xml:space="preserve">
-    <value>{0}: This update requires the toolstack on master to be restarted first</value>
+    <value>{0}: This update requires the toolstack on coordinator to be restarted first</value>
   </data>
   <data name="PROBLEM_POOLPROBLEM_TITLE" xml:space="preserve">
     <value>Pool '{0}'</value>
@@ -11331,7 +11331,7 @@ Check the boot order in the server and reboot again.</value>
 
 To skip this server and continue to the next server in the pool, click Skip This Server. Note that running a pool with servers on different versions of {0} is not supported, and so any servers that are not upgraded during this rolling pool upgrade should be upgraded as soon as possible afterwards.
 
-The master must be upgraded first, so if you skip the master, the rolling pool upgrade will be canceled for this pool.
+The coordinator must be upgraded first, so if you skip the coordinator, the rolling pool upgrade will be canceled for this pool.
 </value>
   </data>
   <data name="ROLLING_UPGRADE_SUCCESS_MANY" xml:space="preserve">
@@ -11380,7 +11380,7 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
     <value>You cannot configure HA while a pool secret rotation is in progress.</value>
   </data>
   <data name="ROTATE_POOL_SECRET_PENDING_NEW_MASTER" xml:space="preserve">
-    <value>You cannot nominate a new master while a pool secret rotation is in progress.</value>
+    <value>You cannot nominate a new coordinator while a pool secret rotation is in progress.</value>
   </data>
   <data name="ROTATE_POOL_SECRET_MENU" xml:space="preserve">
     <value>Rotate &amp;Pool Secret</value>
@@ -11610,7 +11610,7 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
     <value>Querying server capabilities...</value>
   </data>
   <data name="SERVER_TIME" xml:space="preserve">
-    <value>The current time on the pool master is: {0}</value>
+    <value>The current time on the pool coordinator is: {0}</value>
   </data>
   <data name="SERVER_TOO_OLD" xml:space="preserve">
     <value>This version of {0} supports {1} {2} onwards.</value>
@@ -11751,10 +11751,10 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
     <value>Shutting down VM {0} out of {1}</value>
   </data>
   <data name="SHUT_DOWN_POOL_MASTER_MULTIPLE" xml:space="preserve">
-    <value>{0} are pool masters. It is strongly recommended to nominate a new master for each affected pool before proceeding.</value>
+    <value>{0} are pool coordinators. It is strongly recommended to nominate a new coordinator for each affected pool before proceeding.</value>
   </data>
   <data name="SHUT_DOWN_POOL_MASTER_SINGLE" xml:space="preserve">
-    <value>{0} is the pool master. It is strongly recommended to nominate a new master for the pool before proceeding.</value>
+    <value>{0} is the pool coordinator. It is strongly recommended to nominate a new coordinator for the pool before proceeding.</value>
   </data>
   <data name="SIGNING_APPLIANCE" xml:space="preserve">
     <value>Applying digital signature to appliance...</value>
@@ -11784,8 +11784,8 @@ The master must be upgraded first, so if you skip the master, the rolling pool u
     <value>Server '{0}' is a member of pool '{1}' and is already connected.</value>
   </data>
   <data name="SLAVE_CONNECTION_ERROR" xml:space="preserve">
-    <value>Server '{0}' is in a pool.  To connect to a pool, you must connect to the pool master.
-Do you want to connect to the pool master '{1}'?</value>
+    <value>Server '{0}' is in a pool.  To connect to a pool, you must connect to the pool coordinator.
+Do you want to connect to the pool coordinator '{1}'?</value>
   </data>
   <data name="SLAVE_TOO_OLD" xml:space="preserve">
     <value>This pool contains servers earlier than {0} {1}. Please use an earlier version of {2} to manage this pool.</value>
@@ -12976,7 +12976,7 @@ Note that if RBAC is enabled, only updates which you have privileges to dismiss 
     <value>Upgrade pool {0}</value>
   </data>
   <data name="UPGRADE_POOL_MASTER" xml:space="preserve">
-    <value>Upgrade pool master '{0}'</value>
+    <value>Upgrade pool coordinator '{0}'</value>
   </data>
   <data name="UPGRADE_PRECHECKS_TEXT" xml:space="preserve">
     <value>Pre-checks</value>
@@ -13397,7 +13397,7 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>Create the new schedule</value>
   </data>
   <data name="VMSS_HOST_NOT_LIVE" xml:space="preserve">
-    <value>Pool master unreachable</value>
+    <value>Pool coordinator unreachable</value>
   </data>
   <data name="VMSS_INVALID_SCHEDULE" xml:space="preserve">
     <value>Invalid or incomplete schedule</value>


### PR DESCRIPTION
Renamed negative language from .resx strings.