### PR TITLE
CA-293683: Prevent automatic scrolling in RPU wizard if user has scrolled manually

### DIFF
--- a/XenAdmin/Controls/SmartScrollTextBox.cs
+++ b/XenAdmin/Controls/SmartScrollTextBox.cs
@@ -1,0 +1,121 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Windows.Forms;
+using XenCenterLib;
+
+namespace XenAdmin.Controls
+{
+    /// <summary>
+    /// Extension of <see cref="TextBox"/> which implements extra event handlers.
+    /// Currently:
+    /// <list type="table">
+    ///     <item>
+    ///         <term>OnScrollChange</term>
+    ///         <description>Called when user initiates scrolling</description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    internal class SmartScrollTextBox : TextBox
+    {
+        protected internal bool IsVerticalScrollBarAtBottom =>
+            string.IsNullOrEmpty(Text) || GetPositionFromCharIndex(Text.Length).Y < Height;
+
+        #region Custom Events
+
+        /// <summary>
+        /// Delegate for <see cref="OnScrollChange"/> which is fired when the user initiates scrolling.
+        /// <br />
+        /// If the event is fired by <see cref="Keys.PageUp"/> or <see cref="Keys.PageDown"/> , consider hooking into the <see cref="Control.KeyUp"/> event, as the scrollbar position
+        /// changes after the keys have been pressed.
+        /// </summary>
+        /// <param name="newPosition">The new position of the scrollbar.</param>
+        /// <param name="scrollBarOrientation">The orientation of the scrollbar.</param>
+        public delegate void ScrollChange(int newPosition, Orientation scrollBarOrientation);
+
+        /// <summary>
+        /// Event called when user initiates scrolling in the following ways:
+        /// <list type="bullet">
+        ///     <item>Moves the mouse wheel. This also supports horizontal scrolling (performed by holding shift)</item>
+        ///     <item>Drags the scrollbar</item>
+        ///     <item>Presses <see cref="Keys.PageUp"/> or <see cref="Keys.PageDown"/> keys</item>
+        ///     <item>Presses <see cref="Keys.Up"/> or <see cref="Keys.Down"/> keys</item>
+        /// </list>
+        /// </summary>
+        public event ScrollChange OnScrollChange;
+        #endregion
+
+        #region Control Overrides
+        protected override void WndProc(ref Message m)
+        {
+            if (OnScrollChange != null)
+            {
+                int newPosition;
+                switch (m.Msg)
+                {
+                    case Win32.WM_VSCROLL:
+                        newPosition = Win32.GetScrollBarPosition(Handle, Win32.ScrollBarConstants.SB_VERT);
+                        OnScrollChange.Invoke(newPosition, Orientation.Vertical);
+                        break;
+                    case Win32.WM_HSCROLL:
+                        newPosition = Win32.GetScrollBarPosition(Handle, Win32.ScrollBarConstants.SB_HORZ);
+                        OnScrollChange.Invoke(newPosition, Orientation.Vertical);
+                        break;
+                    case Win32.WM_MOUSEWHEEL:
+                        // holding shift is horizontal scrolling
+                        newPosition = Win32.GetScrollBarPosition(Handle, ModifierKeys == Keys.Shift ? Win32.ScrollBarConstants.SB_HORZ : Win32.ScrollBarConstants.SB_VERT);
+                        OnScrollChange.Invoke(newPosition, ModifierKeys == Keys.Shift ? Orientation.Horizontal : Orientation.Vertical);
+                        break;
+
+                }
+            }
+            base.WndProc(ref m);
+        }
+
+        protected override bool ProcessCmdKey(ref Message m, Keys keyData)
+        {
+            if (OnScrollChange != null && (m.Msg == Win32.WM_KEYDOWN || m.Msg == Win32.WM_SYSKEYDOWN))
+            {
+                switch (keyData)
+                {
+                    case Keys.PageDown:
+                    case Keys.PageUp:
+                    case Keys.Down:
+                    case Keys.Up:
+                        OnScrollChange?.Invoke(Win32.GetScrollBarPosition(Handle, Win32.ScrollBarConstants.SB_VERT), Orientation.Vertical);
+                        break;
+                }
+            }
+            return base.ProcessCmdKey(ref m, keyData);
+        }
+        #endregion
+    }
+}

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -50,28 +50,23 @@ namespace XenAdmin.Wizards.PatchingWizard
     public enum Status { NotStarted, Started, Cancelled, Completed }
     public abstract partial class AutomatedUpdatesBasePage : XenTabPage
     {
-        protected static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
-
-        protected bool ThisPageIsCompleted;
-
-        public List<Problem> PrecheckProblemsActuallyResolved { private get; set; }
-        public List<Pool> SelectedPools { private get; set; }
-        public Status Status { get; private set; }
-
-        protected bool IsSuccess => ThisPageIsCompleted && !_failedWorkers.Any();
-
         private List<UpdateProgressBackgroundWorker> _backgroundWorkers = new List<UpdateProgressBackgroundWorker>();
         private List<UpdateProgressBackgroundWorker> _failedWorkers = new List<UpdateProgressBackgroundWorker>();
-
         private readonly List<HostUpdateMapping> _patchMappings = new List<HostUpdateMapping>();
-        protected List<string> HostsThatWillRequireReboot = new List<string>();
-        protected Dictionary<string, List<string>> LivePatchAttempts = new Dictionary<string, List<string>>();
-
-        public Dictionary<XenServerPatch, string> AllDownloadedPatches { get; } = new Dictionary<XenServerPatch, string>();
-
 
         private bool _userMovedVerticalScrollbar;
         private bool _cancelEnabled;
+
+        protected static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
+        protected List<string> HostsThatWillRequireReboot = new List<string>();
+        protected Dictionary<string, List<string>> LivePatchAttempts = new Dictionary<string, List<string>>();
+        protected bool ThisPageIsCompleted;
+        protected bool IsSuccess => ThisPageIsCompleted && !_failedWorkers.Any();
+
+        public Dictionary<XenServerPatch, string> AllDownloadedPatches { get; } = new Dictionary<XenServerPatch, string>();
+        public List<Problem> PrecheckProblemsActuallyResolved { private get; set; }
+        public List<Pool> SelectedPools { private get; set; }
+        public Status Status { get; private set; }
 
         protected AutomatedUpdatesBasePage()
         {
@@ -564,6 +559,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             SkipFailedActions();
         }
+
         private void TextBoxLog_OnScrollChange(int _, Orientation orientation)
         {
             if (orientation == Orientation.Vertical)

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -43,6 +43,7 @@ using System.Windows.Forms;
 using XenAdmin.Diagnostics.Problems;
 using XenAdmin.Dialogs;
 using XenAdmin.Wizards.RollingUpgradeWizard.PlanActions;
+using Console = System.Console;
 
 
 namespace XenAdmin.Wizards.PatchingWizard
@@ -316,10 +317,18 @@ namespace XenAdmin.Wizards.PatchingWizard
                 stringBuilder.Append(sb);
             }
 
-            textBoxLog.Text = stringBuilder.ToString();
-            textBoxLog.SelectionStart = textBoxLog.Text.Length;
+            var newText = stringBuilder.ToString();
+            
             if (!_userMovedVerticalScrollbar)
+            {
+                textBoxLog.Text = newText;
+                textBoxLog.SelectionStart = textBoxLog.Text.Length;
                 textBoxLog.ScrollToCaret();
+            }
+            else
+            {
+                textBoxLog.SetTextWithoutScrolling(newText);
+            }
         }
 
         private void WorkerDoWork(object sender, DoWorkEventArgs doWorkEventArgs)

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.designer.cs
@@ -1,3 +1,5 @@
+using XenAdmin.Controls;
+
 namespace XenAdmin.Wizards.PatchingWizard
 {
     partial class AutomatedUpdatesBasePage
@@ -32,7 +34,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AutomatedUpdatesBasePage));
             this.labelTitle = new System.Windows.Forms.Label();
-            this.textBoxLog = new System.Windows.Forms.TextBox();
+            this.textBoxLog = new SmartScrollTextBox();
             this.progressBar = new System.Windows.Forms.ProgressBar();
             this.labelError = new System.Windows.Forms.Label();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
@@ -56,6 +58,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             resources.ApplyResources(this.textBoxLog, "textBoxLog");
             this.textBoxLog.Name = "textBoxLog";
             this.textBoxLog.ReadOnly = true;
+            textBoxLog.OnScrollChange += TextBoxLog_OnScrollChange;
             // 
             // progressBar
             // 
@@ -126,7 +129,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         #endregion
 
         private System.Windows.Forms.Label labelTitle;
-        private System.Windows.Forms.TextBox textBoxLog;
+        private SmartScrollTextBox textBoxLog;
         private System.Windows.Forms.ProgressBar progressBar;
         private System.Windows.Forms.Label labelError;
         private System.Windows.Forms.PictureBox pictureBox1;

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.designer.cs
@@ -17,7 +17,7 @@ namespace XenAdmin.Wizards.PatchingWizard
         {
             if (disposing)
             {
-                backgroundWorkers.ForEach(bgw => bgw.Dispose());
+                _backgroundWorkers.ForEach(bgw => bgw.Dispose());
                 if (components != null)
                     components.Dispose();
             }

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.resx
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.resx
@@ -409,6 +409,6 @@
     <value>AutomatedUpdatesBasePage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_UploadPage.cs
@@ -141,13 +141,13 @@ namespace XenAdmin.Wizards.PatchingWizard
 
         public override bool EnablePrevious()
         {
-            return _thisPageIsCompleted;
+            return ThisPageIsCompleted;
         }
 
         protected override void PageLeaveCore(PageLoadedDirection direction, ref bool cancel)
         {
             if (direction == PageLoadedDirection.Back)
-                _thisPageIsCompleted = false;
+                ThisPageIsCompleted = false;
         }
 
         #endregion
@@ -215,7 +215,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             var coordinator = Helpers.GetCoordinator(pool);
             var planActions = new List<PlanAction>();
 
-            var alertPatch = SelectedUpdateAlert == null ? null : SelectedUpdateAlert.Patch;
+            var alertPatch = SelectedUpdateAlert?.Patch;
 
             bool download = alertPatch != null && PatchFromDisk.Key == null &&
                             (!AllDownloadedPatches.ContainsKey(alertPatch) || !File.Exists(AllDownloadedPatches[alertPatch]));

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeUpgradePage.cs
@@ -164,7 +164,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             if (ApplySuppPackAfterUpgrade && Helpers.ElyOrGreater(host))
             {
                 var suppPackPlanAction = new RpuUploadAndApplySuppPackPlanAction(host.Connection,
-                    host, hosts, SelectedSuppPackPath, UploadedSuppPacks, hostsThatWillRequireReboot);
+                    host, hosts, SelectedSuppPackPath, UploadedSuppPacks, HostsThatWillRequireReboot);
                 theHostPlan.UpdatesPlanActions.Add(suppPackPlanAction);
             }
         }

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -111,6 +111,9 @@
     <Compile Include="Alerts\Types\MessageAlert.cs" />
     <Compile Include="Alerts\Types\XenServerPatchAlert.cs" />
     <Compile Include="Alerts\Types\XenServerVersionAlert.cs" />
+    <Compile Include="Controls\SmartScrollTextBox.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Commands\CallHomeCommand.cs" />
     <Compile Include="Commands\ChangeControlDomainMemoryCommand.cs" />
     <Compile Include="Commands\DockerContainerCommand.cs" />

--- a/XenCenterLib/Win32.cs
+++ b/XenCenterLib/Win32.cs
@@ -387,6 +387,9 @@ namespace XenCenterLib
         public static extern bool EnumUILanguages(EnumUILanguagesProc pUILanguageEnumProc,
            uint dwFlags, IntPtr lParam);
 
+        [DllImport("user32.dll")]
+        public static extern int SetScrollPos(IntPtr hWnd, int nBar, int nPos, bool bRedraw);
+
         #region Window scrolling functions
 
         /// <summary>
@@ -498,6 +501,10 @@ namespace XenCenterLib
         [return: MarshalAs(UnmanagedType.Bool)]
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+        
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll")] 
+        public static extern bool PostMessageA(IntPtr hWnd, int nBar, int wParam, int lParam);
 
         #region Disk space functions
 

--- a/XenCenterLib/Win32.cs
+++ b/XenCenterLib/Win32.cs
@@ -212,6 +212,7 @@ namespace XenCenterLib
         public const int WM_MBUTTONDBLCLK = 0x209;
         public const int WM_MOUSEWHEEL = 0x20A;
         public const int WM_MOUSEHWHEEL = 0x20E;
+        public const int WM_SYSKEYDOWN = 0x104;
 
         public const int WM_PARENTNOTIFY = 0x210;
 
@@ -387,6 +388,21 @@ namespace XenCenterLib
            uint dwFlags, IntPtr lParam);
 
         #region Window scrolling functions
+
+        /// <summary>
+        /// Get the current position of the input scrollbar
+        /// </summary>
+        /// <param name="scrollBarHandle">Handler of the control. Usually the Handler field</param>
+        /// <param name="scrollBarConstant">SB_VERT or SB_HORZ</param>
+        /// <returns>The position as returned by GetScrollInfo</returns>
+        public static int GetScrollBarPosition(IntPtr scrollBarHandle, ScrollBarConstants scrollBarConstant)
+        {
+            var scrollInfo = new ScrollInfo();
+            scrollInfo.cbSize = (uint)Marshal.SizeOf(scrollInfo);
+            scrollInfo.fMask = (uint)ScrollInfoMask.SIF_TRACKPOS;
+            GetScrollInfo(scrollBarHandle, (int)scrollBarConstant, ref scrollInfo);
+            return scrollInfo.nTrackPos;
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         public struct ScrollInfo


### PR DESCRIPTION
### 🚨 Please review each commit separately
Only the first one contains the fix.

The others are to tidy some aspects of the code.

Feel free to weigh in on the naming and/or location of `AppTextBox`, I wasn't sure what to choose for them.

_______

The basic idea here is that we're not automatically keeping the `TextBox` scrolled all the way down if the user has moved the scrollbar.
If they move it back to the bottom, it'll go back to scrolling automatically.

I have also made the event return the `newPosition` of the bar, and added _ad-hoc_ logic for the horizontal scrollbar. This is just so this event is ready for other use cases that might arise in the future.