### PR TITLE
CA-329538: Tell the user to ensure tools are installed if a VM cannot be migrated via drag-and-drop

### DIFF
--- a/XenAdmin/Controls/MainWindowControls/NavigationView.cs
+++ b/XenAdmin/Controls/MainWindowControls/NavigationView.cs
@@ -742,7 +742,7 @@ namespace XenAdmin.Controls.MainWindowControls
                 if (cmd.CanRun())
                     targetToHighlight = cmd.HighlightNode;
 
-                if (cmd.StatusBarText != null)
+                if (!string.IsNullOrEmpty(cmd.StatusBarText))
                     statusBarText = cmd.StatusBarText;
             }
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -24951,7 +24951,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This VM may not migrate at the moment.
+        ///   Looks up a localized string similar to &apos;{0}&apos; may not migrate at the moment. Please ensure you have installed {1} on it.
         /// </summary>
         public static string MIGRATION_NOT_ALLOWED {
             get {
@@ -24960,7 +24960,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This VM may not migrate because the destination host does not have some of the CPU features that the VM is currently using.
+        ///   Looks up a localized string similar to &apos;{0}&apos; may not migrate because the destination host does not have some of the CPU features that the VM is currently using.
         /// </summary>
         public static string MIGRATION_NOT_ALLOWED_CPU_FEATURES {
             get {
@@ -24969,7 +24969,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This VM may not migrate; it is not on shared storage.
+        ///   Looks up a localized string similar to &apos;{0}&apos; may not migrate because it is not on shared storage.
         /// </summary>
         public static string MIGRATION_NOT_ALLOWED_NO_SHARED_STORAGE {
             get {
@@ -24978,7 +24978,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A VM may not migrate outside of its pool.
+        ///   Looks up a localized string similar to &apos;{0}&apos; may not migrate outside its pool.
         /// </summary>
         public static string MIGRATION_NOT_ALLOWED_OUTSIDE_POOL {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -8677,16 +8677,16 @@ Do you want to continue?</value>
     <value>Please eject your CD</value>
   </data>
   <data name="MIGRATION_NOT_ALLOWED" xml:space="preserve">
-    <value>This VM may not migrate at the moment</value>
+    <value>'{0}' may not migrate at the moment. Please ensure you have installed {1} on it</value>
   </data>
   <data name="MIGRATION_NOT_ALLOWED_CPU_FEATURES" xml:space="preserve">
-    <value>This VM may not migrate because the destination host does not have some of the CPU features that the VM is currently using</value>
+    <value>'{0}' may not migrate because the destination host does not have some of the CPU features that the VM is currently using</value>
   </data>
   <data name="MIGRATION_NOT_ALLOWED_NO_SHARED_STORAGE" xml:space="preserve">
-    <value>This VM may not migrate; it is not on shared storage</value>
+    <value>'{0}' may not migrate because it is not on shared storage</value>
   </data>
   <data name="MIGRATION_NOT_ALLOWED_OUTSIDE_POOL" xml:space="preserve">
-    <value>A VM may not migrate outside of its pool</value>
+    <value>'{0}' may not migrate outside its pool</value>
   </data>
   <data name="MIN" xml:space="preserve">
     <value>Min</value>


### PR DESCRIPTION
Also, show the name of the VM in the various failure messages as drag-and-drop may operate on multiple VMs.