### PR TITLE
Corrected calculation of datasource units (CA-359068). New/Edit Graph dialog enhancements.

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -106,7 +106,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         /// </summary>
         private List<DataSet> SetsAdded;
 
-        private List<Data_source> _enabledDataSources = new List<Data_source>();
+        private List<Data_source> _dataSources = new List<Data_source>();
 
         private IXenObject _xenObject;
 
@@ -186,7 +186,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                         Archives[ArchiveInterval.OneDay].MaxPoints = DaysInOneYear;
                     }
 
-                    _enabledDataSources.Clear();
+                    _dataSources.Clear();
 
                     foreach (DataArchive a in Archives.Values)
                         a.ClearSets();
@@ -197,9 +197,9 @@ namespace XenAdmin.Controls.CustomDataGraph
                         ArchivesUpdated?.Invoke();
 
                         if (xenObject is Host h)
-                            _enabledDataSources = Host.get_data_sources(h.Connection.Session, h.opaque_ref).Where(d => d.enabled).ToList();
+                            _dataSources = Host.get_data_sources(h.Connection.Session, h.opaque_ref);
                         else if (xenObject is VM vm && vm.power_state == vm_power_state.Running)
-                            _enabledDataSources = VM.get_data_sources(vm.Connection.Session, vm.opaque_ref).Where(d => d.enabled).ToList();
+                            _dataSources = VM.get_data_sources(vm.Connection.Session, vm.opaque_ref);
 
                         Get(ArchiveInterval.None, RrdsUri, RRD_Full_InspectCurrentNode, xenObject);
                     }
@@ -428,7 +428,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
                     ArchiveInterval i = GetArchiveIntervalFromFiveSecs(CurrentInterval);
                     if (i != ArchiveInterval.None)
-                        Archives[i].CopyLoad(SetsAdded, _enabledDataSources);
+                        Archives[i].CopyLoad(SetsAdded, _dataSources);
 
                     foreach (DataSet set in SetsAdded)
                         set.Points.Clear();
@@ -442,7 +442,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             if (LastNode == "name")
             {
                 string str = reader.ReadContentAsString();
-                SetsAdded.Add(new DataSet(xmo, false, str, _enabledDataSources));
+                SetsAdded.Add(new DataSet(xmo, false, str, _dataSources));
             }
             else if (LastNode == "step")
             {
@@ -480,7 +480,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
                 DataSet set = SetsAdded[ValueCount];
                 string str = reader.ReadContentAsString();
-                set.AddPoint(str, CurrentTime, SetsAdded, _enabledDataSources);
+                set.AddPoint(str, CurrentTime, SetsAdded, _dataSources);
                 ValueCount++;
             }
         }
@@ -507,19 +507,19 @@ namespace XenAdmin.Controls.CustomDataGraph
                     {
                         Host host = xo.Connection.Cache.Hosts.FirstOrDefault(h => h.uuid == objUuid);
                         if (host != null)
-                            set = new DataSet(host, (xo as Host)?.uuid != objUuid, dataSourceName, _enabledDataSources);
+                            set = new DataSet(host, (xo as Host)?.uuid != objUuid, dataSourceName, _dataSources);
                     }
 
                     if (objType == "vm")
                     {
                         VM vm = xo.Connection.Cache.VMs.FirstOrDefault(v => v.uuid == objUuid);
                         if (vm != null)
-                            set = new DataSet(vm, (xo as VM)?.uuid != objUuid, dataSourceName, _enabledDataSources);
+                            set = new DataSet(vm, (xo as VM)?.uuid != objUuid, dataSourceName, _dataSources);
                     }
                 }
 
                 if (set == null)
-                    set = new DataSet(null, true, str, _enabledDataSources);
+                    set = new DataSet(null, true, str, _dataSources);
 
                 SetsAdded.Add(set);
             }
@@ -533,7 +533,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                 if (SetsAdded.Count <= ValueCount) return;
                 DataSet set = SetsAdded[ValueCount];
                 string str = reader.ReadContentAsString();
-                set.AddPoint(str, CurrentTime, SetsAdded, _enabledDataSources);
+                set.AddPoint(str, CurrentTime, SetsAdded, _dataSources);
                 ValueCount++;
             }
         }

--- a/XenAdmin/Controls/CustomDataGraph/DataRange.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataRange.cs
@@ -37,10 +37,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 {
     public class DataRange
     {
-        public static DataRange UnitRange
-        {
-            get { return new DataRange(1, 0, 1); }
-        }
+        public static DataRange UnitRange => new DataRange(1, 0, 1);
 
         public double Max;
         public double Min;
@@ -71,10 +68,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             ScaleMode = scaleMode;
         }
 
-        public double Delta
-        {
-            get { return Max - Min; }
-        }
+        public double Delta => Max - Min;
 
         private double ConstrainedValue(double value)
         {
@@ -90,12 +84,14 @@ namespace XenAdmin.Controls.CustomDataGraph
 
             switch (Units)
             {
+                case Unit.Unknown:
+                    return Messages.GRAPHS_NO_DATA;
                 case Unit.Bytes:
                     return Util.MemorySizeStringVariousUnits(constrVal);
                 case Unit.BytesPerSecond:
                     return Util.DataRateString(constrVal);
                 case Unit.Percentage:
-                    return string.Format("{0}%", constrVal);
+                    return $"{constrVal}%";
                 case Unit.NanoSeconds:
                     return Util.NanoSecondsString(constrVal);
                 case Unit.CountsPerSecond:
@@ -105,9 +101,10 @@ namespace XenAdmin.Controls.CustomDataGraph
                 case Unit.MilliWatt:
                     return Util.MilliWattString(constrVal);
                 case Unit.Centigrade:
-                    return string.Format("{0}\u2103", constrVal.ToString("0"));
+                    return $"{constrVal:0}\u2103";
                 case Unit.MegaHertz:
                     return Util.MegaHertzString(constrVal);
+                case Unit.None://fall through
                 default:
                     return constrVal.ToString();
             }
@@ -124,6 +121,8 @@ namespace XenAdmin.Controls.CustomDataGraph
 
                 switch (Units)
                 {
+                    case Unit.Unknown:
+                        return Messages.GRAPHS_NO_DATA;
                     case Unit.Bytes:
                         Util.MemorySizeValueVariousUnits(Max, out unit);
                         return unit;
@@ -147,8 +146,9 @@ namespace XenAdmin.Controls.CustomDataGraph
                     case Unit.MegaHertz:
                         Util.MegaHertzValue(Max, out unit);
                         return unit;
+                    case Unit.None://fall through
                     default:
-                        return "";
+                        return String.Empty;
                 }
             }
         }
@@ -159,31 +159,26 @@ namespace XenAdmin.Controls.CustomDataGraph
         public virtual string GetRelativeString(double value)
         {
             double constrVal = ConstrainedValue(value);
-            string unit;
 
             switch (Units)
             {
+                case Unit.Unknown:
+                    return string.Empty;
                 case Unit.Bytes:
-                    return Util.MemorySizeValueVariousUnits(constrVal, out unit);
+                    return Util.MemorySizeValueVariousUnits(constrVal, out _);
                 case Unit.BytesPerSecond:
-                    return Util.DataRateValue(constrVal, out unit);
+                    return Util.DataRateValue(constrVal, out _);
                 case Unit.NanoSeconds:
-                    return Util.NanoSecondsValue(constrVal, out unit);
+                    return Util.NanoSecondsValue(constrVal, out _);
                 case Unit.MilliWatt:
-                    return Util.MilliWattValue(constrVal, out unit);
+                    return Util.MilliWattValue(constrVal, out _);
                 case Unit.MegaHertz:
-                    return Util.MegaHertzValue(constrVal, out unit);
+                    return Util.MegaHertzValue(constrVal, out _);
                 case Unit.CountsPerSecond://fall through
                 case Unit.SecondsPerSecond://fall through
                 default:
                     return constrVal.ToString();
             }
-        }
-
-        public void Shift(double delta)
-        {
-            Max += delta;
-            Min += delta;
         }
 
         internal void UpdateAll(IXenObject xo)
@@ -274,6 +269,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         SecondsPerSecond,
         MilliWatt,
         Centigrade,
-        MegaHertz
+        MegaHertz,
+        Unknown
     }
 }

--- a/XenAdmin/Controls/CustomDataGraph/DataSet.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataSet.cs
@@ -34,7 +34,6 @@ using System.Collections.Generic;
 using System.Linq;
 using XenAPI;
 using XenCenterLib;
-
 using XenAdmin.Core;
 
 namespace XenAdmin.Controls.CustomDataGraph
@@ -83,7 +82,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             else
                 FriendlyName = Helpers.GetFriendlyDataSourceName(datasourceName, xo);
 
-            var units = datasources.FirstOrDefault(d => datasourceName.StartsWith(d.name_label))?.units;
+            var units = datasources.FirstOrDefault(d => datasourceName == d.name_label)?.units;
 
             switch (units)
             {
@@ -140,8 +139,13 @@ namespace XenAdmin.Controls.CustomDataGraph
                 case "Centigrade":
                     CustomYRange = new DataRange(1, 0, 1, Unit.Centigrade, RangeScaleMode.Auto);
                     break;
+                case "unknown":
+                    CustomYRange = new DataRange(1, 0, 1, Unit.Unknown, RangeScaleMode.Auto);
+                    break;
                 default:
-                    if (!string.IsNullOrEmpty(units))
+                    if (string.IsNullOrEmpty(units))
+                        CustomYRange = new DataRange(1, 0, 1, Unit.Unknown, RangeScaleMode.Auto);
+                    else
                         System.Diagnostics.Debug.Assert(false, $"Unhandled units {units}!");
                     break;
             }

--- a/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
+++ b/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
@@ -45,7 +45,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         private static int count;
         private readonly int uid;
 
-        public List<DataSourceItem> DataSources = new List<DataSourceItem>();
+        public List<DataSourceItem> DataSourceItems = new List<DataSourceItem>();
         public string DisplayName;
 
         public DesignedGraph()
@@ -57,16 +57,16 @@ namespace XenAdmin.Controls.CustomDataGraph
         public DesignedGraph(DesignedGraph sourceGraph) : this()
         {
             DisplayName = sourceGraph.DisplayName;
-            foreach (DataSourceItem dsi in sourceGraph.DataSources)
+            foreach (DataSourceItem dsi in sourceGraph.DataSourceItems)
             {
-                DataSources.Add(new DataSourceItem(dsi.DataSource, dsi.ToString(), dsi.Color, dsi.Id));
+                DataSourceItems.Add(new DataSourceItem(dsi.DataSource, dsi.ToString(), dsi.Color, dsi.Id));
             }
         }
 
         public override string ToString()
         {
             List<string> strs = new List<string>();
-            foreach (DataSourceItem item in DataSources)
+            foreach (DataSourceItem item in DataSourceItems)
             {
                 strs.Add(item.GetDataSource());
             }
@@ -86,12 +86,12 @@ namespace XenAdmin.Controls.CustomDataGraph
             if ((this.DisplayName ?? string.Empty) != (other.DisplayName ?? string.Empty))
                 return false;
 
-            if (this.DataSources.Count != other.DataSources.Count)
+            if (this.DataSourceItems.Count != other.DataSourceItems.Count)
                 return false;
 
-            for (int i = 0; i < this.DataSources.Count; i++)
+            for (int i = 0; i < this.DataSourceItems.Count; i++)
             {
-                if (this.DataSources[i].Id != other.DataSources[i].Id)
+                if (this.DataSourceItems[i].Id != other.DataSourceItems[i].Id)
                     return false;
             }
 
@@ -125,20 +125,22 @@ namespace XenAdmin.Controls.CustomDataGraph
         /// </summary>
         public Data_source DataSource;
 
-        public bool Enabled;
-        private string friendlyName;
+        public bool Enabled { get; set; }
+        public bool Hidden { get; }
+        private readonly string friendlyName;
         public Color Color;
         public bool ColorChanged;
-        public string Id;
-        public Helpers.DataSourceCategory Category;
+        public string Id { get; }
+        public Helpers.DataSourceCategory Category { get; }
 
-        public DataSourceItem(Data_source ds, string friendlyname, Color color, string id, IXenObject xo = null)
+        public DataSourceItem(Data_source ds, string friendlyname, Color color, string id)
         {
             DataSource = ds;
             Enabled = DataSource.enabled;
             friendlyName = friendlyname;
             Color = color;
             Id = id;
+            Hidden = string.IsNullOrEmpty(ds.units) || ds.units == "unknown";
 
             if (DataSet.ParseId(id, out _, out _, out string dataSourceName))
                 Category = Helpers.GetDataSourceCategory(dataSourceName);
@@ -189,7 +191,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                     friendlyName = Helpers.GetFriendlyDataSourceName(dataSource.name_label, xenObject);
 
                 string itemUuid = Palette.GetUuid(dataSource.name_label, xenObject);
-                dataSourceItems.Add(new DataSourceItem(dataSource, friendlyName, Palette.GetColour(itemUuid), itemUuid, xenObject));
+                dataSourceItems.Add(new DataSourceItem(dataSource, friendlyName, Palette.GetColour(itemUuid), itemUuid));
             }
 
             // Filter old datasources only if we have their replacement ones

--- a/XenAdmin/Dialogs/ActionProgressDialog.Designer.cs
+++ b/XenAdmin/Dialogs/ActionProgressDialog.Designer.cs
@@ -46,7 +46,6 @@ namespace XenAdmin.Dialogs
             this.labelBottom = new System.Windows.Forms.Label();
             this.labelException = new System.Windows.Forms.Label();
             this.labelSubActionStatus = new System.Windows.Forms.Label();
-            this.labelTop = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.icon)).BeginInit();
             this.SuspendLayout();
@@ -66,20 +65,19 @@ namespace XenAdmin.Dialogs
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.labelStatus, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.icon, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.buttonClose, 1, 6);
-            this.tableLayoutPanel1.Controls.Add(this.buttonCancel, 2, 5);
-            this.tableLayoutPanel1.Controls.Add(this.progressBar1, 1, 5);
-            this.tableLayoutPanel1.Controls.Add(this.labelBottom, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.labelException, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.buttonClose, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.buttonCancel, 2, 4);
+            this.tableLayoutPanel1.Controls.Add(this.progressBar1, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.labelBottom, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.labelException, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.labelSubActionStatus, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.labelTop, 1, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // icon
             // 
             resources.ApplyResources(this.icon, "icon");
             this.icon.Name = "icon";
-            this.tableLayoutPanel1.SetRowSpan(this.icon, 6);
+            this.tableLayoutPanel1.SetRowSpan(this.icon, 5);
             this.icon.TabStop = false;
             // 
             // buttonClose
@@ -110,11 +108,6 @@ namespace XenAdmin.Dialogs
             resources.ApplyResources(this.labelSubActionStatus, "labelSubActionStatus");
             this.labelSubActionStatus.Name = "labelSubActionStatus";
             // 
-            // labelTop
-            // 
-            resources.ApplyResources(this.labelTop, "labelTop");
-            this.labelTop.Name = "labelTop";
-            // 
             // ActionProgressDialog
             // 
             resources.ApplyResources(this, "$this");
@@ -136,7 +129,6 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.Label labelStatus;
         private System.Windows.Forms.ProgressBar progressBar1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Label labelTop;
         private System.Windows.Forms.Label labelException;
         private System.Windows.Forms.Label labelBottom;
         private System.Windows.Forms.PictureBox icon;

--- a/XenAdmin/Dialogs/ActionProgressDialog.resx
+++ b/XenAdmin/Dialogs/ActionProgressDialog.resx
@@ -112,20 +112,20 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelStatus.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelStatus.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="labelStatus.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -151,7 +151,7 @@
     <value>labelStatus</value>
   </data>
   <data name="&gt;&gt;labelStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelStatus.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -166,7 +166,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 120</value>
+    <value>54, 101</value>
   </data>
   <data name="progressBar1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 10, 6, 12</value>
@@ -181,7 +181,7 @@
     <value>progressBar1</value>
   </data>
   <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -226,7 +226,7 @@
     <value>icon</value>
   </data>
   <data name="&gt;&gt;icon.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;icon.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -244,7 +244,7 @@
     <value>NoControl</value>
   </data>
   <data name="buttonClose.Location" type="System.Drawing.Point, System.Drawing">
-    <value>270, 164</value>
+    <value>270, 145</value>
   </data>
   <data name="buttonClose.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 12, 3, 3</value>
@@ -265,7 +265,7 @@
     <value>buttonClose</value>
   </data>
   <data name="&gt;&gt;buttonClose.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;buttonClose.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -280,7 +280,7 @@
     <value>NoControl</value>
   </data>
   <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>351, 119</value>
+    <value>351, 100</value>
   </data>
   <data name="buttonCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 9, 3, 3</value>
@@ -301,7 +301,7 @@
     <value>buttonCancel</value>
   </data>
   <data name="&gt;&gt;buttonCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;buttonCancel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -319,7 +319,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelBottom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>51, 95</value>
+    <value>51, 76</value>
   </data>
   <data name="labelBottom.Size" type="System.Drawing.Size, System.Drawing">
     <value>186, 15</value>
@@ -340,7 +340,7 @@
     <value>labelBottom</value>
   </data>
   <data name="&gt;&gt;labelBottom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelBottom.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -358,7 +358,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelException.Location" type="System.Drawing.Point, System.Drawing">
-    <value>51, 72</value>
+    <value>51, 53</value>
   </data>
   <data name="labelException.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 8, 3, 8</value>
@@ -379,7 +379,7 @@
     <value>labelException</value>
   </data>
   <data name="&gt;&gt;labelException.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelException.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -415,55 +415,13 @@
     <value>labelSubActionStatus</value>
   </data>
   <data name="&gt;&gt;labelSubActionStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelSubActionStatus.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelSubActionStatus.ZOrder" xml:space="preserve">
     <value>7</value>
-  </data>
-  <data name="labelTop.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelTop.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="labelTop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelTop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>51, 49</value>
-  </data>
-  <data name="labelTop.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 4, 3, 0</value>
-  </data>
-  <data name="labelTop.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 15</value>
-  </data>
-  <data name="labelTop.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="labelTop.Text" xml:space="preserve">
-    <value>There was an error with the action:</value>
-  </data>
-  <data name="labelTop.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>TopCenter</value>
-  </data>
-  <data name="labelTop.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;labelTop.Name" xml:space="preserve">
-    <value>labelTop</value>
-  </data>
-  <data name="&gt;&gt;labelTop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelTop.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelTop.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -475,7 +433,7 @@
     <value>8, 5</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>430, 239</value>
@@ -487,7 +445,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -496,9 +454,9 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelStatus" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="icon" Row="0" RowSpan="6" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonClose" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonCancel" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelBottom" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelException" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelSubActionStatus" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelTop" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Absolute,300,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelStatus" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="icon" Row="0" RowSpan="5" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonClose" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonCancel" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelBottom" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelException" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelSubActionStatus" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Absolute,300,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -529,6 +487,6 @@
     <value>ActionProgressDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/GraphDetailsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.Designer.cs
@@ -30,14 +30,8 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GraphDetailsDialog));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             this.GraphNameLabel = new System.Windows.Forms.Label();
             this.SaveButton = new System.Windows.Forms.Button();
             this.CloseButton = new System.Windows.Forms.Button();
@@ -46,21 +40,29 @@
             this.ColumnDisplayOnGraph = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnEnabled = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnColour = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ClearAllButton = new System.Windows.Forms.Button();
-            this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.clearAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.labelProgress = new System.Windows.Forms.Label();
             this.pictureBoxProgress = new System.Windows.Forms.PictureBox();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.labelProgress = new System.Windows.Forms.Label();
             this.searchTextBox = new XenAdmin.Controls.SearchTextBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.dropDownButtonShow = new XenAdmin.Controls.DropDownButton();
+            this.contextMenuStripShow = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolStripMenuItemHidden = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemDisabled = new System.Windows.Forms.ToolStripMenuItem();
+            this.buttonClearAll = new System.Windows.Forms.Button();
+            this.buttonEnable = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).BeginInit();
-            this.contextMenuStrip.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxProgress)).BeginInit();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
+            this.panel1.SuspendLayout();
+            this.contextMenuStripShow.SuspendLayout();
             this.SuspendLayout();
             // 
             // GraphNameLabel
@@ -95,30 +97,32 @@
             this.dataGridView.AllowUserToDeleteRows = false;
             this.dataGridView.AllowUserToResizeColumns = false;
             this.dataGridView.AllowUserToResizeRows = false;
-            resources.ApplyResources(this.dataGridView, "dataGridView");
             this.dataGridView.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             this.dataGridView.BackgroundColor = System.Drawing.SystemColors.Window;
+            this.dataGridView.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.dataGridView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             this.dataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ColumnDisplayOnGraph,
             this.ColumnName,
             this.ColumnType,
+            this.ColumnEnabled,
             this.ColumnColour});
+            resources.ApplyResources(this.dataGridView, "dataGridView");
             this.dataGridView.MultiSelect = false;
             this.dataGridView.Name = "dataGridView";
             this.dataGridView.ReadOnly = true;
             this.dataGridView.RowHeadersVisible = false;
-            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            this.dataGridView.RowsDefaultCellStyle = dataGridViewCellStyle5;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            this.dataGridView.RowsDefaultCellStyle = dataGridViewCellStyle2;
             this.dataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.dataGridView.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.datasourcesGridView_CellClick);
             this.dataGridView.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.datasourcesGridView_CellPainting);
+            this.dataGridView.SelectionChanged += new System.EventHandler(this.dataGridView_SelectionChanged);
             this.dataGridView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridView_SortCompare);
-            this.dataGridView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridView_MouseDown);
             // 
             // ColumnDisplayOnGraph
             // 
@@ -136,9 +140,6 @@
             // ColumnName
             // 
             this.ColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.ColumnName.DefaultCellStyle = dataGridViewCellStyle2;
             resources.ApplyResources(this.ColumnName, "ColumnName");
             this.ColumnName.Name = "ColumnName";
             this.ColumnName.ReadOnly = true;
@@ -146,60 +147,33 @@
             // ColumnType
             // 
             this.ColumnType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.ColumnType.DefaultCellStyle = dataGridViewCellStyle3;
             resources.ApplyResources(this.ColumnType, "ColumnType");
             this.ColumnType.Name = "ColumnType";
             this.ColumnType.ReadOnly = true;
             // 
+            // ColumnEnabled
+            // 
+            resources.ApplyResources(this.ColumnEnabled, "ColumnEnabled");
+            this.ColumnEnabled.Name = "ColumnEnabled";
+            this.ColumnEnabled.ReadOnly = true;
+            // 
             // ColumnColour
             // 
             this.ColumnColour.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.ColumnColour.DefaultCellStyle = dataGridViewCellStyle4;
             resources.ApplyResources(this.ColumnColour, "ColumnColour");
             this.ColumnColour.Name = "ColumnColour";
             this.ColumnColour.ReadOnly = true;
             this.ColumnColour.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.ColumnColour.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
             // 
-            // ClearAllButton
-            // 
-            resources.ApplyResources(this.ClearAllButton, "ClearAllButton");
-            this.ClearAllButton.Name = "ClearAllButton";
-            this.ClearAllButton.UseVisualStyleBackColor = true;
-            this.ClearAllButton.Click += new System.EventHandler(this.ClearAllButton_Click);
-            // 
-            // contextMenuStrip
-            // 
-            this.contextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.clearAllToolStripMenuItem});
-            this.contextMenuStrip.Name = "contextMenuStrip";
-            resources.ApplyResources(this.contextMenuStrip, "contextMenuStrip");
-            // 
-            // clearAllToolStripMenuItem
-            // 
-            this.clearAllToolStripMenuItem.Name = "clearAllToolStripMenuItem";
-            resources.ApplyResources(this.clearAllToolStripMenuItem, "clearAllToolStripMenuItem");
-            this.clearAllToolStripMenuItem.Click += new System.EventHandler(this.clearAllToolStripMenuItem_Click);
-            // 
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.BackColor = System.Drawing.SystemColors.Window;
-            this.tableLayoutPanel1.Controls.Add(this.labelProgress, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.pictureBoxProgress, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.labelProgress, 1, 0);
             this.tableLayoutPanel1.Cursor = System.Windows.Forms.Cursors.Arrow;
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // labelProgress
-            // 
-            resources.ApplyResources(this.labelProgress, "labelProgress");
-            this.labelProgress.BackColor = System.Drawing.SystemColors.Window;
-            this.labelProgress.Name = "labelProgress";
             // 
             // pictureBoxProgress
             // 
@@ -209,46 +183,97 @@
             this.pictureBoxProgress.Name = "pictureBoxProgress";
             this.pictureBoxProgress.TabStop = false;
             // 
-            // dataGridViewTextBoxColumn1
+            // labelProgress
             // 
-            this.dataGridViewTextBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.dataGridViewTextBoxColumn1.DefaultCellStyle = dataGridViewCellStyle6;
-            resources.ApplyResources(this.dataGridViewTextBoxColumn1, "dataGridViewTextBoxColumn1");
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewTextBoxColumn1.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.dataGridViewTextBoxColumn2.DefaultCellStyle = dataGridViewCellStyle7;
-            resources.ApplyResources(this.dataGridViewTextBoxColumn2, "dataGridViewTextBoxColumn2");
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle8.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle8.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.dataGridViewTextBoxColumn3.DefaultCellStyle = dataGridViewCellStyle8;
-            resources.ApplyResources(this.dataGridViewTextBoxColumn3, "dataGridViewTextBoxColumn3");
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewTextBoxColumn3.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            resources.ApplyResources(this.labelProgress, "labelProgress");
+            this.labelProgress.BackColor = System.Drawing.SystemColors.Window;
+            this.labelProgress.Name = "labelProgress";
             // 
             // searchTextBox
             // 
             resources.ApplyResources(this.searchTextBox, "searchTextBox");
+            this.tableLayoutPanel2.SetColumnSpan(this.searchTextBox, 6);
             this.searchTextBox.Name = "searchTextBox";
             this.searchTextBox.TextChanged += new System.EventHandler(this.searchTextBox_TextChanged);
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.tableLayoutPanel2.SetColumnSpan(this.label1, 6);
+            this.label1.Name = "label1";
+            // 
+            // tableLayoutPanel2
+            // 
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.searchTextBox, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.panel1, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.dropDownButtonShow, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.buttonClearAll, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this.buttonEnable, 2, 4);
+            this.tableLayoutPanel2.Controls.Add(this.SaveButton, 4, 5);
+            this.tableLayoutPanel2.Controls.Add(this.CloseButton, 5, 5);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            // 
+            // tableLayoutPanel3
+            // 
+            resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
+            this.tableLayoutPanel2.SetColumnSpan(this.tableLayoutPanel3, 6);
+            this.tableLayoutPanel3.Controls.Add(this.GraphNameLabel, 0, 0);
+            this.tableLayoutPanel3.Controls.Add(this.GraphNameTextBox, 1, 0);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            // 
+            // panel1
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.panel1, 6);
+            this.panel1.Controls.Add(this.tableLayoutPanel1);
+            this.panel1.Controls.Add(this.dataGridView);
+            resources.ApplyResources(this.panel1, "panel1");
+            this.panel1.Name = "panel1";
+            // 
+            // dropDownButtonShow
+            // 
+            this.dropDownButtonShow.ContextMenuStrip = this.contextMenuStripShow;
+            resources.ApplyResources(this.dropDownButtonShow, "dropDownButtonShow");
+            this.dropDownButtonShow.Name = "dropDownButtonShow";
+            this.dropDownButtonShow.UseVisualStyleBackColor = true;
+            // 
+            // contextMenuStripShow
+            // 
+            this.contextMenuStripShow.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemHidden,
+            this.toolStripMenuItemDisabled});
+            this.contextMenuStripShow.Name = "contextMenuStripShow";
+            resources.ApplyResources(this.contextMenuStripShow, "contextMenuStripShow");
+            // 
+            // toolStripMenuItemHidden
+            // 
+            this.toolStripMenuItemHidden.CheckOnClick = true;
+            this.toolStripMenuItemHidden.Name = "toolStripMenuItemHidden";
+            resources.ApplyResources(this.toolStripMenuItemHidden, "toolStripMenuItemHidden");
+            this.toolStripMenuItemHidden.CheckStateChanged += new System.EventHandler(this.toolStripMenuItemHidden_CheckedChanged);
+            // 
+            // toolStripMenuItemDisabled
+            // 
+            this.toolStripMenuItemDisabled.CheckOnClick = true;
+            this.toolStripMenuItemDisabled.Name = "toolStripMenuItemDisabled";
+            resources.ApplyResources(this.toolStripMenuItemDisabled, "toolStripMenuItemDisabled");
+            this.toolStripMenuItemDisabled.CheckStateChanged += new System.EventHandler(this.toolStripMenuItemDisabled_CheckedChanged);
+            // 
+            // buttonClearAll
+            // 
+            resources.ApplyResources(this.buttonClearAll, "buttonClearAll");
+            this.buttonClearAll.Name = "buttonClearAll";
+            this.buttonClearAll.UseVisualStyleBackColor = true;
+            this.buttonClearAll.Click += new System.EventHandler(this.buttonClearAll_Click);
+            // 
+            // buttonEnable
+            // 
+            resources.ApplyResources(this.buttonEnable, "buttonEnable");
+            this.buttonEnable.Name = "buttonEnable";
+            this.buttonEnable.UseVisualStyleBackColor = true;
+            this.buttonEnable.Click += new System.EventHandler(this.buttonEnable_Click);
             // 
             // GraphDetailsDialog
             // 
@@ -256,24 +281,22 @@
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.CloseButton;
-            this.Controls.Add(this.searchTextBox);
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.Controls.Add(this.dataGridView);
-            this.Controls.Add(this.ClearAllButton);
-            this.Controls.Add(this.GraphNameTextBox);
-            this.Controls.Add(this.SaveButton);
-            this.Controls.Add(this.CloseButton);
-            this.Controls.Add(this.GraphNameLabel);
+            this.Controls.Add(this.tableLayoutPanel2);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.Name = "GraphDetailsDialog";
             this.Load += new System.EventHandler(this.GraphDetailsDialog_Load);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).EndInit();
-            this.contextMenuStrip.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxProgress)).EndInit();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel3.PerformLayout();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            this.contextMenuStripShow.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -284,20 +307,24 @@
         private System.Windows.Forms.Button CloseButton;
         private System.Windows.Forms.TextBox GraphNameTextBox;
         private System.Windows.Forms.DataGridView dataGridView;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn2;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn3;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn ColumnDisplayOnGraph;
-        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnName;
-        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnType;
-        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnColour;
-        private System.Windows.Forms.Button ClearAllButton;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
-        private System.Windows.Forms.ToolStripMenuItem clearAllToolStripMenuItem;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label labelProgress;
         private System.Windows.Forms.PictureBox pictureBoxProgress;
         private Controls.SearchTextBox searchTextBox;
-
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemHidden;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemDisabled;
+        private System.Windows.Forms.Button buttonEnable;
+        private Controls.DropDownButton dropDownButtonShow;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripShow;
+        private System.Windows.Forms.Button buttonClearAll;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn ColumnDisplayOnGraph;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnType;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnEnabled;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnColour;
     }
 }

--- a/XenAdmin/Dialogs/GraphDetailsDialog.resx
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="GraphNameLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="GraphNameLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -125,18 +129,17 @@
   <data name="GraphNameLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="GraphNameLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="GraphNameLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 18</value>
+    <value>3, 7</value>
   </data>
   <data name="GraphNameLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>42, 15</value>
   </data>
   <data name="GraphNameLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="GraphNameLabel.Text" xml:space="preserve">
     <value>&amp;Name:</value>
@@ -148,13 +151,10 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GraphNameLabel.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;GraphNameLabel.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="SaveButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+    <value>0</value>
   </data>
   <data name="SaveButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -169,7 +169,7 @@
     <value>NoControl</value>
   </data>
   <data name="SaveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>353, 451</value>
+    <value>345, 433</value>
   </data>
   <data name="SaveButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -178,7 +178,7 @@
     <value>75, 25</value>
   </data>
   <data name="SaveButton.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="SaveButton.Text" xml:space="preserve">
     <value>&amp;Save</value>
@@ -190,13 +190,10 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SaveButton.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;SaveButton.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="CloseButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+    <value>7</value>
   </data>
   <data name="CloseButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -211,7 +208,7 @@
     <value>NoControl</value>
   </data>
   <data name="CloseButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>434, 451</value>
+    <value>426, 433</value>
   </data>
   <data name="CloseButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -220,7 +217,7 @@
     <value>75, 25</value>
   </data>
   <data name="CloseButton.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="CloseButton.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -232,25 +229,25 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CloseButton.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;CloseButton.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="GraphNameTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>Left, Right</value>
   </data>
   <data name="GraphNameTextBox.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="GraphNameTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 15</value>
+    <value>51, 3</value>
   </data>
   <data name="GraphNameTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>440, 23</value>
+    <value>450, 23</value>
   </data>
   <data name="GraphNameTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;GraphNameTextBox.Name" xml:space="preserve">
     <value>GraphNameTextBox</value>
@@ -259,13 +256,10 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GraphNameTextBox.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;GraphNameTextBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="dataGridView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>1</value>
   </data>
   <metadata name="ColumnDisplayOnGraph.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -283,7 +277,7 @@
     <value>True</value>
   </metadata>
   <data name="ColumnName.HeaderText" xml:space="preserve">
-    <value>Datasource</value>
+    <value>Data Source</value>
   </data>
   <data name="ColumnName.MinimumWidth" type="System.Int32, mscorlib">
     <value>100</value>
@@ -298,7 +292,16 @@
     <value>50</value>
   </data>
   <data name="ColumnType.Width" type="System.Int32, mscorlib">
-    <value>57</value>
+    <value>56</value>
+  </data>
+  <metadata name="ColumnEnabled.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="ColumnEnabled.HeaderText" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="ColumnEnabled.Width" type="System.Int32, mscorlib">
+    <value>74</value>
   </data>
   <metadata name="ColumnColour.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -312,20 +315,23 @@
   <data name="ColumnColour.Width" type="System.Int32, mscorlib">
     <value>20</value>
   </data>
+  <data name="dataGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="dataGridView.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="dataGridView.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 95</value>
+    <value>0, 0</value>
   </data>
   <data name="dataGridView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 6</value>
   </data>
   <data name="dataGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 347</value>
+    <value>498, 290</value>
   </data>
   <data name="dataGridView.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;dataGridView.Name" xml:space="preserve">
     <value>dataGridView</value>
@@ -334,70 +340,10 @@
     <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;dataGridView.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>panel1</value>
   </data>
   <data name="&gt;&gt;dataGridView.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ClearAllButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
-  <data name="ClearAllButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="ClearAllButton.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="ClearAllButton.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="ClearAllButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ClearAllButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 451</value>
-  </data>
-  <data name="ClearAllButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="ClearAllButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
-  </data>
-  <data name="ClearAllButton.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="ClearAllButton.Text" xml:space="preserve">
-    <value>Clear &amp;All</value>
-  </data>
-  <data name="&gt;&gt;ClearAllButton.Name" xml:space="preserve">
-    <value>ClearAllButton</value>
-  </data>
-  <data name="&gt;&gt;ClearAllButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ClearAllButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ClearAllButton.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <data name="clearAllToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 22</value>
-  </data>
-  <data name="clearAllToolStripMenuItem.Text" xml:space="preserve">
-    <value>Clear &amp;All</value>
-  </data>
-  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 26</value>
-  </data>
-  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
-    <value>contextMenuStrip</value>
-  </data>
-  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>None</value>
@@ -410,48 +356,6 @@
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="labelProgress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="labelProgress.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelProgress.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="labelProgress.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="labelProgress.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelProgress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>25, 3</value>
-  </data>
-  <data name="labelProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>135, 15</value>
-  </data>
-  <data name="labelProgress.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="labelProgress.Text" xml:space="preserve">
-    <value>Retrieving datasources...</value>
-  </data>
-  <data name="labelProgress.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;labelProgress.Name" xml:space="preserve">
-    <value>labelProgress</value>
-  </data>
-  <data name="&gt;&gt;labelProgress.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProgress.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelProgress.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="pictureBoxProgress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -484,22 +388,61 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;pictureBoxProgress.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelProgress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="labelProgress.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelProgress.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="labelProgress.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="labelProgress.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelProgress.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 3</value>
+  </data>
+  <data name="labelProgress.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 15</value>
+  </data>
+  <data name="labelProgress.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelProgress.Text" xml:space="preserve">
+    <value>Retrieving data sources...</value>
+  </data>
+  <data name="&gt;&gt;labelProgress.Name" xml:space="preserve">
+    <value>labelProgress</value>
+  </data>
+  <data name="&gt;&gt;labelProgress.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelProgress.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelProgress.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>182, 243</value>
+    <value>160, 121</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 22</value>
+    <value>166, 22</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -508,82 +451,304 @@
     <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>panel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelProgress" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pictureBoxProgress" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn1.HeaderText" xml:space="preserve">
-    <value>Datasource</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn1.MinimumWidth" type="System.Int32, mscorlib">
-    <value>100</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn1.Width" type="System.Int32, mscorlib">
-    <value>200</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn2.HeaderText" xml:space="preserve">
-    <value>Type</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn2.MinimumWidth" type="System.Int32, mscorlib">
-    <value>50</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn2.Width" type="System.Int32, mscorlib">
-    <value>58</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn3.HeaderText" xml:space="preserve">
-    <value />
-  </data>
-  <data name="dataGridViewTextBoxColumn3.MinimumWidth" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="dataGridViewTextBoxColumn3.Width" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBoxProgress" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelProgress" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="searchTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>Left, Right</value>
+  </data>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 15</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>498, 15</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Specify a name for the graph and select the data sources you want to include in it.</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel3.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel3.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel3.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 30</value>
+  </data>
+  <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 10</value>
+  </data>
+  <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>504, 29</value>
+  </data>
+  <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.Name" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="GraphNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="GraphNameTextBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 107</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>498, 290</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <metadata name="contextMenuStripShow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>126, 11</value>
+  </metadata>
+  <data name="toolStripMenuItemHidden.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 22</value>
+  </data>
+  <data name="toolStripMenuItemHidden.Text" xml:space="preserve">
+    <value>&amp;Hidden</value>
+  </data>
+  <data name="toolStripMenuItemDisabled.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 22</value>
+  </data>
+  <data name="toolStripMenuItemDisabled.Text" xml:space="preserve">
+    <value>&amp;Disabled</value>
+  </data>
+  <data name="contextMenuStripShow.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 48</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStripShow.Name" xml:space="preserve">
+    <value>contextMenuStripShow</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStripShow.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="dropDownButtonShow.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="dropDownButtonShow.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 403</value>
+  </data>
+  <data name="dropDownButtonShow.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 3, 0</value>
+  </data>
+  <data name="dropDownButtonShow.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 23</value>
+  </data>
+  <data name="dropDownButtonShow.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="dropDownButtonShow.Text" xml:space="preserve">
+    <value>Show &amp;data sources</value>
+  </data>
+  <data name="&gt;&gt;dropDownButtonShow.Name" xml:space="preserve">
+    <value>dropDownButtonShow</value>
+  </data>
+  <data name="&gt;&gt;dropDownButtonShow.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DropDownButton, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dropDownButtonShow.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;dropDownButtonShow.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="buttonClearAll.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonClearAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>147, 403</value>
+  </data>
+  <data name="buttonClearAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonClearAll.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="buttonClearAll.Text" xml:space="preserve">
+    <value>Clear &amp;All</value>
+  </data>
+  <data name="&gt;&gt;buttonClearAll.Name" xml:space="preserve">
+    <value>buttonClearAll</value>
+  </data>
+  <data name="&gt;&gt;buttonClearAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonClearAll.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;buttonClearAll.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="buttonEnable.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonEnable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>228, 403</value>
+  </data>
+  <data name="buttonEnable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonEnable.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="buttonEnable.Text" xml:space="preserve">
+    <value>&amp;Enable</value>
+  </data>
+  <data name="&gt;&gt;buttonEnable.Name" xml:space="preserve">
+    <value>buttonEnable</value>
+  </data>
+  <data name="&gt;&gt;buttonEnable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonEnable.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;buttonEnable.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 10</value>
+  </data>
+  <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>504, 461</value>
+  </data>
+  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="tableLayoutPanel3" Row="1" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="searchTextBox" Row="2" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="panel1" Row="3" RowSpan="1" Column="0" ColumnSpan="6" /&gt;&lt;Control Name="dropDownButtonShow" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonClearAll" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonEnable" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="SaveButton" Row="5" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="CloseButton" Row="5" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,Absolute,30,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="searchTextBox.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="searchTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 60</value>
-  </data>
-  <data name="searchTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 15, 3, 3</value>
+    <value>3, 72</value>
   </data>
   <data name="searchTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 29</value>
+    <value>498, 29</value>
   </data>
   <data name="searchTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;searchTextBox.Name" xml:space="preserve">
     <value>searchTextBox</value>
   </data>
   <data name="&gt;&gt;searchTextBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SearchTextBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.SearchTextBox, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;searchTextBox.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;searchTextBox.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>25</value>
+    <value>67</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>522, 489</value>
+    <value>524, 481</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -592,7 +757,7 @@
     <value>41, 19, 41, 19</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>499, 469</value>
+    <value>540, 520</value>
   </data>
   <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>10, 10, 10, 10</value>
@@ -618,40 +783,34 @@
   <data name="&gt;&gt;ColumnType.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;ColumnEnabled.Name" xml:space="preserve">
+    <value>ColumnEnabled</value>
+  </data>
+  <data name="&gt;&gt;ColumnEnabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;ColumnColour.Name" xml:space="preserve">
     <value>ColumnColour</value>
   </data>
   <data name="&gt;&gt;ColumnColour.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;clearAllToolStripMenuItem.Name" xml:space="preserve">
-    <value>clearAllToolStripMenuItem</value>
+  <data name="&gt;&gt;toolStripMenuItemHidden.Name" xml:space="preserve">
+    <value>toolStripMenuItemHidden</value>
   </data>
-  <data name="&gt;&gt;clearAllToolStripMenuItem.Type" xml:space="preserve">
+  <data name="&gt;&gt;toolStripMenuItemHidden.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;dataGridViewTextBoxColumn1.Name" xml:space="preserve">
-    <value>dataGridViewTextBoxColumn1</value>
+  <data name="&gt;&gt;toolStripMenuItemDisabled.Name" xml:space="preserve">
+    <value>toolStripMenuItemDisabled</value>
   </data>
-  <data name="&gt;&gt;dataGridViewTextBoxColumn1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewTextBoxColumn2.Name" xml:space="preserve">
-    <value>dataGridViewTextBoxColumn2</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewTextBoxColumn2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewTextBoxColumn3.Name" xml:space="preserve">
-    <value>dataGridViewTextBoxColumn3</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewTextBoxColumn3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;toolStripMenuItemDisabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>GraphDetailsDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/RoleElevationDialog.cs
+++ b/XenAdmin/Dialogs/RoleElevationDialog.cs
@@ -111,7 +111,7 @@ namespace XenAdmin.Dialogs
                     }
                 });
 
-                using (var dlg = new ActionProgressDialog(loginAction, ProgressBarStyle.Marquee, false))
+                using (var dlg = new ActionProgressDialog(loginAction, ProgressBarStyle.Marquee) {ShowTryAgainMessage = false})
                     dlg.ShowDialog(this);
                 
                 // The exception would have been handled by the action progress dialog, just return the user to the sudo dialog

--- a/XenAdmin/TabPages/PerformancePage.cs
+++ b/XenAdmin/TabPages/PerformancePage.cs
@@ -197,6 +197,16 @@ namespace XenAdmin.TabPages
             get { return Helpers.FeatureForbidden(XenObject, Host.RestrictPerformanceGraphs); }
         }
 
+        private void LoadDataSources()
+        {
+            if (XenObject == null)
+                return;
+
+            var action = new GetDataSourcesAction(XenObject);
+            action.Completed += SaveGraphs;
+            action.RunAsync();
+        }
+
         private void LoadEvents()
         {
             foreach(XenAPI.Message m in XenObject.Connection.Cache.Messages)
@@ -336,7 +346,7 @@ namespace XenAdmin.TabPages
             if (GraphList.AuthorizedRole)
             {
                 GraphList.ExchangeGraphs(index, index - 1);
-                GraphList.SaveGraphs(null);
+                GraphList.SaveGraphs();
             }
         }
 
@@ -349,7 +359,7 @@ namespace XenAdmin.TabPages
             if (GraphList.AuthorizedRole)
             {
                 GraphList.ExchangeGraphs(index, index + 1);
-                GraphList.SaveGraphs(null);
+                GraphList.SaveGraphs();
             }
         }
 
@@ -360,7 +370,7 @@ namespace XenAdmin.TabPages
             
             if (GraphList.AuthorizedRole)
             {
-                using (var dialog = new GraphDetailsDialog(GraphList, null))
+                using (var dialog = new GraphDetailsDialog(GraphList))
                     dialog.ShowDialog();
             }
         }
@@ -386,7 +396,7 @@ namespace XenAdmin.TabPages
                     if (GraphList.AuthorizedRole)
                     {
                         GraphList.DeleteGraph(GraphList.SelectedGraph);
-                        GraphList.LoadDataSources(SaveGraphs);
+                        LoadDataSources();
                     }
             }
         }
@@ -400,21 +410,20 @@ namespace XenAdmin.TabPages
                     if (GraphList.AuthorizedRole)
                     {
                         GraphList.RestoreDefaultGraphs();
-                        GraphList.LoadDataSources(SaveGraphs);
+                        LoadDataSources();
                     }
             }
         }
 
         private void SaveGraphs(ActionBase sender)
         {
-            Program.Invoke(Program.MainWindow, delegate
+            if (!(sender is GetDataSourcesAction action))
+                return;
+
+            Program.Invoke(Program.MainWindow, () =>
             {
-                var action = sender as GetDataSourcesAction;
-                if (action != null)
-                {
-                    var dataSources = DataSourceItemList.BuildList(action.IXenObject, action.DataSources);
-                    GraphList.SaveGraphs(dataSources);
-                }
+                var dataSourceItems = DataSourceItemList.BuildList(action.XenObject, action.DataSources);
+                GraphList.SaveGraphs(dataSourceItems);
             });
         }
 

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -4930,6 +4930,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\GraphDetailsDialog.resx">
       <DependentUpon>GraphDetailsDialog.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\CustomDataGraph\GraphList.ja.resx">
       <DependentUpon>GraphList.cs</DependentUpon>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -1078,6 +1078,26 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enabling metric &quot;{0}&quot;....
+        /// </summary>
+        public static string ACTION_ENABLING_DATASOURCE {
+            get {
+                return ResourceManager.GetString("ACTION_ENABLING_DATASOURCE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not enable metric &quot;{0}&quot;.
+        ///
+        ///This could be because the data source is not generating any data. Ensure the prerequisites for collecting this metric are met before attempting to enable it..
+        /// </summary>
+        public static string ACTION_ENABLING_DATASOURCE_ERROR {
+            get {
+                return ResourceManager.GetString("ACTION_ENABLING_DATASOURCE_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enabling live patching for &apos;{0}&apos;.
         /// </summary>
         public static string ACTION_ENABLING_LIVE_PATCHING {
@@ -18057,20 +18077,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; Details.
-        /// </summary>
-        public static string GRAPHS_DETAILS_TITLE {
-            get {
-                return ResourceManager.GetString("GRAPHS_DETAILS_TITLE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Edit Graph....
         /// </summary>
         public static string GRAPHS_EDIT {
             get {
                 return ResourceManager.GetString("GRAPHS_EDIT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit &apos;{0}&apos;.
+        /// </summary>
+        public static string GRAPHS_EDIT_TITLE {
+            get {
+                return ResourceManager.GetString("GRAPHS_EDIT_TITLE", resourceCulture);
             }
         }
         
@@ -41553,7 +41573,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occurred when attempting to bind report datasources: {0}.
+        ///   Looks up a localized string similar to An error occurred when attempting to bind report data sources: {0}.
         /// </summary>
         public static string WLB_REPORT_BIND_DATASOURCE {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -456,6 +456,14 @@
   <data name="ACTION_ENABLING_AUTOSTART_ON_VM" xml:space="preserve">
     <value>Enabling autostart for '{0}'</value>
   </data>
+  <data name="ACTION_ENABLING_DATASOURCE" xml:space="preserve">
+    <value>Enabling metric "{0}"...</value>
+  </data>
+  <data name="ACTION_ENABLING_DATASOURCE_ERROR" xml:space="preserve">
+    <value>Could not enable metric "{0}".
+
+This could be because the data source is not generating any data. Ensure the prerequisites for collecting this metric are met before attempting to enable it.</value>
+  </data>
   <data name="ACTION_ENABLING_LIVE_PATCHING" xml:space="preserve">
     <value>Enabling live patching for '{0}'</value>
   </data>
@@ -6281,11 +6289,11 @@ Would you like to eject these ISOs before continuing?</value>
   <data name="GRAPHS_DEFAULT_NAME_NETWORK" xml:space="preserve">
     <value>Network Performance</value>
   </data>
-  <data name="GRAPHS_DETAILS_TITLE" xml:space="preserve">
-    <value>'{0}' Details</value>
-  </data>
   <data name="GRAPHS_EDIT" xml:space="preserve">
     <value>Edit Graph...</value>
+  </data>
+  <data name="GRAPHS_EDIT_TITLE" xml:space="preserve">
+    <value>Edit '{0}'</value>
   </data>
   <data name="GRAPHS_NEW" xml:space="preserve">
     <value>New Graph...</value>
@@ -14352,7 +14360,7 @@ Would you like to adjust the current Optimization Mode to match the schedule?</v
     <value>Back to Parent Report</value>
   </data>
   <data name="WLB_REPORT_BIND_DATASOURCE" xml:space="preserve">
-    <value>An error occurred when attempting to bind report datasources: {0}</value>
+    <value>An error occurred when attempting to bind report data sources: {0}</value>
   </data>
   <data name="WLB_REPORT_CHANGECREDENTIALSTEXT" xml:space="preserve">
     <value>Change Credentials</value>


### PR DESCRIPTION
- CA-359068: Match the whole datasource name (previously the wrong one was picked for disk read/write latency).
- New/edit Graph dialog: differentiate between enabled/disabled datasources and visible/hidden (known/unknown units; the latter may mean no data).
- Some refactoring.