### PR TITLE
CP-38529: Replace built-in PuTTY with user-provided location

### DIFF
--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -1485,7 +1485,7 @@ namespace XenAdmin.ConsoleView
             var customSshConsole = Properties.Settings.Default.CustomSshConsole;
             var sshConsolePath = GetConsolePath(customSshConsole);
 
-            if (string.IsNullOrEmpty(sshConsolePath) || customSshConsole == SshConsole.None)
+            if (string.IsNullOrEmpty(sshConsolePath))
             {
                 OpenSshConsoleNotFoundDialog();
                 return;
@@ -1525,14 +1525,13 @@ namespace XenAdmin.ConsoleView
 
         private void OpenSshConsoleNotFoundDialog()
         {
-            var configureSshClientButton = new ThreeButtonDialog.TBDButton(Messages.CONFIGURE_SSH_CONSOLE_TITLE, DialogResult.Yes,
-                ThreeButtonDialog.ButtonType.NONE);
+            var configureSshClientButton = new ThreeButtonDialog.TBDButton(Messages.CONFIGURE_SSH_CONSOLE_TITLE,
+                DialogResult.OK, ThreeButtonDialog.ButtonType.ACCEPT, true);
 
-            var buttons = new[] { configureSshClientButton, ThreeButtonDialog.ButtonOK };
-            using (var dlg = new WarningDialog(Messages.CONFIGURE_SSH_CONSOLE_NOT_FOUND, buttons))
+            using (var dlg = new WarningDialog(Messages.CONFIGURE_SSH_CONSOLE_NOT_FOUND,
+                       configureSshClientButton, ThreeButtonDialog.ButtonCancel))
             {
-                var result = dlg.ShowDialog(Parent);
-                if (result == DialogResult.Yes)
+                if (dlg.ShowDialog(Parent) == DialogResult.OK)
                 {
                     OpenExternalToolsPage();
                 }
@@ -1541,14 +1540,13 @@ namespace XenAdmin.ConsoleView
 
         private void OpenSshConsoleErrorDialog()
         {
-            var configureSshClientButton = new ThreeButtonDialog.TBDButton(Messages.CONFIGURE_SSH_CONSOLE_TITLE, DialogResult.Yes,
-                ThreeButtonDialog.ButtonType.NONE);
+            var configureSshClientButton = new ThreeButtonDialog.TBDButton(Messages.CONFIGURE_SSH_CONSOLE_TITLE,
+                DialogResult.OK, ThreeButtonDialog.ButtonType.ACCEPT, true);
 
-            var buttons = new[] { configureSshClientButton, ThreeButtonDialog.ButtonOK };
-            using (var dlg = new ErrorDialog(Messages.CONFIGURE_SSH_CONSOLE_ERROR, buttons))
+            using (var dlg = new ErrorDialog(Messages.CONFIGURE_SSH_CONSOLE_ERROR,
+                       configureSshClientButton, ThreeButtonDialog.ButtonCancel))
             {
-                var result = dlg.ShowDialog(Parent);
-                if (result == DialogResult.Yes)
+                if (dlg.ShowDialog(Parent) == DialogResult.OK)
                 {
                     OpenExternalToolsPage();
                 }

--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -30,21 +30,22 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 using System.Threading;
-using XenAdmin.Core;
-using XenAdmin.Network;
-using XenAPI;
+using System.Windows.Forms;
 using XenAdmin.Commands;
-using XenAdmin.Dialogs;
-using System.Collections.Generic;
-using System.Diagnostics;
 using XenAdmin.Controls.ConsoleTab;
 using XenAdmin.Controls.GradientPanel;
+using XenAdmin.Core;
+using XenAdmin.Dialogs;
+using XenAdmin.Network;
+using XenAPI;
 
 
 namespace XenAdmin.ConsoleView
@@ -151,14 +152,14 @@ namespace XenAdmin.ConsoleView
             {
                 source.Connection.Cache.RegisterCollectionChanged<Host>(Host_CollectionChangedWithInvoke);
                 targetHost = source.GetStorageHost(false);
-                
+
                 foreach (Host cachedHost in source.Connection.Cache.Hosts)
                 {
                     log.DebugFormat("'{0}' console: Register Server_EnabledPropertyChanged event listener on {1}",
                                     source.Name(), cachedHost.Name());
                     cachedHost.PropertyChanged += Server_EnabledPropertyChanged;
                 }
-                
+
                 HostLabel.Visible = false;
             }
 
@@ -217,7 +218,7 @@ namespace XenAdmin.ConsoleView
 
             //If RDP enabled and AutoSwitchToRDP selected, switch RDP connection will be done when VNC already get the correct screen resolution.
             //This change is only for Cream, because RDP port scan was removed in Cream.
-            if (Properties.Settings.Default.AutoSwitchToRDP && RDPEnabled )
+            if (Properties.Settings.Default.AutoSwitchToRDP && RDPEnabled)
                 vncScreen.AutoSwitchRDPLater = true;
         }
 
@@ -236,11 +237,11 @@ namespace XenAdmin.ConsoleView
         private void toggleConsoleButton_EnabledChanged(object sender, EventArgs e)
         {
             ButtonBase button = sender as ButtonBase;
-            if(button == null)
+            if (button == null)
                 return;
 
             string format = "Console tab 'Switch to...' button disabled for VM '{0}'";
-            
+
             if (button.Enabled)
                 format = "Console tab 'Switch to...' button enabled for VM '{0}'";
 
@@ -298,7 +299,7 @@ namespace XenAdmin.ConsoleView
             source.Connection.Cache.DeregisterCollectionChanged<VM>(VM_CollectionChangedWithInvoke);
 
             if (this.guestMetrics != null)
-                this.guestMetrics.PropertyChanged -= guestMetrics_PropertyChanged; 
+                this.guestMetrics.PropertyChanged -= guestMetrics_PropertyChanged;
 
             if (source.IsControlDomainZero(out Host host))
             {
@@ -390,17 +391,18 @@ namespace XenAdmin.ConsoleView
             if (Properties.Settings.Default.DockShortcutKey == 1)
             {
                 // Alt + Shift + U
-                KeyHandler.AddKeyHandler(ConsoleShortcutKey.ALT_SHIFT_U, toggleDockUnDock);}
+                KeyHandler.AddKeyHandler(ConsoleShortcutKey.ALT_SHIFT_U, toggleDockUnDock);
+            }
             else if (Properties.Settings.Default.DockShortcutKey == 2)
             {
                 // F11
-                KeyHandler.AddKeyHandler(ConsoleShortcutKey.F11, toggleDockUnDock); 
+                KeyHandler.AddKeyHandler(ConsoleShortcutKey.F11, toggleDockUnDock);
             }
             else if (Properties.Settings.Default.DockShortcutKey == 0)
             {
                 // <none>
                 KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.ALT_SHIFT_U);
-                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.F11); 
+                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.F11);
             }
 
             UpdateDockButton();
@@ -409,12 +411,12 @@ namespace XenAdmin.ConsoleView
             if (Properties.Settings.Default.UncaptureShortcutKey == 0)
             {
                 // Right Ctrl
-                KeyHandler.AddKeyHandler(ConsoleShortcutKey.RIGHT_CTRL, ToggleConsoleFocus); 
+                KeyHandler.AddKeyHandler(ConsoleShortcutKey.RIGHT_CTRL, ToggleConsoleFocus);
             }
             else if (Properties.Settings.Default.UncaptureShortcutKey == 1)
             {
                 // Left Alt
-                KeyHandler.AddKeyHandler(ConsoleShortcutKey.LEFT_ALT, ToggleConsoleFocus); 
+                KeyHandler.AddKeyHandler(ConsoleShortcutKey.LEFT_ALT, ToggleConsoleFocus);
             }
         }
 
@@ -445,31 +447,31 @@ namespace XenAdmin.ConsoleView
             if (Properties.Settings.Default.FullScreenShortcutKey != 3)
             {
                 // Ctrl + Enter
-                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.CTRL_ENTER); 
+                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.CTRL_ENTER);
             }
 
             if (Properties.Settings.Default.DockShortcutKey != 1)
             {
                 // Alt + Shift + U
-                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.ALT_SHIFT_U); 
+                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.ALT_SHIFT_U);
             }
 
             if (Properties.Settings.Default.DockShortcutKey != 2)
             {
                 // F11
-                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.F11); 
+                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.F11);
             }
 
             // Uncapture keyboard and mouse Key
             if (Properties.Settings.Default.UncaptureShortcutKey != 0)
             {
                 // Right Ctrl
-                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.RIGHT_CTRL); 
+                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.RIGHT_CTRL);
             }
             if (Properties.Settings.Default.UncaptureShortcutKey != 1)
             {
                 // Left Alt
-                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.LEFT_ALT); 
+                KeyHandler.RemoveKeyHandler(ConsoleShortcutKey.LEFT_ALT);
             }
         }
 
@@ -523,11 +525,11 @@ namespace XenAdmin.ConsoleView
             else if (e.PropertyName == "guest_metrics")
             {
                 var newGuestMetrics = source.Connection.Resolve(source.guest_metrics);
-                
+
                 //unsubscribing from the previous instance's event
                 if (this.guestMetrics != null)
-                    this.guestMetrics.PropertyChanged -= guestMetrics_PropertyChanged; 
-                
+                    this.guestMetrics.PropertyChanged -= guestMetrics_PropertyChanged;
+
                 this.guestMetrics = newGuestMetrics;
                 if (this.guestMetrics != null)
                     guestMetrics.PropertyChanged += guestMetrics_PropertyChanged;
@@ -595,7 +597,7 @@ namespace XenAdmin.ConsoleView
                 // However, the current guest_metrics indicates that RDP is now supported (HasRDP==true). (eg. XenTools has been installed in the meantime.)
                 // This means that now we should show and enable the toggle RDP button and start polling (if allowed) RDP as well.
 
-                log.DebugFormat( "'{0}' console: Enabling RDP button, because RDP capability has appeared.", source);
+                log.DebugFormat("'{0}' console: Enabling RDP button, because RDP capability has appeared.", source);
 
                 toggleConsoleButton.Visible = true;
                 toggleConsoleButton.Enabled = true;
@@ -975,7 +977,7 @@ namespace XenAdmin.ConsoleView
         {
             Program.AssertOffEventThread();
 
-            Program.Invoke(this, delegate()
+            Program.Invoke(this, delegate ()
             {
                 lock (this.insKeyTimer)
                 {
@@ -1103,7 +1105,7 @@ namespace XenAdmin.ConsoleView
 
                 toggleConsoleButton.Enabled = true;
                 tip.SetToolTip(toggleConsoleButton, null);
-                if (!vncScreen.UserWantsToSwitchProtocol&& Properties.Settings.Default.AutoSwitchToRDP)
+                if (!vncScreen.UserWantsToSwitchProtocol && Properties.Settings.Default.AutoSwitchToRDP)
                 {
                     if (Program.MainWindow.TheTabControl.SelectedTab == Program.MainWindow.TabPageConsole)
                         toggleConsoleButton_Click(null, null);
@@ -1164,7 +1166,7 @@ namespace XenAdmin.ConsoleView
                         DialogResult dialogResult;
                         using (ThreeButtonDialog dlg = new NoIconDialog(Messages.FORCE_ENABLE_RDP,
                             ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo)
-                            {HelpNameSetter = "EnableRDPonVM"})
+                        { HelpNameSetter = "EnableRDPonVM" })
                         {
                             dialogResult = dlg.ShowDialog(Program.MainWindow);
                         }
@@ -1190,7 +1192,7 @@ namespace XenAdmin.ConsoleView
                 Unpause();
                 UpdateButtons();
             }
-            catch(COMException ex)
+            catch (COMException ex)
             {
                 log.DebugFormat("Disabling toggle-console button as COM related exception thrown: {0}", ex.Message);
                 toggleConsoleButton.Enabled = false;
@@ -1328,7 +1330,7 @@ namespace XenAdmin.ConsoleView
 
             if (!RDPControlEnabled)
                 toggleConsoleButton.Enabled = false;
-            
+
             vncScreen.imediatelyPollForConsole();
         }
 
@@ -1472,27 +1474,93 @@ namespace XenAdmin.ConsoleView
             if (vncScreen != null)
                 vncScreen.UpdateRDPResolution(fullscreen);
         }
-        
+
         #region SSH Console methods
 
         private void buttonSSH_Click(object sender, EventArgs e)
         {
-            if (IsSSHConsoleSupported && CanStartSSHConsole)
+            if (!IsSSHConsoleSupported || !CanStartSSHConsole) 
+                return;
+
+            var customSshConsole = Properties.Settings.Default.CustomSshConsole;
+            var sshConsolePath = GetConsolePath(customSshConsole);
+
+            if (string.IsNullOrEmpty(sshConsolePath) || customSshConsole == SshConsole.None)
             {
-                var puttyPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "putty.exe");
+                OpenSshConsoleNotFoundDialog();
+                return;
+            }
 
-                try
+            try
+            {
+                var command = $"{source.IPAddressForSSH()}";
+                if (customSshConsole == SshConsole.OpenSSH)
                 {
-                    var startInfo = new ProcessStartInfo(puttyPath, source.IPAddressForSSH());
-                    Process.Start(startInfo);
+                    // OpenSSH doesn't have an option to prompt the user for the username.
+                    // We use the session's subject.
+                    var currentSubject = source.Connection.Resolve(source.Connection.Session.SessionSubject);
+                    command = $"{currentSubject?.SubjectName ?? "root"}@{source.IPAddressForSSH()}";
                 }
-                catch (Exception ex)
-                {
-                    log.Error("Error starting PuTTY.", ex);
+                Process.Start(new ProcessStartInfo(sshConsolePath, command));
+            }
+            catch (Exception ex)
+            {
+                log.Error("Could not start the selected SSH console.", ex);
+                OpenSshConsoleErrorDialog();
+            }
+        }
 
-                    using (var dlg = new ErrorDialog(Messages.ERROR_PUTTY_LAUNCHING))
-                        dlg.ShowDialog(Parent);
+        private static string GetConsolePath(SshConsole customSshConsole)
+        {
+            switch (customSshConsole)
+            {
+                case SshConsole.Putty:
+                    return Properties.Settings.Default.PuttyLocation;
+                case SshConsole.OpenSSH:
+                    return Properties.Settings.Default.OpenSSHLocation;
+                default:
+                    return null;
+            }
+        }
+
+        private void OpenSshConsoleNotFoundDialog()
+        {
+            var configureSshClientButton = new ThreeButtonDialog.TBDButton(Messages.CONFIGURE_SSH_CONSOLE_TITLE, DialogResult.Yes,
+                ThreeButtonDialog.ButtonType.NONE);
+
+            var buttons = new[] { configureSshClientButton, ThreeButtonDialog.ButtonOK };
+            using (var dlg = new WarningDialog(Messages.CONFIGURE_SSH_CONSOLE_NOT_FOUND, buttons))
+            {
+                var result = dlg.ShowDialog(Parent);
+                if (result == DialogResult.Yes)
+                {
+                    OpenExternalToolsPage();
                 }
+            }
+        }
+
+        private void OpenSshConsoleErrorDialog()
+        {
+            var configureSshClientButton = new ThreeButtonDialog.TBDButton(Messages.CONFIGURE_SSH_CONSOLE_TITLE, DialogResult.Yes,
+                ThreeButtonDialog.ButtonType.NONE);
+
+            var buttons = new[] { configureSshClientButton, ThreeButtonDialog.ButtonOK };
+            using (var dlg = new ErrorDialog(Messages.CONFIGURE_SSH_CONSOLE_ERROR, buttons))
+            {
+                var result = dlg.ShowDialog(Parent);
+                if (result == DialogResult.Yes)
+                {
+                    OpenExternalToolsPage();
+                }
+            }
+        }
+
+        private void OpenExternalToolsPage()
+        {
+            using (var optionsDialog = new OptionsDialog(Program.MainWindow.PluginManager))
+            {
+                optionsDialog.SelectExternalToolsPage();
+                optionsDialog.ShowDialog();
             }
         }
 
@@ -1504,7 +1572,7 @@ namespace XenAdmin.ConsoleView
         }
 
         private bool IsSSHConsoleSupported
-        { 
+        {
             get
             {
                 if (source.IsWindows())

--- a/XenAdmin/ConsoleView/VNCTabView.resx
+++ b/XenAdmin/ConsoleView/VNCTabView.resx
@@ -577,7 +577,7 @@
     <value>2</value>
   </data>
   <data name="buttonSSH.Text" xml:space="preserve">
-    <value>Open SSH Console</value>
+    <value>Launch SSH Console</value>
   </data>
   <data name="&gt;&gt;buttonSSH.Name" xml:space="preserve">
     <value>buttonSSH</value>

--- a/XenAdmin/Dialogs/OptionsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/OptionsDialog.Designer.cs
@@ -39,6 +39,7 @@ namespace XenAdmin.Dialogs
             this.saveAndRestoreOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.SaveAndRestoreOptionsPage();
             this.pluginOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.PluginOptionsPage();
             this.confirmationOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.ConfirmationOptionsPage();
+            this.externalToolsOptionsPage1 = new XenAdmin.Dialogs.OptionsPages.ExternalToolsOptionsPage();
             this.ContentPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
@@ -46,11 +47,11 @@ namespace XenAdmin.Dialogs
             this.splitContainer.SuspendLayout();
             this.blueBorder.SuspendLayout();
             this.SuspendLayout();
-
             // 
             // ContentPanel
             // 
             resources.ApplyResources(this.ContentPanel, "ContentPanel");
+            this.ContentPanel.Controls.Add(this.externalToolsOptionsPage1);
             this.ContentPanel.Controls.Add(this.confirmationOptionsPage1);
             this.ContentPanel.Controls.Add(this.pluginOptionsPage1);
             this.ContentPanel.Controls.Add(this.saveAndRestoreOptionsPage1);
@@ -63,7 +64,7 @@ namespace XenAdmin.Dialogs
             // verticalTabs
             // 
             this.verticalTabs.Items.AddRange(new object[] {
-            this.confirmationOptionsPage1, 
+            this.confirmationOptionsPage1,
             this.pluginOptionsPage1,
             this.saveAndRestoreOptionsPage1,
             this.securityOptionsPage1,
@@ -71,7 +72,7 @@ namespace XenAdmin.Dialogs
             this.graphsOptionsPage1,
             this.consolesOptionsPage1,
             this.connectionOptionsPage1,
-            });
+            this.externalToolsOptionsPage1});
             resources.ApplyResources(this.verticalTabs, "verticalTabs");
             this.verticalTabs.SelectedIndexChanged += new System.EventHandler(this.verticalTabs_SelectedIndexChanged);
             // 
@@ -133,6 +134,11 @@ namespace XenAdmin.Dialogs
             resources.ApplyResources(this.confirmationOptionsPage1, "confirmationOptionsPage1");
             this.confirmationOptionsPage1.Name = "confirmationOptionsPage1";
             // 
+            // externalToolsOptionsPage1
+            // 
+            resources.ApplyResources(this.externalToolsOptionsPage1, "externalToolsOptionsPage1");
+            this.externalToolsOptionsPage1.Name = "externalToolsOptionsPage1";
+            // 
             // OptionsDialog
             // 
             resources.ApplyResources(this, "$this");
@@ -159,5 +165,6 @@ namespace XenAdmin.Dialogs
         private XenAdmin.Dialogs.OptionsPages.SaveAndRestoreOptionsPage saveAndRestoreOptionsPage1;
         private XenAdmin.Dialogs.OptionsPages.PluginOptionsPage pluginOptionsPage1;
         private OptionsPages.ConfirmationOptionsPage confirmationOptionsPage1;
+        private OptionsPages.ExternalToolsOptionsPage externalToolsOptionsPage1;
     }
 }

--- a/XenAdmin/Dialogs/OptionsDialog.cs
+++ b/XenAdmin/Dialogs/OptionsDialog.cs
@@ -94,6 +94,11 @@ namespace XenAdmin.Dialogs
             SelectPage(connectionOptionsPage1);
         }
 
+        public void SelectExternalToolsPage()
+        {
+            SelectPage(externalToolsOptionsPage1);
+        }
+
         private void OptionsDialog_Move(object sender, EventArgs e)
         {
             HideValidationToolTips();

--- a/XenAdmin/Dialogs/OptionsDialog.resx
+++ b/XenAdmin/Dialogs/OptionsDialog.resx
@@ -125,6 +125,40 @@
   <data name="ContentPanel.AutoScrollMinSize" type="System.Drawing.Size, System.Drawing">
     <value>486, 0</value>
   </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="externalToolsOptionsPage1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="externalToolsOptionsPage1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="externalToolsOptionsPage1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="externalToolsOptionsPage1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 49</value>
+  </data>
+  <data name="externalToolsOptionsPage1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="externalToolsOptionsPage1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>534, 466</value>
+  </data>
+  <data name="externalToolsOptionsPage1.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;externalToolsOptionsPage1.Name" xml:space="preserve">
+    <value>externalToolsOptionsPage1</value>
+  </data>
+  <data name="&gt;&gt;externalToolsOptionsPage1.Type" xml:space="preserve">
+    <value>XenAdmin.Dialogs.OptionsPages.ConnectionOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;externalToolsOptionsPage1.Parent" xml:space="preserve">
+    <value>ContentPanel</value>
+  </data>
+  <data name="&gt;&gt;externalToolsOptionsPage1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="confirmationOptionsPage1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -140,7 +174,6 @@
   <data name="confirmationOptionsPage1.Size" type="System.Drawing.Size, System.Drawing">
     <value>534, 466</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="confirmationOptionsPage1.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
@@ -148,13 +181,13 @@
     <value>confirmationOptionsPage1</value>
   </data>
   <data name="&gt;&gt;confirmationOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.ConfirmationOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.ConfirmationOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;confirmationOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;confirmationOptionsPage1.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="pluginOptionsPage1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -178,13 +211,13 @@
     <value>pluginOptionsPage1</value>
   </data>
   <data name="&gt;&gt;pluginOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.PluginOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.PluginOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pluginOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;pluginOptionsPage1.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="saveAndRestoreOptionsPage1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -211,13 +244,13 @@
     <value>saveAndRestoreOptionsPage1</value>
   </data>
   <data name="&gt;&gt;saveAndRestoreOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.SaveAndRestoreOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.SaveAndRestoreOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;saveAndRestoreOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;saveAndRestoreOptionsPage1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="securityOptionsPage1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -241,13 +274,13 @@
     <value>securityOptionsPage1</value>
   </data>
   <data name="&gt;&gt;securityOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.SecurityOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.SecurityOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;securityOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;securityOptionsPage1.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="updatesOptionsPage1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -271,13 +304,13 @@
     <value>updatesOptionsPage1</value>
   </data>
   <data name="&gt;&gt;updatesOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.UpdatesOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.UpdatesOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;updatesOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;updatesOptionsPage1.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="graphsOptionsPage1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -301,13 +334,13 @@
     <value>graphsOptionsPage1</value>
   </data>
   <data name="&gt;&gt;graphsOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.DisplayOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.DisplayOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;graphsOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;graphsOptionsPage1.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="consolesOptionsPage1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -334,13 +367,13 @@
     <value>consolesOptionsPage1</value>
   </data>
   <data name="&gt;&gt;consolesOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.ConsolesOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.ConsolesOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;consolesOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;consolesOptionsPage1.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="connectionOptionsPage1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -367,13 +400,13 @@
     <value>connectionOptionsPage1</value>
   </data>
   <data name="&gt;&gt;connectionOptionsPage1.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.OptionsPages.ConnectionOptionsPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.OptionsPages.ConnectionOptionsPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;connectionOptionsPage1.Parent" xml:space="preserve">
     <value>ContentPanel</value>
   </data>
   <data name="&gt;&gt;connectionOptionsPage1.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="ContentPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -406,7 +439,7 @@
     <value>verticalTabs</value>
   </data>
   <data name="&gt;&gt;verticalTabs.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.VerticalTabs, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.VerticalTabs, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;verticalTabs.Parent" xml:space="preserve">
     <value>splitContainer.Panel1</value>
@@ -490,7 +523,7 @@
     <value>blueBorder</value>
   </data>
   <data name="&gt;&gt;blueBorder.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.BlueBorderPanel, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blueBorder.Parent" xml:space="preserve">
     <value>splitContainer.Panel2</value>
@@ -523,6 +556,6 @@
     <value>OptionsDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.VerticallyTabbedDialog, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.VerticallyTabbedDialog, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.Designer.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.Designer.cs
@@ -1,0 +1,157 @@
+﻿
+namespace XenAdmin.Dialogs.OptionsPages
+{
+    partial class ExternalToolsOptionsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ExternalToolsOptionsPage));
+            this.externalToolsLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.sshConsoleGroupBox = new XenAdmin.Controls.DecentGroupBox();
+            this.sshConsoleLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.sshConsoleInfoLabel = new System.Windows.Forms.Label();
+            this.radioButtonPutty = new System.Windows.Forms.RadioButton();
+            this.radioButtonOpenSsh = new System.Windows.Forms.RadioButton();
+            this.buttonBrowseSsh = new System.Windows.Forms.Button();
+            this.textBoxOpenSsh = new System.Windows.Forms.TextBox();
+            this.textBoxPutty = new System.Windows.Forms.TextBox();
+            this.buttonBrowsePutty = new System.Windows.Forms.Button();
+            this.tooltipValidation = new System.Windows.Forms.ToolTip(this.components);
+            this.externalToolsLayoutPanel.SuspendLayout();
+            this.sshConsoleGroupBox.SuspendLayout();
+            this.sshConsoleLayoutPanel.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // externalToolsLayoutPanel
+            // 
+            resources.ApplyResources(this.externalToolsLayoutPanel, "externalToolsLayoutPanel");
+            this.externalToolsLayoutPanel.Controls.Add(this.sshConsoleGroupBox, 0, 1);
+            this.externalToolsLayoutPanel.Name = "externalToolsLayoutPanel";
+            // 
+            // sshConsoleGroupBox
+            // 
+            resources.ApplyResources(this.sshConsoleGroupBox, "sshConsoleGroupBox");
+            this.sshConsoleGroupBox.Controls.Add(this.sshConsoleLayoutPanel);
+            this.sshConsoleGroupBox.Name = "sshConsoleGroupBox";
+            this.sshConsoleGroupBox.TabStop = false;
+            // 
+            // sshConsoleLayoutPanel
+            // 
+            resources.ApplyResources(this.sshConsoleLayoutPanel, "sshConsoleLayoutPanel");
+            this.sshConsoleLayoutPanel.Controls.Add(this.sshConsoleInfoLabel, 0, 0);
+            this.sshConsoleLayoutPanel.Controls.Add(this.radioButtonPutty, 0, 1);
+            this.sshConsoleLayoutPanel.Controls.Add(this.radioButtonOpenSsh, 0, 3);
+            this.sshConsoleLayoutPanel.Controls.Add(this.buttonBrowseSsh, 1, 4);
+            this.sshConsoleLayoutPanel.Controls.Add(this.textBoxOpenSsh, 0, 4);
+            this.sshConsoleLayoutPanel.Controls.Add(this.textBoxPutty, 0, 2);
+            this.sshConsoleLayoutPanel.Controls.Add(this.buttonBrowsePutty, 1, 2);
+            this.sshConsoleLayoutPanel.Name = "sshConsoleLayoutPanel";
+            // 
+            // sshConsoleInfoLabel
+            // 
+            resources.ApplyResources(this.sshConsoleInfoLabel, "sshConsoleInfoLabel");
+            this.sshConsoleLayoutPanel.SetColumnSpan(this.sshConsoleInfoLabel, 2);
+            this.sshConsoleInfoLabel.Name = "sshConsoleInfoLabel";
+            // 
+            // radioButtonPutty
+            // 
+            resources.ApplyResources(this.radioButtonPutty, "radioButtonPutty");
+            this.radioButtonPutty.Name = "radioButtonPutty";
+            this.radioButtonPutty.TabStop = true;
+            this.radioButtonPutty.UseVisualStyleBackColor = true;
+            // 
+            // radioButtonOpenSsh
+            // 
+            resources.ApplyResources(this.radioButtonOpenSsh, "radioButtonOpenSsh");
+            this.radioButtonOpenSsh.Name = "radioButtonOpenSsh";
+            this.radioButtonOpenSsh.TabStop = true;
+            this.radioButtonOpenSsh.UseVisualStyleBackColor = true;
+            // 
+            // buttonBrowseSsh
+            // 
+            resources.ApplyResources(this.buttonBrowseSsh, "buttonBrowseSsh");
+            this.buttonBrowseSsh.Name = "buttonBrowseSsh";
+            this.buttonBrowseSsh.UseVisualStyleBackColor = true;
+            this.buttonBrowseSsh.Click += new System.EventHandler(this.buttonBrowseSsh_Click);
+            // 
+            // textBoxOpenSsh
+            // 
+            resources.ApplyResources(this.textBoxOpenSsh, "textBoxOpenSsh");
+            this.textBoxOpenSsh.Name = "textBoxOpenSsh";
+            this.textBoxOpenSsh.Text = global::XenAdmin.Properties.Settings.Default.OpenSSHLocation;
+            this.textBoxOpenSsh.TextChanged += new System.EventHandler(this.textBoxOpenSsh_TextChanged);
+            // 
+            // textBoxPutty
+            // 
+            resources.ApplyResources(this.textBoxPutty, "textBoxPutty");
+            this.textBoxPutty.Name = "textBoxPutty";
+            this.textBoxPutty.Text = global::XenAdmin.Properties.Settings.Default.PuttyLocation;
+            this.textBoxPutty.TextChanged += new System.EventHandler(this.textBoxPutty_TextChanged);
+            // 
+            // buttonBrowsePutty
+            // 
+            resources.ApplyResources(this.buttonBrowsePutty, "buttonBrowsePutty");
+            this.buttonBrowsePutty.Name = "buttonBrowsePutty";
+            this.buttonBrowsePutty.UseVisualStyleBackColor = true;
+            this.buttonBrowsePutty.Click += new System.EventHandler(this.buttonBrowsePutty_Click);
+            // 
+            // tooltipValidation
+            // 
+            this.tooltipValidation.IsBalloon = true;
+            this.tooltipValidation.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Warning;
+            // 
+            // ExternalToolsOptionsPage
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.externalToolsLayoutPanel);
+            this.Name = "ExternalToolsOptionsPage";
+            this.externalToolsLayoutPanel.ResumeLayout(false);
+            this.sshConsoleGroupBox.ResumeLayout(false);
+            this.sshConsoleLayoutPanel.ResumeLayout(false);
+            this.sshConsoleLayoutPanel.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel externalToolsLayoutPanel;
+        private Controls.DecentGroupBox sshConsoleGroupBox;
+        protected System.Windows.Forms.TableLayoutPanel sshConsoleLayoutPanel;
+        private System.Windows.Forms.Label sshConsoleInfoLabel;
+        private System.Windows.Forms.RadioButton radioButtonPutty;
+        private System.Windows.Forms.RadioButton radioButtonOpenSsh;
+        private System.Windows.Forms.Button buttonBrowseSsh;
+        private System.Windows.Forms.TextBox textBoxOpenSsh;
+        private System.Windows.Forms.TextBox textBoxPutty;
+        private System.Windows.Forms.Button buttonBrowsePutty;
+        private System.Windows.Forms.ToolTip tooltipValidation;
+    }
+}

--- a/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.cs
@@ -87,7 +87,6 @@ namespace XenAdmin.Dialogs.OptionsPages
             {
                 tooltipValidation.ToolTipTitle = Messages.FILE_NOT_FOUND;
                 HelpersGUI.ShowBalloonMessage(_tooltipControl, tooltipValidation);
-                _tooltipControl = null;
             }
         }
 
@@ -120,16 +119,12 @@ namespace XenAdmin.Dialogs.OptionsPages
 
         private void textBoxPutty_TextChanged(object sender, System.EventArgs e)
         {
-            if (radioButtonOpenSsh.Checked)
-                radioButtonOpenSsh.Checked = false;
             if (!radioButtonPutty.Checked)
                 radioButtonPutty.Checked = true;
         }
 
         private void textBoxOpenSsh_TextChanged(object sender, System.EventArgs e)
         {
-            if (radioButtonPutty.Checked)
-                radioButtonPutty.Checked = false;
             if (!radioButtonOpenSsh.Checked)
                 radioButtonOpenSsh.Checked = true;
         }
@@ -143,6 +138,7 @@ namespace XenAdmin.Dialogs.OptionsPages
         {
             OpenFileSelection(textBoxOpenSsh);
         }
+
         #endregion
 
         private void OpenFileSelection(TextBox textBox)

--- a/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.cs
@@ -1,0 +1,166 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using XenAdmin.Core;
+
+
+namespace XenAdmin.Dialogs.OptionsPages
+{
+    public partial class ExternalToolsOptionsPage : UserControl, IOptionsPage
+    {
+        private TextBox _tooltipControl;
+        public ExternalToolsOptionsPage()
+        {
+            InitializeComponent();
+            sshConsoleInfoLabel.Text = string.Format(sshConsoleInfoLabel.Text, BrandManager.BrandConsole);
+
+            var customSshConsole = Properties.Settings.Default.CustomSshConsole;
+
+            radioButtonOpenSsh.Checked = customSshConsole == SshConsole.OpenSSH;
+            radioButtonPutty.Checked = customSshConsole == SshConsole.Putty;
+        }
+
+        #region IOptionsPage Members
+
+        public void Build()
+        {
+
+        }
+
+        public bool IsValidToSave()
+        {
+            if (radioButtonPutty.Checked && !File.Exists(textBoxPutty.Text))
+            {
+                return false;
+            }
+
+            if (radioButtonOpenSsh.Checked && !File.Exists(textBoxOpenSsh.Text))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public void ShowValidationMessages()
+        {
+            if (radioButtonPutty.Checked && !File.Exists(textBoxPutty.Text))
+            {
+                _tooltipControl = textBoxPutty;
+            }
+            else if (radioButtonOpenSsh.Checked && !File.Exists(textBoxOpenSsh.Text))
+            {
+                _tooltipControl = textBoxOpenSsh;
+            }
+
+            if (_tooltipControl != null)
+            {
+                tooltipValidation.ToolTipTitle = Messages.FILE_NOT_FOUND;
+                HelpersGUI.ShowBalloonMessage(_tooltipControl, tooltipValidation);
+                _tooltipControl = null;
+            }
+        }
+
+        public void HideValidationMessages()
+        {
+            if (_tooltipControl != null)
+                tooltipValidation?.Hide(_tooltipControl);
+        }
+
+        public void Save()
+        {
+            Properties.Settings.Default.CustomSshConsole = radioButtonOpenSsh.Checked ? SshConsole.OpenSSH : SshConsole.Putty;
+            Properties.Settings.Default.OpenSSHLocation = textBoxOpenSsh.Text;
+            Properties.Settings.Default.PuttyLocation = textBoxPutty.Text;
+        }
+
+        #endregion
+
+        #region IVerticalTab Members
+
+        public override string Text => Messages.EXTERNAL_TOOLS;
+
+        public string SubText => Messages.EXTERNAL_TOOLS_DETAILS;
+
+        public Image Image => Images.StaticImages._001_Tools_h32bit_16;
+
+        #endregion
+
+        #region Event Handlers
+
+        private void textBoxPutty_TextChanged(object sender, System.EventArgs e)
+        {
+            if (radioButtonOpenSsh.Checked)
+                radioButtonOpenSsh.Checked = false;
+            if (!radioButtonPutty.Checked)
+                radioButtonPutty.Checked = true;
+        }
+
+        private void textBoxOpenSsh_TextChanged(object sender, System.EventArgs e)
+        {
+            if (radioButtonPutty.Checked)
+                radioButtonPutty.Checked = false;
+            if (!radioButtonOpenSsh.Checked)
+                radioButtonOpenSsh.Checked = true;
+        }
+
+        private void buttonBrowsePutty_Click(object sender, System.EventArgs e)
+        {
+            OpenFileSelection(textBoxPutty);
+        }
+
+        private void buttonBrowseSsh_Click(object sender, System.EventArgs e)
+        {
+            OpenFileSelection(textBoxOpenSsh);
+        }
+        #endregion
+
+        private void OpenFileSelection(TextBox textBox)
+        {
+            using (var dialog = new OpenFileDialog
+            {
+                Multiselect = false,
+                Title = Messages.EXTERNAL_TOOLS_OPEN_FILE_TITLE,
+                CheckFileExists = true,
+                CheckPathExists = true,
+                Filter = Messages.EXTERNAL_TOOLS_OPEN_FILE_TYPE
+            })
+            {
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    textBox.Text = dialog.FileName;
+                }
+            }
+        }
+    }
+}

--- a/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.ja.resx
+++ b/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.ja.resx
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="tooltipValidation.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>17, 17</value>
+  </data>
+</root>

--- a/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.resx
+++ b/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.resx
@@ -185,13 +185,13 @@
     <value>3, 43</value>
   </data>
   <data name="radioButtonPutty.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 19</value>
+    <value>58, 19</value>
   </data>
   <data name="radioButtonPutty.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>1</value>
   </data>
   <data name="radioButtonPutty.Text" xml:space="preserve">
-    <value>PuTTY</value>
+    <value>&amp;PuTTY</value>
   </data>
   <data name="&gt;&gt;radioButtonPutty.Name" xml:space="preserve">
     <value>radioButtonPutty</value>
@@ -221,7 +221,7 @@
     <value>4</value>
   </data>
   <data name="radioButtonOpenSsh.Text" xml:space="preserve">
-    <value>OpenSSH</value>
+    <value>&amp;OpenSSH</value>
   </data>
   <data name="&gt;&gt;radioButtonOpenSsh.Name" xml:space="preserve">
     <value>radioButtonOpenSsh</value>
@@ -245,10 +245,10 @@
     <value>78, 23</value>
   </data>
   <data name="buttonBrowseSsh.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="buttonBrowseSsh.Text" xml:space="preserve">
-    <value>Browse...</value>
+    <value>B&amp;rowse...</value>
   </data>
   <data name="&gt;&gt;buttonBrowseSsh.Name" xml:space="preserve">
     <value>buttonBrowseSsh</value>
@@ -275,7 +275,7 @@
     <value>416, 23</value>
   </data>
   <data name="textBoxOpenSsh.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;textBoxOpenSsh.Name" xml:space="preserve">
     <value>textBoxOpenSsh</value>
@@ -302,7 +302,7 @@
     <value>416, 23</value>
   </data>
   <data name="textBoxPutty.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;textBoxPutty.Name" xml:space="preserve">
     <value>textBoxPutty</value>
@@ -326,10 +326,10 @@
     <value>75, 23</value>
   </data>
   <data name="buttonBrowsePutty.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>3</value>
   </data>
   <data name="buttonBrowsePutty.Text" xml:space="preserve">
-    <value>Browse...</value>
+    <value>&amp;Browse...</value>
   </data>
   <data name="&gt;&gt;buttonBrowsePutty.Name" xml:space="preserve">
     <value>buttonBrowsePutty</value>
@@ -359,7 +359,7 @@
     <value>523, 170</value>
   </data>
   <data name="sshConsoleLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;sshConsoleLayoutPanel.Name" xml:space="preserve">
     <value>sshConsoleLayoutPanel</value>
@@ -374,7 +374,7 @@
     <value>0</value>
   </data>
   <data name="sshConsoleLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sshClientInfoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="radioButtonPutty" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonOpenSsh" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonBrowseSsh" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxOpenSsh" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxPutty" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonBrowsePutty" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sshConsoleInfoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="radioButtonPutty" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonOpenSsh" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonBrowseSsh" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxOpenSsh" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxPutty" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonBrowsePutty" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="sshConsoleGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -395,7 +395,7 @@
     <value>537, 200</value>
   </data>
   <data name="sshConsoleGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="sshConsoleGroupBox.Text" xml:space="preserve">
     <value>External SSH Console</value>
@@ -428,7 +428,7 @@
     <value>543, 288</value>
   </data>
   <data name="externalToolsLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;externalToolsLayoutPanel.Name" xml:space="preserve">
     <value>externalToolsLayoutPanel</value>
@@ -443,7 +443,7 @@
     <value>0</value>
   </data>
   <data name="externalToolsLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sshClientGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sshConsoleGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="tooltipValidation.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>

--- a/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.resx
+++ b/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.resx
@@ -1,0 +1,472 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="externalToolsLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="externalToolsLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="externalToolsLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="sshConsoleGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="sshConsoleInfoLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="sshConsoleInfoLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="sshConsoleInfoLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="sshConsoleInfoLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="sshConsoleInfoLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="sshConsoleInfoLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 10</value>
+  </data>
+  <data name="sshConsoleInfoLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>517, 30</value>
+  </data>
+  <data name="sshConsoleInfoLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="sshConsoleInfoLabel.Text" xml:space="preserve">
+    <value>{0} allows you to use an external SSH console to connect to the server and VMs that support SSH connection. Select below the console of your preference.
+</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleInfoLabel.Name" xml:space="preserve">
+    <value>sshConsoleInfoLabel</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleInfoLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleInfoLabel.Parent" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleInfoLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="radioButtonPutty.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonPutty.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="radioButtonPutty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 43</value>
+  </data>
+  <data name="radioButtonPutty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 19</value>
+  </data>
+  <data name="radioButtonPutty.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="radioButtonPutty.Text" xml:space="preserve">
+    <value>PuTTY</value>
+  </data>
+  <data name="&gt;&gt;radioButtonPutty.Name" xml:space="preserve">
+    <value>radioButtonPutty</value>
+  </data>
+  <data name="&gt;&gt;radioButtonPutty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonPutty.Parent" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;radioButtonPutty.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="radioButtonOpenSsh.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonOpenSsh.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="radioButtonOpenSsh.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 97</value>
+  </data>
+  <data name="radioButtonOpenSsh.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 19</value>
+  </data>
+  <data name="radioButtonOpenSsh.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="radioButtonOpenSsh.Text" xml:space="preserve">
+    <value>OpenSSH</value>
+  </data>
+  <data name="&gt;&gt;radioButtonOpenSsh.Name" xml:space="preserve">
+    <value>radioButtonOpenSsh</value>
+  </data>
+  <data name="&gt;&gt;radioButtonOpenSsh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioButtonOpenSsh.Parent" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;radioButtonOpenSsh.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="buttonBrowseSsh.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="buttonBrowseSsh.Location" type="System.Drawing.Point, System.Drawing">
+    <value>442, 122</value>
+  </data>
+  <data name="buttonBrowseSsh.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 23</value>
+  </data>
+  <data name="buttonBrowseSsh.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="buttonBrowseSsh.Text" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowseSsh.Name" xml:space="preserve">
+    <value>buttonBrowseSsh</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowseSsh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowseSsh.Parent" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowseSsh.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="textBoxOpenSsh.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="textBoxOpenSsh.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 122</value>
+  </data>
+  <data name="textBoxOpenSsh.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>20, 3, 3, 3</value>
+  </data>
+  <data name="textBoxOpenSsh.Size" type="System.Drawing.Size, System.Drawing">
+    <value>416, 23</value>
+  </data>
+  <data name="textBoxOpenSsh.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;textBoxOpenSsh.Name" xml:space="preserve">
+    <value>textBoxOpenSsh</value>
+  </data>
+  <data name="&gt;&gt;textBoxOpenSsh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBoxOpenSsh.Parent" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;textBoxOpenSsh.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="textBoxPutty.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="textBoxPutty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 68</value>
+  </data>
+  <data name="textBoxPutty.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>20, 3, 3, 3</value>
+  </data>
+  <data name="textBoxPutty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>416, 23</value>
+  </data>
+  <data name="textBoxPutty.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;textBoxPutty.Name" xml:space="preserve">
+    <value>textBoxPutty</value>
+  </data>
+  <data name="&gt;&gt;textBoxPutty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBoxPutty.Parent" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;textBoxPutty.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="buttonBrowsePutty.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="buttonBrowsePutty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>442, 68</value>
+  </data>
+  <data name="buttonBrowsePutty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonBrowsePutty.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="buttonBrowsePutty.Text" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowsePutty.Name" xml:space="preserve">
+    <value>buttonBrowsePutty</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowsePutty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowsePutty.Parent" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;buttonBrowsePutty.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 23</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>523, 170</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleLayoutPanel.Name" xml:space="preserve">
+    <value>sshConsoleLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleLayoutPanel.Parent" xml:space="preserve">
+    <value>sshConsoleGroupBox</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="sshConsoleLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sshClientInfoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="radioButtonPutty" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="radioButtonOpenSsh" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonBrowseSsh" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxOpenSsh" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textBoxPutty" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonBrowsePutty" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="sshConsoleGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="sshConsoleGroupBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="sshConsoleGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 5</value>
+  </data>
+  <data name="sshConsoleGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 5, 3, 10</value>
+  </data>
+  <data name="sshConsoleGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>7, 7, 7, 7</value>
+  </data>
+  <data name="sshConsoleGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>537, 200</value>
+  </data>
+  <data name="sshConsoleGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="sshConsoleGroupBox.Text" xml:space="preserve">
+    <value>External SSH Console</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleGroupBox.Name" xml:space="preserve">
+    <value>sshConsoleGroupBox</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleGroupBox.Parent" xml:space="preserve">
+    <value>externalToolsLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sshConsoleGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="externalToolsLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="externalToolsLayoutPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="externalToolsLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="externalToolsLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="externalToolsLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>543, 288</value>
+  </data>
+  <data name="externalToolsLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;externalToolsLayoutPanel.Name" xml:space="preserve">
+    <value>externalToolsLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;externalToolsLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;externalToolsLayoutPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;externalToolsLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="externalToolsLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sshClientGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="tooltipValidation.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>543, 288</value>
+  </data>
+  <data name="&gt;&gt;tooltipValidation.Name" xml:space="preserve">
+    <value>tooltipValidation</value>
+  </data>
+  <data name="&gt;&gt;tooltipValidation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>ExternalToolsOptionsPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.zh-CN.resx
+++ b/XenAdmin/Dialogs/OptionsPages/ExternalToolsOptionsPage.zh-CN.resx
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="tooltipValidation.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>17, 17</value>
+  </data>
+</root>

--- a/XenAdmin/MainWindow.Designer.cs
+++ b/XenAdmin/MainWindow.Designer.cs
@@ -15,7 +15,7 @@ namespace XenAdmin
         {
             Program.Exiting = true;
 
-            pluginManager.PluginsChanged -= pluginManager_PluginsChanged;
+            PluginManager.PluginsChanged -= pluginManager_PluginsChanged;
             UnRegisterEvents();
 
             if (disposing)
@@ -23,7 +23,7 @@ namespace XenAdmin
                 if (components != null)
                     components.Dispose();
 
-                pluginManager.Dispose();
+                PluginManager.Dispose();
 
                 log.Debug("MainWindow disposing of license timer");
                 if (licenseTimer != null)

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -128,7 +128,7 @@ namespace XenAdmin
 
         private static readonly System.Windows.Forms.Timer CheckForUpdatesTimer = new System.Windows.Forms.Timer();
 
-        private readonly PluginManager pluginManager;
+        public readonly PluginManager PluginManager;
         private readonly ContextMenuBuilder contextMenuBuilder;
 
         private readonly LicenseManagerLauncher licenseManagerLauncher;
@@ -220,11 +220,11 @@ namespace XenAdmin
             CommandLineArgType = argType;
             CommandLineParam = args;
 
-            pluginManager = new PluginManager();
-            pluginManager.PluginsChanged += pluginManager_PluginsChanged;
-            pluginManager.LoadPlugins();
-            contextMenuBuilder = new ContextMenuBuilder(pluginManager, this);
-            ((WinformsXenAdminConfigProvider) XenAdminConfigManager.Provider).PluginManager = pluginManager;
+            PluginManager = new PluginManager();
+            PluginManager.PluginsChanged += pluginManager_PluginsChanged;
+            PluginManager.LoadPlugins();
+            contextMenuBuilder = new ContextMenuBuilder(PluginManager, this);
+            ((WinformsXenAdminConfigProvider) XenAdminConfigManager.Provider).PluginManager = PluginManager;
 
             FormFontFixer.Fix(this);
 
@@ -634,7 +634,7 @@ namespace XenAdmin
 
                         if (result && dlg.IsCheckBoxChecked)
                         {
-                            using (var dialog = new OptionsDialog(pluginManager))
+                            using (var dialog = new OptionsDialog(PluginManager))
                             {
                                 dialog.SelectConnectionOptionsPage();
                                 dialog.ShowDialog(this);
@@ -1190,7 +1190,7 @@ namespace XenAdmin
                 }
 
                 selectedTabs.Remove(o);
-                pluginManager.DisposeURLs(o);
+                PluginManager.DisposeURLs(o);
             }
         }
 
@@ -1578,7 +1578,7 @@ namespace XenAdmin
             consoleFeatures = new List<TabPageFeature>();
             otherFeatures = new List<TabPageFeature>();
 
-            var plugins = pluginManager.Plugins;
+            var plugins = PluginManager.Plugins;
             foreach (var p in plugins)
             {
                 var features = p.Features;
@@ -1703,7 +1703,7 @@ namespace XenAdmin
                 bool itemAdded = false;
 
                 // add plugin items for this menu at insertIndex
-                foreach (PluginDescriptor plugin in pluginManager.Plugins)
+                foreach (PluginDescriptor plugin in PluginManager.Plugins)
                 {
                     if (!plugin.Enabled)
                         continue;
@@ -2118,7 +2118,7 @@ namespace XenAdmin
 
         private void UpdateTabePageFeatures()
         {
-            var plugins = pluginManager.Plugins;
+            var plugins = PluginManager.Plugins;
             foreach (var p in plugins)
             {
                 var features = p.Features;
@@ -2689,7 +2689,7 @@ namespace XenAdmin
 
         private void preferencesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            using (var dialog = new OptionsDialog(pluginManager))
+            using (var dialog = new OptionsDialog(PluginManager))
                 dialog.ShowDialog(this);
         }
 

--- a/XenAdmin/Program.cs
+++ b/XenAdmin/Program.cs
@@ -34,18 +34,17 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Configuration;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Windows.Forms;
 using System.Threading;
-using System.Drawing;
-using System.Linq;
+using System.Windows.Forms;
 using XenAdmin.Core;
-using XenAdmin.Network;
 using XenAdmin.Dialogs;
-using XenAdmin.Help;
+using XenAdmin.Network;
 using XenAdmin.XenSearch;
 using XenAPI;
 using XenCenterLib;
@@ -96,7 +95,7 @@ namespace XenAdmin
 
         public static CollectionChangeEventHandler ProgramInvokeHandler(CollectionChangeEventHandler handler)
         {
-            return delegate(object s, CollectionChangeEventArgs args)
+            return delegate (object s, CollectionChangeEventArgs args)
             {
                 if (MainWindow != null)
                 {
@@ -181,14 +180,14 @@ namespace XenAdmin
                 var msg = string.Format("{0}\n\n{1}", Messages.MESSAGEBOX_LOAD_CORRUPTED_TITLE,
                                         string.Format(Messages.MESSAGEBOX_LOAD_CORRUPTED, Settings.GetUserConfigPath()));
                 using (var dlg = new ErrorDialog(msg)
-                               {
-                                   StartPosition = FormStartPosition.CenterScreen,
-                                   //For reasons I do not fully comprehend at the moment, the runtime
-                                   //overrides the above StartPosition with WindowsDefaultPosition if
-                                   //ShowInTaskbar is false. However it's a good idea anyway to show it
-                                   //in the taskbar since the main form is not launched at this point.
-                                   ShowInTaskbar = true
-                               })
+                {
+                    StartPosition = FormStartPosition.CenterScreen,
+                    //For reasons I do not fully comprehend at the moment, the runtime
+                    //overrides the above StartPosition with WindowsDefaultPosition if
+                    //ShowInTaskbar is false. However it's a good idea anyway to show it
+                    //in the taskbar since the main form is not launched at this point.
+                    ShowInTaskbar = true
+                })
                 {
                     dlg.ShowDialog();
                 }
@@ -206,7 +205,7 @@ namespace XenAdmin
 
             Search.InitSearch(BrandManager.ExtensionSearch);
             TreeSearch.InitSearch();
-            
+
             AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             Application.ThreadException -= Application_ThreadException;
@@ -277,6 +276,8 @@ namespace XenAdmin
 
             Application.ApplicationExit -= Application_ApplicationExit;
             Application.ApplicationExit += Application_ApplicationExit;
+
+            Settings.ConfigureExternalSshClientSettings();
 
             MainWindow mainWindow = new MainWindow(firstArgType, tailArgs);
             Application.Run(mainWindow);
@@ -352,7 +353,7 @@ namespace XenAdmin
 
             log.InfoFormat(@"Successfully created pipe '{0}' - proceeding to launch XenCenter", pipe_path);
 
-            pipe.Read += delegate(object sender, NamedPipes.PipeReadEventArgs e)
+            pipe.Read += delegate (object sender, NamedPipes.PipeReadEventArgs e)
             {
                 MainWindow m = MainWindow;
                 if (m == null || RunInAutomatedTestMode)
@@ -362,18 +363,18 @@ namespace XenAdmin
 
                 var firstArgType = ParseFileArgs(bits, out string[] tailArgs);
 
-                    if (firstArgType == ArgType.Passwords)
-                    {
-                        log.ErrorFormat("Refusing to accept passwords request down pipe.  Use {0}Main.exe directly", BrandManager.BrandConsole.Replace(" ",""));
-                        return;
-                    }
-                    if (firstArgType == ArgType.Connect)
-                    {
-                        log.ErrorFormat("Connect not supported down pipe. Use {0}Main.exe directly", BrandManager.BrandConsole.Replace(" ",""));
-                        return;
-                    }
-                    if (firstArgType == ArgType.None)
-                        return;
+                if (firstArgType == ArgType.Passwords)
+                {
+                    log.ErrorFormat("Refusing to accept passwords request down pipe.  Use {0}Main.exe directly", BrandManager.BrandConsole.Replace(" ", ""));
+                    return;
+                }
+                if (firstArgType == ArgType.Connect)
+                {
+                    log.ErrorFormat("Connect not supported down pipe. Use {0}Main.exe directly", BrandManager.BrandConsole.Replace(" ", ""));
+                    return;
+                }
+                if (firstArgType == ArgType.None)
+                    return;
 
                 // The C++ splash screen passes its command line as a literal string.
                 // This means we will get an e.Message like
@@ -460,7 +461,7 @@ namespace XenAdmin
 
             log.InfoFormat("Virtual memory size: {0} B({1})", p.VirtualMemorySize64, Util.MemorySizeStringSuitableUnits(p.VirtualMemorySize64, false));
             log.InfoFormat("Working set: {0} B({1})", p.WorkingSet64, Util.MemorySizeStringSuitableUnits(p.WorkingSet64, false));
-            log.InfoFormat("Private memory size: {0} B({1})",p.PrivateMemorySize64, Util.MemorySizeStringSuitableUnits(p.PrivateMemorySize64, false));
+            log.InfoFormat("Private memory size: {0} B({1})", p.PrivateMemorySize64, Util.MemorySizeStringSuitableUnits(p.PrivateMemorySize64, false));
             log.InfoFormat("Nonpaged system memory size: {0} B({1})", p.NonpagedSystemMemorySize64, Util.MemorySizeStringSuitableUnits(p.NonpagedSystemMemorySize64, false));
             log.InfoFormat("Paged memory size: {0} B({1})", p.PagedMemorySize64, Util.MemorySizeStringSuitableUnits(p.PagedMemorySize64, false));
             log.InfoFormat("Paged system memory size: {0} B({1})", p.PagedSystemMemorySize64, Util.MemorySizeStringSuitableUnits(p.PagedSystemMemorySize64, false));
@@ -513,7 +514,7 @@ namespace XenAdmin
                     string filepath = GetLogFile() ?? Messages.MESSAGEBOX_LOGFILE_MISSING;
 
                     using (var d = new ErrorDialog(String.Format(Messages.MESSAGEBOX_PROGRAM_UNEXPECTED, HelpersGUI.DateTimeToString(DateTime.Now, "yyyy-MM-dd HH:mm:ss", false), filepath))
-                        {WindowTitle = string.Format(Messages.MESSAGEBOX_PROGRAM_UNEXPECTED_TITLE, BrandManager.BrandConsole)})
+                    { WindowTitle = string.Format(Messages.MESSAGEBOX_PROGRAM_UNEXPECTED_TITLE, BrandManager.BrandConsole) })
                     {
                         // CA-44733
                         if (IsInvokable(MainWindow) && !MainWindow.InvokeRequired)
@@ -671,7 +672,7 @@ namespace XenAdmin
             else
             {
                 using (var dlg = new ErrorDialog(msg)
-                    {WindowTitle = string.Format(Messages.MESSAGEBOX_PROGRAM_UNEXPECTED_TITLE, BrandManager.BrandConsole)})
+                { WindowTitle = string.Format(Messages.MESSAGEBOX_PROGRAM_UNEXPECTED_TITLE, BrandManager.BrandConsole) })
                     dlg.ShowDialog();
             }
         }

--- a/XenAdmin/Properties/Settings.Designer.cs
+++ b/XenAdmin/Properties/Settings.Designer.cs
@@ -856,6 +856,7 @@ namespace XenAdmin.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public global::XenAdmin.SshConsole CustomSshConsole {
             get {
                 return ((global::XenAdmin.SshConsole)(this["CustomSshConsole"]));
@@ -868,6 +869,7 @@ namespace XenAdmin.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public string PuttyLocation {
             get {
                 return ((string)(this["PuttyLocation"]));
@@ -880,6 +882,7 @@ namespace XenAdmin.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public string OpenSSHLocation {
             get {
                 return ((string)(this["OpenSSHLocation"]));

--- a/XenAdmin/Properties/Settings.Designer.cs
+++ b/XenAdmin/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace XenAdmin.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -850,6 +850,42 @@ namespace XenAdmin.Properties {
             }
             set {
                 this["RemindChangePassword"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public global::XenAdmin.SshConsole CustomSshConsole {
+            get {
+                return ((global::XenAdmin.SshConsole)(this["CustomSshConsole"]));
+            }
+            set {
+                this["CustomSshConsole"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string PuttyLocation {
+            get {
+                return ((string)(this["PuttyLocation"]));
+            }
+            set {
+                this["PuttyLocation"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string OpenSSHLocation {
+            get {
+                return ((string)(this["OpenSSHLocation"]));
+            }
+            set {
+                this["OpenSSHLocation"] = value;
             }
         }
     }

--- a/XenAdmin/Properties/Settings.settings
+++ b/XenAdmin/Properties/Settings.settings
@@ -197,13 +197,13 @@
     <Setting Name="RemindChangePassword" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="CustomSshConsole" Type="XenAdmin.Core.SSHClient" Scope="User">
+    <Setting Name="CustomSshConsole" Roaming="true" Type="XenAdmin.SshConsole" Scope="User">
       <Value Profile="(Default)">None</Value>
     </Setting>
-    <Setting Name="PuttyLocation" Type="System.String" Scope="User">
+    <Setting Name="PuttyLocation" Roaming="true" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="OpenSSHLocation" Type="System.String" Scope="User">
+    <Setting Name="OpenSSHLocation" Roaming="true" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
   </Settings>

--- a/XenAdmin/Properties/Settings.settings
+++ b/XenAdmin/Properties/Settings.settings
@@ -197,5 +197,14 @@
     <Setting Name="RemindChangePassword" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="CustomSshConsole" Type="XenAdmin.Core.SSHClient" Scope="User">
+      <Value Profile="(Default)">None</Value>
+    </Setting>
+    <Setting Name="PuttyLocation" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="OpenSSHLocation" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/XenAdmin/Settings.cs
+++ b/XenAdmin/Settings.cs
@@ -37,6 +37,7 @@ using XenAdmin.Dialogs;
 using XenAdmin.Dialogs.RestoreSession;
 using XenAdmin.Network;
 using System.Configuration;
+using System.IO;
 using XenCenterLib;
 using System.Linq;
 
@@ -301,6 +302,65 @@ namespace XenAdmin
             }
 
             return true;
+        }
+
+        public static void ConfigureExternalSshClientSettings()
+        {
+            var customSshClient = Properties.Settings.Default.CustomSshConsole;
+            var puttyLocation = Properties.Settings.Default.PuttyLocation;
+            var openSshLocation = Properties.Settings.Default.OpenSSHLocation;
+
+            // if user has uninstalled or moved a client, we reset their locations
+            puttyLocation = File.Exists(puttyLocation) ? puttyLocation : null;
+            openSshLocation = File.Exists(openSshLocation) ? openSshLocation : null;
+            if (string.IsNullOrEmpty(puttyLocation) && customSshClient == SshConsole.Putty ||
+                string.IsNullOrEmpty(openSshLocation) && customSshClient == SshConsole.OpenSSH)
+            {
+                customSshClient = SshConsole.None;
+            }
+
+            // attempt to locate clients in their default locations
+            if (string.IsNullOrEmpty(puttyLocation))
+            {
+                var defaultPaths = new[] {
+                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "PuTTY\\putty.exe"),
+                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "PuTTY\\putty.exe")
+                };
+                puttyLocation = defaultPaths.Where(File.Exists).FirstOrDefault();
+            }
+            if (string.IsNullOrEmpty(openSshLocation))
+            {
+                // https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration
+                var defaultPath = Path.Combine(Environment.SystemDirectory, "OpenSSH\\ssh.exe");
+                openSshLocation = File.Exists(defaultPath) ? defaultPath : openSshLocation;
+            }
+
+            // we prioritize PuTTY since that must have been installed by the user
+            if (customSshClient == SshConsole.None)
+            {
+                if (!string.IsNullOrEmpty(puttyLocation))
+                {
+                    customSshClient = SshConsole.Putty;
+                }
+                else if (!string.IsNullOrEmpty(openSshLocation))
+                {
+                    customSshClient = SshConsole.OpenSSH;
+                }
+            }
+
+            // avoid updating settings if they haven't changed
+            if (customSshClient != Properties.Settings.Default.CustomSshConsole)
+            {
+                Properties.Settings.Default.CustomSshConsole = customSshClient;
+            }
+            if (puttyLocation != null && !puttyLocation.Equals(Properties.Settings.Default.PuttyLocation))
+            {
+                Properties.Settings.Default.PuttyLocation = puttyLocation;
+            }
+            if (openSshLocation != null && !openSshLocation.Equals(Properties.Settings.Default.OpenSSHLocation))
+            {
+                Properties.Settings.Default.OpenSSHLocation = openSshLocation;
+            }
         }
 
         private static void AddConnection(IXenConnection connection)

--- a/XenAdmin/TabPages/GeneralTabPage.Designer.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.Designer.cs
@@ -33,8 +33,6 @@ namespace XenAdmin.TabPages
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GeneralTabPage));
             this.buttonProperties = new System.Windows.Forms.Button();
-            this.buttonViewConsole = new System.Windows.Forms.Button();
-            this.buttonViewLog = new System.Windows.Forms.Button();
             this.linkLabelExpand = new System.Windows.Forms.LinkLabel();
             this.linkLabelCollapse = new System.Windows.Forms.LinkLabel();
             this.panel2 = new XenAdmin.Controls.PanelNoFocusScroll();
@@ -116,20 +114,6 @@ namespace XenAdmin.TabPages
             this.buttonProperties.Name = "buttonProperties";
             this.buttonProperties.UseVisualStyleBackColor = true;
             this.buttonProperties.Click += new System.EventHandler(this.buttonProperties_Click);
-            // 
-            // buttonViewConsole
-            // 
-            resources.ApplyResources(this.buttonViewConsole, "buttonViewConsole");
-            this.buttonViewConsole.Name = "buttonViewConsole";
-            this.buttonViewConsole.UseVisualStyleBackColor = true;
-            this.buttonViewConsole.Click += new System.EventHandler(this.buttonViewConsole_Click);
-            // 
-            // buttonViewLog
-            // 
-            resources.ApplyResources(this.buttonViewLog, "buttonViewLog");
-            this.buttonViewLog.Name = "buttonViewLog";
-            this.buttonViewLog.UseVisualStyleBackColor = true;
-            this.buttonViewLog.Click += new System.EventHandler(this.buttonViewLog_Click);
             // 
             // linkLabelExpand
             // 
@@ -434,8 +418,6 @@ namespace XenAdmin.TabPages
             // tableLayoutPanelButtons
             // 
             resources.ApplyResources(this.tableLayoutPanelButtons, "tableLayoutPanelButtons");
-            this.tableLayoutPanelButtons.Controls.Add(this.buttonViewLog, 2, 0);
-            this.tableLayoutPanelButtons.Controls.Add(this.buttonViewConsole, 1, 0);
             this.tableLayoutPanelButtons.Controls.Add(this.buttonProperties, 0, 0);
             this.tableLayoutPanelButtons.Controls.Add(this.linkLabelCollapse, 5, 0);
             this.tableLayoutPanelButtons.Controls.Add(this.linkLabelExpand, 4, 0);
@@ -522,8 +504,6 @@ namespace XenAdmin.TabPages
         private Controls.PDSection pdSectionDockerInfo;
         private System.Windows.Forms.Panel panelReadCaching;
         private Controls.PDSection pdSectionReadCaching;
-        private System.Windows.Forms.Button buttonViewConsole;
-        private System.Windows.Forms.Button buttonViewLog;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelButtons;
         private System.Windows.Forms.Panel panelCertificate;
         private Controls.PDSection pdSectionCertificate;

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -32,9 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
@@ -57,7 +55,7 @@ namespace XenAdmin.TabPages
 
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private readonly List<PDSection> sections= new List<PDSection>();
+        private readonly List<PDSection> sections = new List<PDSection>();
         private readonly Dictionary<Type, List<PDSection>> _expandedSections = new Dictionary<Type, List<PDSection>>();
 
         private IXenObject xenObject;
@@ -82,7 +80,7 @@ namespace XenAdmin.TabPages
 
             VM_guest_metrics_CollectionChangedWithInvoke = Program.ProgramInvokeHandler(VM_guest_metrics_CollectionChanged);
             OtherConfigAndTagsWatcher.TagsChanged += OtherConfigAndTagsWatcher_TagsChanged;
-            
+
             foreach (Control control in panel2.Controls)
             {
                 if (!(control is Panel p))
@@ -97,7 +95,7 @@ namespace XenAdmin.TabPages
                     s.ContentReceivedFocus += s_ContentReceivedFocus;
                     s.ExpandedChanged += s_ExpandedChanged;
                 }
-            }            
+            }
         }
 
         public override string HelpID => "TabPageSettings";
@@ -190,7 +188,7 @@ namespace XenAdmin.TabPages
 
                 if (xenObject != null && !_expandedSections.TryGetValue(xenObject.GetType(), out expandedSections))
                 {
-                    expandedSections = new List<PDSection> {pdSectionGeneral};
+                    expandedSections = new List<PDSection> { pdSectionGeneral };
                     _expandedSections[xenObject.GetType()] = expandedSections;
                 }
 
@@ -349,22 +347,13 @@ namespace XenAdmin.TabPages
             {
                 buttonProperties.Visible = false;
 
-                buttonViewConsole.Visible = buttonViewLog.Visible = linkLabelCollapse.Visible =
+                linkLabelCollapse.Visible =
                     linkLabelExpand.Visible = !Helpers.StockholmOrGreater(xenObject.Connection);
-
-                if (!Helpers.StockholmOrGreater(xenObject.Connection))
-                {
-                    // Grey out the buttons if the Container management VM is Windows.
-                    // For Linux VM, enable the buttons only when the docker is running.
-                    buttonViewConsole.Enabled = buttonViewLog.Enabled =
-                        !container.Parent.IsWindows() && container.power_state == vm_power_state.Running;
-                }
             }
             else
             {
                 buttonProperties.Visible = true;
                 buttonProperties.Enabled = xenObject != null && !xenObject.Locked && xenObject.Connection != null && xenObject.Connection.IsConnected;
-                buttonViewConsole.Visible = buttonViewLog.Visible = false;
                 linkLabelCollapse.Visible = linkLabelExpand.Visible = true;
             }
         }
@@ -409,7 +398,7 @@ namespace XenAdmin.TabPages
                 s.ClearData();
             }
             // Generate the content of each box, each method performs a cast and only populates if XenObject is the relevant type
-           
+
             if (xenObject is Host && (xenObject.Connection == null || !xenObject.Connection.IsConnected))
             {
                 GenerateDisconnectedHostBox();
@@ -539,7 +528,7 @@ namespace XenAdmin.TabPages
 
             foreach (CustomField customField in customFields)
             {
-                var editValue = new ToolStripMenuItem(Messages.EDIT) {Image = Images.StaticImages.edit_16};
+                var editValue = new ToolStripMenuItem(Messages.EDIT) { Image = Images.StaticImages.edit_16 };
                 editValue.Click += delegate
                     {
                         using (PropertiesDialog dialog = new PropertiesDialog(xenObject))
@@ -672,10 +661,10 @@ namespace XenAdmin.TabPages
             bool detached = !sr.HasPBDs();
 
             var repairItem = new ToolStripMenuItem
-                {
-                    Text = Messages.GENERAL_SR_CONTEXT_REPAIR,
-                    Image = Images.StaticImages._000_StorageBroken_h32bit_16
-                };
+            {
+                Text = Messages.GENERAL_SR_CONTEXT_REPAIR,
+                Image = Images.StaticImages._000_StorageBroken_h32bit_16
+            };
             repairItem.Click += delegate
                 {
                     Program.MainWindow.ShowPerConnectionWizard(xenObject.Connection, new RepairSRDialog(sr));
@@ -885,8 +874,8 @@ namespace XenAdmin.TabPages
 
             PDSection s = pdSectionBootOptions;
 
-        	if (vm.IsHVM())
-            {	
+            if (vm.IsHVM())
+            {
                 s.AddEntry(FriendlyName("VM.BootOrder"), HVMBootOrder(vm),
                     new PropertiesToolStripMenuItem(new VmEditStartupOptionsCommand(Program.MainWindow, vm)));
                 if (Helpers.NaplesOrGreater(vm.Connection))
@@ -1055,8 +1044,8 @@ namespace XenAdmin.TabPages
             if (vm == null)
                 return;
 
-            PDSection s = pdSectionVCPUs; 
-            
+            PDSection s = pdSectionVCPUs;
+
             s.AddEntry(FriendlyName("VM.VCPUs"), vm.VCPUs_at_startup.ToString());
             if (vm.VCPUs_at_startup != vm.VCPUs_max || vm.SupportsVcpuHotplug())
                 s.AddEntry(FriendlyName("VM.MaxVCPUs"), vm.VCPUs_max.ToString());
@@ -1193,7 +1182,8 @@ namespace XenAdmin.TabPages
                         s.AddEntry(Messages.CERTIFICATE_VERIFICATION_KEY,
                             Messages.CERTIFICATE_VERIFICATION_HOST_DISABLED_STANDALONE,
                             Color.Red,
-                            new CommandToolStripMenuItem(new EnableTlsVerificationCommand(Program.MainWindow, pool)));}
+                            new CommandToolStripMenuItem(new EnableTlsVerificationCommand(Program.MainWindow, pool)));
+                    }
                     else
                     {
                         s.AddEntry(Messages.CERTIFICATE_VERIFICATION_KEY,
@@ -1234,11 +1224,11 @@ namespace XenAdmin.TabPages
                     s.AddEntry(Messages.BIOS_STRINGS_COPIED, vm.BiosStringsCopied() ? Messages.YES : Messages.NO);
                 }
 
-				if (vm.Connection != null)
-				{
-					var appl = vm.Connection.Resolve(vm.appliance);
-					if (appl != null)
-					{
+                if (vm.Connection != null)
+                {
+                    var appl = vm.Connection.Resolve(vm.appliance);
+                    if (appl != null)
+                    {
                         void LaunchProperties()
                         {
                             using (PropertiesDialog propertiesDialog = new PropertiesDialog(appl))
@@ -1250,9 +1240,9 @@ namespace XenAdmin.TabPages
 
                         s.AddEntryLink(Messages.VM_APPLIANCE, appl.Name(), LaunchProperties, applProperties);
                     }
-				}
+                }
 
-            	if (vm.is_a_snapshot)
+                if (vm.is_a_snapshot)
                 {
                     VM snapshotOf = vm.Connection.Resolve(vm.snapshot_of);
                     s.AddEntry(Messages.SNAPSHOT_OF, snapshotOf == null ? string.Empty : snapshotOf.Name());
@@ -1362,7 +1352,7 @@ namespace XenAdmin.TabPages
                         if (string.IsNullOrEmpty(hotfixEligibilityString))
                             s.AddEntry(Messages.SOFTWARE_VERSION_PRODUCT_VERSION, coordinator.ProductVersionText());
                         else
-                            s.AddEntry(Messages.SOFTWARE_VERSION_PRODUCT_VERSION, 
+                            s.AddEntry(Messages.SOFTWARE_VERSION_PRODUCT_VERSION,
                                 string.Format(Messages.MAINWINDOW_CONTEXT_REASON, coordinator.ProductVersionText(), hotfixEligibilityString),
                                 Color.Red);
                     }
@@ -1446,7 +1436,7 @@ namespace XenAdmin.TabPages
                     return Messages.HOTFIX_ELIGIBILITY_WARNING_EOL_FREE_NO_DATE;
                 case hotfix_eligibility.none:
                     return Messages.HOTFIX_ELIGIBILITY_WARNING_EOL_NO_DATE;
-                
+
                 // default
                 default:
                     return string.Empty;
@@ -1485,7 +1475,7 @@ namespace XenAdmin.TabPages
                     }
 
                     //Row 3 : vendor device - Windows Update
-                    if(!HiddenFeatures.WindowsUpdateHidden)
+                    if (!HiddenFeatures.WindowsUpdateHidden)
                         sb.Append(vm.has_vendor_device ? Messages.VIRTUALIZATION_STATE_VM_RECEIVING_UPDATES : Messages.VIRTUALIZATION_STATE_VM_NOT_RECEIVING_UPDATES);
 
                     // displaying Row1 - Row3
@@ -1641,7 +1631,7 @@ namespace XenAdmin.TabPages
         private void GenTagRow(PDSection s)
         {
             string[] tags = Tags.GetTags(xenObject);
-            
+
             if (tags != null && tags.Length > 0)
             {
                 ToolStripMenuItem goToTag = new ToolStripMenuItem(Messages.VIEW_TAG_MENU_OPTION);
@@ -1694,11 +1684,11 @@ namespace XenAdmin.TabPages
 
             PDSection s = pdSectionMemory;
 
-      
+
             s.AddEntry(FriendlyName("host.ServerMemory"), host.HostMemoryString());
             s.AddEntry(FriendlyName("host.VMMemory"), host.ResidentVMMemoryUsageString());
             s.AddEntry(FriendlyName("host.XenMemory"), host.XenMemoryString());
-            
+
         }
 
         private void addStringEntry(PDSection s, string key, string value)
@@ -1815,7 +1805,7 @@ namespace XenAdmin.TabPages
 
         private string poolAppliedPatches()
         {
-            return 
+            return
                 Helpers.ElyOrGreater(xenObject.Connection)
                 ? poolUpdateString(update => update.AppliedOnHosts().Count == xenObject.Connection.Cache.HostCount)
                 : poolPatchString(patch => patch.host_patches.Count == xenObject.Connection.Cache.HostCount);
@@ -1928,7 +1918,7 @@ namespace XenAdmin.TabPages
         private List<KeyValuePair<String, String>> CheckHostUpdatesRequiringReboot(Host host)
         {
             var warnings = new List<KeyValuePair<String, String>>();
-            
+
             // Updates that require host restart
             var updateRefs = host.updates_requiring_reboot;
             foreach (var updateRef in updateRefs)
@@ -1973,7 +1963,7 @@ namespace XenAdmin.TabPages
             {
                 value = string.Format(Messages.GENERAL_PANEL_UPDATE_RESTART_TOOLSTACK_WARNING, host.Name(), patch.Name());
             }
-            
+
             return new KeyValuePair<string, string>(key, value);
         }
 
@@ -1984,7 +1974,7 @@ namespace XenAdmin.TabPages
 
             return new KeyValuePair<string, string>(key, value);
         }
- 
+
         private static string FriendlyName(string propertyName)
         {
             return FriendlyNameManager.GetFriendlyName(string.Format("Label-{0}", propertyName)) ?? propertyName;
@@ -2027,61 +2017,13 @@ namespace XenAdmin.TabPages
             new PropertiesCommand(Program.MainWindow, xenObject).Run();
         }
 
-        private void buttonViewConsole_Click(object sender, EventArgs e)
-        {
-            //Set command 'docker attach' to attach to the container.
-            StartPutty("env docker attach --sig-proxy=false");
-        }
-
-        private void buttonViewLog_Click(object sender, EventArgs e)
-        {
-            //Set command 'docker logs' to retrieve the logs of the container.
-            StartPutty( "env docker logs --tail=50 --follow --timestamps");
-        }
-
         private void panel2_Paint(object sender, PaintEventArgs e)
-        {   
+        {
             //Force scrollbar to be repainted to avoid occasional pixel glitch.
             panel2.AutoScroll = sections.Sum(s => s.Parent?.Height ?? s.Height) > panel2.ClientRectangle.Height;
         }
 
         #endregion
-
-        private void StartPutty(string dockerCmd)
-        {
-            if (!(xenObject is DockerContainer dockerContainer) || Helpers.StockholmOrGreater(xenObject.Connection))
-                return;
-
-            string ipAddr = dockerContainer.Parent.IPAddressForSSH();
-            string command = $"{dockerCmd} {dockerContainer.uuid}";
-
-            try
-            {
-                //Write docker command to a temp file.
-                string cmdFile = Path.Combine(Path.GetTempPath(), "ContainerManagementCommand.txt");
-                File.WriteAllText(cmdFile, command);
-
-                //Invoke Putty, SSH to VM and run docker command.
-                var puttyPath = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "putty.exe");
-                string args = "-m " + cmdFile + " -t " + ipAddr;
-
-                //Specify the key for SSH connection.
-                var keyFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "ContainerManagement.ppk");
-                if (File.Exists(keyFile))
-                {
-                    args = args + " -i " + keyFile;
-                }
-                var startInfo = new ProcessStartInfo(puttyPath, args);
-
-                Process.Start(startInfo);
-            }
-            catch (Exception ex)
-            {
-                log.Error("Error starting PuTTY.", ex);
-                using (var dlg = new ErrorDialog(Messages.ERROR_PUTTY_LAUNCHING))
-                    dlg.ShowDialog(Parent);
-            }
-        }
 
         private void ToggleExpandedState(Func<PDSection, bool> expand)
         {

--- a/XenAdmin/TabPages/GeneralTabPage.resx
+++ b/XenAdmin/TabPages/GeneralTabPage.resx
@@ -157,7 +157,7 @@
     <value>pdSectionReadCaching</value>
   </data>
   <data name="&gt;&gt;pdSectionReadCaching.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionReadCaching.Parent" xml:space="preserve">
     <value>panelReadCaching</value>
@@ -226,7 +226,7 @@
     <value>pdSectionDockerInfo</value>
   </data>
   <data name="&gt;&gt;pdSectionDockerInfo.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionDockerInfo.Parent" xml:space="preserve">
     <value>panelDockerInfo</value>
@@ -295,7 +295,7 @@
     <value>pdSectionDockerVersion</value>
   </data>
   <data name="&gt;&gt;pdSectionDockerVersion.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionDockerVersion.Parent" xml:space="preserve">
     <value>panelDockerVersion</value>
@@ -364,7 +364,7 @@
     <value>pdSectionStorageLinkSystemCapabilities</value>
   </data>
   <data name="&gt;&gt;pdSectionStorageLinkSystemCapabilities.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionStorageLinkSystemCapabilities.Parent" xml:space="preserve">
     <value>panelStorageLinkSystemCapabilities</value>
@@ -433,7 +433,7 @@
     <value>pdSectionMultipathBoot</value>
   </data>
   <data name="&gt;&gt;pdSectionMultipathBoot.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionMultipathBoot.Parent" xml:space="preserve">
     <value>panelMultipathBoot</value>
@@ -502,7 +502,7 @@
     <value>pdStorageLink</value>
   </data>
   <data name="&gt;&gt;pdStorageLink.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdStorageLink.Parent" xml:space="preserve">
     <value>panelStorageLink</value>
@@ -571,7 +571,7 @@
     <value>pdSectionVCPUs</value>
   </data>
   <data name="&gt;&gt;pdSectionVCPUs.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionVCPUs.Parent" xml:space="preserve">
     <value>panelMemoryAndVCPUs</value>
@@ -640,7 +640,7 @@
     <value>pdSectionMultipathing</value>
   </data>
   <data name="&gt;&gt;pdSectionMultipathing.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionMultipathing.Parent" xml:space="preserve">
     <value>panelMultipathing</value>
@@ -709,7 +709,7 @@
     <value>pdSectionStatus</value>
   </data>
   <data name="&gt;&gt;pdSectionStatus.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionStatus.Parent" xml:space="preserve">
     <value>panelStatus</value>
@@ -778,7 +778,7 @@
     <value>pdSectionHighAvailability</value>
   </data>
   <data name="&gt;&gt;pdSectionHighAvailability.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionHighAvailability.Parent" xml:space="preserve">
     <value>panelHighAvailability</value>
@@ -847,7 +847,7 @@
     <value>pdSectionBootOptions</value>
   </data>
   <data name="&gt;&gt;pdSectionBootOptions.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionBootOptions.Parent" xml:space="preserve">
     <value>panelBootOptions</value>
@@ -916,7 +916,7 @@
     <value>pdSectionCPU</value>
   </data>
   <data name="&gt;&gt;pdSectionCPU.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionCPU.Parent" xml:space="preserve">
     <value>panelCPU</value>
@@ -985,7 +985,7 @@
     <value>pdSectionMemory</value>
   </data>
   <data name="&gt;&gt;pdSectionMemory.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionMemory.Parent" xml:space="preserve">
     <value>panelMemory</value>
@@ -1054,7 +1054,7 @@
     <value>pdSectionManagementInterfaces</value>
   </data>
   <data name="&gt;&gt;pdSectionManagementInterfaces.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionManagementInterfaces.Parent" xml:space="preserve">
     <value>panelManagementInterfaces</value>
@@ -1123,7 +1123,7 @@
     <value>pdSectionUpdates</value>
   </data>
   <data name="&gt;&gt;pdSectionUpdates.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionUpdates.Parent" xml:space="preserve">
     <value>panelUpdates</value>
@@ -1192,7 +1192,7 @@
     <value>pdSectionVersion</value>
   </data>
   <data name="&gt;&gt;pdSectionVersion.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionVersion.Parent" xml:space="preserve">
     <value>panelVersion</value>
@@ -1261,7 +1261,7 @@
     <value>pdSectionLicense</value>
   </data>
   <data name="&gt;&gt;pdSectionLicense.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionLicense.Parent" xml:space="preserve">
     <value>panelLicense</value>
@@ -1330,7 +1330,7 @@
     <value>pdSectionCustomFields</value>
   </data>
   <data name="&gt;&gt;pdSectionCustomFields.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionCustomFields.Parent" xml:space="preserve">
     <value>panelCustomFields</value>
@@ -1399,7 +1399,7 @@
     <value>pdSectionCertificate</value>
   </data>
   <data name="&gt;&gt;pdSectionCertificate.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionCertificate.Parent" xml:space="preserve">
     <value>panelCertificate</value>
@@ -1468,7 +1468,7 @@
     <value>pdSectionGeneral</value>
   </data>
   <data name="&gt;&gt;pdSectionGeneral.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PDSection, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PDSection, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pdSectionGeneral.Parent" xml:space="preserve">
     <value>panelGeneral</value>
@@ -1519,7 +1519,7 @@
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.PanelNoFocusScroll, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.PanelNoFocusScroll, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
     <value>pageContainerPanel</value>
@@ -1535,60 +1535,6 @@
   </data>
   <data name="tableLayoutPanelButtons.ColumnCount" type="System.Int32, mscorlib">
     <value>6</value>
-  </data>
-  <data name="buttonViewLog.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonViewLog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>180, 3</value>
-  </data>
-  <data name="buttonViewLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
-  </data>
-  <data name="buttonViewLog.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="buttonViewLog.Text" xml:space="preserve">
-    <value>View &amp;Log</value>
-  </data>
-  <data name="&gt;&gt;buttonViewLog.Name" xml:space="preserve">
-    <value>buttonViewLog</value>
-  </data>
-  <data name="&gt;&gt;buttonViewLog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonViewLog.Parent" xml:space="preserve">
-    <value>tableLayoutPanelButtons</value>
-  </data>
-  <data name="&gt;&gt;buttonViewLog.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="buttonViewConsole.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonViewConsole.Location" type="System.Drawing.Point, System.Drawing">
-    <value>84, 3</value>
-  </data>
-  <data name="buttonViewConsole.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
-  </data>
-  <data name="buttonViewConsole.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="buttonViewConsole.Text" xml:space="preserve">
-    <value>View &amp;Console</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.Name" xml:space="preserve">
-    <value>buttonViewConsole</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.Parent" xml:space="preserve">
-    <value>tableLayoutPanelButtons</value>
-  </data>
-  <data name="&gt;&gt;buttonViewConsole.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="buttonProperties.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
@@ -1612,7 +1558,7 @@
     <value>tableLayoutPanelButtons</value>
   </data>
   <data name="&gt;&gt;buttonProperties.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="linkLabelCollapse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
@@ -1642,7 +1588,7 @@
     <value>tableLayoutPanelButtons</value>
   </data>
   <data name="&gt;&gt;linkLabelCollapse.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="linkLabelExpand.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
@@ -1672,7 +1618,7 @@
     <value>tableLayoutPanelButtons</value>
   </data>
   <data name="&gt;&gt;linkLabelExpand.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="tableLayoutPanelButtons.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -1705,7 +1651,7 @@
     <value>1</value>
   </data>
   <data name="tableLayoutPanelButtons.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="buttonViewLog" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="buttonViewConsole" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonProperties" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelCollapse" Row="0" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelExpand" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="buttonProperties" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelCollapse" Row="0" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="linkLabelExpand" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="pageContainerPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 78</value>
@@ -1741,6 +1687,6 @@
     <value>GeneralTabPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.TabPages.BaseTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.TabPages.BaseTabPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -304,6 +304,12 @@
     <Compile Include="Dialogs\OptionsPages\ConfirmationOptionsPage.Designer.cs">
       <DependentUpon>ConfirmationOptionsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="Dialogs\OptionsPages\ExternalToolsOptionsPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Dialogs\OptionsPages\ExternalToolsOptionsPage.Designer.cs">
+      <DependentUpon>ExternalToolsOptionsPage.cs</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\OvfValidationDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1808,6 +1814,15 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\OptionsPages\ConfirmationOptionsPage.zh-CN.resx">
       <DependentUpon>ConfirmationOptionsPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\OptionsPages\ExternalToolsOptionsPage.ja.resx">
+      <DependentUpon>ExternalToolsOptionsPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\OptionsPages\ExternalToolsOptionsPage.resx">
+      <DependentUpon>ExternalToolsOptionsPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\OptionsPages\ExternalToolsOptionsPage.zh-CN.resx">
+      <DependentUpon>ExternalToolsOptionsPage.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\OvfValidationDialog.ja.resx">
       <DependentUpon>OvfValidationDialog.cs</DependentUpon>

--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -195,6 +195,9 @@
             <setting name="RemindChangePassword" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="CustomSshConsole" serializeAs="String">
+                <value>None</value>
+            </setting>
             <setting name="PuttyLocation" serializeAs="String">
                 <value />
             </setting>

--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -195,6 +195,12 @@
             <setting name="RemindChangePassword" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="PuttyLocation" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="OpenSSHLocation" serializeAs="String">
+                <value />
+            </setting>
         </XenAdmin.Properties.Settings>
     </userSettings>
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8040,7 +8040,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configure SSH Console.
+        ///   Looks up a localized string similar to Configure &amp;SSH Console.
         /// </summary>
         public static string CONFIGURE_SSH_CONSOLE_TITLE {
             get {
@@ -17051,14 +17051,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path section {0} matches a device name..
-        /// </summary>
-        public static string FILE_PATH_DEVICE_NAME_ERROR_MESSAGE {
-            get {
-                return ResourceManager.GetString("FILE_PATH_DEVICE_NAME_ERROR_MESSAGE", resourceCulture);
-            }
-        }
-
         ///   Looks up a localized string similar to File not found.
         /// </summary>
         public static string FILE_NOT_FOUND {
@@ -17067,7 +17059,15 @@ namespace XenAdmin {
             }
         }
         
-
+        /// <summary>
+        ///   Looks up a localized string similar to Path section {0} matches a device name..
+        /// </summary>
+        public static string FILE_PATH_DEVICE_NAME_ERROR_MESSAGE {
+            get {
+                return ResourceManager.GetString("FILE_PATH_DEVICE_NAME_ERROR_MESSAGE", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Acrobat (PDF) file.
         /// </summary>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -8022,6 +8022,33 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your external SSH console could not be launched. Please check that you have selected a valid file..
+        /// </summary>
+        public static string CONFIGURE_SSH_CONSOLE_ERROR {
+            get {
+                return ResourceManager.GetString("CONFIGURE_SSH_CONSOLE_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your external SSH console could not be found. Please check that you have selected a valid file..
+        /// </summary>
+        public static string CONFIGURE_SSH_CONSOLE_NOT_FOUND {
+            get {
+                return ResourceManager.GetString("CONFIGURE_SSH_CONSOLE_NOT_FOUND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configure SSH Console.
+        /// </summary>
+        public static string CONFIGURE_SSH_CONSOLE_TITLE {
+            get {
+                return ResourceManager.GetString("CONFIGURE_SSH_CONSOLE_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Configuring Workload Balancing .
         /// </summary>
         public static string CONFIGURING_WLB {
@@ -16826,6 +16853,42 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to External Tools.
+        /// </summary>
+        public static string EXTERNAL_TOOLS {
+            get {
+                return ResourceManager.GetString("EXTERNAL_TOOLS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manage external tools.
+        /// </summary>
+        public static string EXTERNAL_TOOLS_DETAILS {
+            get {
+                return ResourceManager.GetString("EXTERNAL_TOOLS_DETAILS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select SSH console.
+        /// </summary>
+        public static string EXTERNAL_TOOLS_OPEN_FILE_TITLE {
+            get {
+                return ResourceManager.GetString("EXTERNAL_TOOLS_OPEN_FILE_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Executables (*.exe)|*.exe.
+        /// </summary>
+        public static string EXTERNAL_TOOLS_OPEN_FILE_TYPE {
+            get {
+                return ResourceManager.GetString("EXTERNAL_TOOLS_OPEN_FILE_TYPE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed.
         /// </summary>
         public static string FAILED {
@@ -16995,7 +17058,16 @@ namespace XenAdmin {
                 return ResourceManager.GetString("FILE_PATH_DEVICE_NAME_ERROR_MESSAGE", resourceCulture);
             }
         }
+
+        ///   Looks up a localized string similar to File not found.
+        /// </summary>
+        public static string FILE_NOT_FOUND {
+            get {
+                return ResourceManager.GetString("FILE_NOT_FOUND", resourceCulture);
+            }
+        }
         
+
         /// <summary>
         ///   Looks up a localized string similar to Acrobat (PDF) file.
         /// </summary>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2889,7 +2889,7 @@ Do you want to assign it to the schedule '{2}' instead?</value>
     <value>Your external SSH console could not be found. Please check that you have selected a valid file.</value>
   </data>
   <data name="CONFIGURE_SSH_CONSOLE_TITLE" xml:space="preserve">
-    <value>Configure SSH Console</value>
+    <value>Configure &amp;SSH Console</value>
   </data>
   <data name="CONFIGURING_WLB" xml:space="preserve">
     <value>Configuring Workload Balancing </value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -14737,4 +14737,28 @@ Any disk in your VM's DVD drive will be ejected when installing {1}.</value>
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
   </data>
+  <data name="EXTERNAL_TOOLS" xml:space="preserve">
+    <value>External Tools</value>
+  </data>
+  <data name="EXTERNAL_TOOLS_DETAILS" xml:space="preserve">
+    <value>Manage external tools</value>
+  </data>
+  <data name="EXTERNAL_TOOLS_OPEN_FILE_TITLE" xml:space="preserve">
+    <value>Select SSH console</value>
+  </data>
+  <data name="EXTERNAL_TOOLS_OPEN_FILE_TYPE" xml:space="preserve">
+    <value>Executables (*.exe)|*.exe</value>
+  </data>
+  <data name="FILE_NOT_FOUND" xml:space="preserve">
+    <value>File not found</value>
+  </data>
+  <data name="CONFIGURE_SSH_CONSOLE_ERROR" xml:space="preserve">
+    <value>Your external SSH console could not be launched. Please check that you have selected a valid file.</value>
+  </data>
+  <data name="CONFIGURE_SSH_CONSOLE_NOT_FOUND" xml:space="preserve">
+    <value>Your external SSH console could not be found. Please check that you have selected a valid file.</value>
+  </data>
+  <data name="CONFIGURE_SSH_CONSOLE_TITLE" xml:space="preserve">
+    <value>Configure SSH Console</value>
+  </data>
 </root>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2882,6 +2882,15 @@ Do you want to assign it to the schedule '{2}' instead?</value>
   <data name="CONFIGURE_HA_ELLIPSIS" xml:space="preserve">
     <value>&amp;Configure HA...</value>
   </data>
+  <data name="CONFIGURE_SSH_CONSOLE_ERROR" xml:space="preserve">
+    <value>Your external SSH console could not be launched. Please check that you have selected a valid file.</value>
+  </data>
+  <data name="CONFIGURE_SSH_CONSOLE_NOT_FOUND" xml:space="preserve">
+    <value>Your external SSH console could not be found. Please check that you have selected a valid file.</value>
+  </data>
+  <data name="CONFIGURE_SSH_CONSOLE_TITLE" xml:space="preserve">
+    <value>Configure SSH Console</value>
+  </data>
   <data name="CONFIGURING_WLB" xml:space="preserve">
     <value>Configuring Workload Balancing </value>
   </data>
@@ -5884,6 +5893,18 @@ Would you like to eject these ISOs before continuing?</value>
   <data name="EXTERNAL_PLUGIN_WIN32" xml:space="preserve">
     <value>Failed to run plug-in executable. Please see the client log for details.</value>
   </data>
+  <data name="EXTERNAL_TOOLS" xml:space="preserve">
+    <value>External Tools</value>
+  </data>
+  <data name="EXTERNAL_TOOLS_DETAILS" xml:space="preserve">
+    <value>Manage external tools</value>
+  </data>
+  <data name="EXTERNAL_TOOLS_OPEN_FILE_TITLE" xml:space="preserve">
+    <value>Select SSH console</value>
+  </data>
+  <data name="EXTERNAL_TOOLS_OPEN_FILE_TYPE" xml:space="preserve">
+    <value>Executables (*.exe)|*.exe</value>
+  </data>
   <data name="FAILED" xml:space="preserve">
     <value>Failed</value>
   </data>
@@ -5940,6 +5961,9 @@ Would you like to eject these ISOs before continuing?</value>
   </data>
   <data name="FILE_NAME_IS_DEVICE_NAME_ERROR_MESSAGE" xml:space="preserve">
     <value>A file name cannot be a device name.</value>
+  </data>
+  <data name="FILE_NOT_FOUND" xml:space="preserve">
+    <value>File not found</value>
   </data>
   <data name="FILE_PATH_DEVICE_NAME_ERROR_MESSAGE" xml:space="preserve">
     <value>Path section {0} matches a device name.</value>
@@ -14736,29 +14760,5 @@ Any disk in your VM's DVD drive will be ejected when installing {1}.</value>
   </data>
   <data name="YOU_ARE_HERE" xml:space="preserve">
     <value>You are here</value>
-  </data>
-  <data name="EXTERNAL_TOOLS" xml:space="preserve">
-    <value>External Tools</value>
-  </data>
-  <data name="EXTERNAL_TOOLS_DETAILS" xml:space="preserve">
-    <value>Manage external tools</value>
-  </data>
-  <data name="EXTERNAL_TOOLS_OPEN_FILE_TITLE" xml:space="preserve">
-    <value>Select SSH console</value>
-  </data>
-  <data name="EXTERNAL_TOOLS_OPEN_FILE_TYPE" xml:space="preserve">
-    <value>Executables (*.exe)|*.exe</value>
-  </data>
-  <data name="FILE_NOT_FOUND" xml:space="preserve">
-    <value>File not found</value>
-  </data>
-  <data name="CONFIGURE_SSH_CONSOLE_ERROR" xml:space="preserve">
-    <value>Your external SSH console could not be launched. Please check that you have selected a valid file.</value>
-  </data>
-  <data name="CONFIGURE_SSH_CONSOLE_NOT_FOUND" xml:space="preserve">
-    <value>Your external SSH console could not be found. Please check that you have selected a valid file.</value>
-  </data>
-  <data name="CONFIGURE_SSH_CONSOLE_TITLE" xml:space="preserve">
-    <value>Configure SSH Console</value>
   </data>
 </root>

--- a/XenModel/SshConsole.cs
+++ b/XenModel/SshConsole.cs
@@ -1,0 +1,40 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+namespace XenAdmin
+{
+    public enum SshConsole
+    {
+        None = 0,
+        Putty = 1,
+        OpenSSH = 2
+    }
+}

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Actions\ZipStatusReportAction.cs" />
     <Compile Include="Alerts\Types\Alert.cs" />
     <Compile Include="BrandManager.cs" />
+    <Compile Include="SshConsole.cs" />
     <Compile Include="PathValidator.cs" />
     <Compile Include="UnitStrings.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Some automatic whitespace changes so I suggest you remove those diffs.

Tried to make it easy to review commit-by-commit.

You won't be able to see the "warning" version of the error dialog unless CHC can't find either client on first start-up. So best approach is probably to temporarily rename the `.exe`s.

Defaults paths are:

`C:\Windows\System32\OpenSSH\ssh.exe`
`C:\Program Files\PuTTY\putty.exe`