### PR TITLE
CA-366140: Reverted original solution. Handled error thrown when retrieving datasources.

### DIFF
--- a/XenAdmin/Actions/GUIActions/SaveDataSourceStateAction.cs
+++ b/XenAdmin/Actions/GUIActions/SaveDataSourceStateAction.cs
@@ -80,7 +80,7 @@ namespace XenAdmin.Actions
                             else
                                 Host.forget_data_source_archives(Session, host.opaque_ref, ds.DataSource.name_label);
                         }
-                        else if (_xenObject is VM vm && vm.allowed_operations.Contains(vm_operations.data_source_op))
+                        else if (_xenObject is VM vm)
                         {
                             if (ds.Enabled)
                                 VM.record_data_source(Session, vm.opaque_ref, ds.DataSource.name_label);

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -198,8 +198,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
                         if (xenObject is Host h)
                             _dataSources = Host.get_data_sources(h.Connection.Session, h.opaque_ref);
-                        else if (xenObject is VM vm && vm.power_state == vm_power_state.Running &&
-                                 vm.allowed_operations.Contains(vm_operations.data_source_op))
+                        else if (xenObject is VM vm && vm.power_state == vm_power_state.Running)
                             _dataSources = VM.get_data_sources(vm.Connection.Session, vm.opaque_ref);
 
                         Get(ArchiveInterval.None, RrdsUri, RRD_Full_InspectCurrentNode, xenObject);

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -191,17 +191,23 @@ namespace XenAdmin.Controls.CustomDataGraph
                     foreach (DataArchive a in Archives.Values)
                         a.ClearSets();
 
+                    LoadingInitialData = true;
+                    ArchivesUpdated?.Invoke();
+
                     try
                     {
-                        LoadingInitialData = true;
-                        ArchivesUpdated?.Invoke();
-
                         if (xenObject is Host h)
                             _dataSources = Host.get_data_sources(h.Connection.Session, h.opaque_ref);
                         else if (xenObject is VM vm && vm.power_state == vm_power_state.Running)
                             _dataSources = VM.get_data_sources(vm.Connection.Session, vm.opaque_ref);
 
                         Get(ArchiveInterval.None, RrdsUri, RRD_Full_InspectCurrentNode, xenObject);
+                    }
+                    catch (Exception e)
+                    {
+                        //Get handles its own exception;
+                        //anything caught here is thrown by the get_data_sources operations
+                        log.Error($"Failed to retrieve data sources for '{xenObject.Name()}'", e);
                     }
                     finally
                     {

--- a/XenModel/Actions/GetDataSourcesAction.cs
+++ b/XenModel/Actions/GetDataSourcesAction.cs
@@ -52,7 +52,7 @@ namespace XenAdmin.Actions
         {
             List<Data_source> sources;
 
-            if (XenObject is VM vm && vm.allowed_operations.Contains(vm_operations.data_source_op))
+            if (XenObject is VM vm)
                 sources = VM.get_data_sources(Session, vm.opaque_ref);
             else if (XenObject is Host host)
                 sources = Host.get_data_sources(Session, host.opaque_ref);
@@ -106,7 +106,7 @@ namespace XenAdmin.Actions
                     Host.record_data_source(Session, Host.opaque_ref, _dataSource.name_label);
                     DataSources = Host.get_data_sources(Session, Host.opaque_ref);
                 }
-                else if (VM != null && VM.allowed_operations.Contains(vm_operations.data_source_op))
+                else if (VM != null)
                 {
                     VM.record_data_source(Session, VM.opaque_ref, _dataSource.name_label);
                     DataSources = VM.get_data_sources(Session, VM.opaque_ref);


### PR DESCRIPTION
Note that I have only handled the exception when get_data_sources is called in the ArchiveMaintainer. The other two instances of the call are in the Run() method of GetDataSourcesAction and EnableDataSourceAction and exceptions thrown there are handled by the actions' base class.