### PR TITLE
CA-359124 & CA-360426: Add snapshot VIFs to mapping during cross pool migration & fix VIF mapping in cross pool migration

### DIFF
--- a/XenAdmin/Wizards/ConversionWizard/ConversionNetworkPage.cs
+++ b/XenAdmin/Wizards/ConversionWizard/ConversionNetworkPage.cs
@@ -88,8 +88,9 @@ namespace XenAdmin.Wizards.ConversionWizard
             NetworkID = network.Id;
         }
 
+        public string VmNameOverride  => null;
         public string NetworkName { get; }
-        public string MACAddress { get; }
+        public string MACAddress  => null;
         public string NetworkID { get; }
     }
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateNetworkingPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateNetworkingPage.cs
@@ -87,7 +87,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
         {
             var vm = Connection.Resolve(new XenRef<VM>(sysId));
 
-            if(vm == null)
+            if (vm == null)
                 return null;
 
             var vifs = Connection.ResolveAll(vm.VIFs);

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateNetworkingPage.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateNetworkingPage.cs
@@ -91,11 +91,12 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                 return null;
 
             var vifs = Connection.ResolveAll(vm.VIFs);
+            var macs = vifs.Select(v => v.MAC);
 
-            var snapVIFs = VM.get_snapshots(vm.Connection.Session, vm.opaque_ref)
+            var snapVIFs = vm.snapshots
                 .Select(vm.Connection.Resolve)
-                .SelectMany(snap => Connection.ResolveAll(snap.VIFs))
-                .Where(vif => !vifs.Select(vmVif => vmVif.MAC).Contains(vif.MAC))
+                .SelectMany(s => Connection.ResolveAll(s.VIFs))
+                .Where(v => !macs.Contains(v.MAC))
                 .ToList();
 
             vifs.AddRange(snapVIFs);

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationNetworkResource.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationNetworkResource.cs
@@ -38,10 +38,14 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
     internal class CrossPoolMigrationNetworkResource : INetworkResource
     {
         private readonly VIF _vif;
+
         public CrossPoolMigrationNetworkResource(VIF vif)
         {
             _vif = vif;
         }
+
+        public string VmNameOverride => _vif.Connection?.Resolve(_vif.VM)?.Name();
+
         public string NetworkName => _vif.NetworkName();
 
         public string MACAddress => _vif.MAC;
@@ -49,25 +53,24 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
         public string NetworkID => _vif.network.opaque_ref;
     }
 
+
     internal class CrossPoolMigrationNetworkResourceContainer : NetworkResourceContainer
     {
-        private readonly List<VIF> vifs;
-        private int counter;
+        private readonly List<VIF> _vifs;
+        private int _counter;
 
         public CrossPoolMigrationNetworkResourceContainer(List<VIF> vifs)
         {
-            this.vifs = vifs;
+            _vifs = vifs;
         }
+
         public override INetworkResource Next()
         {
-            INetworkResource res =  new CrossPoolMigrationNetworkResource(vifs[counter]);
-            counter++;
+            INetworkResource res =  new CrossPoolMigrationNetworkResource(_vifs[_counter]);
+            _counter++;
             return res;
         }
 
-        public override bool IsNext
-        {
-            get { return counter < vifs.Count; }
-        }
+        public override bool IsNext => _counter < _vifs.Count;
     }
 }

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationNetworkResource.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrationNetworkResource.cs
@@ -37,25 +37,16 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
 {
     internal class CrossPoolMigrationNetworkResource : INetworkResource
     {
-        private readonly VIF vif;
+        private readonly VIF _vif;
         public CrossPoolMigrationNetworkResource(VIF vif)
         {
-            this.vif = vif;
+            _vif = vif;
         }
-        public string NetworkName
-        {
-            get { return vif.NetworkName(); }
-        }
+        public string NetworkName => _vif.NetworkName();
 
-        public string MACAddress
-        {
-            get { return vif.MAC; }
-        }
+        public string MACAddress => _vif.MAC;
 
-        public string NetworkID
-        {
-            get { return vif.network.opaque_ref; }
-        }
+        public string NetworkID => _vif.network.opaque_ref;
     }
 
     internal class CrossPoolMigrationNetworkResourceContainer : NetworkResourceContainer

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -215,9 +215,7 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
         /// <returns>true if at least one snapshot contains a VIF not present in the VM</returns>
         private static bool SnapshotsContainExtraVIFs(VM vm)
         {
-            var snapVIFs = VM.get_snapshots(vm.Connection.Session, vm.opaque_ref)
-                .Select(vm.Connection.Resolve)
-                .SelectMany(snap => snap.VIFs);
+            var snapVIFs = vm.snapshots.Select(vm.Connection.Resolve).SelectMany(snap => snap.VIFs);
             return snapVIFs.Any(snapVIF => !vm.VIFs.Contains(snapVIF));
         }
 

--- a/XenAdmin/Wizards/GenericPages/NetworkResource.cs
+++ b/XenAdmin/Wizards/GenericPages/NetworkResource.cs
@@ -35,6 +35,7 @@ namespace XenAdmin.Wizards.GenericPages
 {
     public interface INetworkResource
     {
+        string VmNameOverride { get; }
         string NetworkName { get; }
         string MACAddress { get; }
         string NetworkID { get; }

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
@@ -57,6 +57,7 @@ namespace XenAdmin.Wizards.GenericPages
 		{
 			public string SysId { get; set; }
 			public string NetworkId { get; set; }
+            public string MACAddress { get; set; }
 		}
 
         protected SelectMultipleVMNetworkPage()
@@ -172,7 +173,7 @@ namespace XenAdmin.Wizards.GenericPages
 
                 var cellSourceNetwork = new DataGridViewTextBoxCell
                 {
-                    Tag = new NetworkDetail {SysId = sysId, NetworkId = networkResource.NetworkID},
+                    Tag = new NetworkDetail {SysId = sysId, NetworkId = networkResource.NetworkID, MACAddress = networkResource.MACAddress},
                     Value = val
                 };
 
@@ -229,10 +230,13 @@ namespace XenAdmin.Wizards.GenericPages
 					if (m_vmMappings.ContainsKey(networkDetail.SysId))
 					{
 						var mapping = m_vmMappings[networkDetail.SysId];
-						var selectedItem = row.Cells[1].Value as ToStringWrapper<XenAPI.Network>;
 
-					    if (selectedItem != null)
-							mapping.Networks[networkDetail.NetworkId] = selectedItem.item;
+                        if (row.Cells[1].Value is ToStringWrapper<XenAPI.Network> selectedItem)
+                        {
+                            mapping.Networks[networkDetail.NetworkId] = selectedItem.item;
+                            mapping.VIFs[networkDetail.MACAddress] = selectedItem.item;
+                        }
+							
 					}
 				}
 

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
@@ -162,12 +162,18 @@ namespace XenAdmin.Wizards.GenericPages
         protected void FillTableRow(object targetRef, string sysId, string vmName)
         {
             var cb = FillGridComboBox(targetRef, sysId);
+            var networkData = NetworkData(sysId);
 
-            foreach (INetworkResource networkResource in NetworkData(sysId))
+            foreach (INetworkResource networkResource in networkData)
             {
                 var val = networkResource.NetworkName;
-                if (!string.IsNullOrEmpty(vmName))
+                var vmNameOverride = networkResource.VmNameOverride;
+
+                if (!string.IsNullOrEmpty(vmNameOverride))
+                    val = $"{vmNameOverride} - {val}";
+                else if (!string.IsNullOrEmpty(vmName))
                     val = $"{vmName} - {val}";
+
                 if (!string.IsNullOrEmpty(networkResource.MACAddress))
                     val = $"{val} ({networkResource.MACAddress})";
 

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.cs
@@ -43,27 +43,27 @@ using XenCenterLib;
 
 namespace XenAdmin.Wizards.GenericPages
 {
-	/// <summary>
-	/// Class representing the page of the ImportAppliance wizard where the user specifies
-	/// a network for the VMs in the appliance that require network access. 
-	/// </summary>
-	internal abstract partial class SelectMultipleVMNetworkPage : XenTabPage
-	{
+    /// <summary>
+    /// Class representing the page of the ImportAppliance wizard where the user specifies
+    /// a network for the VMs in the appliance that require network access. 
+    /// </summary>
+    internal abstract partial class SelectMultipleVMNetworkPage : XenTabPage
+    {
         private bool m_buttonNextEnabled;
         private bool m_buttonPreviousEnabled;
         private Dictionary<string, VmMapping> m_vmMappings;
 
         private struct NetworkDetail
-		{
-			public string SysId { get; set; }
-			public string NetworkId { get; set; }
+        {
+            public string SysId { get; set; }
+            public string NetworkId { get; set; }
             public string MACAddress { get; set; }
-		}
+        }
 
         protected SelectMultipleVMNetworkPage()
-		{
-			InitializeComponent();
-		}
+        {
+            InitializeComponent();
+        }
 
         protected override void OnLoad(EventArgs e)
         {
@@ -120,8 +120,8 @@ namespace XenAdmin.Wizards.GenericPages
         protected override void PageLoadedCore(PageLoadedDirection direction)
         {
             SetButtonPreviousEnabled(true);
-			SetButtonNextEnabled(true);
-		}
+            SetButtonNextEnabled(true);
+        }
 
         public override void PageCancelled(ref bool cancel)
         {
@@ -219,34 +219,34 @@ namespace XenAdmin.Wizards.GenericPages
             return m_buttonPreviousEnabled;
         }
 
-		public Dictionary<string, VmMapping> VmMappings
-		{
-			get
-			{
-				foreach (DataGridViewRow row in m_dataGridView.Rows)
-				{
-					var networkDetail = (NetworkDetail)row.Cells[0].Tag;
+        public Dictionary<string, VmMapping> VmMappings
+        {
+            get
+            {
+                foreach (DataGridViewRow row in m_dataGridView.Rows)
+                {
+                    var networkDetail = (NetworkDetail)row.Cells[0].Tag;
 
-					if (m_vmMappings.ContainsKey(networkDetail.SysId))
-					{
-						var mapping = m_vmMappings[networkDetail.SysId];
+                    if (m_vmMappings.ContainsKey(networkDetail.SysId))
+                    {
+                        var mapping = m_vmMappings[networkDetail.SysId];
 
                         if (row.Cells[1].Value is ToStringWrapper<XenAPI.Network> selectedItem)
                         {
                             mapping.Networks[networkDetail.NetworkId] = selectedItem.item;
                             mapping.VIFs[networkDetail.MACAddress] = selectedItem.item;
                         }
-							
-					}
-				}
+                            
+                    }
+                }
 
-				return m_vmMappings;
-			}
-			set
-			{
-			    m_vmMappings = value;
-			}
-		}
+                return m_vmMappings;
+            }
+            set
+            {
+                m_vmMappings = value;
+            }
+        }
 
         public Dictionary<string, string> RawMappings
         {
@@ -277,25 +277,25 @@ namespace XenAdmin.Wizards.GenericPages
             OnPageUpdated();
         }   
 
-		private DataGridViewComboBoxCell FillGridComboBox(object targetRef, string vsId)
-		{
-		    var cb = new DataGridViewComboBoxCell {FlatStyle = FlatStyle.Flat, Sorted = true};
+        private DataGridViewComboBoxCell FillGridComboBox(object targetRef, string vsId)
+        {
+            var cb = new DataGridViewComboBoxCell {FlatStyle = FlatStyle.Flat, Sorted = true};
 
             var availableNetworks = TargetConnection.Cache.Networks.Where(net => ShowNetwork(targetRef, net, vsId));
 
-			foreach (XenAPI.Network netWork in availableNetworks)
-			{
-				if (!Messages.IMPORT_SELECT_NETWORK_PAGE_NETWORK_FILTER.Contains(netWork.Name()))
-				{
-					var wrapperItem = new ToStringWrapper<XenAPI.Network>(netWork, netWork.Name());
+            foreach (XenAPI.Network netWork in availableNetworks)
+            {
+                if (!Messages.IMPORT_SELECT_NETWORK_PAGE_NETWORK_FILTER.Contains(netWork.Name()))
+                {
+                    var wrapperItem = new ToStringWrapper<XenAPI.Network>(netWork, netWork.Name());
 
-					if (!cb.Items.Contains(wrapperItem))
-						cb.Items.Add(wrapperItem);
-				}
-			}
+                    if (!cb.Items.Contains(wrapperItem))
+                        cb.Items.Add(wrapperItem);
+                }
+            }
 
-			return cb;
-		}
+            return cb;
+        }
 
         private bool ShowNetwork(object targetRef, XenAPI.Network network, string vsId)
         {
@@ -321,21 +321,21 @@ namespace XenAdmin.Wizards.GenericPages
         }
 
         private void m_dataGridView_CellEnter(object sender, DataGridViewCellEventArgs e)
-		{
-			if (e.ColumnIndex != m_colTargetNet.Index || e.RowIndex < 0 || e.RowIndex >= m_dataGridView.RowCount)
-				return;
+        {
+            if (e.ColumnIndex != m_colTargetNet.Index || e.RowIndex < 0 || e.RowIndex >= m_dataGridView.RowCount)
+                return;
 
-			m_dataGridView.BeginEdit(false);
+            m_dataGridView.BeginEdit(false);
 
-			if (m_dataGridView.EditingControl != null && m_dataGridView.EditingControl is ComboBox)
-				(m_dataGridView.EditingControl as ComboBox).DroppedDown = true;
-		}
+            if (m_dataGridView.EditingControl != null && m_dataGridView.EditingControl is ComboBox)
+                (m_dataGridView.EditingControl as ComboBox).DroppedDown = true;
+        }
 
-		private void m_dataGridView_CurrentCellDirtyStateChanged(object sender, EventArgs e)
-		{
-			m_dataGridView.CommitEdit(DataGridViewDataErrorContexts.Commit);
-			IsDirty = true;
-		}
+        private void m_dataGridView_CurrentCellDirtyStateChanged(object sender, EventArgs e)
+        {
+            m_dataGridView.CommitEdit(DataGridViewDataErrorContexts.Commit);
+            IsDirty = true;
+        }
 
         private void buttonRefresh_Click(object sender, EventArgs e)
         {

--- a/XenAdmin/Wizards/ImportWizard/OvfNetworkResource.cs
+++ b/XenAdmin/Wizards/ImportWizard/OvfNetworkResource.cs
@@ -45,6 +45,8 @@ namespace XenAdmin.Wizards.ImportWizard
             rasd = rasdType;
         }
 
+        public string VmNameOverride => null;
+
         public string NetworkName
         {
             get

--- a/XenModel/Actions/VM/VMCrossPoolMigrateAction.cs
+++ b/XenModel/Actions/VM/VMCrossPoolMigrateAction.cs
@@ -145,7 +145,7 @@ namespace XenAdmin.Actions.VMActions
             var vmMacs = vmVifs.Select(vif => vif.MAC);
 
             // CA-359124: add VIFs that are present in the VM's snapshots, but not the VM
-            var snapVIFs = VM.get_snapshots(Connection.Session, vm.opaque_ref)
+            var snapVIFs = vm.snapshots
                 .Select(Connection.Resolve)
                 .SelectMany(snap => Connection.ResolveAll(snap.VIFs))
                 // use MAC to identify VIFs that are not in the VM, opaque_ref differentiates between VM and snapshot VIFs

--- a/XenModel/Mappings/VmMapping.cs
+++ b/XenModel/Mappings/VmMapping.cs
@@ -34,44 +34,45 @@ using XenAPI;
 
 namespace XenAdmin.Mappings
 {
-	public class VmMapping
-	{
-		public VmMapping()
-		{
-			Storage = new Dictionary<string, SR>();
+    public class VmMapping
+    {
+        public VmMapping()
+        {
+            Storage = new Dictionary<string, SR>();
             StorageToAttach = new Dictionary<string, VDI>();
-			Networks = new Dictionary<string, XenAPI.Network>();
+            Networks = new Dictionary<string, XenAPI.Network>();
             VIFs = new Dictionary<string, XenAPI.Network>();
         }
 
-		public string VmNameLabel { get; set; }
+        public string VmNameLabel { get; set; }
         public ulong Capacity { get; set; }
         public ulong CpuCount { get; set; }
         public ulong Memory { get; set; }
         public string BootParams { get; set; }
         public string PlatformSettings { get; set; }
 
-		/// <summary>
-		/// OpaqueRef of the target pool or host
-		/// </summary>
-		public object XenRef { get; set; }
+        /// <summary>
+        /// OpaqueRef of the target pool or host
+        /// </summary>
+        public object XenRef { get; set; }
 
-		/// <summary>
-		/// Name of the target pool or host
-		/// </summary>
-		public string TargetName { get; set; }
+        /// <summary>
+        /// Name of the target pool or host
+        /// </summary>
+        public string TargetName { get; set; }
 
-		/// <summary>
-		/// Keyed on the id in the ovf file
-		/// </summary>
-		public Dictionary<string, SR> Storage { get; set; }
+        /// <summary>
+        /// Keyed on the id in the ovf file
+        /// </summary>
+        public Dictionary<string, SR> Storage { get; set; }
 
         public Dictionary<string, VDI> StorageToAttach { get; set; }
 
-		/// <summary>
-		/// Keyed on the id in the ovf file
-		/// </summary>
-		public Dictionary<string, XenAPI.Network> Networks { get; set; }
+        /// <summary>
+        /// Keyed on the id in the ovf file
+        /// </summary>
+        public Dictionary<string, XenAPI.Network> Networks { get; set; }
+
         public Dictionary<string, XenAPI.Network> VIFs { get; set; }
 
         public override bool Equals(object obj)

--- a/XenModel/Mappings/VmMapping.cs
+++ b/XenModel/Mappings/VmMapping.cs
@@ -41,7 +41,8 @@ namespace XenAdmin.Mappings
 			Storage = new Dictionary<string, SR>();
             StorageToAttach = new Dictionary<string, VDI>();
 			Networks = new Dictionary<string, XenAPI.Network>();
-		}
+            VIFs = new Dictionary<string, XenAPI.Network>();
+        }
 
 		public string VmNameLabel { get; set; }
         public ulong Capacity { get; set; }
@@ -71,6 +72,7 @@ namespace XenAdmin.Mappings
 		/// Keyed on the id in the ovf file
 		/// </summary>
 		public Dictionary<string, XenAPI.Network> Networks { get; set; }
+        public Dictionary<string, XenAPI.Network> VIFs { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/XenModel/XenAPI-Extensions/Failure.cs
+++ b/XenModel/XenAPI-Extensions/Failure.cs
@@ -91,6 +91,7 @@ namespace XenAPI
         public const string UPDATE_ALREADY_APPLIED = "UPDATE_ALREADY_APPLIED";
         public const string UPDATE_ALREADY_EXISTS = "UPDATE_ALREADY_EXISTS";
         public const string MEMORY_CONSTRAINT_VIOLATION = "MEMORY_CONSTRAINT_VIOLATION";
+        public const string VIF_NOT_IN_MAP = "VIF_NOT_IN_MAP";
 
         /// <summary>
         /// Changes a techy RBAC Failure into a pretty print one that shows the roles that would be required to complete the failed action.


### PR DESCRIPTION
Probably best reviewed at once. Also contains minor style fixes.

Since the two issues addressed here are quite tangled, this PR attempts to fix both:

- Fixes VIF mapping in cross pool migration by reflecting the parameters of the corresponding xapi method
- Adds snapshot VIFs to mapping if they are not present within the ones returned by `VM.VIFs` (e.g.: VIF was deleted before cross pool migration, but after snapshot creation)