### PR TITLE
CA-361926: Ensure `Messages.resx` in XenCenter stays alphabetically sorted

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,9 @@ jobs:
             -NOISY `
             -PATHS ./XenModel/Messages.resx, ./XenModel/FriendlyNames.resx, `
                   ./XenModel/InvisibleMessages.resx, ./XenModel/UnitStrings.resx, `
-                  ./XenOvfApi/Content.resx, ./XenOvfApi/Messages.resx;
-
-          ./scripts/check_strings_sorting.ps1 `
-            -NOISY `
-            -PATHS ./Branding/Branding.resx;
+                  ./XenOvfApi/Content.resx, ./XenOvfApi/Messages.resx; `
+          if($lastexitcode -eq 0){ `
+            ./scripts/check_strings_sorting.ps1 `
+              -NOISY `
+              -PATHS ./Branding/Branding.resx `
+          }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,13 @@ jobs:
 
       - name: Run string sort check
         shell: powershell
-        run: ./scripts/check_strings_sorting.ps1 -PATH ./XenModel/Messages.resx -NOISY
+        run: ./scripts/check_strings_sorting.ps1 `
+            -CHECK_LOCALIZED `
+            -NOISY `
+            -PATHS ./XenModel/Messages.resx, ./XenModel/FriendlyNames.resx, `
+                  ./XenModel/InvisibleMessages.resx, ./XenModel/UnitStrings.resx, `
+                  ./XenOvfApi/Content.resx, ./XenOvfApi/Messages.resx;
+
+          ./scripts/check_strings_sorting.ps1 `
+            -NOISY `
+            -PATHS ./Branding/Branding.resx;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,7 @@ jobs:
           cyg-get.bat aspell aspell-en
           $env:Path += ";C:\tools\cygwin\bin;"
           ./scripts/check_spelling.ps1 -NOISY
+
+      - name: Run string sort check
+        shell: powershell
+        run: ./scripts/check_strings_sorting.ps1 -PATH ./XenModel/Messages.resx -NOISY

--- a/scripts/check_strings_sorting.ps1
+++ b/scripts/check_strings_sorting.ps1
@@ -1,0 +1,69 @@
+# Copyright (c) Citrix Systems, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
+# that the following conditions are met:
+#
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer.
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
+#     materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+#Requires -Version 3.0
+
+Param(
+    [Parameter(Mandatory = $true, HelpMessage = "Path of the Messages.resx file.")]
+    [String]$PATH,
+    [Parameter(HelpMessage = "Whether to list the names of the examined strings")]
+    [switch]$NOISY
+)
+
+[xml]$xml = Get-Content $PATH
+
+$strings = $xml.root.data 
+$sortedStrings = $strings | Sort name
+
+for ($i = 0; $i -lt $strings.length ; $i++) {
+    # check that the node contains a name property
+    if("name" -cnotin $strings[$i].PSobject.Properties.Name)
+    {
+        Write-Output "The following data object is missing a $PROPERTY property. Make sure the input file is correctly formatted"
+        Write-Output $strings[$i]
+        exit 1
+    }
+
+    $stringsName = $strings[$i].name
+    $sortedStringsName = $sortedStrings[$i].name
+
+    if($NOISY){
+        Write-Output "Checking $stringsName against expected string $sortedStringsName"
+    }
+   
+    if ($stringsName -ne $sortedStringsName) {
+        Write-Output "The content of $PATH isn't sorted alphabetically. Please sort it using the script in scripts/sort_strings.ps1."
+        exit 1
+    }
+}
+
+Write-Output "Strings in $PATH are sorted"
+
+exit 0

--- a/scripts/check_strings_sorting.ps1
+++ b/scripts/check_strings_sorting.ps1
@@ -79,7 +79,7 @@ function Test-Strings($path)
         # check that the node contains a name property
         if("name" -cnotin $strings[$i].PSobject.Properties.Name)
         {
-            Write-Output "The following data object is missing a $PROPERTY property. Make sure the input file is correctly formatted"
+            Write-Output "The following data object is missing a name property. Make sure the input file is correctly formatted"
             Write-Output $strings[$i]
             exit 1
         }

--- a/scripts/check_strings_sorting.ps1
+++ b/scripts/check_strings_sorting.ps1
@@ -70,7 +70,7 @@ function Test-Strings($path)
 {
     Write-Output "Checking strings in $path"
 
-    [xml]$xml = Get-Content $path
+    [xml]$xml = Get-Content -Encoding "utf8" -Path $path
 
     $strings = $xml.root.data 
     $sortedStrings = $strings | Sort-Object name

--- a/scripts/check_strings_sorting.ps1
+++ b/scripts/check_strings_sorting.ps1
@@ -33,32 +33,34 @@
 Param(
     [Parameter(Mandatory = $true, HelpMessage = "Comma separated paths of the files to check")]
     [String[]]$PATHS,
+    
     [Parameter(HelpMessage = "Whether to also checks for .ja and .zh-CN resx files in the same directory as the input file. Files must be present.")]
     [switch]$CHECK_LOCALIZED,
+
     [Parameter(HelpMessage = "Whether to list the names of the examined strings")]
     [switch]$NOISY
 )
 
 #region Functions
-function Test-Paths($paths){
-    foreach($path in $paths){
-        if((Test-Path $path) -eq $false){
+function Test-Paths($paths) {
+    foreach ($path in $paths) {
+        if ((Test-Path $path) -eq $false) {
             Write-Output "File $path does not exit"
             exit 1;
         }
 
-        if([IO.Path]::GetExtension($path) -cne ".resx"){
+        if ([IO.Path]::GetExtension($path) -cne ".resx") {
             Write-Output "$path is not a .resx file"
             exit 1;
         }
         
-        if($CHECK_LOCALIZED){
+        if ($CHECK_LOCALIZED) {
             $fileName = $path.replace(".resx", "")
-            if((Test-Path "$fileName.ja.resx") -eq $false){
+            if ((Test-Path "$fileName.ja.resx") -eq $false) {
                 Write-Output "Could not find Japanese localized file for $path. Exiting."
                 exit 1
             }
-            if((Test-Path "$fileName.zh-CN.resx") -eq $false ){
+            if ((Test-Path "$fileName.zh-CN.resx") -eq $false ) {
                 Write-Output "Could not find Chinese localized file for $path. Exiting."
                 exit 1
             }
@@ -66,8 +68,7 @@ function Test-Paths($paths){
     }
 }
 
-function Test-Strings($path)
-{
+function Test-Strings($path) {
     Write-Output "Checking strings in $path"
 
     [xml]$xml = Get-Content -Encoding "utf8" -Path $path
@@ -77,8 +78,7 @@ function Test-Strings($path)
 
     for ($i = 0; $i -lt $strings.length ; $i++) {
         # check that the node contains a name property
-        if("name" -cnotin $strings[$i].PSobject.Properties.Name)
-        {
+        if ("name" -cnotin $strings[$i].PSobject.Properties.Name) {
             Write-Output "The following data object is missing a name property. Make sure the input file is correctly formatted"
             Write-Output $strings[$i]
             exit 1
@@ -87,7 +87,7 @@ function Test-Strings($path)
         $stringsName = $strings[$i].name
         $sortedStringsName = $sortedStrings[$i].name
 
-        if($NOISY){
+        if ($NOISY) {
             Write-Output "Checking $stringsName against expected string $sortedStringsName"
         }
     
@@ -108,13 +108,13 @@ function Test-Strings($path)
 
 Test-Paths $PATHS
 
-foreach ($path in $PATHS){
+foreach ($path in $PATHS) {
     # Resolve relative path
     $resolvedPath = Resolve-Path $path
     $path = $resolvedPath.Path
 
     Test-Strings $path
-    if($CHECK_LOCALIZED){
+    if ($CHECK_LOCALIZED) {
         $fileName = $path.replace(".resx", "")
         Test-Strings  "$fileName.ja.resx"
         Test-Strings "$fileName.zh-CN.resx"

--- a/scripts/check_strings_sorting.ps1
+++ b/scripts/check_strings_sorting.ps1
@@ -42,7 +42,7 @@ Param(
 #region Functions
 function Test-Paths($paths){
     foreach($path in $paths){
-        if((Test-Path $path) -ceq $false){
+        if((Test-Path $path) -eq $false){
             Write-Output "File $path does not exit"
             exit 1;
         }
@@ -54,11 +54,11 @@ function Test-Paths($paths){
         
         if($CHECK_LOCALIZED){
             $fileName = $path.replace(".resx", "")
-            if((Test-Path "$fileName.ja.resx") -ceq $false){
+            if((Test-Path "$fileName.ja.resx") -eq $false){
                 Write-Output "Could not find Japanese localized file for $path. Exiting."
                 exit 1
             }
-            if((Test-Path "$fileName.zh-CN.resx") -ceq $false ){
+            if((Test-Path "$fileName.zh-CN.resx") -eq $false ){
                 Write-Output "Could not find Chinese localized file for $path. Exiting."
                 exit 1
             }

--- a/scripts/check_strings_sorting.ps1
+++ b/scripts/check_strings_sorting.ps1
@@ -45,12 +45,12 @@ Param(
 function Test-Paths($paths) {
     foreach ($path in $paths) {
         if ((Test-Path $path) -eq $false) {
-            Write-Output "File $path does not exit"
+            Write-Output "File $path does not exist. Exiting."
             exit 1;
         }
 
         if ([IO.Path]::GetExtension($path) -cne ".resx") {
-            Write-Output "$path is not a .resx file"
+            Write-Output "$path is not a .resx file. Exiting."
             exit 1;
         }
         

--- a/scripts/sort_strings.ps1
+++ b/scripts/sort_strings.ps1
@@ -44,7 +44,7 @@ function Test-Paths($paths){
     foreach($path in $paths){
         $path = Get-Path $path
 
-        if((Test-Path $path) -ceq $false){
+        if((Test-Path $path) -eq $false){
             Write-Output "File $path does not exit"
             exit 1;
         }
@@ -56,11 +56,11 @@ function Test-Paths($paths){
         
         if($CHECK_LOCALIZED){
             $fileName = $path.replace(".resx", "")
-            if((Test-Path "$fileName.ja.resx") -ceq $false){
+            if((Test-Path "$fileName.ja.resx") -eq $false){
                 Write-Output "Could not find Japanese localized file for $path. Exiting."
                 exit 1
             }
-            if((Test-Path "$fileName.zh-CN.resx") -ceq $false ){
+            if((Test-Path "$fileName.zh-CN.resx") -eq $false ){
                 Write-Output "Could not find Chinese localized file for $path. Exiting."
                 exit 1
             }

--- a/scripts/sort_strings.ps1
+++ b/scripts/sort_strings.ps1
@@ -42,7 +42,7 @@ Param(
 #region Functions
 function Test-Paths($paths){
     foreach($path in $paths){
-        $path = Get-Path $path
+        $path = Get-ResolvedPath $path
 
         if((Test-Path $path) -eq $false){
             Write-Output "File $path does not exit"
@@ -103,7 +103,7 @@ function Update-Strings($path){
     $xml.Save($path)    
 }
 
-function Get-Path($path){
+function Get-ResolvedPath($path){
     # Resolve relative path
     $resolvedPath = Resolve-Path $path
     return $resolvedPath.Path
@@ -116,7 +116,7 @@ function Get-Path($path){
 Test-Paths $PATHS
 
 foreach ($path in $PATHS){
-    $path = Get-Path $path
+    $path = Get-ResolvedPath $path
     Update-Strings $path
     if($CHECK_LOCALIZED){
         $fileName = $path.replace(".resx", "")

--- a/scripts/sort_strings.ps1
+++ b/scripts/sort_strings.ps1
@@ -71,7 +71,7 @@ function Test-Paths($paths){
 function Update-Strings($path){
     Write-Output "Fetching content of $path"
     
-    [xml]$xml = Get-Content $path
+    [xml]$xml = Get-Content -Encoding "utf8" -Path $path
     
     $strings = $xml.root.data 
     $sortedStrings = $strings | Sort-Object name

--- a/scripts/sort_strings.ps1
+++ b/scripts/sort_strings.ps1
@@ -1,0 +1,75 @@
+# Copyright (c) Citrix Systems, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
+# that the following conditions are met:
+#
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer.
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
+#     materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+#Requires -Version 3.0
+
+Param(
+    [Parameter(Mandatory = $true, HelpMessage = "Path of the input file")]
+    [String]$PATH,
+    [Parameter(HelpMessage = "Whether to list the names of the strings as they're being manipulated")]
+    [switch]$NOISY
+)
+
+# Resolve relative path
+$resolvedPath = Resolve-Path $PATH
+$PATH = $resolvedPath.Path
+
+Write-Output "Fetching content of $PATH"
+
+[xml]$xml = Get-Content $PATH
+
+$strings = $xml.root.data 
+$sortedStrings = $strings | Sort name
+$count = $strings.length
+
+Write-Output "Found $count strings"
+
+foreach ($_ in $strings) {
+    if($NOISY){
+        Write-Output "Removing string $($_.name)"
+    }
+    # ignore stdout
+    $xml.root.RemoveChild($_) >  $null
+}
+
+Write-Output "Removed unsorted strings"
+
+foreach ($_ in $sortedStrings) {
+    if($NOISY){
+        Write-Output "Adding string $($_.name)"
+    }
+    # ignore stdout
+    $xml.root.AppendChild($_) >  $null
+}
+
+Write-Output "Added sorted strings"
+
+Write-Output "Updating content of $PATH"
+$xml.Save($PATH)

--- a/scripts/sort_strings.ps1
+++ b/scripts/sort_strings.ps1
@@ -40,27 +40,28 @@ Param(
 )
 
 #region Functions
-function Test-Paths($paths){
-    foreach($path in $paths){
+function Test-Paths($paths) {
+    foreach ($path in $paths) {
         $path = Get-ResolvedPath $path
 
-        if((Test-Path $path) -eq $false){
+        if ((Test-Path $path) -eq $false) {
             Write-Output "File $path does not exit"
             exit 1;
         }
 
-        if([IO.Path]::GetExtension($path) -cne ".resx"){
+        if ([IO.Path]::GetExtension($path) -cne ".resx") {
             Write-Output "$path is not a .resx file"
             exit 1;
         }
         
-        if($CHECK_LOCALIZED){
+        if ($CHECK_LOCALIZED) {
             $fileName = $path.replace(".resx", "")
-            if((Test-Path "$fileName.ja.resx") -eq $false){
+            
+            if ((Test-Path "$fileName.ja.resx") -eq $false) {
                 Write-Output "Could not find Japanese localized file for $path. Exiting."
                 exit 1
             }
-            if((Test-Path "$fileName.zh-CN.resx") -eq $false ){
+            if ((Test-Path "$fileName.zh-CN.resx") -eq $false ) {
                 Write-Output "Could not find Chinese localized file for $path. Exiting."
                 exit 1
             }
@@ -68,7 +69,7 @@ function Test-Paths($paths){
     }
 }
 
-function Update-Strings($path){
+function Update-Strings($path) {
     Write-Output "Fetching content of $path"
     
     [xml]$xml = Get-Content -Encoding "utf8" -Path $path
@@ -80,7 +81,7 @@ function Update-Strings($path){
     Write-Output "Found $count strings"
     
     foreach ($_ in $strings) {
-        if($NOISY){
+        if ($NOISY) {
             Write-Output "Removing string $($_.name)"
         }
         # ignore stdout
@@ -90,7 +91,7 @@ function Update-Strings($path){
     Write-Output "Removed unsorted strings"
     
     foreach ($_ in $sortedStrings) {
-        if($NOISY){
+        if ($NOISY) {
             Write-Output "Adding string $($_.name)"
         }
         # ignore stdout
@@ -103,7 +104,7 @@ function Update-Strings($path){
     $xml.Save($path)    
 }
 
-function Get-ResolvedPath($path){
+function Get-ResolvedPath($path) {
     # Resolve relative path
     $resolvedPath = Resolve-Path $path
     return $resolvedPath.Path
@@ -115,10 +116,10 @@ function Get-ResolvedPath($path){
 
 Test-Paths $PATHS
 
-foreach ($path in $PATHS){
+foreach ($path in $PATHS) {
     $path = Get-ResolvedPath $path
     Update-Strings $path
-    if($CHECK_LOCALIZED){
+    if ($CHECK_LOCALIZED) {
         $fileName = $path.replace(".resx", "")
         Update-Strings  "$fileName.ja.resx"
         Update-Strings "$fileName.zh-CN.resx"

--- a/scripts/sort_strings.ps1
+++ b/scripts/sort_strings.ps1
@@ -45,12 +45,12 @@ function Test-Paths($paths) {
         $path = Get-ResolvedPath $path
 
         if ((Test-Path $path) -eq $false) {
-            Write-Output "File $path does not exit"
+            Write-Output "File $path does not exist. Exiting."
             exit 1;
         }
 
         if ([IO.Path]::GetExtension($path) -cne ".resx") {
-            Write-Output "$path is not a .resx file"
+            Write-Output "$path is not a .resx file. Exiting."
             exit 1;
         }
         


### PR DESCRIPTION
As shown by the commits, this PR adds two new scripts and one step to the PR/push action.
It uses the `Sort` function in PowerShell to compare strings.

The action step doesn't reorder. While it was suggested to add it to the pre-push hook, I don't think it'd be a good idea to add side effects like this to hooks. Feel free to comment on the matter.