### PR TITLE
Add GitHub action to update PR labels

### DIFF
--- a/.github/workflows/update-pr-labels.yml
+++ b/.github/workflows/update-pr-labels.yml
@@ -1,0 +1,16 @@
+name: Update PR Labels
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  update-pr-labels:
+    runs-on: ubuntu-latest
+    name: Update PR Labels
+    steps:
+      - name: Update Labels
+        uses: danilo-delbusso/pr-review-labeller@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Action can add/remove the following labels:

- One Approval label
- Two Approvals label
- Changes Requested label
- Updated PR Label

The labels have to exist in the repository already. The defaults of the action correspond to the labels present for `xenadmin` so there is no need to specify them.

Doesn't override existing labels. Only changes:

- 1 approval
- 2 approvals
- updated
- needs updating