### PR TITLE
Point URL in `CHCUpdates.xml` to MSI location

### DIFF
--- a/scripts/xenadmin-build.sh
+++ b/scripts/xenadmin-build.sh
@@ -221,13 +221,16 @@ cp ${REPO}/XenAdmin/bin/Release/{CommandLib.pdb,${BRANDING_BRAND_CONSOLE_NO_SPAC
 
 cd ${OUTPUT_DIR} && zip -r -m  ${BRANDING_BRAND_CONSOLE_NO_SPACE}.Symbols.zip *.pdb
 
-msi_checksum_with_file_name=`sha256sum ./CitrixHypervisorCenter.msi`
+msi_checksum_with_file_name=`sha256sum ./${BRANDING_BRAND_CONSOLE_NO_SPACE}.msi`
 echo $msi_checksum_with_file_name > ${OUTPUT_DIR}/${BRANDING_BRAND_CONSOLE_NO_SPACE}.msi.checksum
 msi_checksum=($msi_checksum_with_file_name)
 
 sha256sum ${OUTPUT_DIR}/${BRANDING_BRAND_CONSOLE_NO_SPACE}-source.zip > ${OUTPUT_DIR}/${BRANDING_BRAND_CONSOLE_NO_SPACE}-source.zip.checksum
 
 echo "INFO: Generating CHCUpdates.xml"
+
+# UPDATE_URL points at the updates XML, we need to point to the MSI
+msi_url="${UPDATES_URL/CHCUpdates.xml/$BRANDING_BRAND_CONSOLE_NO_SPACE.msi}"
 
 output_xml="<?xml version=\"1.0\" ?>
 <patchdata>
@@ -237,7 +240,7 @@ output_xml="<?xml version=\"1.0\" ?>
             latestcr=\"true\"
             name=\"${BRANDING_BRAND_CONSOLE} ${BRANDING_XC_PRODUCT_VERSION}.${1}\"
             timestamp=\"`date -u +"%Y-%m-%dT%H:%M:%SZ"`\"
-            url=\"${UPDATES_URL}\"
+            url=\"${msi_url}\"
             checksum=\"${msi_checksum}\"
             value=\"${BRANDING_XC_PRODUCT_VERSION}.${1}\"
         />	
@@ -248,6 +251,6 @@ echo $output_xml > ${OUTPUT_DIR}/CHCUpdates.xml
 
 echo "INFO: Generating stage-test-CHCUpdates.xml. URL is a placeholder value"
 
-echo "${output_xml/"url=\"${UPDATES_URL}\""/"url=\"@DEV_MSI_URL_PLACEHOLDER@\""}" > ${OUTPUT_DIR}/stage-test-CHCUpdates.xml
+echo "${output_xml/"url=\"${msi_url}\""/"url=\"@DEV_MSI_URL_PLACEHOLDER@\""}" > ${OUTPUT_DIR}/stage-test-CHCUpdates.xml
 
 set +u


### PR DESCRIPTION
Previously, the URL would point to the XML itself, causing checksum check errors

Also fixes issue whereby building non-branded builds would fail