### PR TITLE
CA-334613: Clip region within which performance graph lines are drawn

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/LineRenderer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/LineRenderer.cs
@@ -43,6 +43,10 @@ namespace XenAdmin.Controls.CustomDataGraph
             if (points.Count == 0)
                 return;
 
+            // CA-334613: Sharp turns in the graph can result in
+            // the line being drawn outside of the box
+            g.SetClip(r);
+
             int index = points.FindIndex(dataPoint => dataPoint.Y < 0);
             if (index >= 0)
             {


### PR DESCRIPTION
Sharp turns in the graph can result in the line being drawn outside of the box.
This change makes sure the line is only rendered within the input rectangle.

It's easier to replicate if you shrink the window size as much as possible

#### Before:

![image](https://user-images.githubusercontent.com/32554698/161036787-46d2490b-bd86-4df7-9837-0a1458d56913.png)
#### After:

![image](https://user-images.githubusercontent.com/32554698/161036803-5914455c-88b9-48cc-b0ff-a63a1b71cae1.png)