### PR TITLE
CA-371356 [XSI-1327]: Add option to prevent resetting pwd prompt function on disconnection

### DIFF
--- a/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootPlanAction.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PlanActions/RebootPlanAction.cs
@@ -133,7 +133,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
                 if (coordinator)
                 {
                     Connection.SuppressErrors = true;
-
+                    Connection.PreventResettingPasswordPrompt = true;
                     //
                     // Wait for a disconnection
                     //
@@ -158,6 +158,7 @@ namespace XenAdmin.Wizards.PatchingWizard.PlanActions
             finally
             {
                 Connection.SuppressErrors = false;
+                Connection.PreventResettingPasswordPrompt = false;
             }
             return session;
         }

--- a/XenModel/Network/IXenConnection.cs
+++ b/XenModel/Network/IXenConnection.cs
@@ -67,6 +67,7 @@ namespace XenAdmin.Network
         List<string> PoolMembers { get; set; }
         void LoadCache(Session session);
         bool SuppressErrors { get; set; }
+        bool PreventResettingPasswordPrompt { get;set; }
         bool CoordinatorMayChange { get; set; }
         bool SaveDisconnected { get; set; }
         string HostnameWithPort { get; }

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -47,9 +47,9 @@ using XenAdmin.ServerDBs;
 
 
 namespace XenAdmin.Network
-{   
+{
     [DebuggerDisplay("IXenConnection :{HostnameWithPort}")]
-    public class XenConnection : IXenConnection,IXmlSerializable
+    public class XenConnection : IXenConnection, IXmlSerializable
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -98,7 +98,7 @@ namespace XenAdmin.Network
             set => _suppressErrors = value;
         }
 
-        
+
         private volatile bool _preventResettingPasswordPrompt;
 
         /// <summary>
@@ -200,14 +200,14 @@ namespace XenAdmin.Network
                                                      now.ToString("o", CultureInfo.InvariantCulture),
                                                      (now.Subtract(value)).ToString("o", CultureInfo.InvariantCulture));
 
-                       if (m_startTime.Ticks == 0)//log it the first time it is detected
+                        if (m_startTime.Ticks == 0)//log it the first time it is detected
                         {
                             m_startTime = now;
                             log.Info(debugMsg);
                         }
 
                         //then log every 5mins
-                       int currDebug = (int)((now - m_startTime).TotalSeconds) / 300;
+                        int currDebug = (int)((now - m_startTime).TotalSeconds) / 300;
                         if (currDebug > m_lastDebug)
                         {
                             m_lastDebug = currDebug;
@@ -475,9 +475,9 @@ namespace XenAdmin.Network
                                 }
                                 break;
                             case Failure.HOST_IS_SLAVE:
-                                // we know it is a supporter so there there is no need to try and connect again, we need to connect to the coordinator
+                            // we know it is a supporter so there there is no need to try and connect again, we need to connect to the coordinator
                             case Failure.RBAC_PERMISSION_DENIED:
-                                // No point retrying this, the user needs the read only role at least to log in
+                            // No point retrying this, the user needs the read only role at least to log in
                             case Failure.HOST_UNKNOWN_TO_MASTER:
                                 // Will never succeed, CA-74718
                                 throw;
@@ -598,7 +598,7 @@ namespace XenAdmin.Network
 
             //InvokeHelper.Synchronizer is used for synchronizing the cache update. Must not be null at this point. It can be initialized through InvokeHelper.Initialize()
             Trace.Assert(InvokeHelper.Synchronizer != null);
-            
+
             InvokeHelper.AssertOnEventThread();
 
             if (initiateCoordinatorSearch)
@@ -1082,7 +1082,7 @@ namespace XenAdmin.Network
 
             if (events.Count > 0)
             {
-                InvokeHelper.Invoke(delegate()
+                InvokeHelper.Invoke(delegate ()
                 {
                     try
                     {
@@ -1170,7 +1170,7 @@ namespace XenAdmin.Network
             }
         }
 
-        private readonly string eventNextConnectionGroupName = Guid.NewGuid().ToString(); 
+        private readonly string eventNextConnectionGroupName = Guid.NewGuid().ToString();
 
         /// <summary>
         /// The main method for a connection to a XenServer. This method runs until the connection is lost, and
@@ -1237,8 +1237,8 @@ namespace XenAdmin.Network
                             log.DebugFormat("Exception (disruption is expected) in XenObjectDownloader.GetEvents: {0}", exn.GetType().Name);
 
                             // ignoring some exceptions when disruption is expected
-                            if (exn is XmlRpcIllFormedXmlException || 
-                                exn is System.IO.IOException || 
+                            if (exn is XmlRpcIllFormedXmlException ||
+                                exn is System.IO.IOException ||
                                 (exn is WebException && ((exn as WebException).Status == WebExceptionStatus.KeepAliveFailure || (exn as WebException).Status == WebExceptionStatus.ConnectFailure)))
                             {
                                 if (!eventsExceptionLogged)
@@ -1297,7 +1297,7 @@ namespace XenAdmin.Network
                             task.Connected = true;
 
                             string poolName = pool.Name();
-                            
+
                             FriendlyName = !string.IsNullOrEmpty(poolName)
                                 ? poolName
                                 : !string.IsNullOrEmpty(coordinator.Name())
@@ -1459,7 +1459,7 @@ namespace XenAdmin.Network
                     {
                         // Create a new log message to say the connection attempt failed
                         string title = string.Format(Messages.CONNECTION_FAILED_TITLE, HostnameWithPort);
-                        var action =  new DummyAction(title, reason, reason);
+                        var action = new DummyAction(title, reason, reason);
                         SetPoolAndHostInAction(action, pool, PoolOpaqueRef);
                         action.Run();
                     }
@@ -1611,7 +1611,7 @@ namespace XenAdmin.Network
 
             string title = string.Format(Messages.CONNECTION_LOST_NOTICE_TITLE,
                                          LastConnectionFullName);
-            var action =  new DummyAction(title, description, description);
+            var action = new DummyAction(title, description, description);
             SetPoolAndHostInAction(action, pool, poolopaqueref);
             action.Run();
             OnConnectionLost();
@@ -1681,13 +1681,13 @@ namespace XenAdmin.Network
         {
             if (PoolMemberRemaining())
                 StartReconnectCoordinatorTimer(SEARCH_NEXT_SUPPORTER_TIMEOUT_MS);
-           else
-                OnConnectionResult(false, reason, error); 
+            else
+                OnConnectionResult(false, reason, error);
         }
 
         private void StartReconnectCoordinatorTimer(int timeout)
         {
-            OnConnectionMessageChanged(string.Format(Messages.CONNECTION_WILL_RETRY_SUPPORTER, LastConnectionFullName.Ellipsise(25) , timeout / 1000));
+            OnConnectionMessageChanged(string.Format(Messages.CONNECTION_WILL_RETRY_SUPPORTER, LastConnectionFullName.Ellipsise(25), timeout / 1000));
             ReconnectionTimer =
                 new System.Threading.Timer((TimerCallback)ReconnectCoordinatorTimer, null,
                                            timeout, Timeout.Infinite);
@@ -1718,7 +1718,7 @@ namespace XenAdmin.Network
             log.DebugFormat("Reconnecting to server {0}...", Hostname);
             if (!XenAdminConfigManager.Provider.Exiting)
             {
-                InvokeHelper.Invoke(delegate()
+                InvokeHelper.Invoke(delegate ()
                 {
                     /*ConnectionResult += new EventHandler<ConnectionResultEventArgs>(XenConnection_ConnectionResult);
                     CachePopulated += new EventHandler<EventArgs>(XenConnection_CachePopulated);*/
@@ -1754,7 +1754,7 @@ namespace XenAdmin.Network
             // Add an informational entry to the log
             string title = string.Format(Messages.CONNECTION_FINDING_COORDINATOR_TITLE, LastConnectionFullName);
             string descr = string.Format(Messages.CONNECTION_FINDING_COORDINATOR_DESCRIPTION, LastConnectionFullName, Hostname);
-            var action =  new DummyAction(title, descr);
+            var action = new DummyAction(title, descr);
             SetPoolAndHostInAction(action, null, PoolOpaqueRef);
             action.Run();
             log.DebugFormat("Looking for coordinator for {0} on {1}...", LastConnectionFullName, Hostname);
@@ -1839,7 +1839,7 @@ namespace XenAdmin.Network
         {
             // Using BeginInvoke here means that the XenObjectsUpdated event gets fired after any
             // CollectionChanged events fired by ChangeableDictionary during Cache.UpdateFrom.
-            InvokeHelper.BeginInvoke(delegate()
+            InvokeHelper.BeginInvoke(delegate ()
             {
                 if (XenObjectsUpdated != null)
                     XenObjectsUpdated(this, null);
@@ -1968,7 +1968,7 @@ namespace XenAdmin.Network
 
         public void WriteXml(System.Xml.XmlWriter writer)
         {
-            writer.WriteElementString("Hostname",Hostname);
+            writer.WriteElementString("Hostname", Hostname);
         }
 
         #endregion
@@ -1987,7 +1987,7 @@ namespace XenAdmin.Network
         private bool disposed;
         protected virtual void Dispose(bool disposing)
         {
-            if(!disposed)
+            if (!disposed)
             {
                 if (disposing)
                 {

--- a/XenModel/Network/XenConnection.cs
+++ b/XenModel/Network/XenConnection.cs
@@ -98,6 +98,20 @@ namespace XenAdmin.Network
             set => _suppressErrors = value;
         }
 
+        
+        private volatile bool _preventResettingPasswordPrompt;
+
+        /// <summary>
+        /// The password prompting function (<see cref="_promptForNewPassword"/>) is set to null when the connection is closed.
+        /// Set this value to true in order to prevent that from happening.
+        /// n.b.: remember to set the value back to false once it's not needed anymore
+        /// </summary>
+        public bool PreventResettingPasswordPrompt
+        {
+            get => _preventResettingPasswordPrompt;
+            set => _preventResettingPasswordPrompt = value;
+        }
+
         /// <summary>
         /// Indicates whether we are expecting the pool coordinator to change soon (e.g. when explicitly designating a new coordinator).
         /// </summary>
@@ -767,8 +781,13 @@ namespace XenAdmin.Network
             {
                 ClearCache();
             }
-
-            _promptForNewPassword = null;
+            if (!PreventResettingPasswordPrompt)
+            {
+                // CA-371356: Preventing the reset of the prompt allows
+                // for it to be shown when attempting to reconnect to a host
+                // whose password has changed since last login
+                _promptForNewPassword = null;
+            }
             OnConnectionClosed();
         }
 


### PR DESCRIPTION
This is only one type of solution. We could also:

- use `Connection.ExpectDisruption` insted of the new field.
- Never set `_promptForNewPassword` to null after disconnection. I didn't because there might be a reason and I didn't want to set side effects. However not doing so might mean that the issue could prop up under a different plan action. (I didn't find it, but I'm not knowledgeable around this domain)

Once it's merged, we can backport to Stockholm, too