### PR TITLE
(Stockholm) CA-362018: Improve update notification dismissal message

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -36621,7 +36621,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have applied filters to the list of updates. Do you want to dismiss all updates from every connected server, or only the updates you have chosen to view? In both cases the dismissed updates will be removed from the servers permanently.
+        ///   Looks up a localized string similar to You have applied filters to the list of update notifications. Do you want to dismiss all update notifications for every connected server, or only the update notifications you have chosen to view?
         ///
         ///Note that if RBAC is enabled, only updates which you have privileges to dismiss will be affected..
         /// </summary>
@@ -36632,7 +36632,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This operation will remove permanently all updates from every connected server. Do you want to continue?
+        ///   Looks up a localized string similar to This operation will dismiss all update notifications for every connected server. Do you want to continue?
         ///
         ///Note that if RBAC is enabled, only updates which you have privileges to dismiss will be affected..
         /// </summary>
@@ -36652,7 +36652,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This operation will remove the selected updates from the servers permanently. Do you want to continue?
+        ///   Looks up a localized string similar to This operation will dismiss all the selected update notifications. Do you want to continue?
         ///
         ///Note that if RBAC is enabled, only updates which you have privileges to dismiss will be affected..
         /// </summary>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12968,12 +12968,12 @@ Please check your settings and try again.</value>
     <value>{0}: Check skipped because WLB is enabled on pool {1}.</value>
   </data>
   <data name="UPDATE_DISMISS_ALL_CONTINUE" xml:space="preserve">
-    <value>You have applied filters to the list of updates. Do you want to dismiss all updates from every connected server, or only the updates you have chosen to view? In both cases the dismissed updates will be removed from the servers permanently.
+    <value>You have applied filters to the list of update notifications. Do you want to dismiss all update notifications for every connected server, or only the update notifications you have chosen to view?
 
 Note that if RBAC is enabled, only updates which you have privileges to dismiss will be affected.</value>
   </data>
   <data name="UPDATE_DISMISS_ALL_NO_FILTER_CONTINUE" xml:space="preserve">
-    <value>This operation will remove permanently all updates from every connected server. Do you want to continue?
+    <value>This operation will dismiss all update notifications for every connected server. Do you want to continue?
 
 Note that if RBAC is enabled, only updates which you have privileges to dismiss will be affected.</value>
   </data>
@@ -12981,7 +12981,7 @@ Note that if RBAC is enabled, only updates which you have privileges to dismiss 
     <value>Are you sure you want to dismiss this update?</value>
   </data>
   <data name="UPDATE_DISMISS_SELECTED_CONFIRM" xml:space="preserve">
-    <value>This operation will remove the selected updates from the servers permanently. Do you want to continue?
+    <value>This operation will dismiss all the selected update notifications. Do you want to continue?
 
 Note that if RBAC is enabled, only updates which you have privileges to dismiss will be affected.</value>
   </data>


### PR DESCRIPTION
Also removes the wording related to permanent dismissal, since we give users the option to restore update notifications.

Please advise on if the new wording does not correctly reflect XC's behaviour here.