### PR TITLE
Some layout and logic changes so the `DRFailoverWizardRecoverPage` looks and behaves more like the other wizard pages with progress bars

### DIFF
--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizard.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizard.cs
@@ -61,11 +61,8 @@ namespace XenAdmin.Wizards.DRWizards
         private DRWizardType WizardType;
         private SummaryReport SummaryReport = new SummaryReport();
 
-        public DRFailoverWizard(Pool pool)
-            : this(pool, DRWizardType.Unknown)
-        { }
-         
-        public DRFailoverWizard(Pool pool, DRWizardType wizardType)
+
+        public DRFailoverWizard(Pool pool, DRWizardType wizardType = DRWizardType.Unknown)
             : base(pool.Connection)
         {
             InitializeComponent();

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardRecoverPage.Designer.cs
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardRecoverPage.Designer.cs
@@ -38,7 +38,6 @@
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.labelContinue = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
@@ -104,20 +103,12 @@
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.labelContinue, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.labelTitle, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.linkLabel1, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.dataGridView1, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.labelOverallProgress, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.progressBar1, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.dataGridView1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.labelOverallProgress, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.progressBar1, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.linkLabel1, 0, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // labelContinue
-            // 
-            resources.ApplyResources(this.labelContinue, "labelContinue");
-            this.labelContinue.AutoEllipsis = true;
-            this.tableLayoutPanel1.SetColumnSpan(this.labelContinue, 3);
-            this.labelContinue.Name = "labelContinue";
             // 
             // DRFailoverWizardRecoverPage
             // 
@@ -144,7 +135,6 @@
         private System.Windows.Forms.ProgressBar progressBar1;
         private System.Windows.Forms.LinkLabel linkLabel1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Label labelContinue;
 
 
     }

--- a/XenAdmin/Wizards/DRWizards/DRFailoverWizardRecoverPage.resx
+++ b/XenAdmin/Wizards/DRWizards/DRFailoverWizardRecoverPage.resx
@@ -112,31 +112,28 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelOverallProgress.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="labelOverallProgress.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="labelOverallProgress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 22</value>
-  </data>
-  <data name="labelOverallProgress.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 6</value>
+    <value>3, 323</value>
   </data>
   <data name="labelOverallProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 22</value>
+    <value>67, 13</value>
   </data>
   <data name="labelOverallProgress.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
+    <value>3</value>
   </data>
   <data name="labelOverallProgress.Text" xml:space="preserve">
     <value>1 of 20 done</value>
@@ -145,21 +142,21 @@
     <value>labelOverallProgress</value>
   </data>
   <data name="&gt;&gt;labelOverallProgress.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelOverallProgress.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelOverallProgress.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>2</value>
   </data>
-  <metadata name="ColumnHost.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnHost.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnHost.HeaderText" xml:space="preserve">
     <value>Task</value>
   </data>
-  <metadata name="ColumnIcon.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnIcon.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnIcon.HeaderText" xml:space="preserve">
@@ -168,7 +165,7 @@
   <data name="ColumnIcon.Width" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <metadata name="ColumnStatus.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnStatus.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ColumnStatus.HeaderText" xml:space="preserve">
@@ -184,25 +181,25 @@
     <value>Fill</value>
   </data>
   <data name="dataGridView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 73</value>
+    <value>3, 31</value>
   </data>
   <data name="dataGridView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>519, 239</value>
+    <value>519, 271</value>
   </data>
   <data name="dataGridView1.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Name" xml:space="preserve">
     <value>dataGridView1</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;dataGridView1.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="labelTitle.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -211,19 +208,16 @@
     <value>NoControl</value>
   </data>
   <data name="labelTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 0</value>
   </data>
   <data name="labelTitle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="labelTitle.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 6</value>
+    <value>3, 0, 3, 15</value>
   </data>
   <data name="labelTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>283, 22</value>
+    <value>283, 13</value>
   </data>
   <data name="labelTitle.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+    <value>0</value>
   </data>
   <data name="labelTitle.Text" xml:space="preserve">
     <value>Disaster Recovery is in progress. This may take some time.</value>
@@ -232,109 +226,79 @@
     <value>labelTitle</value>
   </data>
   <data name="&gt;&gt;labelTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;labelTitle.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelTitle.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
-  <data name="progressBar1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+  <data name="progressBar1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
   </data>
   <data name="progressBar1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 47</value>
+    <value>3, 339</value>
   </data>
   <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
     <value>519, 20</value>
   </data>
   <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
     <value>progressBar1</value>
   </data>
   <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="linkLabel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+    <value>Top, Right</value>
+  </data>
+  <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="linkLabel1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="linkLabel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 315</value>
+    <value>468, 305</value>
+  </data>
+  <data name="linkLabel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 5</value>
   </data>
   <data name="linkLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>519, 24</value>
+    <value>54, 13</value>
   </data>
   <data name="linkLabel1.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>2</value>
   </data>
   <data name="linkLabel1.Text" xml:space="preserve">
     <value>Open Log</value>
-  </data>
-  <data name="linkLabel1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
   </data>
   <data name="&gt;&gt;linkLabel1.Name" xml:space="preserve">
     <value>linkLabel1</value>
   </data>
   <data name="&gt;&gt;linkLabel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;linkLabel1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="labelContinue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="labelContinue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelContinue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 339</value>
-  </data>
-  <data name="labelContinue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>519, 23</value>
-  </data>
-  <data name="labelContinue.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="labelContinue.Text" xml:space="preserve">
-    <value>Click Finish to close this wizard.</value>
-  </data>
-  <data name="labelContinue.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;labelContinue.Name" xml:space="preserve">
-    <value>labelContinue</value>
-  </data>
-  <data name="&gt;&gt;labelContinue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelContinue.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelContinue.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -343,19 +307,19 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>525, 362</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -364,9 +328,9 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelContinue" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="labelTitle" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="linkLabel1" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="dataGridView1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelOverallProgress" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,50,AutoSize,50,AutoSize,75,Percent,100,AutoSize,46,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelTitle" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="dataGridView1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelOverallProgress" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="progressBar1" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="linkLabel1" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -379,24 +343,24 @@
     <value>ColumnHost</value>
   </data>
   <data name="&gt;&gt;ColumnHost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnIcon.Name" xml:space="preserve">
     <value>ColumnIcon</value>
   </data>
   <data name="&gt;&gt;ColumnIcon.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewImageColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnStatus.Name" xml:space="preserve">
     <value>ColumnStatus</value>
   </data>
   <data name="&gt;&gt;ColumnStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>DRFailoverWizardRecoverPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -14635,6 +14635,39 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Test failover is in progress. This may take some time.
+        ///
+        ///Once done, click Next to remove the vApps and VMs that were failed over and to see the summary report..
+        /// </summary>
+        public static string DR_WIZARD_RECOVERPAGE_BLURB_DRYRUN {
+            get {
+                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_BLURB_DRYRUN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failback is in progress. This may take some time.
+        ///
+        ///Once done,  click Next to see the summary report..
+        /// </summary>
+        public static string DR_WIZARD_RECOVERPAGE_BLURB_FAILBACK {
+            get {
+                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_BLURB_FAILBACK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} Disaster Recovery is in progress. This may take some time.
+        ///
+        ///Once done, click Next to see the summary report..
+        /// </summary>
+        public static string DR_WIZARD_RECOVERPAGE_BLURB_FAILOVER {
+            get {
+                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_BLURB_FAILOVER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Test failover to pool &apos;{0}&apos; is complete..
         /// </summary>
         public static string DR_WIZARD_RECOVERPAGE_COMPLETE_DRYRUN {
@@ -14658,60 +14691,6 @@ namespace XenAdmin {
         public static string DR_WIZARD_RECOVERPAGE_COMPLETE_FAILOVER {
             get {
                 return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_COMPLETE_FAILOVER", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Click Next to remove the vApps and VMs that were failed over and to see the summary report..
-        /// </summary>
-        public static string DR_WIZARD_RECOVERPAGE_CONTINUE_DRYRUN {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_CONTINUE_DRYRUN", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Click Next to see the summary report..
-        /// </summary>
-        public static string DR_WIZARD_RECOVERPAGE_CONTINUE_FAILBACK {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_CONTINUE_FAILBACK", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Click Next to see the summary report..
-        /// </summary>
-        public static string DR_WIZARD_RECOVERPAGE_CONTINUE_FAILOVER {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_CONTINUE_FAILOVER", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Test failover is in progress. This may take some time..
-        /// </summary>
-        public static string DR_WIZARD_RECOVERPAGE_IN_PROGRESS_DRYRUN {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_IN_PROGRESS_DRYRUN", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failback is in progress. This may take some time..
-        /// </summary>
-        public static string DR_WIZARD_RECOVERPAGE_IN_PROGRESS_FAILBACK {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_IN_PROGRESS_FAILBACK", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} Disaster Recovery is in progress. This may take some time..
-        /// </summary>
-        public static string DR_WIZARD_RECOVERPAGE_IN_PROGRESS_FAILOVER {
-            get {
-                return ResourceManager.GetString("DR_WIZARD_RECOVERPAGE_IN_PROGRESS_FAILOVER", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5163,6 +5163,21 @@ Click Cancel if you prefer to reconfigure your VMs' memory settings manually.</v
   <data name="DR_WIZARD_PROBLEM_RUNNING_VM_HELPMESSAGE" xml:space="preserve">
     <value>Shut down VM</value>
   </data>
+  <data name="DR_WIZARD_RECOVERPAGE_BLURB_DRYRUN" xml:space="preserve">
+    <value>Test failover is in progress. This may take some time.
+
+Once done, click Next to remove the vApps and VMs that were failed over and to see the summary report.</value>
+  </data>
+  <data name="DR_WIZARD_RECOVERPAGE_BLURB_FAILBACK" xml:space="preserve">
+    <value>Failback is in progress. This may take some time.
+
+Once done,  click Next to see the summary report.</value>
+  </data>
+  <data name="DR_WIZARD_RECOVERPAGE_BLURB_FAILOVER" xml:space="preserve">
+    <value>{0} Disaster Recovery is in progress. This may take some time.
+
+Once done, click Next to see the summary report.</value>
+  </data>
   <data name="DR_WIZARD_RECOVERPAGE_COMPLETE_DRYRUN" xml:space="preserve">
     <value>Test failover to pool '{0}' is complete.</value>
   </data>
@@ -5171,24 +5186,6 @@ Click Cancel if you prefer to reconfigure your VMs' memory settings manually.</v
   </data>
   <data name="DR_WIZARD_RECOVERPAGE_COMPLETE_FAILOVER" xml:space="preserve">
     <value>{0} Disaster Recovery is complete.</value>
-  </data>
-  <data name="DR_WIZARD_RECOVERPAGE_CONTINUE_DRYRUN" xml:space="preserve">
-    <value>Click Next to remove the vApps and VMs that were failed over and to see the summary report.</value>
-  </data>
-  <data name="DR_WIZARD_RECOVERPAGE_CONTINUE_FAILBACK" xml:space="preserve">
-    <value>Click Next to see the summary report.</value>
-  </data>
-  <data name="DR_WIZARD_RECOVERPAGE_CONTINUE_FAILOVER" xml:space="preserve">
-    <value>Click Next to see the summary report.</value>
-  </data>
-  <data name="DR_WIZARD_RECOVERPAGE_IN_PROGRESS_DRYRUN" xml:space="preserve">
-    <value>Test failover is in progress. This may take some time.</value>
-  </data>
-  <data name="DR_WIZARD_RECOVERPAGE_IN_PROGRESS_FAILBACK" xml:space="preserve">
-    <value>Failback is in progress. This may take some time.</value>
-  </data>
-  <data name="DR_WIZARD_RECOVERPAGE_IN_PROGRESS_FAILOVER" xml:space="preserve">
-    <value>{0} Disaster Recovery is in progress. This may take some time.</value>
   </data>
   <data name="DR_WIZARD_RECOVERPAGE_OVERALL_PROGRESS" xml:space="preserve">
     <value>Overall progress: {0} of {1} tasks completed</value>


### PR DESCRIPTION
Normally we don't change the blurb at the top of the page, only the status text at the bottom. I also moved the progress bar to the bottom, so now the only wizard page where the progress bar is not at the bottom is the `AutomatedUpdates` page.