### PR TITLE
CA-361078: Parse OVFs without a `Limit` element in the vCPUs section

### DIFF
--- a/XenModel/Actions/OvfActions/Import.cs
+++ b/XenModel/Actions/OvfActions/Import.cs
@@ -533,13 +533,14 @@ namespace XenAdmin.Actions.OvfActions
                 //There may be more than one entries corresponding to CPUs
                 //The VirtualQuantity in each one is Cores
 
-                foreach (RASD_Type rasd in rasds)
+                foreach (var rasd in rasds)
                 {
                     cpuCount += rasd.VirtualQuantity.Value;
                     // CA-361078: Older versions of CHC/XC used to set the limit to 100,000 by default, and use 
                     // VirtualQuantity for max vCPUs.
                     // This way, we keep backwards compatibility with older OVFs.
-                    maxCpusCount += rasd.Limit.Value >= 100_000 ? rasd.VirtualQuantity.Value : rasd.Limit.Value;
+                    var limit = rasd.Limit?.Value ?? 100_000;
+                    maxCpusCount += limit >= 100_000 ? rasd.VirtualQuantity.Value : limit;
                 }
                    
             }


### PR DESCRIPTION
VMWare OVFs don't export the value, which caused an exception to be thrown when importing them.

If you need a VMWare OVF to test this, feel free to DM me.

![image](https://user-images.githubusercontent.com/32554698/154652885-a8ec4e1b-fc6f-4c77-a7f0-6ec0a7ccc2f4.png)

