### PR TITLE
CA-343229: Changing roles when logged in as an AD user only takes effect after logging out/in

### DIFF
--- a/XenAdmin/TabPages/AdPage.resx
+++ b/XenAdmin/TabPages/AdPage.resx
@@ -322,7 +322,7 @@
     <value>tTipRemoveButton</value>
   </data>
   <data name="&gt;&gt;tTipRemoveButton.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.ToolTipContainer, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tTipRemoveButton.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -379,7 +379,7 @@
     <value>tTipLogoutButton</value>
   </data>
   <data name="&gt;&gt;tTipLogoutButton.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.ToolTipContainer, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tTipLogoutButton.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -436,7 +436,7 @@
     <value>tTipChangeRole</value>
   </data>
   <data name="&gt;&gt;tTipChangeRole.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.ToolTipContainer, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tTipChangeRole.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -826,6 +826,6 @@
     <value>AdPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.TabPages.BaseTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.TabPages.BaseTabPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenModel/Actions/AD/AddRemoveRolesAction.cs
+++ b/XenModel/Actions/AD/AddRemoveRolesAction.cs
@@ -86,7 +86,6 @@ namespace XenAdmin.Actions
             {
                 log.DebugFormat("Removing role {0} from subject '{1}'.", r.FriendlyName(), subj);
                 Subject.remove_from_roles(Session, subject.opaque_ref, r.opaque_ref);
-                done++;
                 PercentComplete = 100 * ++done / count;
             }
 

--- a/XenModel/Actions/AD/AddRemoveSubjectsAction.cs
+++ b/XenModel/Actions/AD/AddRemoveSubjectsAction.cs
@@ -254,7 +254,7 @@ namespace XenAdmin.Actions
                 {
                     if (!Connection.Session.IsLocalSuperuser && selfSid == sid)
                     {
-                        // Committing suicide. We will log ourselves out later.
+                        // We will log ourselves out later.
                         logoutSession = true;
                     }
                     else

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -3780,6 +3780,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Assigning new roles to subjects &apos;{0}&apos;.
+        /// </summary>
+        public static string AD_ADDING_REMOVING_ROLES_ON_MULTIPLE {
+            get {
+                return ResourceManager.GetString("AD_ADDING_REMOVING_ROLES_ON_MULTIPLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to (Always granted access).
         /// </summary>
         public static string AD_ALWAYS_GRANTED_ACCESS {
@@ -4051,7 +4060,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are currently logged in as one of the selected users. If you continue you will be logged out of &apos;{0}&apos;.
+        ///   Looks up a localized string similar to You are currently logged in as one of the selected users. If you continue you will be logged out of &apos;{0}&apos;. All other selected users will also be logged out.
         ///
         ///Do you want to continue?.
         /// </summary>
@@ -36317,6 +36326,15 @@ namespace XenAdmin {
         public static string TERMINATING_USER_SESSION {
             get {
                 return ResourceManager.GetString("TERMINATING_USER_SESSION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Terminating session for users &apos;{0}&apos;.
+        /// </summary>
+        public static string TERMINATING_USER_SESSION_MULTIPLE {
+            get {
+                return ResourceManager.GetString("TERMINATING_USER_SESSION_MULTIPLE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -4060,9 +4060,9 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are currently logged in as one of the selected users. If you continue you will be logged out of &apos;{0}&apos;. All other selected users will also be logged out.
+        ///   Looks up a localized string similar to You are currently logged in as one of the selected users. If you continue, you will be logged out of &apos;{0}&apos;. All other selected users will also be logged out.
         ///
-        ///Do you want to continue?.
+        ///Are you sure you want to continue?.
         /// </summary>
         public static string AD_LOGOUT_CURRENT_USER_MANY {
             get {
@@ -4071,13 +4071,75 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are currently logged in as the selected user. If you continue you will be logged out of &apos;{0}&apos;.
+        ///   Looks up a localized string similar to You are currently logged in as one of the selected users. If you assign a new role, you will be logged out of &apos;{0}&apos;. All other selected users that are logged in will also be logged out.
         ///
-        ///Do you want to continue?.
+        ///Are you sure you want to continue?.
+        /// </summary>
+        public static string AD_LOGOUT_CURRENT_USER_MANY_ROLE_CHANGE {
+            get {
+                return ResourceManager.GetString("AD_LOGOUT_CURRENT_USER_MANY_ROLE_CHANGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are currently logged in as the selected user. If you continue, you will be logged out of &apos;{0}&apos;.
+        ///
+        ///Are you sure you want to continue?.
         /// </summary>
         public static string AD_LOGOUT_CURRENT_USER_ONE {
             get {
                 return ResourceManager.GetString("AD_LOGOUT_CURRENT_USER_ONE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are currently logged in as the selected user. If you assign a new role, you will be logged out of &apos;{0}&apos;.
+        ///
+        ///Are you sure you want to continue?.
+        /// </summary>
+        public static string AD_LOGOUT_CURRENT_USER_ONE_ROLE_CHANGE {
+            get {
+                return ResourceManager.GetString("AD_LOGOUT_CURRENT_USER_ONE_ROLE_CHANGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to log out these {0} users?.
+        /// </summary>
+        public static string AD_LOGOUT_USER_MANY {
+            get {
+                return ResourceManager.GetString("AD_LOGOUT_USER_MANY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If you assign a new role to logged in users, they will be logged out.
+        ///
+        ///Are you sure you want to continue?.
+        /// </summary>
+        public static string AD_LOGOUT_USER_MANY_ROLE_CHANGE {
+            get {
+                return ResourceManager.GetString("AD_LOGOUT_USER_MANY_ROLE_CHANGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to log out the user &apos;{0}&apos;?.
+        /// </summary>
+        public static string AD_LOGOUT_USER_ONE {
+            get {
+                return ResourceManager.GetString("AD_LOGOUT_USER_ONE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If you assign a new role to user &apos;{0}&apos;, the user will be logged out.
+        ///
+        ///Are you sure you want to continue?.
+        /// </summary>
+        public static string AD_LOGOUT_USER_ONE_ROLE_CHANGE {
+            get {
+                return ResourceManager.GetString("AD_LOGOUT_USER_ONE_ROLE_CHANGE", resourceCulture);
             }
         }
         
@@ -4096,6 +4158,24 @@ namespace XenAdmin {
         public static string AD_NOT_CONFIGURED_BLURB_HOST {
             get {
                 return ResourceManager.GetString("AD_NOT_CONFIGURED_BLURB_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to remove these {0} users?.
+        /// </summary>
+        public static string AD_REMOVE_USER_MANY {
+            get {
+                return ResourceManager.GetString("AD_REMOVE_USER_MANY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to remove the user &apos;{0}&apos;?.
+        /// </summary>
+        public static string AD_REMOVE_USER_ONE {
+            get {
+                return ResourceManager.GetString("AD_REMOVE_USER_ONE", resourceCulture);
             }
         }
         
@@ -31835,42 +31915,6 @@ namespace XenAdmin {
         public static string QUESTION_ADMIN_EXIT_PROCEDURE_SOME_OF_MANY {
             get {
                 return ResourceManager.GetString("QUESTION_ADMIN_EXIT_PROCEDURE_SOME_OF_MANY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to log out these {0} users?.
-        /// </summary>
-        public static string QUESTION_LOGOUT_AD_USER_MANY {
-            get {
-                return ResourceManager.GetString("QUESTION_LOGOUT_AD_USER_MANY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to log out the user &apos;{0}&apos;?.
-        /// </summary>
-        public static string QUESTION_LOGOUT_AD_USER_ONE {
-            get {
-                return ResourceManager.GetString("QUESTION_LOGOUT_AD_USER_ONE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to remove these {0} users?.
-        /// </summary>
-        public static string QUESTION_REMOVE_AD_USER_MANY {
-            get {
-                return ResourceManager.GetString("QUESTION_REMOVE_AD_USER_MANY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to remove the user &apos;{0}&apos;?.
-        /// </summary>
-        public static string QUESTION_REMOVE_AD_USER_ONE {
-            get {
-                return ResourceManager.GetString("QUESTION_REMOVE_AD_USER_ONE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -3864,6 +3864,32 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are about to revoke the permissions for user &apos;{0}&apos;.
+        ///
+        ///You are currently logged in as &apos;{0}&apos; on &apos;{1}&apos;, and doing this will disconnect you from &apos;{1}&apos;. To reconnect, you will need to supply the local root account credentials, or the credentials for another authorized AD user.
+        ///
+        ///Do you want to continue?.
+        /// </summary>
+        public static string AD_CONFIRM_LOGOUT_CURRENT_USER {
+            get {
+                return ResourceManager.GetString("AD_CONFIRM_LOGOUT_CURRENT_USER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are about to revoke the permissions for group &apos;{0}&apos;.
+        ///
+        ///The user you are currently logged into &apos;{1}&apos; with is a member of &apos;{0}&apos;. Proceeding will disconnect you and any other members of this group from &apos;{1}&apos;. To reconnect, you will need to supply the local root account credentials, or the credentials for another authorized AD user.
+        ///
+        ///Do you want to continue?.
+        /// </summary>
+        public static string AD_CONFIRM_LOGOUT_CURRENT_USER_GROUP {
+            get {
+                return ResourceManager.GetString("AD_CONFIRM_LOGOUT_CURRENT_USER_GROUP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to terminate this user session?
         ///
         ///This will disconnect you from &apos;{0}&apos;..
@@ -3880,32 +3906,6 @@ namespace XenAdmin {
         public static string AD_CONFIRM_SELF_TERMINATE_OK {
             get {
                 return ResourceManager.GetString("AD_CONFIRM_SELF_TERMINATE_OK", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You are about to revoke the permissions for user &apos;{0}&apos;.
-        ///
-        ///You are currently logged in as &apos;{0}&apos; on &apos;{1}&apos;, and doing this will disconnect you from &apos;{1}&apos;. To reconnect, you will need to supply the local root account credentials, or the credentials for another authorized AD user.
-        ///
-        ///Do you want to continue?.
-        /// </summary>
-        public static string AD_CONFIRM_SUICIDE {
-            get {
-                return ResourceManager.GetString("AD_CONFIRM_SUICIDE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You are about to revoke the permissions for group &apos;{0}&apos;.
-        ///
-        ///The user you are currently logged into &apos;{1}&apos; with is a member of &apos;{0}&apos;. Proceeding will disconnect you and any other members of this group from &apos;{1}&apos;. To reconnect, you will need to supply the local root account credentials, or the credentials for another authorized AD user.
-        ///
-        ///Do you want to continue?.
-        /// </summary>
-        public static string AD_CONFIRM_SUICIDE_GROUP {
-            get {
-                return ResourceManager.GetString("AD_CONFIRM_SUICIDE_GROUP", resourceCulture);
             }
         }
         
@@ -4064,9 +4064,9 @@ namespace XenAdmin {
         ///
         ///Do you want to continue?.
         /// </summary>
-        public static string AD_LOGOUT_SUICIDE_MANY {
+        public static string AD_LOGOUT_CURRENT_USER_MANY {
             get {
-                return ResourceManager.GetString("AD_LOGOUT_SUICIDE_MANY", resourceCulture);
+                return ResourceManager.GetString("AD_LOGOUT_CURRENT_USER_MANY", resourceCulture);
             }
         }
         
@@ -4075,9 +4075,9 @@ namespace XenAdmin {
         ///
         ///Do you want to continue?.
         /// </summary>
-        public static string AD_LOGOUT_SUICIDE_ONE {
+        public static string AD_LOGOUT_CURRENT_USER_ONE {
             get {
-                return ResourceManager.GetString("AD_LOGOUT_SUICIDE_ONE", resourceCulture);
+                return ResourceManager.GetString("AD_LOGOUT_CURRENT_USER_ONE", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1654,14 +1654,46 @@ Do you want to continue?</value>
     <value>Local root account</value>
   </data>
   <data name="AD_LOGOUT_CURRENT_USER_MANY" xml:space="preserve">
-    <value>You are currently logged in as one of the selected users. If you continue you will be logged out of '{0}'. All other selected users will also be logged out.
+    <value>You are currently logged in as one of the selected users. If you continue, you will be logged out of '{0}'. All other selected users will also be logged out.
 
-Do you want to continue?</value>
+Are you sure you want to continue?</value>
+  </data>
+  <data name="AD_LOGOUT_CURRENT_USER_MANY_ROLE_CHANGE" xml:space="preserve">
+    <value>You are currently logged in as one of the selected users. If you assign a new role, you will be logged out of '{0}'. All other selected users that are logged in will also be logged out.
+
+Are you sure you want to continue?</value>
   </data>
   <data name="AD_LOGOUT_CURRENT_USER_ONE" xml:space="preserve">
-    <value>You are currently logged in as the selected user. If you continue you will be logged out of '{0}'.
+    <value>You are currently logged in as the selected user. If you continue, you will be logged out of '{0}'.
 
-Do you want to continue?</value>
+Are you sure you want to continue?</value>
+  </data>
+  <data name="AD_LOGOUT_CURRENT_USER_ONE_ROLE_CHANGE" xml:space="preserve">
+    <value>You are currently logged in as the selected user. If you assign a new role, you will be logged out of '{0}'.
+
+Are you sure you want to continue?</value>
+  </data>
+  <data name="AD_LOGOUT_USER_MANY" xml:space="preserve">
+    <value>Are you sure you want to log out these {0} users?</value>
+  </data>
+  <data name="AD_LOGOUT_USER_MANY_ROLE_CHANGE" xml:space="preserve">
+    <value>If you assign a new role to logged in users, they will be logged out.
+
+Are you sure you want to continue?</value>
+  </data>
+  <data name="AD_LOGOUT_USER_ONE" xml:space="preserve">
+    <value>Are you sure you want to log out the user '{0}'?</value>
+  </data>
+  <data name="AD_LOGOUT_USER_ONE_ROLE_CHANGE" xml:space="preserve">
+    <value>If you assign a new role to user '{0}', the user will be logged out.
+
+Are you sure you want to continue?</value>
+  </data>
+  <data name="AD_REMOVE_USER_MANY" xml:space="preserve">
+    <value>Are you sure you want to remove these {0} users?</value>
+  </data>
+  <data name="AD_REMOVE_USER_ONE" xml:space="preserve">
+    <value>Are you sure you want to remove the user '{0}'?</value>
   </data>
   <data name="AD_NOT_CONFIGURED_BLURB" xml:space="preserve">
     <value>AD is not currently configured for pool '{0}'. To enable AD authentication, click Join Domain.</value>
@@ -11023,18 +11055,6 @@ Click Previous if you need to go back and specify a different network location o
   </data>
   <data name="QUESTION_ADMIN_EXIT_PROCEDURE_SOME_OF_MANY" xml:space="preserve">
     <value>{0} of the users you are about to remove are Pool Administrators.</value>
-  </data>
-  <data name="QUESTION_LOGOUT_AD_USER_MANY" xml:space="preserve">
-    <value>Are you sure you want to log out these {0} users?</value>
-  </data>
-  <data name="QUESTION_LOGOUT_AD_USER_ONE" xml:space="preserve">
-    <value>Are you sure you want to log out the user '{0}'?</value>
-  </data>
-  <data name="QUESTION_REMOVE_AD_USER_MANY" xml:space="preserve">
-    <value>Are you sure you want to remove these {0} users?</value>
-  </data>
-  <data name="QUESTION_REMOVE_AD_USER_ONE" xml:space="preserve">
-    <value>Are you sure you want to remove the user '{0}'?</value>
   </data>
   <data name="QUIESCED_SNAPSHOTS" xml:space="preserve">
     <value>Quiesced snapshots</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1654,7 +1654,7 @@ Do you want to continue?</value>
     <value>Local root account</value>
   </data>
   <data name="AD_LOGOUT_SUICIDE_MANY" xml:space="preserve">
-    <value>You are currently logged in as one of the selected users. If you continue you will be logged out of '{0}'.
+    <value>You are currently logged in as one of the selected users. If you continue you will be logged out of '{0}'. All other selected users will also be logged out.
 
 Do you want to continue?</value>
   </data>
@@ -14773,5 +14773,11 @@ Any disk in your VM's DVD drive will be ejected when installing {1}.</value>
   </data>
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
+  </data>
+  <data name="AD_ADDING_REMOVING_ROLES_ON_MULTIPLE" xml:space="preserve">
+    <value>Assigning new roles to subjects '{0}'</value>
+  </data>
+  <data name="TERMINATING_USER_SESSION_MULTIPLE" xml:space="preserve">
+    <value>Terminating session for users '{0}'</value>
   </data>
 </root>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1579,14 +1579,14 @@ This will disconnect you from '{0}'.</value>
   <data name="AD_CONFIRM_SELF_TERMINATE_OK" xml:space="preserve">
     <value>Terminate Session</value>
   </data>
-  <data name="AD_CONFIRM_SUICIDE" xml:space="preserve">
+  <data name="AD_CONFIRM_LOGOUT_CURRENT_USER" xml:space="preserve">
     <value>You are about to revoke the permissions for user '{0}'.
 
 You are currently logged in as '{0}' on '{1}', and doing this will disconnect you from '{1}'. To reconnect, you will need to supply the local root account credentials, or the credentials for another authorized AD user.
 
 Do you want to continue?</value>
   </data>
-  <data name="AD_CONFIRM_SUICIDE_GROUP" xml:space="preserve">
+  <data name="AD_CONFIRM_LOGOUT_CURRENT_USER_GROUP" xml:space="preserve">
     <value>You are about to revoke the permissions for group '{0}'.
 
 The user you are currently logged into '{1}' with is a member of '{0}'. Proceeding will disconnect you and any other members of this group from '{1}'. To reconnect, you will need to supply the local root account credentials, or the credentials for another authorized AD user.
@@ -1653,12 +1653,12 @@ Do you want to continue?</value>
   <data name="AD_LOCAL_ROOT_ACCOUNT" xml:space="preserve">
     <value>Local root account</value>
   </data>
-  <data name="AD_LOGOUT_SUICIDE_MANY" xml:space="preserve">
+  <data name="AD_LOGOUT_CURRENT_USER_MANY" xml:space="preserve">
     <value>You are currently logged in as one of the selected users. If you continue you will be logged out of '{0}'. All other selected users will also be logged out.
 
 Do you want to continue?</value>
   </data>
-  <data name="AD_LOGOUT_SUICIDE_ONE" xml:space="preserve">
+  <data name="AD_LOGOUT_CURRENT_USER_ONE" xml:space="preserve">
     <value>You are currently logged in as the selected user. If you continue you will be logged out of '{0}'.
 
 Do you want to continue?</value>

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1912,6 +1912,12 @@ namespace XenAdmin.Core
             return connection?.Cache.GPU_groups.Any(g => g.PGPUs.Count > 0 && g.supported_VGPU_types.Count != 0) ?? false;
         }
 
+        public static List<Subject> LoggedInSubjects(IXenConnection connection)
+        {
+            var loggedInSids = connection.Session.get_all_subject_identifiers();
+            return connection.Cache.Subjects.Where(sub => loggedInSids.Contains(sub.subject_identifier)).ToList();
+        }
+
         public static bool ConnectionRequiresRbac(IXenConnection connection)
         {
             if (connection?.Session == null)

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1912,12 +1912,6 @@ namespace XenAdmin.Core
             return connection?.Cache.GPU_groups.Any(g => g.PGPUs.Count > 0 && g.supported_VGPU_types.Count != 0) ?? false;
         }
 
-        public static List<Subject> LoggedInSubjects(IXenConnection connection)
-        {
-            var loggedInSids = connection.Session.get_all_subject_identifiers();
-            return connection.Cache.Subjects.Where(sub => loggedInSids.Contains(sub.subject_identifier)).ToList();
-        }
-
         public static bool ConnectionRequiresRbac(IXenConnection connection)
         {
             if (connection?.Session == null)


### PR DESCRIPTION
Best reviewed commit-by-commit. Whitespace differences are the automatic indent as completed by VS2019.

Took advantage to improve UX slightly:
- Grouped logging out actions into a `MultipleAction` to avoid one RBAc prompt per user disconnection
- Tell user that they're also going to disconnect other users when the selected users include the current one.

Users will still need to insert credentials for two RBAC prompts if they're changing roles to logged in users (one for changing the roles, one for disconnections if necessary). Not ideal but it makes the code tidier since we can reuse methods.


Tested with:

| Changing current user 	| Changing other user(s) 	| Other user(s) are(is) logged in 	| More than one user involved 	| Result 	|
|:---:	|:---:	|---	|---	|---	|
| NO 	| YES 	| NO 	| YES 	| ✅ 	|
| NO 	| YES 	| YES 	| NO 	| ✅ 	|
| NO 	| YES 	| YES 	| YES 	| ✅ 	|
| NO 	| YES 	| NO 	| NO 	| ✅ 	|
| YES 	| NO 	| NO 	| NO 	| ✅ 	|
| YES 	| NO 	| YES 	| NO 	| ✅ 	|
| YES 	| YES 	| YES 	| YES 	| ✅ 	|