### PR TITLE
CA-370847: Unable to collect status report for multiple servers

### DIFF
--- a/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageSelectCapabilities.cs
+++ b/XenAdmin/Wizards/BugToolWizardFiles/BugToolPageSelectCapabilities.cs
@@ -564,6 +564,11 @@ namespace XenAdmin.Wizards.BugToolWizardFiles
             return _name;
         }
 
+        public override int GetHashCode()
+        {
+            return Key == null ? 0 : Key.GetHashCode();
+        }
+
         public int CompareTo(Capability other)
         {
             return StringUtility.NaturalCompare(Key, other?.Key);


### PR DESCRIPTION
Linq.Intersect was failing to combine server capabilities because the helper class did not implement GetHashCode.