### PR TITLE
CP-38893: Make internal roles unavailable for selection. Some refactoring of Role extension method overloads.

### DIFF
--- a/XenAdmin/Commands/HACommand.cs
+++ b/XenAdmin/Commands/HACommand.cs
@@ -108,7 +108,7 @@ namespace XenAdmin.Commands
                         dlg.ShowDialog(Program.MainWindow);
                     }
                 }
-                else if (!Role.CanPerform(HA_PERMISSION_CHECKS, pool.Connection))
+                else if (!Role.CanPerform(HA_PERMISSION_CHECKS, pool.Connection, out _))
                 {
                     var msg = string.Format(Messages.RBAC_HA_CONFIGURE_WARNING,
                         Role.FriendlyCSVRoleList(Role.ValidRoleList(HA_PERMISSION_CHECKS, pool.Connection)),

--- a/XenAdmin/Commands/InstallToolsCommand.cs
+++ b/XenAdmin/Commands/InstallToolsCommand.cs
@@ -288,7 +288,7 @@ namespace XenAdmin.Commands
 
             //whether RBAC allows connection to the VM's console
             return vm.Connection.Session != null &&
-                   Role.CanPerform(new RbacMethodList("http/connect_console"), vm.Connection, out _, false);
+                   Role.CanPerform(new RbacMethodList("http/connect_console"), vm.Connection, out _);
         }
 
         protected override bool CanRunCore(SelectedItemCollection selection)

--- a/XenAdmin/Controls/Wlb/WlbOptimizePool.cs
+++ b/XenAdmin/Controls/Wlb/WlbOptimizePool.cs
@@ -797,7 +797,7 @@ namespace XenAdmin.Controls.Wlb
 
         private bool PassedRbacChecks()
         {
-            return Role.CanPerform(WLB_PERMISSION_CHECKS, this._pool.Connection);
+            return Role.CanPerform(WLB_PERMISSION_CHECKS, this._pool.Connection, out _);
         }
         #endregion
 

--- a/XenAdmin/Core/HealthCheck.cs
+++ b/XenAdmin/Core/HealthCheck.cs
@@ -110,7 +110,7 @@ namespace XenAdmin.Core
 
         public static bool PassedRbacChecks(IXenConnection connection)
         {
-            return Role.CanPerform(new RbacMethodList("pool.set_health_check_config"), connection);
+            return Role.CanPerform(new RbacMethodList("pool.set_health_check_config"), connection, out _);
         }
 
         private static void actionCompleted(ActionBase sender)

--- a/XenAdmin/Dialogs/RoleSelectionDialog.cs
+++ b/XenAdmin/Dialogs/RoleSelectionDialog.cs
@@ -82,7 +82,9 @@ namespace XenAdmin.Dialogs
             }
 
             // Get the list of roles off the server and arrange them into rank
-            var serverRoles = connection.Cache.Roles.Where(r => r.subroles.Count > 0).OrderBy(r => r).Reverse().ToList();
+            var serverRoles = connection.Cache.Roles
+                .Where(r => (!Helpers.Post82X(connection) || !r.is_internal) && r.subroles.Count > 0)
+                .OrderBy(r => r).Reverse().ToList();
             _subjectsPerRole = new Dictionary<Role, List<Subject>>();
 
             foreach (Role role in serverRoles)

--- a/XenAdmin/TabPages/WlbPage.cs
+++ b/XenAdmin/TabPages/WlbPage.cs
@@ -348,7 +348,7 @@ namespace XenAdmin.TabPages
 
         private bool PassedRbacChecks()
         {
-            return Role.CanPerform(WLB_PERMISSION_CHECKS, _pool.Connection);
+            return Role.CanPerform(WLB_PERMISSION_CHECKS, _pool.Connection, out _);
         }
 
         private void SetButtonState()

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_SelectServers.cs
@@ -391,7 +391,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 //Do RBAC check
                 foreach (Host coordinator in coordinators)
                 {
-                    if (!(Role.CanPerform(new RbacMethodList("pool_patch.apply"), coordinator.Connection)))
+                    if (!Role.CanPerform(new RbacMethodList("pool_patch.apply"), coordinator.Connection, out _))
                     {
                         string nameLabel = coordinator.Name();
                         Pool pool = Helpers.GetPoolOfOne(coordinator.Connection);

--- a/XenModel/Actions/AD/AddRemoveRolesAction.cs
+++ b/XenModel/Actions/AD/AddRemoveRolesAction.cs
@@ -63,7 +63,9 @@ namespace XenAdmin.Actions
 
         protected override void Run()
         {
-            var serverRoles = Connection.Cache.Roles.Where(r => r.subroles.Count > 0).ToList();
+            var serverRoles = Connection.Cache.Roles
+                .Where(r => (!Helpers.Post82X(Connection) || !r.is_internal) && r.subroles.Count > 0)
+                .ToList();
 
             var toAdd = serverRoles.Where(role => _newRoles.Contains(role) &&
                                                   !subject.roles.Contains(new XenRef<Role>(role.opaque_ref))).ToList();

--- a/XenModel/PoolJoinRules.cs
+++ b/XenModel/PoolJoinRules.cs
@@ -524,7 +524,7 @@ namespace XenAdmin.Core
 
         private static bool RoleOK(IXenConnection connection)
         {
-            return Role.CanPerform(new RbacMethodList("pool.join"), connection);
+            return Role.CanPerform(new RbacMethodList("pool.join"), connection, out _);
         }
 
         private static bool DifferentNetworkBackends(Host supporter, Host coordinator)

--- a/XenModel/RbacMethod.cs
+++ b/XenModel/RbacMethod.cs
@@ -87,7 +87,7 @@ namespace XenAdmin.Core
         }
 
         /// <summary>
-        /// Note that this constructor takes simple API calls, or complex ones with hash table edits and keys deliminated by a RbacMethod.KEY_SPLITTER
+        /// Note that this constructor takes simple API calls, or complex ones with hash table edits and keys delimited by a RbacMethod.KEY_SPLITTER
         /// Silently ignores blank methods, blank keys and entries with too many RbacMethod.KEY_SPLITTER
         /// </summary>
         public RbacMethodList(params string[] methods)

--- a/XenModel/XenAPI-Extensions/Role.cs
+++ b/XenModel/XenAPI-Extensions/Role.cs
@@ -60,7 +60,7 @@ namespace XenAPI
 
         public string FriendlyDescription()
         {
-            return FriendlyNameManager.GetFriendlyName(String.Format("Role.{0}.Description", this.name_label.ToLowerInvariant()));
+            return FriendlyNameManager.GetFriendlyName(string.Format("Role.{0}.Description", this.name_label.ToLowerInvariant()));
         }
 
         public override string Name()
@@ -71,7 +71,6 @@ namespace XenAPI
         /// <summary>
         /// Currently all RBAC roles can be arranged in a rank so that each one has all the privileges of the next. Use this function for sorting based on this ordering.
         /// </summary>
-        /// <returns></returns>
         public int RoleRank()
         {
             switch (name_label.ToLowerInvariant())
@@ -106,8 +105,6 @@ namespace XenAPI
         /// <summary>
         /// Takes a list of role objects and returns as a comma separated friendly string
         /// </summary>
-        /// <param name="roles"></param>
-        /// <returns></returns>
         public static string FriendlyCSVRoleList(List<Role> roles)
         {
             if (roles == null)
@@ -116,93 +113,84 @@ namespace XenAPI
             return String.Join(", ", roles.ConvertAll(r => r.FriendlyName()).ToArray());
         }
 
-
-         /// <summary>
-        /// Retrieves all the server RBAC roles which are able to complete all the api methods supplied. If on George or less this will return an empty list.
-        /// </summary>
-        /// <param name="ApiMethodsToRoleCheck">list of RbacMethods to check</param>
-        /// <param name="Connection">server connection to retrieve roles from</param>
-        /// <returns></returns>
-        public static List<Role> ValidRoleList(RbacMethodList ApiMethodsToRoleCheck, IXenConnection Connection)
-        {
-            return ValidRoleList(ApiMethodsToRoleCheck, Connection, true);
-        }
-
         /// <summary>
-        /// Retrieves all the server RBAC roles which are able to complete all the api methods supplied. If on George or less this will return an empty list.
+        /// Retrieves all the server RBAC roles which are able to complete all the api methods supplied.
+        /// If on George or less this will return an empty list.
         /// </summary>
-        /// <param name="ApiMethodsToRoleCheck">list of RbacMethods to check</param>
-        /// <param name="Connection">server connection to retrieve roles from</param>
-        /// <returns></returns>
-        public static List<Role> ValidRoleList(RbacMethodList ApiMethodsToRoleCheck, IXenConnection Connection, bool debug)
+        /// <param name="apiMethodsToRoleCheck">list of RbacMethods to check</param>
+        /// <param name="connection">server connection to retrieve roles from</param>
+        public static List<Role> ValidRoleList(RbacMethodList apiMethodsToRoleCheck, IXenConnection connection)
         {
-            List<Role> rolesAbleToCompleteAction = new List<Role>();
-            if (debug)
-                log.DebugFormat("Checking roles required to complete the following calls: {0}", String.Join(", ", ApiMethodsToRoleCheck.ToStringArray()));
-            foreach (RbacMethod method in ApiMethodsToRoleCheck)
+            log.DebugFormat("Checking roles required to complete the following calls: {0}",
+                string.Join(", ", apiMethodsToRoleCheck.ToStringArray()));
+
+            var rolesAbleToCompleteAction = new List<Role>();
+
+            foreach (RbacMethod method in apiMethodsToRoleCheck)
             {
-                // For every call in the list, compile a list of the roles that can perform it, taking the intersection of the
-                // roles able to perform the call in question and those in the list already.
-                List<Role> rolesAbleToCompleteApiCall = ValidRoleList(method, Connection);
+                List<Role> rolesAbleToCompleteApiCall = ValidRoleList(method, connection);
                 if (rolesAbleToCompleteAction.Count == 0)
                 {
                     rolesAbleToCompleteAction.AddRange(rolesAbleToCompleteApiCall);
                     continue;
                 }
-                if (rolesAbleToCompleteApiCall.Count != 0)  // zero is a bug: see Assert below
-                {
-                    // take intersection of existing authorized roles and this set of authorized roles
-                    rolesAbleToCompleteAction.RemoveAll(delegate(Role r)
-                    {
-                        return !rolesAbleToCompleteApiCall.Contains(r);
-                    });
-                }
+
+                //the permissions to run a list of API calls should be those of the
+                //most restricted call in the list; if more permissions have been added
+                //by the previous calls in the list, these have to be removed
+
+                if (rolesAbleToCompleteApiCall.Count > 0)
+                    rolesAbleToCompleteAction.RemoveAll(r => !rolesAbleToCompleteApiCall.Contains(r));
             }
+
             return rolesAbleToCompleteAction;
         }
 
         /// <summary>
-        /// Retrieves all the server RBAC roles which are able to complete the api method supplied. If on George or less this will return an empty list.
+        /// Retrieves all the server RBAC roles which are able to complete the api method supplied.
+        /// If on George or less this will return an empty list.
         /// </summary>
-        /// <param name="ApiMethodToRoleCheck">RbacMethod to check</param>
-        /// <param name="Connection">server connection to retrieve roles from</param>
-        /// <returns></returns>
-        public static List<Role> ValidRoleList(RbacMethod ApiMethodToRoleCheck, IXenConnection Connection)
+        /// <param name="apiMethodToRoleCheck">RbacMethod to check</param>
+        /// <param name="connection">server connection to retrieve roles from</param>
+        private static List<Role> ValidRoleList(RbacMethod apiMethodToRoleCheck, IXenConnection connection)
         {
             List<Role> rolesAbleToCompleteApiCall = new List<Role>();
-            foreach (Role role in Connection.Cache.Roles)
+            foreach (Role role in connection.Cache.Roles)
             {
-                List<Role> subroles = (List<Role>)Connection.ResolveAll<Role>(role.subroles);
-                if (subroles.Find(
-                    delegate(Role r)
-                    {
-                        return r.CanPerform(ApiMethodToRoleCheck);
-                    })
-                    != null)
+                List<Role> subroles = connection.ResolveAll(role.subroles);
+                if (subroles.Find(r => r.CanPerform(apiMethodToRoleCheck)) != null)
                 {
                     rolesAbleToCompleteApiCall.Add(role);
                 }
             }
 
-            // don't do this assert with simulator connections. These will always have no roles.
-            if (!Connection.HostnameWithPort.EndsWith(".xml", StringComparison.InvariantCultureIgnoreCase))
+            // On connections with roles (i.e. non-simulator connections), each API call
+            // should be available to at least Pool Admins (because the latter can do
+            // everything). No roles is usually caused by a typo in the apiMethodToRoleCheck,
+            // or by running a new action against an old server without checking.
+
+            if (!connection.HostnameWithPort.EndsWith(".xml", StringComparison.InvariantCultureIgnoreCase))
             {
-                // No roles able to perform API call is a bug, because Pool Admins should be able to do everything.
-                // Usually caused by a typo, or by running a new action against an old server without checking.
-                System.Diagnostics.Trace.Assert(rolesAbleToCompleteApiCall.Count > 0, String.Format("No roles able to perform API call {0}", ApiMethodToRoleCheck));
+                var msg = $"No roles able to perform API call {apiMethodToRoleCheck}";
+
+                if (rolesAbleToCompleteApiCall.Count < 1)
+                    log.Debug(msg);
+
+                System.Diagnostics.Debug.Assert(rolesAbleToCompleteApiCall.Count > 0, msg);
             }
+
             return rolesAbleToCompleteApiCall;
         }
 
         /// <summary>
-        /// Retrieves all the server RBAC roles which are able to complete the api method supplied. If on George or less this will return an empty list.
+        /// Retrieves all the server RBAC roles which are able to complete the api method supplied.
+        /// If on George or less this will return an empty list.
         /// </summary>
-        /// <param name="ApiMethodToRoleCheck">object.method</param>
-        /// <param name="Connection">server connection to retrieve roles from</param>
-        /// <returns></returns>
-        public static List<Role> ValidRoleList(string ApiMethodToRoleCheck, IXenConnection Connection)
+        /// <param name="apiMethodToRoleCheck">object.method</param>
+        /// <param name="connection">server connection to retrieve roles from</param>
+        public static List<Role> ValidRoleList(string apiMethodToRoleCheck, IXenConnection connection)
         {
-            return ValidRoleList(new RbacMethod(ApiMethodToRoleCheck), Connection);
+            return ValidRoleList(new RbacMethod(apiMethodToRoleCheck), connection);
         }
 
         /// <summary>
@@ -212,15 +200,15 @@ namespace XenAPI
         /// <param name="apiMethodsToRoleCheck">The methods to check</param>
         /// <param name="connection">The connection on which to perform the methods</param>
         /// <param name="validRoleList">The list of roles which can perform all the methods</param>
-        public static bool CanPerform(RbacMethodList apiMethodsToRoleCheck, IXenConnection connection, out List<Role> validRoleList, bool debug)
+        public static bool CanPerform(RbacMethodList apiMethodsToRoleCheck, IXenConnection connection, out List<Role> validRoleList)
         {
             if (!connection.IsConnected)
             {
                 validRoleList = new List<Role>();
                 return false;
             }
-            else
-                validRoleList = ValidRoleList(apiMethodsToRoleCheck, connection, debug);
+            
+            validRoleList = ValidRoleList(apiMethodsToRoleCheck, connection);
             
             if (connection.Session != null && connection.Session.IsLocalSuperuser)
                 return true;
@@ -234,39 +222,15 @@ namespace XenAPI
         }
 
         /// <summary>
-        /// Can the main session on this connection already perform all the API methods? If on George or less this will return false.
-        /// Also return the list of valid roles.
-        /// </summary>
-        /// <param name="apiMethodsToRoleCheck">The methods to check</param>
-        /// <param name="connection">The connection on which to perform the methods</param>
-        /// <param name="validRoleList">The list of roles which can perform all the methods</param>
-        public static bool CanPerform(RbacMethodList apiMethodsToRoleCheck, IXenConnection connection, out List<Role> validRoleList)
-        {
-            return CanPerform(apiMethodsToRoleCheck, connection, out validRoleList, true);
-        }
-
-        /// <summary>
-        /// Can the main session on this connection already perform all the API methods? If on George or less this will return false.
-        /// </summary>
-        /// <param name="apiMethodsToRoleCheck">The methods to check</param>
-        /// <param name="connection">The connection on which to perform the methods</param>
-        public static bool CanPerform(RbacMethodList apiMethodsToRoleCheck, IXenConnection connection)
-        {
-            List<Role> validRoleList;
-            return CanPerform(apiMethodsToRoleCheck, connection, out validRoleList);
-        }
-
-        /// <summary>
         /// Can this subrole perform this API call?
         /// </summary>
         /// <param name="rbacMethod">The API call which we want to perform</param>
-        /// <returns></returns>
         private bool CanPerform(RbacMethod rbacMethod)
         {
             // Does the method name match?
             if (name_label == rbacMethod.Method)
                 return true;
-            
+
             // Is the call a hash table modification, and if so, does the
             // more specific name match?
             if (!String.IsNullOrEmpty(rbacMethod.Key))
@@ -288,8 +252,6 @@ namespace XenAPI
             return false;
         }
 
-       
-
         #region XenObjectComparable<Role> Members
 
         public override int CompareTo(Role other)
@@ -301,12 +263,7 @@ namespace XenAPI
 
         public override bool Equals(object obj)
         {
-            Role r = obj as Role;
-            if (r != null)
-            {
-                return r.opaque_ref == this.opaque_ref;
-            }
-            return base.Equals(obj);
+            return obj is Role r ? r.opaque_ref == opaque_ref : base.Equals(obj);
         }
 
         public override int GetHashCode()

--- a/XenModel/XenAPI-Extensions/Session.cs
+++ b/XenModel/XenAPI-Extensions/Session.cs
@@ -261,7 +261,7 @@ namespace XenAPI
                 return Messages.AD_LOCAL_ROOT_ACCOUNT;
 
             //Sort roles from highest to lowest
-            roles.Sort((r1, r2) => { return r2.CompareTo(r1); });
+            roles.Sort((r1, r2) => r2.CompareTo(r1));
             //Take the highest role
             return roles[0].FriendlyName();
         }


### PR DESCRIPTION
Commits best viewed separately.