### PR TITLE
CP-38814: Add friendly names to new xapi alerts

### DIFF
--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class FriendlyNames {
@@ -4752,6 +4752,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checkpoint for virtual machine has been created.
+        /// </summary>
+        public static string Message_name_vm_checkpointed {
+            get {
+                return ResourceManager.GetString("Message.name-vm_checkpointed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to VM Cloned.
         /// </summary>
         public static string Message_name_vm_cloned {
@@ -4766,6 +4775,24 @@ namespace XenAdmin {
         public static string Message_name_vm_crashed {
             get {
                 return ResourceManager.GetString("Message.name-vm_crashed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Virtual Machine has been migrated.
+        /// </summary>
+        public static string Message_name_vm_migrated {
+            get {
+                return ResourceManager.GetString("Message.name-vm_migrated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Virtual machine has been paused.
+        /// </summary>
+        public static string Message_name_vm_paused {
+            get {
+                return ResourceManager.GetString("Message.name-vm_paused", resourceCulture);
             }
         }
         
@@ -4806,6 +4833,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Snapshot for virtual machine has been reverted.
+        /// </summary>
+        public static string Message_name_vm_snapshot_reverted {
+            get {
+                return ResourceManager.GetString("Message.name-vm_snapshot_reverted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Snapshot for virtual machine has been created.
+        /// </summary>
+        public static string Message_name_vm_snapshotted {
+            get {
+                return ResourceManager.GetString("Message.name-vm_snapshotted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to VM Started.
         /// </summary>
         public static string Message_name_vm_started {
@@ -4829,6 +4874,15 @@ namespace XenAdmin {
         public static string Message_name_vm_uncooperative {
             get {
                 return ResourceManager.GetString("Message.name-vm_uncooperative", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Virtual machine has been unpaused.
+        /// </summary>
+        public static string Message_name_vm_unpaused {
+            get {
+                return ResourceManager.GetString("Message.name-vm_unpaused", resourceCulture);
             }
         }
         

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1682,11 +1682,20 @@
   <data name="Message.name-vif_qos_failed" xml:space="preserve">
     <value>VM Network Interface QoS Failed</value>
   </data>
+  <data name="Message.name-vm_checkpointed" xml:space="preserve">
+    <value>Checkpoint for virtual machine has been created</value>
+  </data>
   <data name="Message.name-vm_cloned" xml:space="preserve">
     <value>VM Cloned</value>
   </data>
   <data name="Message.name-vm_crashed" xml:space="preserve">
     <value>VM Crashed</value>
+  </data>
+  <data name="Message.name-vm_migrated" xml:space="preserve">
+    <value>Virtual Machine has been migrated</value>
+  </data>
+  <data name="Message.name-vm_paused" xml:space="preserve">
+    <value>Virtual machine has been paused</value>
   </data>
   <data name="Message.name-vm_rebooted" xml:space="preserve">
     <value>VM Rebooted</value>
@@ -1700,6 +1709,12 @@
   <data name="Message.name-vm_shutdown" xml:space="preserve">
     <value>VM Shut down</value>
   </data>
+  <data name="Message.name-vm_snapshot_reverted" xml:space="preserve">
+    <value>Snapshot for virtual machine has been reverted</value>
+  </data>
+  <data name="Message.name-vm_snapshotted" xml:space="preserve">
+    <value>Snapshot for virtual machine has been created</value>
+  </data>
   <data name="Message.name-vm_started" xml:space="preserve">
     <value>VM Started</value>
   </data>
@@ -1708,6 +1723,9 @@
   </data>
   <data name="Message.name-vm_uncooperative" xml:space="preserve">
     <value>VM Uncooperative</value>
+  </data>
+  <data name="Message.name-vm_unpaused" xml:space="preserve">
+    <value>Virtual machine has been unpaused</value>
   </data>
   <data name="Message.name-vmss_license_error" xml:space="preserve">
     <value>Snapshot schedule failed: insufficient license for Scheduled snapshots</value>

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -651,6 +651,12 @@
   <data name="INVALID_REPOMD_XML" xml:space="preserve">
     <value>The repomd.xml is invalid.</value>
   </data>
+  <data name="INVALID_REPOSITORY_PROXY_CREDENTIAL" xml:space="preserve">
+    <value>The repository proxy username/password is invalid.</value>
+  </data>
+  <data name="INVALID_REPOSITORY_PROXY_URL" xml:space="preserve">
+    <value>The repository proxy URL is invalid.</value>
+  </data>
   <data name="INVALID_UPDATE" xml:space="preserve">
     <value>The uploaded update package is invalid.</value>
   </data>

--- a/XenModel/XenAPI/JsonRpcClient.cs
+++ b/XenModel/XenAPI/JsonRpcClient.cs
@@ -207,6 +207,13 @@ namespace XenAPI
             return Rpc<string>("session.get_originator", new JArray(session, _session ?? ""), serializer);
         }
 
+        public bool session_get_client_certificate(string session, string _session)
+        {
+            var converters = new List<JsonConverter> {};
+            var serializer = CreateSerializer(converters);
+            return Rpc<bool>("session.get_client_certificate", new JArray(session, _session ?? ""), serializer);
+        }
+
         public void session_set_other_config(string session, string _session, Dictionary<string, string> _other_config)
         {
             var converters = new List<JsonConverter> {new StringStringMapConverter()};
@@ -753,6 +760,20 @@ namespace XenAPI
             Rpc("task.set_progress", new JArray(session, _task ?? "", _value), serializer);
         }
 
+        public void task_set_result(string session, string _task, string _value)
+        {
+            var converters = new List<JsonConverter> {};
+            var serializer = CreateSerializer(converters);
+            Rpc("task.set_result", new JArray(session, _task ?? "", _value ?? ""), serializer);
+        }
+
+        public void task_set_error_info(string session, string _task, string[] _value)
+        {
+            var converters = new List<JsonConverter> {};
+            var serializer = CreateSerializer(converters);
+            Rpc("task.set_error_info", new JArray(session, _task ?? "", _value == null ? new JArray() : JArray.FromObject(_value)), serializer);
+        }
+
         public List<XenRef<Task>> task_get_all(string session)
         {
             var converters = new List<JsonConverter> {new XenRefListConverter<Task>()};
@@ -1073,6 +1094,20 @@ namespace XenAPI
             var converters = new List<JsonConverter> {};
             var serializer = CreateSerializer(converters);
             return Rpc<string>("pool.get_client_certificate_auth_name", new JArray(session, _pool ?? ""), serializer);
+        }
+
+        public string pool_get_repository_proxy_url(string session, string _pool)
+        {
+            var converters = new List<JsonConverter> {};
+            var serializer = CreateSerializer(converters);
+            return Rpc<string>("pool.get_repository_proxy_url", new JArray(session, _pool ?? ""), serializer);
+        }
+
+        public string pool_get_repository_proxy_username(string session, string _pool)
+        {
+            var converters = new List<JsonConverter> {};
+            var serializer = CreateSerializer(converters);
+            return Rpc<string>("pool.get_repository_proxy_username", new JArray(session, _pool ?? ""), serializer);
         }
 
         public void pool_set_name_label(string session, string _pool, string _name_label)
@@ -1971,18 +2006,18 @@ namespace XenAPI
             return Rpc<XenRef<Task>>("Async.pool.remove_repository", new JArray(session, _pool ?? "", _value ?? ""), serializer);
         }
 
-        public string pool_sync_updates(string session, string _pool, bool _force)
+        public string pool_sync_updates(string session, string _pool, bool _force, string _token, string _token_id)
         {
             var converters = new List<JsonConverter> {};
             var serializer = CreateSerializer(converters);
-            return Rpc<string>("pool.sync_updates", new JArray(session, _pool ?? "", _force), serializer);
+            return Rpc<string>("pool.sync_updates", new JArray(session, _pool ?? "", _force, _token ?? "", _token_id ?? ""), serializer);
         }
 
-        public XenRef<Task> async_pool_sync_updates(string session, string _pool, bool _force)
+        public XenRef<Task> async_pool_sync_updates(string session, string _pool, bool _force, string _token, string _token_id)
         {
             var converters = new List<JsonConverter> {new XenRefConverter<Task>()};
             var serializer = CreateSerializer(converters);
-            return Rpc<XenRef<Task>>("Async.pool.sync_updates", new JArray(session, _pool ?? "", _force), serializer);
+            return Rpc<XenRef<Task>>("Async.pool.sync_updates", new JArray(session, _pool ?? "", _force, _token ?? "", _token_id ?? ""), serializer);
         }
 
         public string[] pool_check_update_readiness(string session, string _pool, bool _requires_reboot)
@@ -2025,6 +2060,20 @@ namespace XenAPI
             var converters = new List<JsonConverter> {new XenRefConverter<Task>()};
             var serializer = CreateSerializer(converters);
             return Rpc<XenRef<Task>>("Async.pool.disable_client_certificate_auth", new JArray(session, _pool ?? ""), serializer);
+        }
+
+        public void pool_configure_repository_proxy(string session, string _pool, string _url, string _username, string _password)
+        {
+            var converters = new List<JsonConverter> {};
+            var serializer = CreateSerializer(converters);
+            Rpc("pool.configure_repository_proxy", new JArray(session, _pool ?? "", _url ?? "", _username ?? "", _password ?? ""), serializer);
+        }
+
+        public XenRef<Task> async_pool_configure_repository_proxy(string session, string _pool, string _url, string _username, string _password)
+        {
+            var converters = new List<JsonConverter> {new XenRefConverter<Task>()};
+            var serializer = CreateSerializer(converters);
+            return Rpc<XenRef<Task>>("Async.pool.configure_repository_proxy", new JArray(session, _pool ?? "", _url ?? "", _username ?? "", _password ?? ""), serializer);
         }
 
         public List<XenRef<Pool>> pool_get_all(string session)

--- a/XenModel/XenAPI/Message2.cs
+++ b/XenModel/XenAPI/Message2.cs
@@ -105,7 +105,7 @@ namespace XenAPI
             VM_SECURE_BOOT_FAILED,
             VM_CLONED,
             VM_CRASHED,
-            VM_UNPAUSE,
+            VM_UNPAUSED,
             VM_PAUSED,
             VM_RESUMED,
             VM_SUSPENDED,
@@ -281,8 +281,8 @@ namespace XenAPI
                         return MessageType.VM_CLONED;
                     case "VM_CRASHED":
                         return MessageType.VM_CRASHED;
-                    case "VM_UNPAUSE":
-                        return MessageType.VM_UNPAUSE;
+                    case "VM_UNPAUSED":
+                        return MessageType.VM_UNPAUSED;
                     case "VM_PAUSED":
                         return MessageType.VM_PAUSED;
                     case "VM_RESUMED":

--- a/XenModel/XenAPI/Proxy.cs
+++ b/XenModel/XenAPI/Proxy.cs
@@ -138,6 +138,10 @@ namespace XenAPI
         Response<string>
         session_get_originator(string session, string _session);
 
+        [XmlRpcMethod("session.get_client_certificate")]
+        Response<bool>
+        session_get_client_certificate(string session, string _session);
+
         [XmlRpcMethod("session.set_other_config")]
         Response<string>
         session_set_other_config(string session, string _session, Object _other_config);
@@ -450,6 +454,14 @@ namespace XenAPI
         Response<string>
         task_set_progress(string session, string _task, double _value);
 
+        [XmlRpcMethod("task.set_result")]
+        Response<string>
+        task_set_result(string session, string _task, string _value);
+
+        [XmlRpcMethod("task.set_error_info")]
+        Response<string>
+        task_set_error_info(string session, string _task, string [] _value);
+
         [XmlRpcMethod("task.get_all")]
         Response<string []>
         task_get_all(string session);
@@ -633,6 +645,14 @@ namespace XenAPI
         [XmlRpcMethod("pool.get_client_certificate_auth_name")]
         Response<string>
         pool_get_client_certificate_auth_name(string session, string _pool);
+
+        [XmlRpcMethod("pool.get_repository_proxy_url")]
+        Response<string>
+        pool_get_repository_proxy_url(string session, string _pool);
+
+        [XmlRpcMethod("pool.get_repository_proxy_username")]
+        Response<string>
+        pool_get_repository_proxy_username(string session, string _pool);
 
         [XmlRpcMethod("pool.set_name_label")]
         Response<string>
@@ -1148,11 +1168,11 @@ namespace XenAPI
 
         [XmlRpcMethod("pool.sync_updates")]
         Response<string>
-        pool_sync_updates(string session, string _pool, bool _force);
+        pool_sync_updates(string session, string _pool, bool _force, string _token, string _token_id);
 
         [XmlRpcMethod("Async.pool.sync_updates")]
         Response<string>
-        async_pool_sync_updates(string session, string _pool, bool _force);
+        async_pool_sync_updates(string session, string _pool, bool _force, string _token, string _token_id);
 
         [XmlRpcMethod("pool.check_update_readiness")]
         Response<string []>
@@ -1177,6 +1197,14 @@ namespace XenAPI
         [XmlRpcMethod("Async.pool.disable_client_certificate_auth")]
         Response<string>
         async_pool_disable_client_certificate_auth(string session, string _pool);
+
+        [XmlRpcMethod("pool.configure_repository_proxy")]
+        Response<string>
+        pool_configure_repository_proxy(string session, string _pool, string _url, string _username, string _password);
+
+        [XmlRpcMethod("Async.pool.configure_repository_proxy")]
+        Response<string>
+        async_pool_configure_repository_proxy(string session, string _pool, string _url, string _username, string _password);
 
         [XmlRpcMethod("pool.get_all")]
         Response<string []>
@@ -8660,6 +8688,7 @@ namespace XenAPI
         public string [] tasks;
         public string parent;
         public string originator;
+        public bool client_certificate;
     }
 
     [XmlRpcMissingMapping(MappingAction.Ignore)]
@@ -8752,6 +8781,8 @@ namespace XenAPI
         public string [] repositories;
         public bool client_certificate_auth_enabled;
         public string client_certificate_auth_name;
+        public string repository_proxy_url;
+        public string repository_proxy_username;
     }
 
     [XmlRpcMissingMapping(MappingAction.Ignore)]

--- a/XenModel/XenAPI/Task.cs
+++ b/XenModel/XenAPI/Task.cs
@@ -685,6 +685,36 @@ namespace XenAPI
         }
 
         /// <summary>
+        /// Set the task result
+        /// First published in Unreleased.
+        /// </summary>
+        /// <param name="session">The session</param>
+        /// <param name="_task">The opaque_ref of the given task</param>
+        /// <param name="_value">Task result to be set</param>
+        public static void set_result(Session session, string _task, string _value)
+        {
+            if (session.JsonRpcClient != null)
+                session.JsonRpcClient.task_set_result(session.opaque_ref, _task, _value);
+            else
+                session.XmlRpcProxy.task_set_result(session.opaque_ref, _task ?? "", _value ?? "").parse();
+        }
+
+        /// <summary>
+        /// Set the task error info
+        /// First published in Unreleased.
+        /// </summary>
+        /// <param name="session">The session</param>
+        /// <param name="_task">The opaque_ref of the given task</param>
+        /// <param name="_value">Task error info to be set</param>
+        public static void set_error_info(Session session, string _task, string[] _value)
+        {
+            if (session.JsonRpcClient != null)
+                session.JsonRpcClient.task_set_error_info(session.opaque_ref, _task, _value);
+            else
+                session.XmlRpcProxy.task_set_error_info(session.opaque_ref, _task ?? "", _value).parse();
+        }
+
+        /// <summary>
         /// Return a list of all the tasks known to the system.
         /// First published in XenServer 4.0.
         /// </summary>

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -169,6 +169,11 @@
     <Compile Include="Alerts\Types\Alert.cs" />
     <Compile Include="BrandManager.cs" />
     <Compile Include="SshConsole.cs" />
+    <Compile Include="FriendlyNames.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>FriendlyNames.resx</DependentUpon>
+    </Compile>
     <Compile Include="PathValidator.cs" />
     <Compile Include="UnitStrings.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -191,11 +196,6 @@
     <Compile Include="CustomFields\CustomFieldsManager.cs" />
     <Compile Include="DockerContainer.cs" />
     <Compile Include="Folders.cs" />
-    <Compile Include="FriendlyNames.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>FriendlyNames.resx</DependentUpon>
-    </Compile>
     <Compile Include="FriendlyNameManager.cs" />
     <Compile Include="HealthCheckSettings.cs" />
     <Compile Include="InvokeHelper.cs" />


### PR DESCRIPTION
This PR contains a temporary fix to the SDK. ~Commit can be removed if we instead prefer to update the entire SDK.~ 

🚨🚨🚨🚨🚨
SDK has been updated to `xapi 21.3.0/1.xs8`, **with a modification** needed to avoid issues related to CA-355432 as pointed out by @kc284.
🚨🚨🚨🚨🚨

The following additions have been made:

```
vm_migrated
vm_snapshotted
vm_snapshot_reverted
vm_checkpointed
vm_paused
vm_unpaused
```