### PR TITLE
CP-32667 Added download action to CHC

### DIFF
--- a/XenAdmin/Alerts/Types/ClientUpdateAlert.cs
+++ b/XenAdmin/Alerts/Types/ClientUpdateAlert.cs
@@ -68,6 +68,13 @@ namespace XenAdmin.Alerts
 
         public override string HelpID => "XenCenterUpdateAlert";
 
+        public bool Downloadable { 
+            get {
+                // TODO: Implement proper check in CP-31587
+                return false; 
+            }
+        }
+
         static int DISMISSED_XC_VERSIONS_LIMIT = 5;
 
         public override void Dismiss()

--- a/XenAdmin/TabPages/ManageUpdatesPage.cs
+++ b/XenAdmin/TabPages/ManageUpdatesPage.cs
@@ -830,6 +830,14 @@ namespace XenAdmin.TabPages
                 items.Add(fix);
             }
 
+            if (alert is ClientUpdateAlert)
+            {
+                var download = new ToolStripMenuItem(Messages.UPDATES_DOWNLOAD_AND_INSTALL);
+                download.Click += ToolStripMenuItemDownloadInstall_Click;
+                download.Enabled = (alert as ClientUpdateAlert).Downloadable; 
+                items.Add(download);
+            }
+
             if (items.Count > 0)
                 items.Add(new ToolStripSeparator());
 
@@ -954,6 +962,11 @@ namespace XenAdmin.TabPages
                 var selectedAlerts = from DataGridViewRow row in dataGridViewUpdates.SelectedRows select row.Tag as Alert;
                 DismissUpdates(selectedAlerts.ToList());
             }
+        }
+
+        private void ToolStripMenuItemDownloadInstall_Click(object sender, EventArgs e)
+        {
+            throw new NotImplementedException("To be implemented via CP-31587");
         }
 
         private void ToolStripMenuItemDismiss_Click(object sender, EventArgs e)


### PR DESCRIPTION
Added the interface option to download and install updates for client updates. Disabled by default until CP-31587 does the proper checks

Signed-off-by: Christophe25 <christopher.lancaste1@citrix.com>