### PR TITLE
CA-261979: Use utf-8 encoding for logging…

### DIFF
--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -235,6 +235,7 @@
   <log4net>
     <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender">
       <file value="${APPDATA}/[Citrix]/[XenCenter_No_Space]/logs/[XenCenter].log"/>
+      <encoding value="utf-8" />
       <appendToFile value="true"/>
       <maxSizeRollBackups value="5"/>
       <maximumFileSize value="10MB"/>
@@ -246,6 +247,7 @@
     </appender>
     <appender name="NetworkTraceAppender" type="log4net.Appender.RollingFileAppender">
       <file value="${APPDATA}/[Citrix]/[XenCenter_No_Space]/logs/[XenCenter] Network Trace.log"/>
+      <encoding value="utf-8" />
       <appendToFile value="true"/>
       <maxSizeRollBackups value="5"/>
       <maximumFileSize value="10MB"/>
@@ -272,6 +274,7 @@
          and all failed operations at WARN. -->
     <appender name="AuditAppender" type="log4net.Appender.RollingFileAppender">
       <file value="${APPDATA}/[Citrix]/[XenCenter_No_Space]/logs/[XenCenter] Audit Trail.log"/>
+      <encoding value="utf-8" />
       <appendToFile value="true"/>
       <maxSizeRollBackups value="5"/>
       <maximumFileSize value="10MB"/>

--- a/XenServerHealthCheck/app.config
+++ b/XenServerHealthCheck/app.config
@@ -14,6 +14,7 @@
   <log4net>
     <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender">
       <file value="${PROGRAMDATA}/[Citrix]/XenServerHealthCheck/logs/XenServerHealthCheck.log"/>
+      <encoding value="utf-8" />
       <appendToFile value="true"/>
       <maxSizeRollBackups value="5"/>
       <maximumFileSize value="10MB"/>


### PR DESCRIPTION
… (or on localised systems the log files may contain illegible characters).