### PR TITLE
Corrected registry key name; bumped branding.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@
  * SUCH DAMAGE.
  */
 
-def XENADMIN_BRANDING_TAG = 'v4.5'
+def XENADMIN_BRANDING_TAG = 'v4.6'
 
 @Library(['PacmanSharedLibrary', "xencenter-pipeline@v4.4"])
 import com.citrix.pipeline.xencenter.*

--- a/XenAdmin/Core/Registry.cs
+++ b/XenAdmin/Core/Registry.cs
@@ -195,7 +195,7 @@ namespace XenAdmin.Core
         private const string FORCE_SYSTEM_FONTS = "ForceSystemFonts";
         private const string DISABLE_PLUGINS = "DisablePlugins";
         private const string DONT_SUDO = "DontSudo";
-        private static readonly string XENCENTER_LOCAL_KEYS = @"SOFTWARE\" + BrandManager.CompanyNameShort + @"\" + BrandManager.BrandConsole.Replace(" ", "");
+        private static readonly string XENCENTER_LOCAL_KEYS = @"SOFTWARE\" + BrandManager.CompanyNameShort + @"\" + BrandManager.BrandConsoleNoSpace;
         private const string PSExecutionPolicyKey = @"Software\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell";
         private const string PSExecutionPolicyName = "ExecutionPolicy";
         private const string PowerShellKey = @"Software\Microsoft\PowerShell\1";


### PR DESCRIPTION
Now that we have made the updates URL a branded string both on `master` and `release/stockholm/lcm` (see https://github.com/xenserver/xenadmin/pull/3037 and https://github.com/xenserver/xenadmin/pull/2976), the default value in the code is a placeholder and results in an error, so in order to debug the application one always needs to fill  `Computer\HKEY_CURRENT_USER\SOFTWARE\[Citrix]\[XenCenter]\CheckForUpdatesXmlLocationOverride` in the registry with a proper location (URL or file). So far the aforementioned location served both branches, but the values are not the same for both. This PR makes the application read from `Computer\HKEY_CURRENT_USER\SOFTWARE\[Citrix]\[XenCenter_No_Space]\CheckForUpdatesXmlLocationOverride)` when running from source code on master. Note that the change affects all registry keys the application uses. There should be no difference for the branded application because, after the placeholder replacement, `BrandConsole.Replace(" ", "") == BrandConsoleNoSpace`.