### PR TITLE
Some corrections on the DRWizard prechecks page:

### DIFF
--- a/XenAdmin/Diagnostics/Problems/PoolProblem/MissingSRProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/MissingSRProblem.cs
@@ -54,34 +54,30 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             this.device_config = device_config;
         }
 
-        public override string Title
-        {
-            get { return Check.Description; }
-        }
+        public override string Title => Check.Description;
 
 
         public override string Description
         {
             get
             {
-                return String.Format(sr.shared ? Messages.DR_WIZARD_PROBLEM_MISSING_SR : Messages.DR_WIZARD_PROBLEM_LOCAL_STORAGE, sr.Name());
+                if (sr == null)
+                    return Messages.DR_WIZARD_PROBLEM_MISSING_SR_NO_INFO;
+
+                return string.Format(sr.shared ? Messages.DR_WIZARD_PROBLEM_MISSING_SR : Messages.DR_WIZARD_PROBLEM_LOCAL_STORAGE, sr.Name());
             }
         }
 
-        public override string HelpMessage
-        {
-            get
-            {
-                return sr.shared ? Messages.DR_WIZARD_PROBLEM_MISSING_SR_HELPMESSAGE : "";
-            }
-        }
+        public override string HelpMessage => sr != null && sr.shared
+            ? Messages.DR_WIZARD_PROBLEM_MISSING_SR_HELPMESSAGE
+            : "";
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
             Program.AssertOnEventThread();
             cancelled = false;
 
-            if (!sr.shared)
+            if (sr == null || !sr.shared)
             {
                 return null;
             }

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.Designer.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.Designer.cs
@@ -13,9 +13,12 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                _worker.Dispose();
+
+                if (components != null)
+                    components.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -31,8 +34,8 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DRFailoverWizardPrecheckPage));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.checkBoxViewPrecheckFailuresOnly = new System.Windows.Forms.CheckBox();
-            this.panelErrorsFound = new System.Windows.Forms.Panel();
+            this.checkBoxHideSuccessful = new System.Windows.Forms.CheckBox();
+            this.panelErrorsFound = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
@@ -52,31 +55,30 @@
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // checkBoxViewPrecheckFailuresOnly
+            // checkBoxHideSuccessful
             // 
-            resources.ApplyResources(this.checkBoxViewPrecheckFailuresOnly, "checkBoxViewPrecheckFailuresOnly");
-            this.checkBoxViewPrecheckFailuresOnly.Name = "checkBoxViewPrecheckFailuresOnly";
-            this.checkBoxViewPrecheckFailuresOnly.UseVisualStyleBackColor = true;
-            this.checkBoxViewPrecheckFailuresOnly.CheckedChanged += new System.EventHandler(this.checkBoxViewPrecheckFailuresOnly_CheckedChanged);
+            resources.ApplyResources(this.checkBoxHideSuccessful, "checkBoxHideSuccessful");
+            this.checkBoxHideSuccessful.Name = "checkBoxHideSuccessful";
+            this.checkBoxHideSuccessful.UseVisualStyleBackColor = true;
+            this.checkBoxHideSuccessful.CheckedChanged += new System.EventHandler(this.checkBoxViewPrecheckFailuresOnly_CheckedChanged);
             // 
             // panelErrorsFound
             // 
             resources.ApplyResources(this.panelErrorsFound, "panelErrorsFound");
             this.tableLayoutPanel1.SetColumnSpan(this.panelErrorsFound, 3);
-            this.panelErrorsFound.Controls.Add(this.label1);
-            this.panelErrorsFound.Controls.Add(this.pictureBox1);
+            this.panelErrorsFound.Controls.Add(this.label1, 1, 0);
+            this.panelErrorsFound.Controls.Add(this.pictureBox1, 0, 0);
             this.panelErrorsFound.Name = "panelErrorsFound";
             // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
-            this.label1.AutoEllipsis = true;
             this.label1.Name = "label1";
             // 
             // pictureBox1
             // 
             resources.ApplyResources(this.pictureBox1, "pictureBox1");
-            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._000_error_h32bit_16;
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.TabStop = false;
             // 
@@ -152,7 +154,6 @@
             // 
             // labelPrechecksFirstLine
             // 
-            this.labelPrechecksFirstLine.AutoEllipsis = true;
             resources.ApplyResources(this.labelPrechecksFirstLine, "labelPrechecksFirstLine");
             this.tableLayoutPanel1.SetColumnSpan(this.labelPrechecksFirstLine, 3);
             this.labelPrechecksFirstLine.Name = "labelPrechecksFirstLine";
@@ -160,27 +161,25 @@
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.labelContinue, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelPrecheckStatus, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.panelErrorsFound, 0, 5);
-            this.tableLayoutPanel1.Controls.Add(this.checkBoxViewPrecheckFailuresOnly, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.progressBar1, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.dataGridView1, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.buttonResolveAll, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.buttonReCheckProblems, 2, 4);
+            this.tableLayoutPanel1.Controls.Add(this.labelContinue, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.labelPrecheckStatus, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.panelErrorsFound, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.checkBoxHideSuccessful, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.progressBar1, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.dataGridView1, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.buttonResolveAll, 2, 3);
+            this.tableLayoutPanel1.Controls.Add(this.buttonReCheckProblems, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.labelPrechecksFirstLine, 0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // labelContinue
             // 
             resources.ApplyResources(this.labelContinue, "labelContinue");
-            this.labelContinue.AutoEllipsis = true;
             this.tableLayoutPanel1.SetColumnSpan(this.labelContinue, 3);
             this.labelContinue.Name = "labelContinue";
             // 
             // labelPrecheckStatus
             // 
-            this.labelPrecheckStatus.AutoEllipsis = true;
             resources.ApplyResources(this.labelPrecheckStatus, "labelPrecheckStatus");
             this.tableLayoutPanel1.SetColumnSpan(this.labelPrecheckStatus, 3);
             this.labelPrecheckStatus.Name = "labelPrecheckStatus";
@@ -192,6 +191,7 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "DRFailoverWizardPrecheckPage";
             this.panelErrorsFound.ResumeLayout(false);
+            this.panelErrorsFound.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -202,8 +202,8 @@
 
         #endregion
 
-        private System.Windows.Forms.CheckBox checkBoxViewPrecheckFailuresOnly;
-        private System.Windows.Forms.Panel panelErrorsFound;
+        private System.Windows.Forms.CheckBox checkBoxHideSuccessful;
+        private System.Windows.Forms.TableLayoutPanel panelErrorsFound;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.ProgressBar progressBar1;

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.resx
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardPrecheckPage.resx
@@ -112,49 +112,52 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="checkBoxViewPrecheckFailuresOnly.AutoSize" type="System.Boolean, mscorlib">
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="checkBoxHideSuccessful.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="checkBoxHideSuccessful.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="checkBoxViewPrecheckFailuresOnly.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="checkBoxHideSuccessful.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="checkBoxViewPrecheckFailuresOnly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 326</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="checkBoxHideSuccessful.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 307</value>
   </data>
-  <data name="checkBoxViewPrecheckFailuresOnly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="checkBoxHideSuccessful.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 2, 0, 0</value>
   </data>
-  <data name="checkBoxViewPrecheckFailuresOnly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 19</value>
+  <data name="checkBoxHideSuccessful.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 19</value>
   </data>
-  <data name="checkBoxViewPrecheckFailuresOnly.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="checkBoxViewPrecheckFailuresOnly.Text" xml:space="preserve">
-    <value>&amp;View only pre-check failures/issues</value>
-  </data>
-  <data name="&gt;&gt;checkBoxViewPrecheckFailuresOnly.Name" xml:space="preserve">
-    <value>checkBoxViewPrecheckFailuresOnly</value>
-  </data>
-  <data name="&gt;&gt;checkBoxViewPrecheckFailuresOnly.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxViewPrecheckFailuresOnly.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;checkBoxViewPrecheckFailuresOnly.ZOrder" xml:space="preserve">
+  <data name="checkBoxHideSuccessful.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="panelErrorsFound.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+  <data name="checkBoxHideSuccessful.Text" xml:space="preserve">
+    <value>&amp;Hide successful pre-checks</value>
+  </data>
+  <data name="&gt;&gt;checkBoxHideSuccessful.Name" xml:space="preserve">
+    <value>checkBoxHideSuccessful</value>
+  </data>
+  <data name="&gt;&gt;checkBoxHideSuccessful.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxHideSuccessful.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;checkBoxHideSuccessful.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="panelErrorsFound.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -163,19 +166,25 @@
     <value>3</value>
   </data>
   <data name="labelContinue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>Left</value>
+  </data>
+  <data name="labelContinue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="labelContinue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelContinue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 381</value>
+    <value>3, 32</value>
+  </data>
+  <data name="labelContinue.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 10</value>
   </data>
   <data name="labelContinue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>540, 23</value>
+    <value>317, 13</value>
   </data>
   <data name="labelContinue.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>1</value>
   </data>
   <data name="labelContinue.Text" xml:space="preserve">
     <value>Click Fail Over to begin recovery of the selected vApps and VMs. </value>
@@ -187,13 +196,16 @@
     <value>labelContinue</value>
   </data>
   <data name="&gt;&gt;labelContinue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelContinue.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelContinue.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="labelPrecheckStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="labelPrecheckStatus.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -202,28 +214,22 @@
     <value>NoControl</value>
   </data>
   <data name="labelPrecheckStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 39</value>
-  </data>
-  <data name="labelPrecheckStatus.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="labelPrecheckStatus.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 6</value>
+    <value>3, 359</value>
   </data>
   <data name="labelPrecheckStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
+    <value>149, 13</value>
   </data>
   <data name="labelPrecheckStatus.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>7</value>
   </data>
   <data name="labelPrecheckStatus.Text" xml:space="preserve">
-    <value>Failover pre-checks completed: {0} issues found</value>
+    <value>Running failover pre-checks...</value>
   </data>
   <data name="&gt;&gt;labelPrecheckStatus.Name" xml:space="preserve">
     <value>labelPrecheckStatus</value>
   </data>
   <data name="&gt;&gt;labelPrecheckStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelPrecheckStatus.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -238,19 +244,22 @@
     <value>NoControl</value>
   </data>
   <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 64</value>
+    <value>3, 378</value>
+  </data>
+  <data name="progressBar1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 6, 3, 3</value>
   </data>
   <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
     <value>540, 23</value>
   </data>
   <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
     <value>progressBar1</value>
   </data>
   <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -258,7 +267,7 @@
   <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <metadata name="ColumnState.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnState.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnState.HeaderText" xml:space="preserve">
@@ -270,13 +279,13 @@
   <data name="ColumnState.Width" type="System.Int32, mscorlib">
     <value>20</value>
   </data>
-  <metadata name="ColumnDescription.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnDescription.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnDescription.HeaderText" xml:space="preserve">
     <value />
   </data>
-  <metadata name="ColumnSolution.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnSolution.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnSolution.HeaderText" xml:space="preserve">
@@ -292,22 +301,22 @@
     <value>Fill</value>
   </data>
   <data name="dataGridView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 93</value>
+    <value>0, 58</value>
   </data>
   <data name="dataGridView1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 0, 3</value>
   </data>
   <data name="dataGridView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>546, 227</value>
+    <value>546, 241</value>
   </data>
   <data name="dataGridView1.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Name" xml:space="preserve">
     <value>dataGridView1</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -315,17 +324,23 @@
   <data name="&gt;&gt;dataGridView1.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="buttonResolveAll.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="buttonResolveAll.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="buttonResolveAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="buttonResolveAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>377, 326</value>
+    <value>463, 305</value>
   </data>
   <data name="buttonResolveAll.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 23</value>
   </data>
   <data name="buttonResolveAll.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>5</value>
   </data>
   <data name="buttonResolveAll.Text" xml:space="preserve">
     <value>&amp;Resolve All</value>
@@ -334,7 +349,7 @@
     <value>buttonResolveAll</value>
   </data>
   <data name="&gt;&gt;buttonResolveAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;buttonResolveAll.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -342,26 +357,32 @@
   <data name="&gt;&gt;buttonResolveAll.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="buttonReCheckProblems.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="buttonReCheckProblems.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="buttonReCheckProblems.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="buttonReCheckProblems.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 326</value>
+    <value>377, 305</value>
   </data>
   <data name="buttonReCheckProblems.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 23</value>
   </data>
   <data name="buttonReCheckProblems.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>4</value>
   </data>
   <data name="buttonReCheckProblems.Text" xml:space="preserve">
-    <value>&amp;Check again</value>
+    <value>&amp;Check Again</value>
   </data>
   <data name="&gt;&gt;buttonReCheckProblems.Name" xml:space="preserve">
     <value>buttonReCheckProblems</value>
   </data>
   <data name="&gt;&gt;buttonReCheckProblems.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;buttonReCheckProblems.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -372,23 +393,23 @@
   <data name="labelPrechecksFirstLine.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="labelPrechecksFirstLine.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
   <data name="labelPrechecksFirstLine.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelPrechecksFirstLine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 0</value>
   </data>
   <data name="labelPrechecksFirstLine.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="labelPrechecksFirstLine.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 10</value>
+    <value>3, 0, 3, 6</value>
   </data>
   <data name="labelPrechecksFirstLine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>525, 39</value>
+    <value>540, 26</value>
   </data>
   <data name="labelPrechecksFirstLine.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>0</value>
   </data>
   <data name="labelPrechecksFirstLine.Text" xml:space="preserve">
     <value>Failover pre-checks are performed to ensure that the selected vApps and VMs can be failed over. Please take appropriate action to resolve any issues. </value>
@@ -397,7 +418,7 @@
     <value>labelPrechecksFirstLine</value>
   </data>
   <data name="&gt;&gt;labelPrechecksFirstLine.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelPrechecksFirstLine.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -418,13 +439,13 @@
     <value>546, 404</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -433,19 +454,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelContinue" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="labelPrecheckStatus" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="panelErrorsFound" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="checkBoxViewPrecheckFailuresOnly" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="dataGridView1" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="buttonResolveAll" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonReCheckProblems" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="labelPrechecksFirstLine" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,50,AutoSize,180" /&gt;&lt;Rows Styles="AutoSize,20,AutoSize,61,AutoSize,50,Percent,100,AutoSize,36,AutoSize,49,AutoSize,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelContinue" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="labelPrecheckStatus" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="panelErrorsFound" Row="4" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="checkBoxHideSuccessful" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="dataGridView1" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="buttonResolveAll" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="buttonReCheckProblems" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelPrechecksFirstLine" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>Left</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>25, 0</value>
+    <value>25, 4</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>512, 23</value>
+    <value>391, 13</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -460,7 +484,7 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>panelErrorsFound</value>
@@ -469,19 +493,16 @@
     <value>0</value>
   </data>
   <data name="pictureBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left</value>
+    <value>Left</value>
   </data>
   <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="pictureBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 0, 0</value>
+    <value>3, 3</value>
   </data>
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>25, 23</value>
+    <value>16, 16</value>
   </data>
   <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -490,7 +511,7 @@
     <value>pictureBox1</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
     <value>panelErrorsFound</value>
@@ -498,14 +519,17 @@
   <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="panelErrorsFound.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
   <data name="panelErrorsFound.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 355</value>
+    <value>3, 334</value>
   </data>
   <data name="panelErrorsFound.Size" type="System.Drawing.Size, System.Drawing">
-    <value>540, 23</value>
+    <value>540, 22</value>
   </data>
   <data name="panelErrorsFound.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>6</value>
   </data>
   <data name="panelErrorsFound.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -514,7 +538,7 @@
     <value>panelErrorsFound</value>
   </data>
   <data name="&gt;&gt;panelErrorsFound.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panelErrorsFound.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -522,7 +546,10 @@
   <data name="&gt;&gt;panelErrorsFound.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="panelErrorsFound.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -535,24 +562,24 @@
     <value>ColumnState</value>
   </data>
   <data name="&gt;&gt;ColumnState.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnDescription.Name" xml:space="preserve">
     <value>ColumnDescription</value>
   </data>
   <data name="&gt;&gt;ColumnDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnSolution.Name" xml:space="preserve">
     <value>ColumnSolution</value>
   </data>
   <data name="&gt;&gt;ColumnSolution.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>DRFailoverWizardPrecheckPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -14401,7 +14401,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Click Fail Over to begin the test recovery of the selected vApps and VMs..
+        ///   Looks up a localized string similar to Once done, click Fail Over to begin the test recovery of the selected vApps and VMs..
         /// </summary>
         public static string DR_WIZARD_PRECHECKPAGE_CONTINUE_DRYRUN {
             get {
@@ -14410,7 +14410,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Click Fail Back to begin recovery of the selected vApps and VMs to your primary data site..
+        ///   Looks up a localized string similar to Once done, click Fail Back to begin recovery of the selected vApps and VMs to your primary data site..
         /// </summary>
         public static string DR_WIZARD_PRECHECKPAGE_CONTINUE_FAILBACK {
             get {
@@ -14419,7 +14419,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Click Fail Over to begin recovery of the selected vApps and VMs..
+        ///   Looks up a localized string similar to Once done, click Fail Over to begin recovery of the selected vApps and VMs..
         /// </summary>
         public static string DR_WIZARD_PRECHECKPAGE_CONTINUE_FAILOVER {
             get {
@@ -14505,33 +14505,6 @@ namespace XenAdmin {
         public static string DR_WIZARD_PRECHECKPAGE_RESOLVE {
             get {
                 return ResourceManager.GetString("DR_WIZARD_PRECHECKPAGE_RESOLVE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failover pre-checks completed: {0} issues found.
-        /// </summary>
-        public static string DR_WIZARD_PRECHECKPAGE_STATUS_FAILURE {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_PRECHECKPAGE_STATUS_FAILURE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Running failover pre-checks:.
-        /// </summary>
-        public static string DR_WIZARD_PRECHECKPAGE_STATUS_RUNNING {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_PRECHECKPAGE_STATUS_RUNNING", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failover pre-checks completed: No issues found.
-        /// </summary>
-        public static string DR_WIZARD_PRECHECKPAGE_STATUS_SUCCESS {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_PRECHECKPAGE_STATUS_SUCCESS", resourceCulture);
             }
         }
         
@@ -14667,6 +14640,15 @@ namespace XenAdmin {
         public static string DR_WIZARD_PROBLEM_MISSING_SR_HELPMESSAGE {
             get {
                 return ResourceManager.GetString("DR_WIZARD_PROBLEM_MISSING_SR_HELPMESSAGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Missing SR information not found.
+        /// </summary>
+        public static string DR_WIZARD_PROBLEM_MISSING_SR_NO_INFO {
+            get {
+                return ResourceManager.GetString("DR_WIZARD_PROBLEM_MISSING_SR_NO_INFO", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5086,13 +5086,13 @@ Click Cancel if you prefer to reconfigure your VMs' memory settings manually.</v
     <value>Failover prerequisites</value>
   </data>
   <data name="DR_WIZARD_PRECHECKPAGE_CONTINUE_DRYRUN" xml:space="preserve">
-    <value>Click Fail Over to begin the test recovery of the selected vApps and VMs.</value>
+    <value>Once done, click Fail Over to begin the test recovery of the selected vApps and VMs.</value>
   </data>
   <data name="DR_WIZARD_PRECHECKPAGE_CONTINUE_FAILBACK" xml:space="preserve">
-    <value>Click Fail Back to begin recovery of the selected vApps and VMs to your primary data site.</value>
+    <value>Once done, click Fail Back to begin recovery of the selected vApps and VMs to your primary data site.</value>
   </data>
   <data name="DR_WIZARD_PRECHECKPAGE_CONTINUE_FAILOVER" xml:space="preserve">
-    <value>Click Fail Over to begin recovery of the selected vApps and VMs.</value>
+    <value>Once done, click Fail Over to begin recovery of the selected vApps and VMs.</value>
   </data>
   <data name="DR_WIZARD_PRECHECKPAGE_DESCRIPTION_FAILBACK" xml:space="preserve">
     <value>Failover pre-checks are performed to ensure that the selected vApps and VMs can be failed back to the selected pool. Please take appropriate action to resolve any issues.</value>
@@ -5120,15 +5120,6 @@ Click Cancel if you prefer to reconfigure your VMs' memory settings manually.</v
   </data>
   <data name="DR_WIZARD_PRECHECKPAGE_RESOLVE" xml:space="preserve">
     <value>Resolve</value>
-  </data>
-  <data name="DR_WIZARD_PRECHECKPAGE_STATUS_FAILURE" xml:space="preserve">
-    <value>Failover pre-checks completed: {0} issues found</value>
-  </data>
-  <data name="DR_WIZARD_PRECHECKPAGE_STATUS_RUNNING" xml:space="preserve">
-    <value>Running failover pre-checks:</value>
-  </data>
-  <data name="DR_WIZARD_PRECHECKPAGE_STATUS_SUCCESS" xml:space="preserve">
-    <value>Failover pre-checks completed: No issues found</value>
   </data>
   <data name="DR_WIZARD_PRECHECKPAGE_TEXT" xml:space="preserve">
     <value>Pre-checks</value>
@@ -5174,6 +5165,9 @@ Click Cancel if you prefer to reconfigure your VMs' memory settings manually.</v
   </data>
   <data name="DR_WIZARD_PROBLEM_MISSING_SR_HELPMESSAGE" xml:space="preserve">
     <value>Attach SR</value>
+  </data>
+  <data name="DR_WIZARD_PROBLEM_MISSING_SR_NO_INFO" xml:space="preserve">
+    <value>Missing SR information not found</value>
   </data>
   <data name="DR_WIZARD_PROBLEM_RUNNING_APPLIANCE" xml:space="preserve">
     <value>Is running on pool '{0}'</value>


### PR DESCRIPTION
- Re-arranged and re-worded controls so that this page looks more like
  the precheck page of the patching and RPU wizards.
- Do not show the failure message unless issues are found.
- Do no enable the Resolve All button unless all issues are fixable.
- Fixed crash when the required SR is present in the pool but detached.