### PR TITLE
CA-365297, CP-39323: DMC checks when attempting cross-pool migration

### DIFF
--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -147,6 +147,17 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                             throw new Failure(Messages.OLDER_THAN_CURRENT_SERVER);
                         }
 
+                        if (Host.RestrictDMC(host) &&
+                            (vm.power_state == vm_power_state.Running ||
+                             vm.power_state == vm_power_state.Paused ||
+                             vm.power_state == vm_power_state.Suspended) &&
+                            (vm.memory_static_min > vm.memory_dynamic_min || //corner case, probably unlikely
+                             vm.memory_dynamic_min != vm.memory_dynamic_max ||
+                             vm.memory_dynamic_max != vm.memory_static_max))
+                        {
+                            throw new Failure(FriendlyErrorNames.DYNAMIC_MEMORY_CONTROL_UNAVAILABLE);
+                        }
+
                         PIF managementPif = host.Connection.Cache.PIFs.First(p => p.management);
                         XenAPI.Network managementNetwork = host.Connection.Cache.Resolve(managementPif.network);
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/Filters/CrossPoolMigrateCanMigrateFilter.cs
@@ -179,8 +179,11 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard.Filters
                             vmIsMigratable = true;
                             break;
                         }
+
                         if (failure.ErrorDescription.Count > 0 && failure.ErrorDescription[0] == Failure.RBAC_PERMISSION_DENIED)
                             disableReason = failure.Message.Split('\n')[0].TrimEnd('\r'); // we want the first line only
+                        else if (failure.ErrorDescription.Count > 1 && failure.ErrorDescription[1].Contains(Failure.DYNAMIC_MEMORY_CONTROL_UNAVAILABLE))
+                            disableReason = FriendlyErrorNames.DYNAMIC_MEMORY_CONTROL_UNAVAILABLE;
                         else
                             disableReason = failure.Message;
 

--- a/XenModel/XenAPI-Extensions/Failure.cs
+++ b/XenModel/XenAPI-Extensions/Failure.cs
@@ -40,6 +40,7 @@ namespace XenAPI
     {
         public const string CANNOT_EVACUATE_HOST = "CANNOT_EVACUATE_HOST";
         public const string DEVICE_ALREADY_DETACHED = "DEVICE_ALREADY_DETACHED";
+        public const string DYNAMIC_MEMORY_CONTROL_UNAVAILABLE = "DYNAMIC_MEMORY_CONTROL_UNAVAILABLE";
         public const string HANDLE_INVALID = "HANDLE_INVALID";
         public const string HA_NO_PLAN = "HA_NO_PLAN";
         public const string HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN = "HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN";

--- a/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
+++ b/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
@@ -835,6 +835,15 @@ namespace XenAPI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The VM requires Dynamic Memory Control (DMC), which is unavailable.
+        /// </summary>
+        public static string DYNAMIC_MEMORY_CONTROL_UNAVAILABLE {
+            get {
+                return ResourceManager.GetString("DYNAMIC_MEMORY_CONTROL_UNAVAILABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No other server available to nominate as coordinator.  Please add or enable some other servers..
         /// </summary>
         public static string EVACUATE_NO_OTHER_HOSTS_FOR_MASTER {
@@ -1663,6 +1672,24 @@ namespace XenAPI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The repository proxy username/password is invalid..
+        /// </summary>
+        public static string INVALID_REPOSITORY_PROXY_CREDENTIAL {
+            get {
+                return ResourceManager.GetString("INVALID_REPOSITORY_PROXY_CREDENTIAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The repository proxy URL is invalid..
+        /// </summary>
+        public static string INVALID_REPOSITORY_PROXY_URL {
+            get {
+                return ResourceManager.GetString("INVALID_REPOSITORY_PROXY_URL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The uploaded update package is invalid..
         /// </summary>
         public static string INVALID_UPDATE {
@@ -1924,7 +1951,7 @@ namespace XenAPI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The dynamic memory range violates constraint static_min = dynamic_min = dynamic_max = static_max..
+        ///   Looks up a localized string similar to The dynamic memory range violates constraint static_min &lt;= dynamic_min = dynamic_max = static_max..
         /// </summary>
         public static string MEMORY_CONSTRAINT_VIOLATION_MAXPIN {
             get {
@@ -3081,7 +3108,7 @@ namespace XenAPI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Syning with remote YUM repository failed..
+        ///   Looks up a localized string similar to Syncing with remote YUM repository failed..
         /// </summary>
         public static string REPOSYNC_FAILED {
             get {

--- a/XenModel/XenAPI/FriendlyErrorNames.resx
+++ b/XenModel/XenAPI/FriendlyErrorNames.resx
@@ -375,6 +375,9 @@
   <data name="DUPLICATE_VM" xml:space="preserve">
     <value>Cannot restore this VM because it would create a duplicate</value>
   </data>
+  <data name="DYNAMIC_MEMORY_CONTROL_UNAVAILABLE" xml:space="preserve">
+    <value>The VM requires Dynamic Memory Control (DMC), which is unavailable</value>
+  </data>
   <data name="EVACUATE_NO_OTHER_HOSTS_FOR_MASTER" xml:space="preserve">
     <value>No other server available to nominate as coordinator.  Please add or enable some other servers.</value>
   </data>
@@ -739,7 +742,7 @@
     <value>The dynamic memory range does not satisfy the following constraint.</value>
   </data>
   <data name="MEMORY_CONSTRAINT_VIOLATION_MAXPIN" xml:space="preserve">
-    <value>The dynamic memory range violates constraint static_min = dynamic_min = dynamic_max = static_max.</value>
+    <value>The dynamic memory range violates constraint static_min &lt;= dynamic_min = dynamic_max = static_max.</value>
   </data>
   <data name="MEMORY_CONSTRAINT_VIOLATION_ORDER" xml:space="preserve">
     <value>The dynamic memory range violates constraint static_min &lt;= dynamic_min &lt;= dynamic_max &lt;= static_max.</value>
@@ -1134,7 +1137,7 @@ Authorized Roles: {1}</value>
     <value>The repository is in use.</value>
   </data>
   <data name="REPOSYNC_FAILED" xml:space="preserve">
-    <value>Syning with remote YUM repository failed.</value>
+    <value>Syncing with remote YUM repository failed.</value>
   </data>
   <data name="REPOSYNC_IN_PROGRESS" xml:space="preserve">
     <value>The pool is syncing with the enabled remote YUM repository.</value>


### PR DESCRIPTION
Note that the change in FriendlyErroNames should be part of an SDK drop really, but for the time being I have added it as an isolated change  until the server side changes are merged and the issues plaguing the SDK generation are solved.