### PR TITLE
CA-368321: Update Json.NET from `10.0.2` to `13.0.1`

### DIFF
--- a/XenAdminTests/XenAdminTests.csproj
+++ b/XenAdminTests/XenAdminTests.csproj
@@ -44,7 +44,7 @@
     <Reference Include="Moq, Version=4.5.3.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json.CH, Version=10.0.2.1, Culture=neutral, PublicKeyToken=d247b8b0ac7959e9, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json.CH, Version=13.0.1.0, Culture=neutral, PublicKeyToken=d247b8b0ac7959e9, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.CH.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -45,7 +45,7 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=d247b8b0ac7959e9, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json.CH, Version=10.0.2.1, Culture=neutral, PublicKeyToken=d247b8b0ac7959e9, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json.CH, Version=13.0.1.0, Culture=neutral, PublicKeyToken=d247b8b0ac7959e9, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.CH.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/packages/DOTNET_BUILD_LOCATION
+++ b/packages/DOTNET_BUILD_LOCATION
@@ -1,1 +1,1 @@
-xc-local-release/dotnet-packages/master/40
+xc-local-release/dotnet-packages/master/41


### PR DESCRIPTION
For Stockholm LCM some `dotnet-packges` changes are necessary (see CA-369804). Another PR will follow once those have been completed.

The `packages/DOTNET_BUILD_LOCATION` points to release but you should be using the internal location for testing.