### PR TITLE
Corrected Host.evacuate overloads.

### DIFF
--- a/XenModel/XenAPI/Host.cs
+++ b/XenModel/XenAPI/Host.cs
@@ -2543,8 +2543,22 @@ namespace XenAPI
         /// </summary>
         /// <param name="session">The session</param>
         /// <param name="_host">The opaque_ref of the given host</param>
+        public static void evacuate(Session session, string _host)
+        {
+            if (session.JsonRpcClient != null)
+                session.JsonRpcClient.host_evacuate(session.opaque_ref, _host);
+            else
+                session.XmlRpcProxy.host_evacuate(session.opaque_ref, _host ?? "").parse();
+        }
+        
+        /// <summary>
+        /// Migrate all VMs off of this host, where possible.
+        /// First published in XenServer 4.1.
+        /// </summary>
+        /// <param name="session">The session</param>
+        /// <param name="_host">The opaque_ref of the given host</param>
         /// <param name="_network">Optional preferred network for migration First published in Unreleased.</param>
-        public static void evacuate(Session session, string _host, string _network = null)
+        public static void evacuate(Session session, string _host, string _network)
         {
             if (session.JsonRpcClient != null)
                 session.JsonRpcClient.host_evacuate(session.opaque_ref, _host, _network);
@@ -2558,8 +2572,22 @@ namespace XenAPI
         /// </summary>
         /// <param name="session">The session</param>
         /// <param name="_host">The opaque_ref of the given host</param>
+        public static XenRef<Task> async_evacuate(Session session, string _host)
+        {
+          if (session.JsonRpcClient != null)
+              return session.JsonRpcClient.async_host_evacuate(session.opaque_ref, _host);
+          else
+              return XenRef<Task>.Create(session.XmlRpcProxy.async_host_evacuate(session.opaque_ref, _host ?? "").parse());
+        }
+        
+        /// <summary>
+        /// Migrate all VMs off of this host, where possible.
+        /// First published in XenServer 4.1.
+        /// </summary>
+        /// <param name="session">The session</param>
+        /// <param name="_host">The opaque_ref of the given host</param>
         /// <param name="_network">Optional preferred network for migration First published in Unreleased.</param>
-        public static XenRef<Task> async_evacuate(Session session, string _host, string _network = null)
+        public static XenRef<Task> async_evacuate(Session session, string _host, string _network)
         {
           if (session.JsonRpcClient != null)
               return session.JsonRpcClient.async_host_evacuate(session.opaque_ref, _host, _network);

--- a/XenModel/XenAPI/JsonRpcClient.cs
+++ b/XenModel/XenAPI/JsonRpcClient.cs
@@ -6549,11 +6549,25 @@ namespace XenAPI
             return Rpc<XenRef<Task>>("Async.host.get_uncooperative_resident_VMs", new JArray(session, _host ?? ""), serializer);
         }
 
+        public void host_evacuate(string session, string _host)
+        {
+            var converters = new List<JsonConverter> {};
+            var serializer = CreateSerializer(converters);
+            Rpc("host.evacuate", new JArray(session, _host ?? ""), serializer);
+        }
+
         public void host_evacuate(string session, string _host, string _network)
         {
             var converters = new List<JsonConverter> {new XenRefConverter<Network>()};
             var serializer = CreateSerializer(converters);
             Rpc("host.evacuate", new JArray(session, _host ?? "", _network ?? ""), serializer);
+        }
+
+        public XenRef<Task> async_host_evacuate(string session, string _host)
+        {
+            var converters = new List<JsonConverter> {new XenRefConverter<Task>()};
+            var serializer = CreateSerializer(converters);
+            return Rpc<XenRef<Task>>("Async.host.evacuate", new JArray(session, _host ?? ""), serializer);
         }
 
         public XenRef<Task> async_host_evacuate(string session, string _host, string _network)

--- a/XenModel/XenAPI/Proxy.cs
+++ b/XenModel/XenAPI/Proxy.cs
@@ -3764,7 +3764,15 @@ namespace XenAPI
 
         [XmlRpcMethod("host.evacuate")]
         Response<string>
+        host_evacuate(string session, string _host);
+
+        [XmlRpcMethod("host.evacuate")]
+        Response<string>
         host_evacuate(string session, string _host, string _network);
+
+        [XmlRpcMethod("Async.host.evacuate")]
+        Response<string>
+        async_host_evacuate(string session, string _host);
 
         [XmlRpcMethod("Async.host.evacuate")]
         Response<string>


### PR DESCRIPTION
This is a correction for https://github.com/xenserver/xenadmin/commit/a3b4ad0de68a6d47cf94a02763422c4d5f371e87. For the time being the overloads for this method have to be provided manually due to CA-355432.