### PR TITLE
CP-39929: Improvements on the RPU/Updates wizard

### DIFF
--- a/XenAdmin/Core/ExtensionMethods.cs
+++ b/XenAdmin/Core/ExtensionMethods.cs
@@ -109,11 +109,12 @@ namespace XenAdmin.Core
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to which the modified value will be appended.</param>
         /// <param name="value">The value to format before appending.</param>
-        /// <param name="addTimestamp">true if each line should be prepended with a timestamp</param>
+        /// <param name="timestamp">The timestamp to prepend to each line. If null, no timestamp will be added.</param>
+        /// <param name="showTimestamp">Override for the timestamp. If set to false, no timestamp will be shown even if the value is null.</param>
         /// <param name="indent">true if each line should be prepended with indentation. Uses the default indentation defined in <see cref="ExtensionMethods"/>: <see cref="DEFAULT_STRING_INDENTATION"/></param>
         /// <param name="addExtraLine">true to append an extra line.</param>
         /// <returns>The input <see cref="StringBuilder"/> after the operation has been completed.</returns>
-        public static StringBuilder AppendFormattedLine(this StringBuilder builder, string value, bool addTimestamp = false, bool indent = false, bool addExtraLine = false)
+        public static StringBuilder AppendFormattedLine(this StringBuilder builder, string value, DateTime? timestamp, bool showTimestamp = true, bool indent = false, bool addExtraLine = false)
         {
             var formattedValue = value;
             if (!string.IsNullOrWhiteSpace(value))
@@ -122,9 +123,9 @@ namespace XenAdmin.Core
                 {
                     formattedValue = PrependIndentation(formattedValue);
                 }
-                if (addTimestamp)
+                if (timestamp != null && showTimestamp)
                 {
-                    formattedValue = PrependTimestamps(formattedValue);
+                    formattedValue = PrependTimestamps(formattedValue, (DateTime) timestamp);
                 }
             }
 
@@ -155,12 +156,12 @@ namespace XenAdmin.Core
         /// Prepend every line in the input value with a formatted string of <see cref="DateTime.Now"/>.
         /// </summary>
         /// <param name="value">The input value</param>
+        /// <param name="timestamp">The timestamp to show</param>
         /// <param name="localize">true to format the string with the user's locale</param>
         /// <returns>The input value with prepended timestamps/</returns>
-        public static string PrependTimestamps(string value, bool localize = true)
+        public static string PrependTimestamps(string value, DateTime timestamp, bool localize = true)
         {
-            var timestamp = DateTime.Now;
-            var timestampString = HelpersGUI.DateTimeToString(timestamp, Messages.DATEFORMAT_HMS, localize);
+            var timestampString = HelpersGUI.DateTimeToString(timestamp, Messages.DATEFORMAT_DM_HM, localize);
             // normalise all line endings before splitting
             var lines = value.Replace(Environment.NewLine, "\n").Split('\n');
             return string.Join(Environment.NewLine, lines.Select(line => $"{timestampString}> {line}"));

--- a/XenAdmin/Core/ExtensionMethods.cs
+++ b/XenAdmin/Core/ExtensionMethods.cs
@@ -164,7 +164,7 @@ namespace XenAdmin.Core
             var timestampString = HelpersGUI.DateTimeToString(timestamp, Messages.DATEFORMAT_DM_HM, localize);
             // normalise all line endings before splitting
             var lines = value.Replace(Environment.NewLine, "\n").Split('\n');
-            return string.Join(Environment.NewLine, lines.Select(line => $"{timestampString}> {line}"));
+            return string.Join(Environment.NewLine, lines.Select(line => $"{timestampString} | {line}"));
         }
     }
 }

--- a/XenAdmin/Core/ExtensionMethods.cs
+++ b/XenAdmin/Core/ExtensionMethods.cs
@@ -29,30 +29,32 @@
  * SUCH DAMAGE.
  */
 
-﻿using System.Drawing;
+using System;
+using System.Drawing;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 
-
 namespace XenAdmin.Core
 {
-	internal static class ExtensionMethods
-	{
-		/// <summary>
-		/// Internationalization of True/False
-		/// </summary>
-		public static string ToStringI18n(this bool value)
-		{
-			return value ? Messages.TRUE : Messages.FALSE;
-		}
+    internal static class ExtensionMethods
+    {
+        private const int DEFAULT_STRING_INDENTATION = 2;
+        /// <summary>
+        /// Internationalization of True/False
+        /// </summary>
+        public static string ToStringI18n(this bool value)
+        {
+            return value ? Messages.TRUE : Messages.FALSE;
+        }
 
-		/// <summary>
-		/// Turns a bool to internationalized Yes/No (on occasion it's user friendlier than True/False)
-		/// </summary>
-		public static string ToYesNoStringI18n(this bool value)
-		{
-			return value ? Messages.YES : Messages.NO;
-		}
+        /// <summary>
+        /// Turns a bool to internationalized Yes/No (on occasion it's user friendlier than True/False)
+        /// </summary>
+        public static string ToYesNoStringI18n(this bool value)
+        {
+            return value ? Messages.YES : Messages.NO;
+        }
 
         /// <summary>
         /// This has the same bahvoiur as the standard ellipsise extension but this uses graphics
@@ -88,24 +90,79 @@ namespace XenAdmin.Core
             return text.Ellipsise(c);
         }
 
-        public static StringBuilder AppendIndented(this StringBuilder builder, string value, int indent = 2)
+        /// <summary>
+        /// Append the input value after it's been prepended with the specified amount of spaces.
+        /// If the value spans multiple lines, each line will be indented.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to which the modified value will be appended.</param>
+        /// <param name="value">The value to prepend with spaces and then append.</param>
+        /// <param name="indent">The amount of spaces to prepend to each line in the input value.</param>
+        /// <returns>The input <see cref="StringBuilder"/> after the operation has been completed.</returns>
+        public static StringBuilder AppendIndented(this StringBuilder builder, string value, int indent = DEFAULT_STRING_INDENTATION)
         {
-            var indentString = "";
-            var i = 0;
-            while (i++ < indent)
-                indentString += " ";
-            var newvalue = value.Replace(System.Environment.NewLine, string.Format("{0}{1}", System.Environment.NewLine, indentString));
-            return builder.Append(string.Format("{0}{1}", indentString, newvalue));
+            return builder.Append(PrependIndentation(value, indent));
         }
 
-        public static StringBuilder AppendIndented(this StringBuilder builder, StringBuilder value, int indent = 2)
+        /// <summary>
+        /// Add a new line to the input <see cref="StringBuilder"/>, with options to format the input value before it's appended.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to which the modified value will be appended.</param>
+        /// <param name="value">The value to format before appending.</param>
+        /// <param name="addTimestamp">true if each line should be prepended with a timestamp</param>
+        /// <param name="indent">true if each line should be prepended with indentation. Uses the default indentation defined in <see cref="ExtensionMethods"/>: <see cref="DEFAULT_STRING_INDENTATION"/></param>
+        /// <param name="addExtraLine">true to append an extra line.</param>
+        /// <returns>The input <see cref="StringBuilder"/> after the operation has been completed.</returns>
+        public static StringBuilder AppendFormattedLine(this StringBuilder builder, string value, bool addTimestamp = false, bool indent = false, bool addExtraLine = false)
         {
-            var indentString = "";
-            var i = 0;
-            while (i++ < indent)
-                indentString += " ";
-            var newvalue = value.Replace(System.Environment.NewLine, string.Format("{0}{1}", System.Environment.NewLine, indentString));
-            return builder.Append(string.Format("{0}{1}", indentString, newvalue));
+            var formattedValue = value;
+            if (!string.IsNullOrEmpty(value))
+            {
+                if (indent)
+                {
+                    formattedValue = PrependIndentation(formattedValue);
+                }
+                if (addTimestamp)
+                {
+                    formattedValue = PrependTimestamps(formattedValue);
+                }
+            }
+
+            builder.AppendLine(formattedValue);
+
+            if (addExtraLine)
+            {
+                builder.AppendLine();
+            }
+
+            return builder;
         }
-	}
+
+        /// <summary>
+        /// Prepend every line in the input value with the specified indentation level.
+        /// </summary>
+        /// <param name="value">The value to which indentation will be applied</param>
+        /// <param name="indent">The level of indentation, i.e. the number of spaces to prepend to every line in the value.</param>
+        /// <returns>The input value with prepended indentation./</returns>
+        private static string PrependIndentation(string value, int indent = DEFAULT_STRING_INDENTATION)
+        {
+            var indentString = new string(' ', indent);
+            var newValue = value.Replace(Environment.NewLine, $"{Environment.NewLine}{indentString}");
+            return $"{indentString}{newValue}";
+        }
+
+        /// <summary>
+        /// Prepend every line in the input value with a formatted string of <see cref="DateTime.Now"/>.
+        /// </summary>
+        /// <param name="value">The input value</param>
+        /// <param name="localize">true to format the string with the user's locale</param>
+        /// <returns>The input value with prepended timestamps/</returns>
+        public static string PrependTimestamps(string value, bool localize = true)
+        {
+            var timestamp = DateTime.Now;
+            var timestampString = HelpersGUI.DateTimeToString(timestamp, Messages.DATEFORMAT_HMS, localize);
+            // normalise all line endings before splitting
+            var lines = value.Replace(Environment.NewLine, "\n").Split('\n');
+            return string.Join(Environment.NewLine, lines.Select(line => $"{timestampString}> {line}"));
+        }
+    }
 }

--- a/XenAdmin/Core/ExtensionMethods.cs
+++ b/XenAdmin/Core/ExtensionMethods.cs
@@ -105,6 +105,7 @@ namespace XenAdmin.Core
 
         /// <summary>
         /// Add a new line to the input <see cref="StringBuilder"/>, with options to format the input value before it's appended.
+        /// timestamps and indentation will be ignored if the input value is an null or whitespace
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to which the modified value will be appended.</param>
         /// <param name="value">The value to format before appending.</param>
@@ -115,7 +116,7 @@ namespace XenAdmin.Core
         public static StringBuilder AppendFormattedLine(this StringBuilder builder, string value, bool addTimestamp = false, bool indent = false, bool addExtraLine = false)
         {
             var formattedValue = value;
-            if (!string.IsNullOrEmpty(value))
+            if (!string.IsNullOrWhiteSpace(value))
             {
                 if (indent)
                 {

--- a/XenAdmin/Core/ExtensionMethods.cs
+++ b/XenAdmin/Core/ExtensionMethods.cs
@@ -161,7 +161,7 @@ namespace XenAdmin.Core
         /// <returns>The input value with prepended timestamps/</returns>
         public static string PrependTimestamps(string value, DateTime timestamp, bool localize = true)
         {
-            var timestampString = HelpersGUI.DateTimeToString(timestamp, Messages.DATEFORMAT_DM_HM, localize);
+            var timestampString = HelpersGUI.DateTimeToString(timestamp, Messages.DATEFORMAT_DM_HMS, localize);
             // normalise all line endings before splitting
             var lines = value.Replace(Environment.NewLine, "\n").Split('\n');
             return string.Join(Environment.NewLine, lines.Select(line => $"{timestampString} | {line}"));

--- a/XenAdmin/Diagnostics/Problems/HostProblem/ConflictingUpdatePresent.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/ConflictingUpdatePresent.cs
@@ -45,17 +45,8 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             this.conflictingUpdates = conflictingUpdates;
         }
 
-        public override string Description
-        {
-            get 
-            {
-                return string.Format(Messages.UPDATES_WIZARD_PRECHECK_FAILED_CONFLICTING_UPDATE, ServerName, conflictingUpdates);
-            }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_PRECHECK_FAILED_CONFLICTING_UPDATE, ServerName, conflictingUpdates);
 
-        public override string HelpMessage
-        {
-            get { return string.Empty; }
-        }
+        public override string HelpMessage => string.Empty;
     }
 }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
@@ -39,8 +39,8 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 {
     public class HostMaintenanceMode : HostProblem
     {
-        public HostMaintenanceMode(Check check,  Host host)
-            : base(check,  host)
+        public HostMaintenanceMode(Check check, Host host)
+            : base(check, host)
         {
         }
 

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostMaintenanceMode.cs
@@ -44,10 +44,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         {
         }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_HOST_MAINTENANCE_MODE, ServerName); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_HOST_MAINTENANCE_MODE, ServerName);
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
@@ -56,10 +53,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             return new EnableHostAction(Server, false, AddHostToPoolCommand.EnableNtolDialog);
         }
 
-        public override string HelpMessage
-        {
-            get { return Messages.ENABLE_PLAIN; }
-        }
+        public override string HelpMessage => Messages.ENABLE_PLAIN;
 
         public override AsyncAction CreateUnwindChangesAction()
         {

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostMemoryPostUpgradeWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostMemoryPostUpgradeWarning.cs
@@ -70,11 +70,11 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
                 if (dom0MemoryAfterUpgrade > 0)
                     return string.Format(Messages.HOST_MEMORY_POST_UPGRADE_DOM0_MEMORY_WARNING_LONG,
                         Helpers.GetName(host), Util.MemorySizeStringSuitableUnits(dom0MemoryAfterUpgrade, true));
-                
+
                 if (string.IsNullOrEmpty(upgradeProductVersion))
                     return string.Format(Messages.HOST_MEMORY_POST_UPGRADE_DEFAULT_WARNING_LONG,
                         BrandManager.ProductBrand, BrandManager.ProductVersion80, Helpers.GetName(host));
-                
+
                 return string.Format(Messages.HOST_MEMORY_POST_UPGRADE_VERSION_WARNING_LONG,
                     Helpers.GetName(host), BrandManager.ProductBrand, upgradeProductVersion);
             }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostNeedsReboot.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostNeedsReboot.cs
@@ -52,8 +52,8 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 
         public override string Description => livePatchingRestricted
             ? string.Format(Messages.UPDATES_WIZARD_REBOOT_NEEDED_LIVEPATCH_RESTRICTED, host.name_label)
-            : livePatchingDisabled 
-                ? string.Format(Messages.UPDATES_WIZARD_REBOOT_NEEDED_LIVEPATCH_DISABLED, host.name_label) 
+            : livePatchingDisabled
+                ? string.Format(Messages.UPDATES_WIZARD_REBOOT_NEEDED_LIVEPATCH_DISABLED, host.name_label)
                 : string.Format(Messages.UPDATES_WIZARD_REBOOT_NEEDED, host.name_label);
     }
 }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostNotLive.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostNotLive.cs
@@ -45,15 +45,9 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         {
         }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_HOST_NOT_LIVE, ServerName); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_HOST_NOT_LIVE, ServerName);
 
-        public override string HelpMessage
-        {
-            get { return CanStartHost() ? Messages.START_HOST : string.Empty; }
-        }
+        public override string HelpMessage => CanStartHost() ? Messages.START_HOST : string.Empty;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
@@ -85,17 +79,8 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             this.host = host;
         }
 
-        public override string Title
-        {
-            get { return Check.Description; }
-        }
+        public override string Title => Check.Description;
 
-        public override string Description
-        {
-            get
-            {
-                return string.Format(Messages.UPDATES_WIZARD_HOST_NOT_LIVE_WARNING, host);
-            }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_HOST_NOT_LIVE_WARNING, host);
     }
 }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostOutOfSpaceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostOutOfSpaceProblem.cs
@@ -46,7 +46,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         private readonly Pool_update update;
 
         public HostOutOfSpaceProblem(Check check, Host host, Pool_patch patch, DiskSpaceRequirements diskSpaceReq)
-            : base(check,  host)
+            : base(check, host)
         {
             this.patch = patch;
             this.diskSpaceReq = diskSpaceReq;
@@ -82,13 +82,13 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 
                 switch (diskSpaceReq.Operation)
                 {
-                    case DiskSpaceRequirements.OperationTypes.install :
+                    case DiskSpaceRequirements.OperationTypes.install:
                         return string.Format(Messages.NOT_ENOUGH_SPACE_MESSAGE_INSTALL, ServerName, name);
-                    
-                    case DiskSpaceRequirements.OperationTypes.upload :
+
+                    case DiskSpaceRequirements.OperationTypes.upload:
                         return string.Format(Messages.NOT_ENOUGH_SPACE_MESSAGE_UPLOAD, ServerName, name);
-                    
-                    case DiskSpaceRequirements.OperationTypes.automatedUpdates :
+
+                    case DiskSpaceRequirements.OperationTypes.automatedUpdates:
                         return string.Format(Messages.NOT_ENOUGH_SPACE_MESSAGE_AUTO_UPDATE, ServerName);
 
                     case DiskSpaceRequirements.OperationTypes.automatedUpdatesUploadOne:
@@ -108,7 +108,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 
             if (patch != null && diskSpaceReq.CanCleanup)
             {
-                Program.Invoke(Program.MainWindow, delegate()
+                Program.Invoke(Program.MainWindow, delegate ()
                 {
                     using (var dlg = new WarningDialog(diskSpaceReq.GetSpaceRequirementsMessage(),
                         new ThreeButtonDialog.TBDButton(Messages.YES, DialogResult.Yes, selected: true),
@@ -122,15 +122,15 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
                 });
             }
             else
-            { 
-                Program.Invoke(Program.MainWindow, delegate()
+            {
+                Program.Invoke(Program.MainWindow, delegate ()
                 {
                     using (var dlg = new WarningDialog(diskSpaceReq.GetSpaceRequirementsMessage()))
                         dlg.ShowDialog();
                 });
             }
             cancelled = action == null;
-            
+
             return action;
         }
 

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostOutOfSpaceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostOutOfSpaceProblem.cs
@@ -134,18 +134,9 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             return action;
         }
 
-        public override string HelpMessage
-        {
-            get { return diskSpaceReq.GetMessageForActionLink(); }
-        }
+        public override string HelpMessage => diskSpaceReq.GetMessageForActionLink();
 
-        public override bool IsFixable
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool IsFixable => false;
 
         public override bool Equals(object obj)
         {

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostPrepareToUpgradeProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostPrepareToUpgradeProblem.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         public override bool IsFixable => false;
 
         public override string Description => _shortMessage;
-       
+
         public override string HelpMessage => Messages.MORE_INFO;
 
         protected override Actions.AsyncAction CreateAction(out bool cancelled)

--- a/XenAdmin/Diagnostics/Problems/HostProblem/HostProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/HostProblem.cs
@@ -38,7 +38,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 {
     public abstract class HostProblem : Problem
     {
-        protected HostProblem(Check check,  Host server)
+        protected HostProblem(Check check, Host server)
             : base(check)
         {
             Server = server;

--- a/XenAdmin/Diagnostics/Problems/HostProblem/NotEnoughMem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/NotEnoughMem.cs
@@ -51,10 +51,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         {
         }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_NO_MEMORY, ServerName); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_NO_MEMORY, ServerName);
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
@@ -75,10 +72,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             return null;
         }
 
-        public override string HelpMessage
-        {
-            get { return Messages.SUSPEND_VMS; }
-        }
+        public override string HelpMessage => Messages.SUSPEND_VMS;
 
         public override AsyncAction CreateUnwindChangesAction()
         {

--- a/XenAdmin/Diagnostics/Problems/HostProblem/NotEnoughMem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/NotEnoughMem.cs
@@ -47,7 +47,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         private List<VM> VmsToShutdown = new List<VM>();
 
         public NotEnoughMem(Check check, Host host)
-            : base(check,  host)
+            : base(check, host)
         {
         }
 
@@ -76,7 +76,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
 
         public override AsyncAction CreateUnwindChangesAction()
         {
-            return new ResumeAndStartVMsAction(Server.Connection, Server, VmsToSuspend, VmsToShutdown,VMOperationCommand.WarningDialogHAInvalidConfig,VMOperationCommand.StartDiagnosisForm);
+            return new ResumeAndStartVMsAction(Server.Connection, Server, VmsToSuspend, VmsToShutdown, VMOperationCommand.WarningDialogHAInvalidConfig, VMOperationCommand.StartDiagnosisForm);
         }
 
 

--- a/XenAdmin/Diagnostics/Problems/HostProblem/PatchAlreadyApplied.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/PatchAlreadyApplied.cs
@@ -46,19 +46,10 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             _host = host;
         }
 
-        public override string Title
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_PATCH_ALREADY_APPLIED_TITLE, Helpers.GetName(_host).Ellipsise(30)); }
-        }
+        public override string Title => string.Format(Messages.UPDATES_WIZARD_PATCH_ALREADY_APPLIED_TITLE, Helpers.GetName(_host).Ellipsise(30));
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_PATCH_ALREADY_APPLIED, Helpers.GetName(_host).Ellipsise(30)); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_PATCH_ALREADY_APPLIED, Helpers.GetName(_host).Ellipsise(30));
 
-        public override string HelpMessage
-        {
-            get { return string.Empty; }
-        }
+        public override string HelpMessage => string.Empty;
     }
 }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/PatchAlreadyApplied.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/PatchAlreadyApplied.cs
@@ -40,7 +40,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
     {
         private readonly Host _host;
 
-        public PatchAlreadyApplied(Check check,  Host host)
+        public PatchAlreadyApplied(Check check, Host host)
             : base(check)
         {
             _host = host;

--- a/XenAdmin/Diagnostics/Problems/HostProblem/PowerOniLoProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/PowerOniLoProblem.cs
@@ -50,7 +50,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             cancelled = false;
             var mode = new KeyValuePair<Host, Host.PowerOnMode>(Server, new Host.PowerOnModeDisabled());
             return new SavePowerOnSettingsAction(Server.Connection,
-                new List<KeyValuePair<Host, Host.PowerOnMode>> {mode}, false);
+                new List<KeyValuePair<Host, Host.PowerOnMode>> { mode }, false);
         }
 
         public override string Description =>

--- a/XenAdmin/Diagnostics/Problems/HostProblem/PrecheckFailed.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/PrecheckFailed.cs
@@ -40,7 +40,7 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         private readonly Failure Failure;
 
         public PrecheckFailed(Check check, Host host, Failure failure)
-            : base(check,  host)
+            : base(check, host)
         {
             Failure = failure;
         }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/PrerequisiteUpdateMissing.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/PrerequisiteUpdateMissing.cs
@@ -44,17 +44,8 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
             this.requiredUpdates = requiredUpdates;
         }
 
-        public override string Description
-        {
-            get 
-            {
-                return string.Format(Messages.UPDATES_WIZARD_PRECHECK_FAILED_REQUIRED_UPDATE_MISSING, ServerName, requiredUpdates);
-            }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_PRECHECK_FAILED_REQUIRED_UPDATE_MISSING, ServerName, requiredUpdates);
 
-        public override string HelpMessage
-        {
-            get { return string.Empty; }
-        }
+        public override string HelpMessage => string.Empty;
     }
 }

--- a/XenAdmin/Diagnostics/Problems/HostProblem/WrongServerVersion.cs
+++ b/XenAdmin/Diagnostics/Problems/HostProblem/WrongServerVersion.cs
@@ -50,17 +50,8 @@ namespace XenAdmin.Diagnostics.Problems.HostProblem
         {
         }
 
-        public override string Description
-        {
-            get 
-            {
-                return string.Format(Messages.UPDATE_FOR_DIFFERENT_XENSERVER_VERSION, ServerName);
-            }
-        }
+        public override string Description => string.Format(Messages.UPDATE_FOR_DIFFERENT_XENSERVER_VERSION, ServerName);
 
-        public override string HelpMessage
-        {
-            get { return string.Empty; }
-        }
+        public override string HelpMessage => string.Empty;
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/CPUIncompatibilityProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/CPUIncompatibilityProblem.cs
@@ -82,7 +82,7 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
                 var vm = vmOnHost.Key;
 
                 // check if the vm is still in the cache and is halted
-                if (vm.Connection.Resolve(new XenRef<VM>(vm.opaque_ref)) == null || vm.power_state != vm_power_state.Halted) 
+                if (vm.Connection.Resolve(new XenRef<VM>(vm.opaque_ref)) == null || vm.power_state != vm_power_state.Halted)
                     continue;
 
                 var startOn = vm.Connection.Resolve(vmOnHost.Value);

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/CPUIncompatibilityProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/CPUIncompatibilityProblem.cs
@@ -99,21 +99,9 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             return null;
         }
 
-        public override string Description
-        {
-            get
-            {
-                return String.Format(Messages.UPGRADEWIZARD_PROBLEM_INCOMPATIBLE_CPUS, Pool);
-            }
-        }
+        public override string Description => String.Format(Messages.UPGRADEWIZARD_PROBLEM_INCOMPATIBLE_CPUS, Pool);
 
-        public override string HelpMessage
-        {
-            get
-            {
-                return Messages.UPGRADEWIZARD_PROBLEM_INCOMPATIBLE_CPUS_HELPMESSAGE;
-            }
-        }
+        public override string HelpMessage => Messages.UPGRADEWIZARD_PROBLEM_INCOMPATIBLE_CPUS_HELPMESSAGE;
     }
 
     class CPUCIncompatibilityWarning : Warning
@@ -128,17 +116,8 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             this.host = host;
         }
 
-        public override string Title
-        {
-            get { return Check.Description; }
-        }
+        public override string Title => Check.Description;
 
-        public override string Description
-        {
-            get
-            {
-                return string.Format(Messages.UPGRADEWIZARD_WARNING_INCOMPATIBLE_CPUS, host, pool);
-            }
-        }
+        public override string Description => string.Format(Messages.UPGRADEWIZARD_WARNING_INCOMPATIBLE_CPUS, host, pool);
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/HAEnabledProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/HAEnabledProblem.cs
@@ -72,21 +72,9 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             return pool != null ? new EnableHAAction(pool, null, HeartbeatSrs, FailuresToTolerate) : null;
         }
 
-        public override string Description
-        {
-            get 
-            {
-                return String.Format(Messages.UPDATES_WIZARD_HA_ON_DESCRIPTION, Pool);
-            }
-        }
+        public override string Description => String.Format(Messages.UPDATES_WIZARD_HA_ON_DESCRIPTION, Pool);
 
-        public override string HelpMessage
-        {
-            get
-            {
-                return Messages.TURN_HA_OFF;
-            }
-        }
+        public override string HelpMessage => Messages.TURN_HA_OFF;
     }
 
     class DrHAEnabledProblem : HAEnabledProblem
@@ -96,10 +84,7 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
         {
         }
 
-        public override string Description
-        {
-            get { return Messages.DR_WIZARD_PROBLEM_HA_ENABLED; }
-        }
+        public override string Description => Messages.DR_WIZARD_PROBLEM_HA_ENABLED;
     }
 
     class HAEnabledWarning : Warning
@@ -114,17 +99,8 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             this.host = host;
         }
 
-        public override string Title
-        {
-            get { return Check.Description; }
-        }
+        public override string Title => Check.Description;
 
-        public override string Description
-        {
-            get
-            {
-                return string.Format(Messages.UPDATES_WIZARD_HA_ON_WARNING, host, pool);
-            }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_HA_ON_WARNING, host, pool);
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/MasterIsPendingRestartProblems.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/MasterIsPendingRestartProblems.cs
@@ -41,22 +41,14 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             : base(check, pool)
         { }
 
-        public override string Description
-        {
-            get 
-            {
-                return string.Format(
-                    ((RestartHostOrToolstackPendingOnCoordinatorCheck)Check).UpdateUuid != null
+        public override string Description =>
+            string.Format(
+                ((RestartHostOrToolstackPendingOnCoordinatorCheck)Check).UpdateUuid != null
                     ? Messages.PROBLEM_COORDINATOR_PENDING_RESTART_HOST_THIS_UPDATE
                     : Messages.PROBLEM_COORDINATOR_PENDING_RESTART_HOST,
-                    Helpers.GetName(Pool).Ellipsise(30));
-            }
-        }
+                Helpers.GetName(Pool).Ellipsise(30));
 
-        public override string HelpMessage
-        {
-            get { return null; }
-        }
+        public override string HelpMessage => null;
     }
 
     class CoordinatorIsPendingRestartToolstackProblem : PoolProblem
@@ -65,21 +57,13 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             : base(check, pool)
         { }
 
-        public override string Description
-        {
-            get
-            {
-                return string.Format(
-                    ((RestartHostOrToolstackPendingOnCoordinatorCheck)Check).UpdateUuid != null
+        public override string Description =>
+            string.Format(
+                ((RestartHostOrToolstackPendingOnCoordinatorCheck)Check).UpdateUuid != null
                     ? Messages.PROBLEM_COORDINATOR_PENDING_RESTART_TOOLSTACK_THIS_UPDATE
                     : Messages.PROBLEM_COORDINATOR_PENDING_RESTART_TOOLSTACK,
-                    Helpers.GetName(Pool).Ellipsise(30));
-            }
-        }
+                Helpers.GetName(Pool).Ellipsise(30));
 
-        public override string HelpMessage
-        {
-            get { return null; }
-        }
+        public override string HelpMessage => null;
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/MissingMultipleFCSRsProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/MissingMultipleFCSRsProblem.cs
@@ -50,15 +50,9 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             this.srDeviceConfigList = srDeviceConfigList;
         }
 
-        private bool EmptySRDeviceConfigList
-        {
-            get { return srDeviceConfigList == null || srDeviceConfigList.Count == 0; }
-        }
+        private bool EmptySRDeviceConfigList => srDeviceConfigList == null || srDeviceConfigList.Count == 0;
 
-        public override string Title
-        {
-            get { return Check.Description; }
-        }
+        public override string Title => Check.Description;
 
         public override string Description
         {

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasGFS2SRProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasGFS2SRProblem.cs
@@ -70,13 +70,6 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             }
         }
 
-        public override string HelpMessage
-        {
-            get
-            {
-                return "";
-            }
-        }
-
+        public override string HelpMessage => "";
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasGFS2SRProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasGFS2SRProblem.cs
@@ -39,7 +39,7 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
     {
         public bool clusterEnabled;
         public bool gfs2;
-        
+
 
         public PoolHasGFS2SRProblem(Check check, Pool pool, bool clusteringEnabled, bool hasGfs2Sr)
             : base(check, pool)

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasVmsWithDmcProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasVmsWithDmcProblem.cs
@@ -74,11 +74,11 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
                 using (var dlg = new ErrorDialog(Message,
                            new ThreeButtonDialog.TBDButton(Messages.DMC_DISABLE, DialogResult.OK, ThreeButtonDialog.ButtonType.ACCEPT),
                            new ThreeButtonDialog.TBDButton(Messages.CANCEL, DialogResult.Cancel, ThreeButtonDialog.ButtonType.CANCEL, true))
-                       {
-                           LinkText = Messages.LEARN_MORE,
-                           LinkData = InvisibleMessages.DMC_REMOVAL_URL,
-                           ShowLinkLabel = true
-                       })
+                {
+                    LinkText = Messages.LEARN_MORE,
+                    LinkData = InvisibleMessages.DMC_REMOVAL_URL,
+                    ShowLinkLabel = true
+                })
                 {
                     if (dlg.ShowDialog(Control) == DialogResult.OK)
                         DisableDmc();
@@ -128,11 +128,11 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
                 using (var dlg = new WarningDialog(Message,
                            new ThreeButtonDialog.TBDButton(Messages.DMC_DISABLE, DialogResult.OK, ThreeButtonDialog.ButtonType.ACCEPT),
                            new ThreeButtonDialog.TBDButton(Messages.CANCEL, DialogResult.Cancel, ThreeButtonDialog.ButtonType.CANCEL, true))
-                       {
-                           LinkText = Messages.LEARN_MORE,
-                           LinkData = InvisibleMessages.DMC_REMOVAL_URL,
-                           ShowLinkLabel = true
-                       })
+                {
+                    LinkText = Messages.LEARN_MORE,
+                    LinkData = InvisibleMessages.DMC_REMOVAL_URL,
+                    ShowLinkLabel = true
+                })
                 {
                     if (dlg.ShowDialog(Control) == DialogResult.OK)
                         DisableDmc();

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolProblem.cs
@@ -46,17 +46,8 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             _pool = pool;
         }
 
-        public Pool Pool
-        {
-            get
-            {
-                return _pool;
-            }
-        }
+        public Pool Pool => _pool;
 
-        public sealed override string Title
-        {
-            get { return string.Format(Messages.PROBLEM_POOLPROBLEM_TITLE, Helpers.GetName(Pool).Ellipsise(30)); }
-        }
+        public sealed override string Title => string.Format(Messages.PROBLEM_POOLPROBLEM_TITLE, Helpers.GetName(Pool).Ellipsise(30));
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/ServerSelectionProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/ServerSelectionProblem.cs
@@ -42,15 +42,9 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
         {
         }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_SERVER_SELECTION_PROBLEM, Pool); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_SERVER_SELECTION_PROBLEM, Pool);
 
-        public override string HelpMessage
-        {
-            get { return null; }
-        }
+        public override string HelpMessage => null;
     }
 
     class MixedPoolServerSelectionWarning : Warning
@@ -63,17 +57,8 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             this.pool = pool;
         }
 
-        public override string Title
-        {
-            get { return Check.Description; }
-        }
+        public override string Title => Check.Description;
 
-        public override string Description
-        {
-            get
-            {
-                return string.Format(Messages.UPDATES_WIZARD_MIXED_POOL_SERVER_SELECTION_WARNING, pool);
-            }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_MIXED_POOL_SERVER_SELECTION_WARNING, pool);
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/VSwitchControllerProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/VSwitchControllerProblem.cs
@@ -46,7 +46,7 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             _pool = pool;
         }
 
-        public override string LinkData  => InvisibleMessages.DEPRECATION_URL;
+        public override string LinkData => InvisibleMessages.DEPRECATION_URL;
         public override string LinkText => Messages.LEARN_MORE;
 
         public override string Description =>
@@ -68,7 +68,7 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             this.pool = pool;
         }
 
-        public override string LinkData  => InvisibleMessages.DEPRECATION_URL;
+        public override string LinkData => InvisibleMessages.DEPRECATION_URL;
         public override string LinkText => Messages.LEARN_MORE;
 
         public override string Description =>

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/WLBEnabledProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/WLBEnabledProblem.cs
@@ -46,15 +46,9 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
         {
         }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.CHECK_WLB_ENABLED, Pool); }
-        }
+        public override string Description => string.Format(Messages.CHECK_WLB_ENABLED, Pool);
 
-        public override string HelpMessage
-        {
-            get { return Messages.HELP_MESSAGE_DISABLE_WLB; }
-        }
+        public override string HelpMessage => Messages.HELP_MESSAGE_DISABLE_WLB;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
@@ -87,17 +81,8 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             this.host = host;
         }
 
-        public override string Title
-        {
-            get { return Check.Description; }
-        }
+        public override string Title => Check.Description;
 
-        public override string Description
-        {
-            get
-            {
-                return string.Format(Messages.UPDATES_WIZARD_WLB_ON_WARNING, host, pool);
-            }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_WLB_ON_WARNING, host, pool);
     }
 }

--- a/XenAdmin/Diagnostics/Problems/Problem.cs
+++ b/XenAdmin/Diagnostics/Problems/Problem.cs
@@ -144,10 +144,10 @@ namespace XenAdmin.Diagnostics.Problems
                 return new List<AsyncAction>();
 
             var actions = from problem in problems
-                where problem.SolutionActionCompleted
-                let action = problem.CreateUnwindChangesAction()
-                where action != null && action.Connection != null && action.Connection.IsConnected
-                select action;
+                          where problem.SolutionActionCompleted
+                          let action = problem.CreateUnwindChangesAction()
+                          where action != null && action.Connection != null && action.Connection.IsConnected
+                          select action;
 
             return actions.ToList();
         }

--- a/XenAdmin/Diagnostics/Problems/UtilityProblem/CfuNotAvailableProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/UtilityProblem/CfuNotAvailableProblem.cs
@@ -42,10 +42,7 @@ namespace XenAdmin.Diagnostics.Problems.UtilityProblem
         {
         }
 
-        public override string Description
-        {
-            get { return Messages.UPGRADEWIZARD_PROBLEM_CFU_STATUS; }
-        }
+        public override string Description => Messages.UPGRADEWIZARD_PROBLEM_CFU_STATUS;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
@@ -58,14 +55,8 @@ namespace XenAdmin.Diagnostics.Problems.UtilityProblem
 
         public override string HelpMessage => Messages.MORE_INFO;
 
-        public sealed override string Title
-        {
-            get { return string.Empty; }
-        }
+        public sealed override string Title => string.Empty;
 
-        public override bool IsFixable
-        {
-            get { return false; }
-        }
+        public override bool IsFixable => false;
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
@@ -45,10 +45,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             : base(check, vm)
         { }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.AUTOSTART_ENABLED_CHECK_DESCRIPTION, ServerName, Helpers.GetName(VM).Ellipsise(30)); }
-        }
+        public override string Description => string.Format(Messages.AUTOSTART_ENABLED_CHECK_DESCRIPTION, ServerName, Helpers.GetName(VM).Ellipsise(30));
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
@@ -56,10 +53,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             return new DelegatedAsyncAction(VM.Connection, Messages.ACTION_DISABLE_AUTOSTART_ON_VM, string.Format(Messages.ACTION_DISABLING_AUTOSTART_ON_VM, Helpers.GetName(VM)), null, ActionDelegate(false));
         }
 
-        public override string HelpMessage
-        {
-            get { return Messages.DISABLE_NOAMP; }
-        }
+        public override string HelpMessage => Messages.DISABLE_NOAMP;
 
         private Action<Session> ActionDelegate(bool autostartValue)
         {

--- a/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/AutoStartEnabled.cs
@@ -57,7 +57,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
         private Action<Session> ActionDelegate(bool autostartValue)
         {
-            return delegate(Session session)
+            return delegate (Session session)
                        {
                            var vm = VM.Connection.Resolve(new XenRef<VM>(VM.opaque_ref));
                            var vmclone = (VM)vm.Clone();

--- a/XenAdmin/Diagnostics/Problems/VMProblem/CannotMigrateVM.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/CannotMigrateVM.cs
@@ -43,14 +43,14 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         public enum CannotMigrateVMReason { Unknown, LicenseRestriction, CannotMigrateVm, CannotMigrateVmNoTools, CannotMigrateVmNoGpu, LacksFeatureSuspend, HasPCIAttached, OperationInProgress }
 
         public CannotMigrateVM(Check check, VM vm, CannotMigrateVMReason licenseRestriction = CannotMigrateVMReason.Unknown)
-            : base(check, vm) 
+            : base(check, vm)
         {
             this.reason = licenseRestriction;
         }
 
         public override string Description
         {
-            get 
+            get
             {
                 string descriptionFormat;
 
@@ -72,7 +72,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
                         descriptionFormat = Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_SUSPEND_REASON;
                         break;
 
-                    case CannotMigrateVMReason.LicenseRestriction :
+                    case CannotMigrateVMReason.LicenseRestriction:
                         descriptionFormat = Messages.UPDATES_WIZARD_CANNOT_MIGRATE_VM_LICENSE_REASON;
                         break;
 
@@ -89,7 +89,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
                         break;
                 }
 
-                return String.Format(descriptionFormat, ServerName, VM.Name()); 
+                return String.Format(descriptionFormat, ServerName, VM.Name());
             }
         }
     }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmProblem.cs
@@ -42,7 +42,7 @@ using XenAdmin.Actions.DR;
 
 namespace XenAdmin.Diagnostics.Problems.VMProblem
 {
-    public class ExistingVmProblem: VMProblem
+    public class ExistingVmProblem : VMProblem
     {
         public ExistingVmProblem(Check check, VM vm)
             : base(check, vm)
@@ -60,7 +60,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             DialogResult dialogResult;
             using (var dlg = new WarningDialog(string.Format(Messages.CONFIRM_DELETE_VM, VM.Name(), VM.Connection.Name),
                     ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo)
-                {WindowTitle = Messages.ACTION_SHUTDOWN_AND_DESTROY_VM_TITLE})
+            { WindowTitle = Messages.ACTION_SHUTDOWN_AND_DESTROY_VM_TITLE })
             {
                 dialogResult = dlg.ShowDialog();
             }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmProblem.cs
@@ -49,18 +49,9 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         {
         }
 
-        public override string Description
-        {
-            get
-            {
-                return String.Format(Messages.DR_WIZARD_PROBLEM_EXISTING_VM, Helpers.GetPoolOfOne(VM.Connection).Name()); 
-            } 
-        }
+        public override string Description => String.Format(Messages.DR_WIZARD_PROBLEM_EXISTING_VM, Helpers.GetPoolOfOne(VM.Connection).Name());
 
-        public override string HelpMessage
-        {
-            get { return Messages.DR_WIZARD_PROBLEM_EXISTING_VM_HELPMESSAGE; } 
-        }
+        public override string HelpMessage => Messages.DR_WIZARD_PROBLEM_EXISTING_VM_HELPMESSAGE;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {

--- a/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmWarning.cs
@@ -52,5 +52,5 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         public sealed override string Title => string.Format(Messages.PROBLEM_VMPROBLEM_TITLE, Helpers.GetName(Vm).Ellipsise(30));
 
         public override string Description => String.Format(Messages.DR_WIZARD_WARNING_EXISTING_VM, Helpers.GetPoolOfOne(Vm.Connection).Name());
-    }   
+    }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/ExistingVmWarning.cs
@@ -47,22 +47,10 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             _vm = vm;
         }
 
-        protected VM Vm
-        {
-            get
-            {
-                return _vm.Connection.WaitForCache(new XenRef<VM>(_vm.opaque_ref));
-            }
-        }
+        protected VM Vm => _vm.Connection.WaitForCache(new XenRef<VM>(_vm.opaque_ref));
 
-        public sealed override string Title
-        {
-            get { return string.Format(Messages.PROBLEM_VMPROBLEM_TITLE, Helpers.GetName(Vm).Ellipsise(30)); }
-        }
+        public sealed override string Title => string.Format(Messages.PROBLEM_VMPROBLEM_TITLE, Helpers.GetName(Vm).Ellipsise(30));
 
-        public override string Description
-        {
-            get { return String.Format(Messages.DR_WIZARD_WARNING_EXISTING_VM, Helpers.GetPoolOfOne(Vm.Connection).Name()); } 
-        }
+        public override string Description => String.Format(Messages.DR_WIZARD_WARNING_EXISTING_VM, Helpers.GetPoolOfOne(Vm.Connection).Name());
     }   
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/InvalidVCPUConfiguration.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/InvalidVCPUConfiguration.cs
@@ -67,7 +67,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
                         action = ee.Action;
                     }
                 };
-                
+
                 propertiesDialog.ShowDialog(Program.MainWindow);
                 if (propertiesDialog.DialogResult != DialogResult.Yes || action == null)
                     cancelled = true;

--- a/XenAdmin/Diagnostics/Problems/VMProblem/InvalidVCPUConfiguration.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/InvalidVCPUConfiguration.cs
@@ -44,15 +44,9 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         public InvalidVCPUConfiguration(Check check, VM vm)
             : base(check, vm) { }
 
-        public override string Description
-        {
-            get { return String.Format(Messages.UPGRADEWIZARD_PROBLEM_INVALID_VCPU_SETTINGS, ServerName, VM.Name()); }
-        }
+        public override string Description => String.Format(Messages.UPGRADEWIZARD_PROBLEM_INVALID_VCPU_SETTINGS, ServerName, VM.Name());
 
-        public override string HelpMessage
-        {
-            get { return Messages.UPGRADEWIZARD_PROBLEM_INVALID_VCPU_SETTINGS_HELPMESSAGE; }
-        }
+        public override string HelpMessage => Messages.UPGRADEWIZARD_PROBLEM_INVALID_VCPU_SETTINGS_HELPMESSAGE;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {

--- a/XenAdmin/Diagnostics/Problems/VMProblem/LocalCD.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/LocalCD.cs
@@ -41,10 +41,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         public LocalCD(Check check, VM vm)
             : base(check, vm) { }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_LOCAL_CD, ServerName, VM.Name()); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_LOCAL_CD, ServerName, VM.Name());
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {
@@ -60,10 +57,6 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
         }
 
-        public override string HelpMessage
-        {
-            get { return Messages.EJECT_CD; }
-        }
-
+        public override string HelpMessage => Messages.EJECT_CD;
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/LocalCD.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/LocalCD.cs
@@ -43,7 +43,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
         public override string Description
         {
-            get { return string.Format(Messages.UPDATES_WIZARD_LOCAL_CD, ServerName, VM.Name().Ellipsise(25)); }
+            get { return string.Format(Messages.UPDATES_WIZARD_LOCAL_CD, ServerName, VM.Name()); }
         }
 
         protected override AsyncAction CreateAction(out bool cancelled)

--- a/XenAdmin/Diagnostics/Problems/VMProblem/LocalStorage.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/LocalStorage.cs
@@ -40,9 +40,6 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         public LocalStorage(Check check, VM vm)
             : base(check, vm) { }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_LOCAL_STORAGE, ServerName, VM.Name()); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_LOCAL_STORAGE, ServerName, VM.Name());
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/LocalStorage.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/LocalStorage.cs
@@ -42,7 +42,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
         public override string Description
         {
-            get { return string.Format(Messages.UPDATES_WIZARD_LOCAL_STORAGE, ServerName, VM.Name().Ellipsise(15)); }
+            get { return string.Format(Messages.UPDATES_WIZARD_LOCAL_STORAGE, ServerName, VM.Name()); }
         }
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/NoHosts.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/NoHosts.cs
@@ -44,7 +44,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
         public override string Description
         {
-            get { return string.Format(Messages.UPDATES_WIZARD_NO_HOSTS, ServerName, VM.Name().Ellipsise(15)); }
+            get { return string.Format(Messages.UPDATES_WIZARD_NO_HOSTS, ServerName, VM.Name()); }
         }
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/NoHosts.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/NoHosts.cs
@@ -42,9 +42,6 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         {
         }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_NO_HOSTS, ServerName, VM.Name()); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_NO_HOSTS, ServerName, VM.Name());
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/NoPVDrivers.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/NoPVDrivers.cs
@@ -37,7 +37,7 @@ using XenAPI;
 
 namespace XenAdmin.Diagnostics.Problems.VMProblem
 {
-    public class NoPVDrivers: VMProblem
+    public class NoPVDrivers : VMProblem
     {
         public NoPVDrivers(Check check, VM vm)
             : base(check, vm)

--- a/XenAdmin/Diagnostics/Problems/VMProblem/RunningVMProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/RunningVMProblem.cs
@@ -49,18 +49,9 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             this.hardShutdown = hardShutdown;
         }
 
-        public override string Description
-        {
-            get
-            {
-                return String.Format(Messages.DR_WIZARD_PROBLEM_RUNNING_VM, Helpers.GetPoolOfOne(VM.Connection).Name()); 
-            } 
-        }
+        public override string Description => String.Format(Messages.DR_WIZARD_PROBLEM_RUNNING_VM, Helpers.GetPoolOfOne(VM.Connection).Name());
 
-        public override string HelpMessage
-        {
-            get { return Messages.DR_WIZARD_PROBLEM_RUNNING_VM_HELPMESSAGE; } 
-        }
+        public override string HelpMessage => Messages.DR_WIZARD_PROBLEM_RUNNING_VM_HELPMESSAGE;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {

--- a/XenAdmin/Diagnostics/Problems/VMProblem/RunningVMProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/RunningVMProblem.cs
@@ -39,7 +39,7 @@ using XenAPI;
 
 namespace XenAdmin.Diagnostics.Problems.VMProblem
 {
-    public class RunningVMProblem: VMProblem
+    public class RunningVMProblem : VMProblem
     {
         private readonly bool hardShutdown;
 

--- a/XenAdmin/Diagnostics/Problems/VMProblem/ToolsCD.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/ToolsCD.cs
@@ -37,8 +37,8 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 {
     class ToolsCD : LocalCD
     {
-        public ToolsCD(Check check,  VM vm)
-            : base(check,  vm)
+        public ToolsCD(Check check, VM vm)
+            : base(check, vm)
         {
         }
 

--- a/XenAdmin/Diagnostics/Problems/VMProblem/ToolsCD.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/ToolsCD.cs
@@ -42,9 +42,6 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         {
         }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_TOOLS_CD, ServerName, VM.Name()); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_TOOLS_CD, ServerName, VM.Name());
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/VMCannotSeeNetwork.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/VMCannotSeeNetwork.cs
@@ -40,8 +40,8 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
     {
         private readonly XenAPI.Network Network;
 
-        public VMCannotSeeNetwork(Check check,  VM vm, XenAPI.Network network)
-            : base(check,  vm)
+        public VMCannotSeeNetwork(Check check, VM vm, XenAPI.Network network)
+            : base(check, vm)
         {
             Network = network;
         }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/VMCannotSeeNetwork.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/VMCannotSeeNetwork.cs
@@ -46,9 +46,6 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             Network = network;
         }
 
-        public override string Description
-        {
-            get { return String.Format(Messages.UPDATES_WIZARD_CANNOT_SEE_NETWORK, ServerName, VM.Name(), Network.Name()); }
-        }
+        public override string Description => String.Format(Messages.UPDATES_WIZARD_CANNOT_SEE_NETWORK, ServerName, VM.Name(), Network.Name());
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VMProblem/VMProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/VMProblem.cs
@@ -100,7 +100,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
 
             Debug.Assert(VM.power_state == vm_power_state.Halted ||
                          VM.power_state == vm_power_state.Suspended, "Expected VM to be suspended or shut down!");
-            if(VM.power_state==vm_power_state.Halted)
+            if (VM.power_state == vm_power_state.Halted)
                 return new VMStartOnAction(VM, residentOn, VMOperationCommand.WarningDialogHAInvalidConfig, VMOperationCommand.StartDiagnosisForm);
             else
             {

--- a/XenAdmin/Diagnostics/Problems/VMProblem/VMProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/VMProblem.cs
@@ -53,13 +53,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         }
 
 
-        protected string ServerName
-        {
-            get
-            {
-                return residentOn != null ? Helpers.GetName(residentOn).Ellipsise(30) : Helpers.GetName(Helpers.GetPoolOfOne(VM.Connection)).Ellipsise(30);
-            }
-        }
+        protected string ServerName => residentOn != null ? Helpers.GetName(residentOn).Ellipsise(30) : Helpers.GetName(Helpers.GetPoolOfOne(VM.Connection)).Ellipsise(30);
 
         public override string HelpMessage
         {
@@ -74,10 +68,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             }
         }
 
-        public sealed override string Title
-        {
-            get { return string.Format(Messages.PROBLEM_VMPROBLEM_TITLE, VM.uuid); }
-        }
+        public sealed override string Title => string.Format(Messages.PROBLEM_VMPROBLEM_TITLE, VM.uuid);
 
         protected AsyncAction SuspendVM()
         {
@@ -89,13 +80,7 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
             return new VMHardShutdown(VM);
         }
 
-        protected virtual bool CanSuspendVM
-        {
-            get
-            {
-                return VM.allowed_operations.Contains(vm_operations.suspend);
-            }
-        }
+        protected virtual bool CanSuspendVM => VM.allowed_operations.Contains(vm_operations.suspend);
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {

--- a/XenAdmin/Diagnostics/Problems/VMProblem/VmHasVgpu.cs
+++ b/XenAdmin/Diagnostics/Problems/VMProblem/VmHasVgpu.cs
@@ -39,9 +39,6 @@ namespace XenAdmin.Diagnostics.Problems.VMProblem
         public VmHasVgpu(Check check, VM vm)
             : base(check, vm) { }
 
-        public override string Description
-        {
-            get { return string.Format(Messages.UPDATES_WIZARD_VM_HAS_VGPU, ServerName, VM.Name()); }
-        }
+        public override string Description => string.Format(Messages.UPDATES_WIZARD_VM_HAS_VGPU, ServerName, VM.Name());
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VmApplianceProblem/ExistingVmApplianceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VmApplianceProblem/ExistingVmApplianceProblem.cs
@@ -52,18 +52,9 @@ namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
             this.vmsToDestroy = vmsToDestroy;
         }
 
-        public override string Description
-        {
-            get
-            {
-                return String.Format(Messages.DR_WIZARD_PROBLEM_EXISTING_APPLIANCE, Helpers.GetPoolOfOne(vmsToDestroy[0].Connection).Name()); 
-            } 
-        }
+        public override string Description => String.Format(Messages.DR_WIZARD_PROBLEM_EXISTING_APPLIANCE, Helpers.GetPoolOfOne(vmsToDestroy[0].Connection).Name());
 
-        public override string HelpMessage
-        {
-            get { return Messages.DR_WIZARD_PROBLEM_EXISTING_APPLIANCE_HELPMESSAGE; } 
-        }
+        public override string HelpMessage => Messages.DR_WIZARD_PROBLEM_EXISTING_APPLIANCE_HELPMESSAGE;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {

--- a/XenAdmin/Diagnostics/Problems/VmApplianceProblem/ExistingVmApplianceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VmApplianceProblem/ExistingVmApplianceProblem.cs
@@ -43,7 +43,7 @@ using XenAdmin.Actions.DR;
 
 namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
 {
-    public class ExistingVmApplianceProblem: VmApplianceProblem
+    public class ExistingVmApplianceProblem : VmApplianceProblem
     {
         private readonly List<VM> vmsToDestroy;
         public ExistingVmApplianceProblem(Check check, VM_appliance vmAppliance, List<VM> vmsToDestroy)
@@ -64,7 +64,7 @@ namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
             DialogResult dialogResult;
             using (var dlg = new WarningDialog(string.Format(Messages.CONFIRM_DELETE_VMS, vmNames, vmsToDestroy[0].Connection.Name),
                     ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo)
-                {WindowTitle = Messages.ACTION_SHUTDOWN_AND_DESTROY_VMS_TITLE})
+            { WindowTitle = Messages.ACTION_SHUTDOWN_AND_DESTROY_VMS_TITLE })
             {
                 dialogResult = dlg.ShowDialog();
             }

--- a/XenAdmin/Diagnostics/Problems/VmApplianceProblem/ExistingVmApplianceWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/VmApplianceProblem/ExistingVmApplianceWarning.cs
@@ -47,22 +47,10 @@ namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
             this.vmAppliance = vmAppliance;
         }
 
-        protected VM_appliance VmAppliance
-        {
-            get
-            {
-                return vmAppliance.Connection.WaitForCache(new XenRef<VM_appliance>(vmAppliance.opaque_ref));
-            }
-        }
+        protected VM_appliance VmAppliance => vmAppliance.Connection.WaitForCache(new XenRef<VM_appliance>(vmAppliance.opaque_ref));
 
-        public sealed override string Title
-        {
-            get { return Helpers.GetName(VmAppliance).Ellipsise(30); }
-        }
+        public sealed override string Title => Helpers.GetName(VmAppliance).Ellipsise(30);
 
-        public override string Description
-        {
-            get { return String.Format(Messages.DR_WIZARD_WARNING_EXISTING_VM, Helpers.GetPoolOfOne(VmAppliance.Connection).Name()); } 
-        }
+        public override string Description => String.Format(Messages.DR_WIZARD_WARNING_EXISTING_VM, Helpers.GetPoolOfOne(VmAppliance.Connection).Name());
     }
 }

--- a/XenAdmin/Diagnostics/Problems/VmApplianceProblem/RunningVmApplianceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VmApplianceProblem/RunningVmApplianceProblem.cs
@@ -76,14 +76,14 @@ namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
 
             //shut down appliance action
             AsyncAction shutDownAction = hardShutdown
-                                             ? (AsyncAction) new HardShutDownApplianceAction(VmAppliance)
+                                             ? (AsyncAction)new HardShutDownApplianceAction(VmAppliance)
                                              : new ShutDownApplianceAction(VmAppliance);
 
             if (!shutdown)
                 return shutDownAction;
 
             //shut down fate-sharing VMs
-            var actions = new List<AsyncAction> {shutDownAction};
+            var actions = new List<AsyncAction> { shutDownAction };
 
             foreach (var vm in fateSharingVms)
             {

--- a/XenAdmin/Diagnostics/Problems/VmApplianceProblem/RunningVmApplianceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VmApplianceProblem/RunningVmApplianceProblem.cs
@@ -52,18 +52,9 @@ namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
             this.hardShutdown = hardShutdown;
         }
 
-        public override string Description
-        {
-            get
-            {
-                return String.Format(Messages.DR_WIZARD_PROBLEM_RUNNING_APPLIANCE, Helpers.GetPoolOfOne(VmAppliance.Connection).Name()); 
-            } 
-        }
+        public override string Description => String.Format(Messages.DR_WIZARD_PROBLEM_RUNNING_APPLIANCE, Helpers.GetPoolOfOne(VmAppliance.Connection).Name());
 
-        public override string HelpMessage
-        {
-            get { return Messages.DR_WIZARD_PROBLEM_RUNNING_APPLIANCE_HELPMESSAGE; } 
-        }
+        public override string HelpMessage => Messages.DR_WIZARD_PROBLEM_RUNNING_APPLIANCE_HELPMESSAGE;
 
         protected override AsyncAction CreateAction(out bool cancelled)
         {

--- a/XenAdmin/Diagnostics/Problems/VmApplianceProblem/VmApplianceProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/VmApplianceProblem/VmApplianceProblem.cs
@@ -46,18 +46,8 @@ namespace XenAdmin.Diagnostics.Problems.VmApplianceProblem
             _vmAppliance = vmAppliance;
         }
 
-        public VM_appliance VmAppliance
-        {
-            get
-            {
-                return _vmAppliance;
-            }
-        }
+        public VM_appliance VmAppliance => _vmAppliance;
 
-        public sealed override string Title
-        {
-            get { return string.Format(Messages.PROBLEM_VMAPPLIANCEPROBLEM_TITLE, Helpers.GetName(VmAppliance).Ellipsise(30)); }
-        }
-
+        public sealed override string Title => string.Format(Messages.PROBLEM_VMAPPLIANCEPROBLEM_TITLE, Helpers.GetName(VmAppliance).Ellipsise(30));
     }
 }

--- a/XenAdmin/Diagnostics/Problems/Warning.cs
+++ b/XenAdmin/Diagnostics/Problems/Warning.cs
@@ -57,7 +57,7 @@ namespace XenAdmin.Diagnostics.Problems
         protected WarningWithMoreInfo(Check check) : base(check)
         {
         }
-        
+
         public override string HelpMessage => Messages.MORE_INFO;
 
         protected override Actions.AsyncAction CreateAction(out bool cancelled)
@@ -86,7 +86,7 @@ namespace XenAdmin.Diagnostics.Problems
         public virtual string LinkText => LinkData;
     }
 
- 
+
     public abstract class WarningWithInformationUrl : Warning
     {
         protected WarningWithInformationUrl(Check check) : base(check)

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.Designer.cs
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.Designer.cs
@@ -30,6 +30,9 @@ namespace XenAdmin.Dialogs.OptionsPages
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DisplayOptionsPage));
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.updateLogOptionsDecentGroupBox = new XenAdmin.Controls.DecentGroupBox();
+            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+            this.showTimestampsCheckBox = new System.Windows.Forms.CheckBox();
             this.GraphTypeGroupBox = new XenAdmin.Controls.DecentGroupBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label5 = new XenAdmin.Controls.Common.AutoHeightLabel();
@@ -41,6 +44,8 @@ namespace XenAdmin.Dialogs.OptionsPages
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.checkBoxStoreTab = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel3.SuspendLayout();
+            this.updateLogOptionsDecentGroupBox.SuspendLayout();
+            this.tableLayoutPanel4.SuspendLayout();
             this.GraphTypeGroupBox.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
@@ -52,9 +57,31 @@ namespace XenAdmin.Dialogs.OptionsPages
             // tableLayoutPanel3
             // 
             resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
+            this.tableLayoutPanel3.Controls.Add(this.updateLogOptionsDecentGroupBox, 0, 2);
             this.tableLayoutPanel3.Controls.Add(this.GraphTypeGroupBox, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.TabGroupBox, 0, 1);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            // 
+            // updateLogOptionsDecentGroupBox
+            // 
+            resources.ApplyResources(this.updateLogOptionsDecentGroupBox, "updateLogOptionsDecentGroupBox");
+            this.updateLogOptionsDecentGroupBox.Controls.Add(this.tableLayoutPanel4);
+            this.updateLogOptionsDecentGroupBox.Name = "updateLogOptionsDecentGroupBox";
+            this.updateLogOptionsDecentGroupBox.TabStop = false;
+            // 
+            // tableLayoutPanel4
+            // 
+            resources.ApplyResources(this.tableLayoutPanel4, "tableLayoutPanel4");
+            this.tableLayoutPanel4.Controls.Add(this.showTimestampsCheckBox, 0, 0);
+            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
+            // 
+            // showTimestampsCheckBox
+            // 
+            resources.ApplyResources(this.showTimestampsCheckBox, "showTimestampsCheckBox");
+            this.showTimestampsCheckBox.Checked = true;
+            this.showTimestampsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.showTimestampsCheckBox.Name = "showTimestampsCheckBox";
+            this.showTimestampsCheckBox.UseVisualStyleBackColor = true;
             // 
             // GraphTypeGroupBox
             // 
@@ -135,6 +162,10 @@ namespace XenAdmin.Dialogs.OptionsPages
             this.Name = "DisplayOptionsPage";
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
+            this.updateLogOptionsDecentGroupBox.ResumeLayout(false);
+            this.updateLogOptionsDecentGroupBox.PerformLayout();
+            this.tableLayoutPanel4.ResumeLayout(false);
+            this.tableLayoutPanel4.PerformLayout();
             this.GraphTypeGroupBox.ResumeLayout(false);
             this.GraphTypeGroupBox.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -163,5 +194,8 @@ namespace XenAdmin.Dialogs.OptionsPages
         private System.Windows.Forms.PictureBox pictureBox2;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.CheckBox checkBoxStoreTab;
+        private Controls.DecentGroupBox updateLogOptionsDecentGroupBox;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
+        private System.Windows.Forms.CheckBox showTimestampsCheckBox;
     }
 }

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.cs
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.cs
@@ -48,6 +48,7 @@ namespace XenAdmin.Dialogs.OptionsPages
             GraphAreasRadioButton.Checked = Properties.Settings.Default.FillAreaUnderGraphs;
             GraphLinesRadioButton.Checked = !Properties.Settings.Default.FillAreaUnderGraphs;
             checkBoxStoreTab.Checked = Properties.Settings.Default.RememberLastSelectedTab;
+            showTimestampsCheckBox.Checked = Properties.Settings.Default.ShowTimestampsInUpdatesLog;
         }
 
         #region IOptionsPage Members
@@ -59,20 +60,24 @@ namespace XenAdmin.Dialogs.OptionsPages
 
         public void ShowValidationMessages()
         {
+            // no message
         }
 
         public void HideValidationMessages()
         {
+            // no message
         }
 
         public void Save()
         {
             if (GraphAreasRadioButton.Checked != Properties.Settings.Default.FillAreaUnderGraphs)
                 Properties.Settings.Default.FillAreaUnderGraphs = GraphAreasRadioButton.Checked;
- 
+
             if (checkBoxStoreTab.Checked != Properties.Settings.Default.RememberLastSelectedTab)
                 Properties.Settings.Default.RememberLastSelectedTab = checkBoxStoreTab.Checked;
- 
+
+            if (showTimestampsCheckBox.Checked != Properties.Settings.Default.ShowTimestampsInUpdatesLog)
+                Properties.Settings.Default.ShowTimestampsInUpdatesLog = showTimestampsCheckBox.Checked;
         }
 
         #endregion

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.resx
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.resx
@@ -160,7 +160,7 @@
     <value>0</value>
   </data>
   <data name="showTimestampsCheckBox.Text" xml:space="preserve">
-    <value>Show timestamps in the update logs</value>
+    <value>&amp;Show timestamps on the update and upgrade log consoles</value>
   </data>
   <data name="&gt;&gt;showTimestampsCheckBox.Name" xml:space="preserve">
     <value>showTimestampsCheckBox</value>
@@ -223,7 +223,7 @@
     <value>2</value>
   </data>
   <data name="updateLogOptionsDecentGroupBox.Text" xml:space="preserve">
-    <value>Update logs options</value>
+    <value>Log consoles options</value>
   </data>
   <data name="&gt;&gt;updateLogOptionsDecentGroupBox.Name" xml:space="preserve">
     <value>updateLogOptionsDecentGroupBox</value>
@@ -520,7 +520,7 @@
     <value>0</value>
   </data>
   <data name="checkBoxStoreTab.Text" xml:space="preserve">
-    <value>Remember the last selected Tab for a resource</value>
+    <value>&amp;Remember the last selected Tab for a resource</value>
   </data>
   <data name="&gt;&gt;checkBoxStoreTab.Name" xml:space="preserve">
     <value>checkBoxStoreTab</value>

--- a/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.resx
+++ b/XenAdmin/Dialogs/OptionsPages/DisplayOptionsPage.resx
@@ -128,6 +128,115 @@
   <data name="tableLayoutPanel3.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
+  <data name="updateLogOptionsDecentGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel4.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="showTimestampsCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showTimestampsCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="showTimestampsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="showTimestampsCheckBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 0, 0</value>
+  </data>
+  <data name="showTimestampsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 17</value>
+  </data>
+  <data name="showTimestampsCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="showTimestampsCheckBox.Text" xml:space="preserve">
+    <value>Show timestamps in the update logs</value>
+  </data>
+  <data name="&gt;&gt;showTimestampsCheckBox.Name" xml:space="preserve">
+    <value>showTimestampsCheckBox</value>
+  </data>
+  <data name="&gt;&gt;showTimestampsCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showTimestampsCheckBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;showTimestampsCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>617, 49</value>
+  </data>
+  <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.Name" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.Parent" xml:space="preserve">
+    <value>updateLogOptionsDecentGroupBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="showTimestampsCheckBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,49,Absolute,49,Absolute,49" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 337</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 6</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 71</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="updateLogOptionsDecentGroupBox.Text" xml:space="preserve">
+    <value>Update logs options</value>
+  </data>
+  <data name="&gt;&gt;updateLogOptionsDecentGroupBox.Name" xml:space="preserve">
+    <value>updateLogOptionsDecentGroupBox</value>
+  </data>
+  <data name="&gt;&gt;updateLogOptionsDecentGroupBox.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.DecentGroupBox, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;updateLogOptionsDecentGroupBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;updateLogOptionsDecentGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="GraphTypeGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -146,7 +255,6 @@
   <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label5.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
   </data>
@@ -172,7 +280,7 @@
     <value>label5</value>
   </data>
   <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>XenAdmin.Controls.Common.AutoHeightLabel, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;label5.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -373,13 +481,13 @@
     <value>GraphTypeGroupBox</value>
   </data>
   <data name="&gt;&gt;GraphTypeGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DecentGroupBox, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;GraphTypeGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;GraphTypeGroupBox.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="TabGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -481,13 +589,13 @@
     <value>TabGroupBox</value>
   </data>
   <data name="&gt;&gt;TabGroupBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DecentGroupBox, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TabGroupBox.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;TabGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="tableLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -520,7 +628,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="GraphTypeGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TabGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="updateLogOptionsDecentGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="GraphTypeGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TabGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/Properties/Settings.Designer.cs
+++ b/XenAdmin/Properties/Settings.Designer.cs
@@ -865,5 +865,18 @@ namespace XenAdmin.Properties {
                 this["IgnoreFirstRunWizards"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool ShowTimestampsInUpdatesLog {
+            get {
+                return ((bool)(this["ShowTimestampsInUpdatesLog"]));
+            }
+            set {
+                this["ShowTimestampsInUpdatesLog"] = value;
+            }
+        }
     }
 }

--- a/XenAdmin/Properties/Settings.Designer.cs
+++ b/XenAdmin/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace XenAdmin.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -58,20 +58,6 @@ namespace XenAdmin.Properties {
             }
             set {
                 this["SaveSession"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
-            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" />")]
-        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
-        public string[] ServerList {
-            get {
-                return ((string[])(this["ServerList"]));
-            }
-            set {
-                this["ServerList"] = value;
             }
         }
         
@@ -478,20 +464,6 @@ namespace XenAdmin.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
-            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" />")]
-        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
-        public string[] DisabledPlugins {
-            get {
-                return ((string[])(this["DisabledPlugins"]));
-            }
-            set {
-                this["DisabledPlugins"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public string[] CslgCredentials {
             get {
@@ -499,20 +471,6 @@ namespace XenAdmin.Properties {
             }
             set {
                 this["CslgCredentials"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
-            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" />")]
-        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
-        public string[] IgnoreFirstRunWizards {
-            get {
-                return ((string[])(this["IgnoreFirstRunWizards"]));
-            }
-            set {
-                this["IgnoreFirstRunWizards"] = value;
             }
         }
         
@@ -863,6 +821,48 @@ namespace XenAdmin.Properties {
             }
             set {
                 this["OpenSSHLocation"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsd=\"http://www.w3." +
+            "org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" />")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public string[] ServerList {
+            get {
+                return ((string[])(this["ServerList"]));
+            }
+            set {
+                this["ServerList"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsd=\"http://www.w3." +
+            "org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" />")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public string[] DisabledPlugins {
+            get {
+                return ((string[])(this["DisabledPlugins"]));
+            }
+            set {
+                this["DisabledPlugins"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsd=\"http://www.w3." +
+            "org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" />")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public string[] IgnoreFirstRunWizards {
+            get {
+                return ((string[])(this["IgnoreFirstRunWizards"]));
+            }
+            set {
+                this["IgnoreFirstRunWizards"] = value;
             }
         }
     }

--- a/XenAdmin/Properties/Settings.settings
+++ b/XenAdmin/Properties/Settings.settings
@@ -11,10 +11,6 @@
     <Setting Name="SaveSession" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="ServerList" Roaming="true" Type="System.String[]" Scope="User">
-      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /&gt;</Value>
-    </Setting>
     <Setting Name="LocalSRsVisible" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
@@ -108,16 +104,8 @@
     <Setting Name="LoadPlugins" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="DisabledPlugins" Roaming="true" Type="System.String[]" Scope="User">
-      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /&gt;</Value>
-    </Setting>
     <Setting Name="CslgCredentials" Roaming="true" Type="System.String[]" Scope="User">
       <Value Profile="(Default)" />
-    </Setting>
-    <Setting Name="IgnoreFirstRunWizards" Roaming="true" Type="System.String[]" Scope="User">
-      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /&gt;</Value>
     </Setting>
     <Setting Name="ServerStatusPath" Roaming="true" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
@@ -199,6 +187,18 @@
     </Setting>
     <Setting Name="OpenSSHLocation" Roaming="true" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="ServerList" Roaming="true" Type="System.String[]" Scope="User">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" /&gt;</Value>
+    </Setting>
+    <Setting Name="DisabledPlugins" Roaming="true" Type="System.String[]" Scope="User">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" /&gt;</Value>
+    </Setting>
+    <Setting Name="IgnoreFirstRunWizards" Roaming="true" Type="System.String[]" Scope="User">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" /&gt;</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/XenAdmin/Properties/Settings.settings
+++ b/XenAdmin/Properties/Settings.settings
@@ -200,5 +200,8 @@
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
 &lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" /&gt;</Value>
     </Setting>
+    <Setting Name="ShowTimestampsInUpdatesLog" Roaming="true" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -97,7 +97,8 @@ namespace XenAdmin.Wizards.PatchingWizard
                 return;
 
             using (var dialog = new WarningDialog(ReconsiderCancellationMessage(),
-                ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo){WindowTitle = Text})
+                ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo)
+            { WindowTitle = Text })
             {
                 if (dialog.ShowDialog(this) != DialogResult.Yes)
                 {
@@ -164,7 +165,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             _backgroundWorkers = new List<UpdateProgressBackgroundWorker>();
             _failedWorkers = new List<UpdateProgressBackgroundWorker>();
             var atLeastOneWorkerStarted = false;
-            
+
             foreach (var pool in SelectedPools)
             {
                 var planActions = GenerateHostPlans(pool, out _);
@@ -253,9 +254,11 @@ namespace XenAdmin.Wizards.PatchingWizard
                 newVal = 0;
             else if (newVal > 100)
                 newVal = 100;
-            progressBar.Value = (int) newVal;
+            progressBar.Value = (int)newVal;
 
             var stringBuilder = new StringBuilder();
+
+            var addTimestamp = Properties.Settings.Default.ShowTimestampsInUpdatesLog;
 
             foreach (var bgw in _backgroundWorkers)
             {
@@ -265,13 +268,13 @@ namespace XenAdmin.Wizards.PatchingWizard
                 var errorSb = new StringBuilder();
 
                 if (!string.IsNullOrEmpty(bgw.Name))
-                    sb.AppendLine($"{bgw.Name}:");
+                    sb.AppendFormattedLine($"{bgw.Name}:", addTimestamp);
 
                 foreach (var pa in bgw.DoneActions)
                 {
-                    pa.ProgressHistory.ForEach(step => sb.AppendIndented(step).AppendLine());
+                    pa.ProgressHistory.ForEach(step => sb.AppendFormattedLine(step, addTimestamp, true));
 
-                    if (pa.Error == null) 
+                    if (pa.Error == null)
                         continue;
 
                     if (pa.Error is CancelledException)
@@ -279,14 +282,12 @@ namespace XenAdmin.Wizards.PatchingWizard
                         bgwCancellationCount++;
                         continue;
                     }
-
-                    errorSb.AppendLine(!(pa.Error.InnerException is Failure innerEx) ? pa.Error.Message : innerEx.Message);
+                    errorSb.AppendFormattedLine(!(pa.Error.InnerException is Failure innerEx) ? pa.Error.Message : innerEx.Message, addTimestamp, true, true);
 
                     if (pa.IsSkippable)
                     {
                         Debug.Assert(!string.IsNullOrEmpty(pa.Title));
-                        errorSb.AppendLine(string.Format(Messages.RPU_WIZARD_ERROR_SKIP_MSG, pa.Title))
-                            .AppendLine();
+                        errorSb.AppendFormattedLine(string.Format(Messages.RPU_WIZARD_ERROR_SKIP_MSG, pa.Title), addTimestamp, true, true);
                     }
 
                     bgwErrorCount++;
@@ -294,23 +295,25 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 foreach (var pa in bgw.InProgressActions)
                 {
-                    pa.ProgressHistory.ForEach(step => sb.AppendIndented(step).AppendLine());
+                    pa.ProgressHistory.ForEach(step => sb.AppendFormattedLine(step, addTimestamp, true));
                 }
 
                 sb.AppendLine();
 
                 if (bgwCancellationCount > 0)
                 {
-                    sb.AppendIndented(UserCancellationMessage()).AppendLine();
+                    sb.AppendFormattedLine(UserCancellationMessage(), addTimestamp, indent: true);
                 }
                 else if (bgwErrorCount > 0)
                 {
-                    sb.AppendIndented(FailureMessagePerPool(bgwErrorCount > 1)).AppendLine();
-                    sb.AppendIndented(errorSb);
+                    sb.AppendFormattedLine(FailureMessagePerPool(bgwErrorCount > 1), addTimestamp, true);
+
+                    // we don't add formatting since errorSb has its own
+                    sb.Append(errorSb.ToString());
                 }
                 else if (!bgw.IsBusy)
                 {
-                    sb.AppendIndented(WarningMessagePerPool(bgw.Pool) ?? SuccessMessagePerPool(bgw.Pool)).AppendLine();
+                    sb.AppendFormattedLine(WarningMessagePerPool(bgw.Pool) ?? SuccessMessagePerPool(bgw.Pool), addTimestamp, true);
                 }
 
                 sb.AppendLine();
@@ -318,7 +321,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
 
             var newText = stringBuilder.ToString();
-            
+
             if (!_userMovedVerticalScrollbar)
             {
                 textBoxLog.Text = newText;
@@ -361,7 +364,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                     // Step 2: UpdatesPlanActions  (priority update action)
                     bgw.ProgressIncrement = bgw.UpdatesActionsIncrement(hp);
-                    var planActions = hp.UpdatesPlanActions; 
+                    var planActions = hp.UpdatesPlanActions;
                     foreach (var a in planActions)
                     {
                         action = a;
@@ -539,7 +542,7 @@ namespace XenAdmin.Wizards.PatchingWizard
 
             using (var dlg = new WarningDialog(string.Format(skippableWorkers.Count > 1 ? Messages.MESSAGEBOX_SKIP_RPU_STEPS : Messages.MESSAGEBOX_SKIP_RPU_STEP, msg),
                     ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo)
-                {WindowTitle = ParentForm != null ? ParentForm.Text : BrandManager.BrandConsole})
+            { WindowTitle = ParentForm != null ? ParentForm.Text : BrandManager.BrandConsole })
             {
                 if (dlg.ShowDialog(this) != DialogResult.Yes)
                     return;
@@ -578,7 +581,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             }
         }
         #endregion
-        
+
         protected HostPlan GetUpdatePlanActionsForHost(Host host, List<Host> hosts, List<XenServerPatch> minimalPatches,
             List<XenServerPatch> uploadedPatches, KeyValuePair<XenServerPatch, string> patchFromDisk, bool repatriateVms = true)
         {
@@ -651,7 +654,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                                   ?? planActionsPerHost.FindLast(a => a is RestartHostPlanAction);
 
                 if (lastRestart != null)
-                    ((RestartHostPlanAction) lastRestart).EnableOnly = false;
+                    ((RestartHostPlanAction)lastRestart).EnableOnly = false;
             }
 
             return new HostPlan(host, null, planActionsPerHost, delayedActionsPerHost);

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -282,7 +282,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                         bgwCancellationCount++;
                         continue;
                     }
-                    errorSb.AppendFormattedLine(!(pa.Error.InnerException is Failure innerEx) ? pa.Error.Message : innerEx.Message, addTimestamp, true, true);
+                    errorSb.AppendFormattedLine(pa.Error.InnerException is Failure innerEx ? innerEx.Message : pa.Error.Message , addTimestamp, true);
 
                     if (pa.IsSkippable)
                     {

--- a/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/AutomatedUpdatesBasePage.cs
@@ -43,7 +43,6 @@ using System.Windows.Forms;
 using XenAdmin.Diagnostics.Problems;
 using XenAdmin.Dialogs;
 using XenAdmin.Wizards.RollingUpgradeWizard.PlanActions;
-using Console = System.Console;
 
 
 namespace XenAdmin.Wizards.PatchingWizard
@@ -268,11 +267,11 @@ namespace XenAdmin.Wizards.PatchingWizard
                 var errorSb = new StringBuilder();
 
                 if (!string.IsNullOrEmpty(bgw.Name))
-                    sb.AppendFormattedLine($"{bgw.Name}:", addTimestamp);
+                    sb.AppendLine($"{bgw.Name}:");
 
                 foreach (var pa in bgw.DoneActions)
                 {
-                    pa.ProgressHistory.ForEach(step => sb.AppendFormattedLine(step, addTimestamp, true));
+                    pa.ProgressHistory.ForEach(step => sb.AppendFormattedLine(value: step.Description, timestamp: step.Timestamp, showTimestamp: addTimestamp ,indent: true));
 
                     if (pa.Error == null)
                         continue;
@@ -282,12 +281,12 @@ namespace XenAdmin.Wizards.PatchingWizard
                         bgwCancellationCount++;
                         continue;
                     }
-                    errorSb.AppendFormattedLine(pa.Error.InnerException is Failure innerEx ? innerEx.Message : pa.Error.Message , addTimestamp, true);
+                    errorSb.AppendFormattedLine(pa.Error.InnerException is Failure innerEx ? innerEx.Message : pa.Error.Message , timestamp: pa.Timestamp, showTimestamp: addTimestamp, indent: true);
 
                     if (pa.IsSkippable)
                     {
                         Debug.Assert(!string.IsNullOrEmpty(pa.Title));
-                        errorSb.AppendFormattedLine(string.Format(Messages.RPU_WIZARD_ERROR_SKIP_MSG, pa.Title), addTimestamp, true, true);
+                        errorSb.AppendFormattedLine(string.Format(Messages.RPU_WIZARD_ERROR_SKIP_MSG, pa.Title), timestamp : pa.Timestamp, showTimestamp: addTimestamp, indent: true, addExtraLine: true);
                     }
 
                     bgwErrorCount++;
@@ -295,25 +294,25 @@ namespace XenAdmin.Wizards.PatchingWizard
 
                 foreach (var pa in bgw.InProgressActions)
                 {
-                    pa.ProgressHistory.ForEach(step => sb.AppendFormattedLine(step, addTimestamp, true));
+                    pa.ProgressHistory.ForEach(step => sb.AppendFormattedLine(value: step.Description, timestamp: step.Timestamp, showTimestamp: addTimestamp, indent: true));
                 }
 
                 sb.AppendLine();
 
                 if (bgwCancellationCount > 0)
                 {
-                    sb.AppendFormattedLine(UserCancellationMessage(), addTimestamp, indent: true);
+                    sb.AppendFormattedLine(UserCancellationMessage(), timestamp: DateTime.Now, showTimestamp: addTimestamp, indent: true);
                 }
                 else if (bgwErrorCount > 0)
                 {
-                    sb.AppendFormattedLine(FailureMessagePerPool(bgwErrorCount > 1), addTimestamp, true);
+                    sb.AppendFormattedLine(FailureMessagePerPool(bgwErrorCount > 1), timestamp: DateTime.Now, showTimestamp: addTimestamp, indent: true);
 
                     // we don't add formatting since errorSb has its own
-                    sb.Append(errorSb.ToString());
+                    sb.Append(errorSb);
                 }
                 else if (!bgw.IsBusy)
                 {
-                    sb.AppendFormattedLine(WarningMessagePerPool(bgw.Pool) ?? SuccessMessagePerPool(bgw.Pool), addTimestamp, true);
+                    sb.AppendFormattedLine(WarningMessagePerPool(bgw.Pool) ?? SuccessMessagePerPool(bgw.Pool), DateTime.Now, showTimestamp: addTimestamp, indent: true);
                 }
 
                 sb.AppendLine();

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard.Designer.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard.Designer.cs
@@ -52,7 +52,7 @@ namespace XenAdmin.Wizards.PatchingWizard
             ((System.ComponentModel.ISupportInitialize)(this.XSHelpButton)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
-
+            this.MaximizeBox = true;
         }
 
         #endregion

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_ModePage.cs
@@ -106,7 +106,7 @@ namespace XenAdmin.Wizards.PatchingWizard
                 foreach (var kvp in ManualTextInstructions)
                 {
                     sb.AppendFormat("{0}:", kvp.Key).AppendLine();
-                    sb.AppendIndented(kvp.Value).AppendLine();
+                    sb.AppendIndented(kvp.Value.ToString()).AppendLine();
                 }
                 textBoxLog.Text = sb.ToString();
             }

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard.Designer.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard.Designer.cs
@@ -46,11 +46,11 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             // 
             resources.ApplyResources(this, "$this");
             this.Name = "RollingUpgradeWizard";
+            this.MaximizeBox = true;
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxWizard)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.XSHelpButton)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -195,6 +195,9 @@
                     <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
                 </value>
             </setting>
+            <setting name="ShowTimestampsInUpdatesLog" serializeAs="String">
+                <value>True</value>
+            </setting>
         </XenAdmin.Properties.Settings>
     </userSettings>
 

--- a/XenAdmin/app.config
+++ b/XenAdmin/app.config
@@ -15,12 +15,6 @@
             <setting name="SaveSession" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="ServerList" serializeAs="Xml">
-                <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-                </value>
-            </setting>
             <setting name="LocalSRsVisible" serializeAs="String">
                 <value>True</value>
             </setting>
@@ -108,18 +102,6 @@
             <setting name="LoadPlugins" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="DisabledPlugins" serializeAs="Xml">
-                <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-                </value>
-            </setting>
-            <setting name="IgnoreFirstRunWizards" serializeAs="Xml">
-                <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-                </value>
-            </setting>
             <setting name="ServerStatusPath" serializeAs="String">
                 <value />
             </setting>
@@ -197,6 +179,21 @@
             </setting>
             <setting name="OpenSSHLocation" serializeAs="String">
                 <value />
+            </setting>
+            <setting name="ServerList" serializeAs="Xml">
+                <value>
+                    <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+                </value>
+            </setting>
+            <setting name="DisabledPlugins" serializeAs="Xml">
+                <value>
+                    <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+                </value>
+            </setting>
+            <setting name="IgnoreFirstRunWizards" serializeAs="Xml">
+                <value>
+                    <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+                </value>
             </setting>
         </XenAdmin.Properties.Settings>
     </userSettings>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -11935,6 +11935,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MMM d, h:mm:ss.
+        /// </summary>
+        public static string DATEFORMAT_DM_HM {
+            get {
+                return ResourceManager.GetString("DATEFORMAT_DM_HM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MMM d, yyyy.
         /// </summary>
         public static string DATEFORMAT_DMY {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -11935,11 +11935,11 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MMM d, h:mm:ss.
+        ///   Looks up a localized string similar to MMM d, hh:mm:ss.
         /// </summary>
-        public static string DATEFORMAT_DM_HM {
+        public static string DATEFORMAT_DM_HMS {
             get {
-                return ResourceManager.GetString("DATEFORMAT_DM_HM", resourceCulture);
+                return ResourceManager.GetString("DATEFORMAT_DM_HMS", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -4245,6 +4245,9 @@ For optimal performance and reliability during VM migration, ensure that the net
   <data name="DATEFORMAT_DM" xml:space="preserve">
     <value>MMM d</value>
   </data>
+  <data name="DATEFORMAT_DM_HM" xml:space="preserve">
+    <value>MMM d, h:mm:ss</value>
+  </data>
   <data name="DATEFORMAT_DMY" xml:space="preserve">
     <value>MMM d, yyyy</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -4245,8 +4245,8 @@ For optimal performance and reliability during VM migration, ensure that the net
   <data name="DATEFORMAT_DM" xml:space="preserve">
     <value>MMM d</value>
   </data>
-  <data name="DATEFORMAT_DM_HM" xml:space="preserve">
-    <value>MMM d, h:mm:ss</value>
+  <data name="DATEFORMAT_DM_HMS" xml:space="preserve">
+    <value>MMM d, hh:mm:ss</value>
   </data>
   <data name="DATEFORMAT_DMY" xml:space="preserve">
     <value>MMM d, yyyy</value>


### PR DESCRIPTION
I suggest to review one commit at a time, without whitespace diffs.

______________

### Commit breakdown

[CP-39929: Remove ellipsing from VMProblem descriptions](https://github.com/xenserver/xenadmin/commit/824a46d5410ee2a35656e6a4ddae39f4174a29f4):
> VM names are elipsized, which hides which VM has issues

[CP-39929: Enable use of maximize box for RPU Wizard](https://github.com/xenserver/xenadmin/commit/cf44274a1448eea3c39913c77076022ba8b3ce61)
> Enabling the maximize button would be nice, as it's disabled, yet I can resize the dialog to be full screen, seems an odd ui choice, but as it's a non-modal dialog it'd nice to be able to see more of what's being logged)

[CP-39929: Tidy up settings files](https://github.com/xenserver/xenadmin/commit/1fd39713f14783c31c72c313377873285e6bc836)
These changes were generated automatically by VS 2022

[CP-39929: Add timestamps to update logs](https://github.com/xenserver/xenadmin/commit/54a9f22c874476f23aec301383e0ddddf2f97664)
- Add option to the display options page. Feel free to suggest other names for the setting and the labels.
- Add related setting to `Settings.setting`
- Refactor `ExtensionMethods` to be more compact and flexible.
