### PR TITLE
CA-368958: Reset clip region once performance lines are drawn

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/DataPlot.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataPlot.cs
@@ -236,7 +236,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         protected override void OnDrawToBuffer(PaintEventArgs paintEventArgs)
         {
             Program.AssertOnEventThread();
-
+            var originalClipRectangle = paintEventArgs.ClipRectangle;
             Rectangle SlightlySmaller = GraphRectangle(paintEventArgs.ClipRectangle);
             // Fill BG
             paintEventArgs.Graphics.FillRectangle(Palette.PaperBrush, SlightlySmaller);
@@ -374,7 +374,13 @@ namespace XenAdmin.Controls.CustomDataGraph
                         {
                             using (var shadowBrush = Palette.CreateBrush(set.Id))
                             {
+                                // CA-334613: Sharp turns in the graph can result in
+                                // the line being drawn outside of the box
+                                paintEventArgs.Graphics.SetClip(SlightlySmaller);
                                 LineRenderer.Render(paintEventArgs.Graphics, SlightlySmaller, DataPlotNav.XRange, set.CustomYRange ?? SelectedYRange, set.Selected ? thickPen : normalPen, shadowBrush, set.CurrentlyDisplayed, true);
+                                // CA-368958: Resetting the clip so that on the next
+                                // render we don't hide labels and title
+                                paintEventArgs.Graphics.SetClip(originalClipRectangle);
                             }
                         }
                     }

--- a/XenAdmin/Controls/CustomDataGraph/LineRenderer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/LineRenderer.cs
@@ -43,10 +43,6 @@ namespace XenAdmin.Controls.CustomDataGraph
             if (points.Count == 0)
                 return;
 
-            // CA-334613: Sharp turns in the graph can result in
-            // the line being drawn outside of the box
-            g.SetClip(r);
-
             int index = points.FindIndex(dataPoint => dataPoint.Y < 0);
             if (index >= 0)
             {


### PR DESCRIPTION
Resetting the clip so that on the next render we don't hide labels and title.
Also moved logic outside `LineRenderer.cs`

Below is an after / before comparison. The below is the build before the fix for CA-334613 was merged.

![image](https://user-images.githubusercontent.com/32554698/180182210-c6a41160-16b4-4708-b5b8-7a887498f676.png)