### PR TITLE
Random fixes:

### DIFF
--- a/XenAdmin/Commands/AddVirtualDiskCommand.cs
+++ b/XenAdmin/Commands/AddVirtualDiskCommand.cs
@@ -70,7 +70,7 @@ namespace XenAdmin.Commands
             {
                 if (vm.VBDs.Count < vm.MaxVBDsAllowed())
                 {
-                    new NewDiskDialog(vm.Connection, vm).ShowPerXenObject(vm, Program.MainWindow);
+                    new NewDiskDialog(vm.Connection, vm, vm.Home()).ShowPerXenObject(vm, Program.MainWindow);
                 }
                 else
                 {

--- a/XenAdmin/Controls/AffinityPicker.Designer.cs
+++ b/XenAdmin/Controls/AffinityPicker.Designer.cs
@@ -109,6 +109,7 @@ namespace XenAdmin.Controls
             this.ReasonColumn});
             resources.ApplyResources(this.ServersGridView, "ServersGridView");
             this.ServersGridView.Name = "ServersGridView";
+            this.ServersGridView.SelectionChanged += new System.EventHandler(this.ServersGridView_SelectionChanged);
             this.ServersGridView.VisibleChanged += new System.EventHandler(this.ServersGridView_VisibleChanged);
             // 
             // ImageColumn

--- a/XenAdmin/Dialogs/NewDiskDialog.cs
+++ b/XenAdmin/Dialogs/NewDiskDialog.cs
@@ -65,10 +65,6 @@ namespace XenAdmin.Dialogs
             SrListBox.PopulateAsync(SrPicker.SRPickerType.InstallFromTemplate, connection, null, sr, null);
         }
 
-        public NewDiskDialog(IXenConnection connection, VM vm)
-            : this(connection, vm, vm.Home())
-        { }
-
         public NewDiskDialog(IXenConnection connection, VM vm, Host affinity,
             SrPicker.SRPickerType pickerUsage = SrPicker.SRPickerType.VM, VDI diskTemplate = null,
             bool canResize = true, long minSize = 0, IEnumerable<VDI> vdiNamesInUse = null)

--- a/XenAdmin/TabPages/SrStoragePage.cs
+++ b/XenAdmin/TabPages/SrStoragePage.cs
@@ -429,6 +429,11 @@ namespace XenAdmin.TabPages
             {
                 buttonRescan.Enabled = false;
             }
+            else if (sr.IsDetached())
+            {
+                buttonRescan.Enabled = false;
+                toolTipContainerRescan.SetToolTip(Messages.SR_DETACHED);
+            }
             else if (HelpersGUI.BeingScanned(sr))
             {
                 buttonRescan.Enabled = false;

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -269,7 +269,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             {
                 if (!page_4_HomeServer.DisableStep)
                 {
-                    m_affinity = page_4_HomeServer.SelectedHomeServer;
+                    m_affinity = page_4_HomeServer.Affinity;
                     page_6_Storage.Affinity = m_affinity;
                     page_CloudConfigParameters.Affinity = m_affinity;
                 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_HomeServer.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_HomeServer.Designer.cs
@@ -36,7 +36,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             // 
             resources.ApplyResources(this.affinityPicker1, "affinityPicker1");
             this.affinityPicker1.Name = "affinityPicker1";
-            this.affinityPicker1.SelectedAffinityChanged += new System.EventHandler(this.affinityPicker1_SelectedAffinityChanged);
+            this.affinityPicker1.SelectedAffinityChanged += new System.Action(this.affinityPicker1_SelectedAffinityChanged);
             // 
             // Page_HomeServer
             // 

--- a/XenAdmin/Wizards/NewVMWizard/Page_HomeServer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_HomeServer.cs
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 
+using System;
 using System.Collections.Generic;
 using XenAdmin.Actions.VMActions;
 using XenAPI;
@@ -49,31 +50,18 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         #region XenTabPage overrides
 
-        public override string Text
-        {
-            get { return Messages.NEWVMWIZARD_HOMESERVERPAGE_NAME; }
-        }
+        public override string Text => Messages.NEWVMWIZARD_HOMESERVERPAGE_NAME;
 
-        public override string PageTitle
-        {
-            get { return Messages.NEWVMWIZARD_HOMESERVERPAGE_TITLE; }
-        }
+        public override string PageTitle => Messages.NEWVMWIZARD_HOMESERVERPAGE_TITLE;
 
-        public override string HelpID
-        {
-            get { return "HomeServer"; }
-        }
+        public override string HelpID => "HomeServer";
 
-        public override List<KeyValuePair<string, string>> PageSummary
-        {
-            get
+        public override List<KeyValuePair<string, string>> PageSummary =>
+            new List<KeyValuePair<string, string>>
             {
-                List<KeyValuePair<string, string>> sum = new List<KeyValuePair<string, string>>();
-                sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_HOMESERVERPAGE_HOMESERVER,
-                                                         Affinity != null ? Affinity.Name() : Messages.NEWVMWIZARD_HOMESERVER_NONE));
-                return sum;
-            }
-        }
+                new KeyValuePair<string, string>(Messages.NEWVMWIZARD_HOMESERVERPAGE_HOMESERVER,
+                    Affinity != null ? Affinity.Name() : Messages.NEWVMWIZARD_HOMESERVER_NONE)
+            };
 
         public override bool EnableNext()
         {
@@ -122,17 +110,16 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         #region Accessors
 
-        public Host SelectedHomeServer { get { return affinityPicker1.SelectedAffinity; } }
-
-        public Host Affinity { private get; set; }
+        public Host Affinity { get; set; }
         public VM SelectedTemplate { private get; set; }
         public InstallMethod SelectedInstallMethod { private get; set; }
         public VDI SelectedCD { private get; set; }
 
         #endregion
 
-        private void affinityPicker1_SelectedAffinityChanged(object sender, System.EventArgs e)
+        private void affinityPicker1_SelectedAffinityChanged()
         {
+            Affinity = affinityPicker1.SelectedAffinity;
             OnPageUpdated();
         }
     }


### PR DESCRIPTION
- The Finish page of the NewVM wizard was not showing the selected home server correctly.
- Disable the Rescan button on the SR storage page when the SR is detached because the operation fails anyway.
- Removed NewDiskDialog constructor as it was not particularly useful.