### PR TITLE
CP-41048: Add each SR to the SrPicker as soon as its scan finishes, without waiting for the other scans to finish.

### DIFF
--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -31,12 +31,12 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
-using System.Windows.Forms;
+using System.Linq;
 using XenAdmin.Actions;
+using XenAdmin.Core;
 using XenAdmin.Network;
 using XenAPI;
-using XenAdmin.Core;
+using XenCenterLib;
 
 
 namespace XenAdmin.Controls
@@ -48,19 +48,22 @@ namespace XenAdmin.Controls
 
         #region Private fields
 
+        private const int MAX_SCANS_PER_CONNECTION = 3;
+        private readonly ChangeableList<SrRefreshAction> _refreshQueue = new ChangeableList<SrRefreshAction>();
         private SRPickerType _usage = SRPickerType.VM;
         private VDI[] _existingVDIs;
         private IXenConnection _connection;
         private Host _affinity;
         private SR defaultSR;
         private readonly CollectionChangeEventHandler SR_CollectionChangedWithInvoke;
-        private volatile int _scanCount;
+        private readonly object _lock = new object();
 
         #endregion
 
         public SrPicker()
         {
             SR_CollectionChangedWithInvoke = Program.ProgramInvokeHandler(SR_CollectionChanged);
+            _refreshQueue.CollectionChanged += _refreshQueue_CollectionChanged;
         }
 
         #region Properties
@@ -75,36 +78,33 @@ namespace XenAdmin.Controls
 
         public SR SR => SelectedItem is SrPickerItem srpITem && srpITem.Enabled ? srpITem.TheSR : null;
 
-        public bool ValidSelectionExists
+        public bool ValidSelectionExists(out string invalidReason)
         {
-            get
-            {
-                foreach (SrPickerItem item in Items)
-                {
-                    if (item != null && item.Enabled)
-                        return true;
-                }
+            invalidReason = string.Empty;
+            bool allScanning = true;
 
-                return false;
+            foreach (SrPickerItem item in Items)
+            {
+                if (item != null)
+                {
+                    if (item.Enabled)
+                        return true;
+
+                    if (!item.Scanning)
+                        allScanning = false;
+                }
             }
+
+            if (!allScanning)
+                invalidReason = Messages.NO_VALID_DISK_LOCATION;
+
+            return false;
         }
 
         #endregion
 
-        protected override void OnPaint(PaintEventArgs e)
-        {
-            if (_scanCount > 0)
-            {
-                var size = e.Graphics.MeasureString(Messages.SR_REFRESH_ACTION_TITLE_MANY, Font);
-                e.Graphics.DrawString(Messages.SR_REFRESH_ACTION_TITLE_MANY, Font, SystemBrushes.WindowText, (Width - size.Width) / 2, (Height - size.Height) / 2);
-                return;
-            }
-
-            base.OnPaint(e);
-        }
-
         public void PopulateAsync(SRPickerType usage, IXenConnection connection, Host affinity,
-            SR preselectedSR, VDI[] existingVdis)
+            SR preselectedSr, VDI[] existingVdis)
         {
             _usage = usage;
             _connection = connection;
@@ -118,111 +118,198 @@ namespace XenAdmin.Controls
             if (pool != null)
             {
                 defaultSR = _connection.Resolve(pool.default_SR);
-                pool.PropertyChanged -= Server_PropertyChanged;
-                pool.PropertyChanged += Server_PropertyChanged;
+                pool.PropertyChanged -= pool_PropertyChanged;
+                pool.PropertyChanged += pool_PropertyChanged;
             }
 
             _connection.Cache.RegisterCollectionChanged<SR>(SR_CollectionChangedWithInvoke);
 
-            var items = GetSrPickerItems();
-            _scanCount = items.Count;
-            Invalidate();//force redrawing so as to show the scanning message
+            foreach (var sr in _connection.Cache.SRs)
+                AddNewSr(sr);
 
-            foreach (var item in items)
-            {
-                var action = new SrRefreshAction(item.TheSR, true);
-                action.Completed += obj =>
-                {
-                    _scanCount--;
-
-                    if (_scanCount > 0)
-                        return;
-
-                    Program.Invoke(this, () => Rebuild(items, preselectedSR));
-                };
-                action.RunAsync();
-            }
-        }
-
-        private List<SrPickerItem> GetSrPickerItems()
-        {
-            var items = new List<SrPickerItem>();
-
-            foreach (SR sr in _connection.Cache.SRs)
-            {
-                var item = SrPickerItem.Create(sr, _usage, _affinity, _existingVDIs);
-                if (item.Show)
-                    items.Add(item);
-
-                foreach (PBD pbd in sr.Connection.ResolveAll(sr.PBDs))
-                {
-                    if (pbd != null)
-                    {
-                        pbd.PropertyChanged -= Server_PropertyChanged;
-                        pbd.PropertyChanged += Server_PropertyChanged;
-                    }
-                }
-
-                sr.PropertyChanged -= Server_PropertyChanged;
-                sr.PropertyChanged += Server_PropertyChanged;
-            }
-
-            return items;
-        }
-
-        private void Rebuild(List<SrPickerItem> items = null, SR preselectedSr = null)
-        {
-            Program.AssertOnEventThread();
-            Invalidate();
-
-            SR selectedSr = preselectedSr ?? SR;
-            var theItems = items ?? GetSrPickerItems();
-
-            try
-            {
-                BeginUpdate();
-                ClearAllNodes();
-
-                foreach (var item in theItems)
-                    AddNode(item);
-            }
-            finally
-            {
-                EndUpdate();
-            }
-
-            _ = SelectSR(selectedSr) || SelectDefaultSR() || SelectAnySR();
+            _ = SelectSR(preselectedSr) || SelectDefaultSR() || SelectAnySR();
         }
 
         public void UpdateDisks(params VDI[] vdi)
         {
             Program.AssertOnEventThread();
-            try
+            foreach (SrPickerItem node in Items)
+                node.UpdateDisks(vdi);
+        }
+
+        private void AddNewSr(SR sr)
+        {
+            var item = SrPickerItem.Create(sr, _usage, _affinity, _existingVDIs);
+            if (!item.Show)
+                return;
+
+            foreach (PBD pbd in sr.Connection.ResolveAll(sr.PBDs))
             {
-                foreach (SrPickerItem node in Items)
-                    node.UpdateDisks(vdi);
+                if (pbd != null)
+                {
+                    pbd.PropertyChanged -= pbd_PropertyChanged;
+                    pbd.PropertyChanged += pbd_PropertyChanged;
+                }
             }
-            finally
+
+            sr.PropertyChanged -= sr_PropertyChanged;
+            sr.PropertyChanged += sr_PropertyChanged;
+
+            item.ItemUpdated += Item_ItemUpdated;
+            item.Scanning = true;
+            AddNode(item);
+
+            var srRefreshAction = new SrRefreshAction(item.TheSR, true);
+            srRefreshAction.Completed += SrRefreshAction_Completed;
+
+            lock (_lock)
+                _refreshQueue.Add(srRefreshAction);
+        }
+
+        private void _refreshQueue_CollectionChanged(object sender, CollectionChangeEventArgs e)
+        {
+            lock (_lock)
             {
-                Refresh();
+                var srRefreshAction = _refreshQueue.FirstOrDefault(a => !a.StartedRunning && !a.IsCompleted);
+
+                if (srRefreshAction != null && _refreshQueue.Count(a => a.StartedRunning && !a.IsCompleted) < MAX_SCANS_PER_CONNECTION)
+                    srRefreshAction.RunAsync();
             }
         }
 
-        private void Server_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Item_ItemUpdated(SrPickerItem item)
         {
-            if (_scanCount > 0)
+            Invalidate();
+        }
+
+        private void SrRefreshAction_Completed(ActionBase obj)
+        {
+            if (!(obj is SrRefreshAction action))
                 return;
 
-            if (e.PropertyName == "name_label" || e.PropertyName == "PBDs" || e.PropertyName == "physical_utilisation" || e.PropertyName == "currently_attached" || e.PropertyName == "default_SR")
-                Program.Invoke(this, () => Rebuild());
+            lock (_lock)
+                _refreshQueue.Remove(action);
+
+            Program.Invoke(this, () =>
+            {
+                foreach (var item in Items)
+                {
+                    if (item is SrPickerItem it && it.TheSR.opaque_ref == action.SR.opaque_ref)
+                    {
+                        it.Scanning = false;
+                        break;
+                    }
+                }
+            });
+        }
+
+        private void pool_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (sender is Pool && e.PropertyName == "default_SR")
+            {
+                Program.Invoke(this, () =>
+                {
+                    foreach (var item in Items)
+                    {
+                        if (item is SrPickerItem it && !it.Scanning)
+                            it.Update();
+                    }
+                });
+            }
+        }
+
+        private void pbd_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (sender is PBD pbd && e.PropertyName == "currently_attached")
+            {
+                Program.Invoke(this, () =>
+                {
+                    foreach (var item in Items)
+                    {
+                        if (item is SrPickerItem it && !it.Scanning && it.TheSR.opaque_ref == pbd.SR.opaque_ref)
+                        {
+                            it.Update();
+                            break;
+                        }
+                    }
+                });
+            }
+        }
+
+        private void sr_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (sender is SR sr &&
+                (e.PropertyName == "name_label" || e.PropertyName == "PBDs" ||
+                 e.PropertyName == "physical_utilisation" || e.PropertyName == "virtual_allocation"))
+            {
+                Program.Invoke(this, () =>
+                {
+                    foreach (var item in Items)
+                    {
+                        if (item is SrPickerItem it && !it.Scanning && it.TheSR.opaque_ref == sr.opaque_ref)
+                        {
+                            it.Update();
+                            break;
+                        }
+                    }
+                });
+            }
         }
 
         private void SR_CollectionChanged(object sender, CollectionChangeEventArgs e)
         {
-            if (_scanCount > 0)
-                return;
+            if (e.Action == CollectionChangeAction.Add && e.Element is SR addedSr)
+            {
+                Program.Invoke(this, () =>
+                {
+                    foreach (var item in Items)
+                    {
+                        if (item is SrPickerItem it && it.TheSR.opaque_ref == addedSr.opaque_ref)
+                            return;
+                    }
 
-            Program.Invoke(this, () => Rebuild());
+                    AddNewSr(addedSr);
+                });
+                return;
+            }
+            
+            if (e.Action == CollectionChangeAction.Remove)
+            {
+                var removedSrs = new List<string>();
+
+                if (e.Element is SR storage)
+                    removedSrs.Add(storage.opaque_ref);
+                else if (e.Element is List<SR> range)
+                    removedSrs = range.Select(sr => sr.opaque_ref).ToList();
+                else
+                    return;
+
+                Program.Invoke(this, () =>
+                {
+                    var itemsToRemove = new List<SrPickerItem>();
+
+                    foreach (var item in Items)
+                    {
+                        if (item is SrPickerItem it && removedSrs.Contains(it.TheSR.opaque_ref))
+                        {
+                            foreach (var pbdRef in it.TheSR.PBDs)
+                            {
+                                var pbd = it.TheSR.Connection.Resolve(pbdRef);
+                                if (pbd != null)
+                                    pbd.PropertyChanged -= pbd_PropertyChanged;
+                            }
+                            it.TheSR.PropertyChanged -= sr_PropertyChanged;
+
+                            it.ItemUpdated -= Item_ItemUpdated;
+                            itemsToRemove.Add(it);
+                            break;
+                        }
+                    }
+
+                    foreach (var item in itemsToRemove)
+                        RemoveNode(item);
+                });
+            }
         }
 
         private void UnregisterHandlers()
@@ -232,16 +319,16 @@ namespace XenAdmin.Controls
 
             var pool = Helpers.GetPoolOfOne(_connection);
             if (pool != null)
-                pool.PropertyChanged -= Server_PropertyChanged;
+                pool.PropertyChanged -= pool_PropertyChanged;
 
             foreach (var sr in _connection.Cache.SRs)
             {
                 foreach (var pbd in sr.Connection.ResolveAll(sr.PBDs))
                 {
                     if (pbd != null)
-                        pbd.PropertyChanged -= Server_PropertyChanged;
+                        pbd.PropertyChanged -= pbd_PropertyChanged;
                 }
-                sr.PropertyChanged -= Server_PropertyChanged;
+                sr.PropertyChanged -= sr_PropertyChanged;
             }
 
             _connection.Cache.DeregisterCollectionChanged<SR>(SR_CollectionChangedWithInvoke);
@@ -298,7 +385,18 @@ namespace XenAdmin.Controls
         protected override void Dispose(bool disposing)
         {
             if (disposing)
+            {
+                lock (_lock)
+                {
+                    foreach (var action in _refreshQueue)
+                    {
+                        action.Completed -= SrRefreshAction_Completed;
+                        if (!action.IsCompleted)
+                            action.Cancel();
+                    }
+                }
                 UnregisterHandlers();
+            }
 
             base.Dispose(disposing);
         }

--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -57,17 +58,31 @@ namespace XenAdmin.Controls
         private SR _defaultSr;
         private SR _preselectedSr;
         private readonly CollectionChangeEventHandler _srCollectionChangedWithInvoke;
-        private readonly object _lock = new object();
 
         #endregion
+
+        public event Action CanBeScannedChanged;
 
         public SrPicker()
         {
             _srCollectionChangedWithInvoke = Program.ProgramInvokeHandler(SR_CollectionChanged);
-            _refreshQueue.CollectionChanged += RefreshQueue_CollectionChanged;
         }
 
         #region Properties
+
+        public bool CanBeScanned
+        {
+            get
+            {
+                foreach (var item in Items)
+                {
+                    if (item is SrPickerItem it && !it.Scanning && !it.TheSR.IsDetached())
+                        return true;
+                }
+
+                return false;
+            }
+        }
 
         public override bool ShowCheckboxes => false;
 
@@ -79,34 +94,17 @@ namespace XenAdmin.Controls
 
         public SR SR => SelectedItem is SrPickerItem srpITem && srpITem.Enabled ? srpITem.TheSR : null;
 
-        public bool ValidSelectionExists(out string invalidReason)
-        {
-            invalidReason = string.Empty;
-            bool allScanning = true;
-
-            foreach (SrPickerItem item in Items)
-            {
-                if (item != null)
-                {
-                    if (item.Enabled)
-                        return true;
-
-                    if (!item.Scanning)
-                        allScanning = false;
-                }
-            }
-
-            if (!allScanning)
-                invalidReason = Messages.NO_VALID_DISK_LOCATION;
-
-            return false;
-        }
-
         #endregion
 
-        public void PopulateAsync(SRPickerType usage, IXenConnection connection, Host affinity,
+        public void Populate(SRPickerType usage, IXenConnection connection, Host affinity,
             SR preselectedSr, VDI[] existingDisks)
         {
+            foreach (var action in _refreshQueue)
+                action.Completed -= SrRefreshAction_Completed;
+
+            _refreshQueue.Clear();
+            ClearAllNodes();
+
             _usage = usage;
             _connection = connection;
             _affinity = affinity;
@@ -128,6 +126,25 @@ namespace XenAdmin.Controls
 
             foreach (var sr in _connection.Cache.SRs)
                 AddNewSr(sr);
+        }
+
+        public void ScanSRs()
+        {
+            foreach (var item in Items)
+            {
+                if (item is SrPickerItem it && !it.Scanning && !it.TheSR.IsDetached())
+                {
+                    it.Scanning = true;
+                    var srRefreshAction = new SrRefreshAction(it.TheSR);
+                    srRefreshAction.Completed += SrRefreshAction_Completed;
+
+                    _refreshQueue.Add(srRefreshAction);
+
+                    if (_refreshQueue.Count(a => a.StartedRunning && !a.IsCompleted) < MAX_SCANS_PER_CONNECTION)
+                        srRefreshAction.RunAsync();
+                }
+            }
+            OnCanBeScannedChanged();
         }
 
         public void UpdateDisks(params VDI[] vdi)
@@ -156,25 +173,19 @@ namespace XenAdmin.Controls
             sr.PropertyChanged += sr_PropertyChanged;
 
             item.ItemUpdated += Item_ItemUpdated;
-            item.Scanning = true;
+            if (HelpersGUI.BeingScanned(item.TheSR, out var scanAction))
+            {
+                item.Scanning = true;
+                scanAction.Completed += SrRefreshAction_Completed;
+                _refreshQueue.Add(scanAction);
+            }
             AddNode(item);
-
-            var srRefreshAction = new SrRefreshAction(item.TheSR, true);
-            srRefreshAction.Completed += SrRefreshAction_Completed;
-
-            lock (_lock)
-                _refreshQueue.Add(srRefreshAction);
+            OnCanBeScannedChanged();
         }
 
-        private void RefreshQueue_CollectionChanged(object sender, CollectionChangeEventArgs e)
+        private void OnCanBeScannedChanged()
         {
-            lock (_lock)
-            {
-                var srRefreshAction = _refreshQueue.FirstOrDefault(a => !a.StartedRunning && !a.IsCompleted);
-
-                if (srRefreshAction != null && _refreshQueue.Count(a => a.StartedRunning && !a.IsCompleted) < MAX_SCANS_PER_CONNECTION)
-                    srRefreshAction.RunAsync();
-            }
+            Program.Invoke(this, () => CanBeScannedChanged?.Invoke());
         }
 
         private void Item_ItemUpdated(SrPickerItem item)
@@ -187,16 +198,21 @@ namespace XenAdmin.Controls
             if (!(obj is SrRefreshAction action))
                 return;
 
-            lock (_lock)
-                _refreshQueue.Remove(action);
-
             Program.Invoke(this, () =>
             {
+                _refreshQueue.Remove(action);
+
+                var srRefreshAction = _refreshQueue.FirstOrDefault(a => !a.StartedRunning && !a.IsCompleted);
+
+                if (srRefreshAction != null && _refreshQueue.Count(a => a.StartedRunning && !a.IsCompleted) < MAX_SCANS_PER_CONNECTION)
+                    srRefreshAction.RunAsync();
+
                 foreach (var item in Items)
                 {
                     if (item is SrPickerItem it && it.TheSR.opaque_ref == action.SR.opaque_ref)
                     {
                         it.Scanning = false;
+                        OnCanBeScannedChanged();
 
                         if (_preselectedSr != null)
                         {
@@ -245,6 +261,7 @@ namespace XenAdmin.Controls
                         if (item is SrPickerItem it && !it.Scanning && it.TheSR.opaque_ref == pbd.SR.opaque_ref)
                         {
                             it.Update();
+                            OnCanBeScannedChanged();
                             break;
                         }
                     }
@@ -324,6 +341,8 @@ namespace XenAdmin.Controls
 
                     foreach (var item in itemsToRemove)
                         RemoveNode(item);
+
+                    OnCanBeScannedChanged();
                 });
             }
         }
@@ -354,15 +373,9 @@ namespace XenAdmin.Controls
         {
             if (disposing)
             {
-                lock (_lock)
-                {
-                    foreach (var action in _refreshQueue)
-                    {
-                        action.Completed -= SrRefreshAction_Completed;
-                        if (!action.IsCompleted)
-                            action.Cancel();
-                    }
-                }
+                foreach (var action in _refreshQueue)
+                    action.Completed -= SrRefreshAction_Completed;
+
                 UnregisterHandlers();
             }
 

--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -51,19 +51,20 @@ namespace XenAdmin.Controls
         private const int MAX_SCANS_PER_CONNECTION = 3;
         private readonly ChangeableList<SrRefreshAction> _refreshQueue = new ChangeableList<SrRefreshAction>();
         private SRPickerType _usage = SRPickerType.VM;
-        private VDI[] _existingVDIs;
+        private VDI[] _existingDisks;
         private IXenConnection _connection;
         private Host _affinity;
-        private SR defaultSR;
-        private readonly CollectionChangeEventHandler SR_CollectionChangedWithInvoke;
+        private SR _defaultSr;
+        private SR _preselectedSr;
+        private readonly CollectionChangeEventHandler _srCollectionChangedWithInvoke;
         private readonly object _lock = new object();
 
         #endregion
 
         public SrPicker()
         {
-            SR_CollectionChangedWithInvoke = Program.ProgramInvokeHandler(SR_CollectionChanged);
-            _refreshQueue.CollectionChanged += _refreshQueue_CollectionChanged;
+            _srCollectionChangedWithInvoke = Program.ProgramInvokeHandler(SR_CollectionChanged);
+            _refreshQueue.CollectionChanged += RefreshQueue_CollectionChanged;
         }
 
         #region Properties
@@ -104,12 +105,13 @@ namespace XenAdmin.Controls
         #endregion
 
         public void PopulateAsync(SRPickerType usage, IXenConnection connection, Host affinity,
-            SR preselectedSr, VDI[] existingVdis)
+            SR preselectedSr, VDI[] existingDisks)
         {
             _usage = usage;
             _connection = connection;
             _affinity = affinity;
-            _existingVDIs = existingVdis;
+            _existingDisks = existingDisks;
+            _preselectedSr = preselectedSr;
 
             if (_connection == null)
                 return;
@@ -117,17 +119,15 @@ namespace XenAdmin.Controls
             Pool pool = Helpers.GetPoolOfOne(_connection);
             if (pool != null)
             {
-                defaultSR = _connection.Resolve(pool.default_SR);
+                _defaultSr = _connection.Resolve(pool.default_SR);
                 pool.PropertyChanged -= pool_PropertyChanged;
                 pool.PropertyChanged += pool_PropertyChanged;
             }
 
-            _connection.Cache.RegisterCollectionChanged<SR>(SR_CollectionChangedWithInvoke);
+            _connection.Cache.RegisterCollectionChanged<SR>(_srCollectionChangedWithInvoke);
 
             foreach (var sr in _connection.Cache.SRs)
                 AddNewSr(sr);
-
-            _ = SelectSR(preselectedSr) || SelectDefaultSR() || SelectAnySR();
         }
 
         public void UpdateDisks(params VDI[] vdi)
@@ -139,7 +139,7 @@ namespace XenAdmin.Controls
 
         private void AddNewSr(SR sr)
         {
-            var item = SrPickerItem.Create(sr, _usage, _affinity, _existingVDIs);
+            var item = SrPickerItem.Create(sr, _usage, _affinity, _existingDisks);
             if (!item.Show)
                 return;
 
@@ -166,7 +166,7 @@ namespace XenAdmin.Controls
                 _refreshQueue.Add(srRefreshAction);
         }
 
-        private void _refreshQueue_CollectionChanged(object sender, CollectionChangeEventArgs e)
+        private void RefreshQueue_CollectionChanged(object sender, CollectionChangeEventArgs e)
         {
             lock (_lock)
             {
@@ -197,6 +197,22 @@ namespace XenAdmin.Controls
                     if (item is SrPickerItem it && it.TheSR.opaque_ref == action.SR.opaque_ref)
                     {
                         it.Scanning = false;
+
+                        if (_preselectedSr != null)
+                        {
+                            if (it.TheSR.opaque_ref == _preselectedSr.opaque_ref)
+                                SelectedItem = item;
+                        }
+                        else if (_defaultSr != null)
+                        {
+                            if (it.TheSR.opaque_ref == _defaultSr.opaque_ref)
+                                SelectedItem = item;
+                        }
+                        else if (SelectedItem == null)
+                        {
+                            SelectedItem = item;
+                        }
+
                         break;
                     }
                 }
@@ -331,55 +347,7 @@ namespace XenAdmin.Controls
                 sr.PropertyChanged -= sr_PropertyChanged;
             }
 
-            _connection.Cache.DeregisterCollectionChanged<SR>(SR_CollectionChangedWithInvoke);
-        }
-
-        private bool SelectDefaultSR()
-        {
-            if (defaultSR == null)
-                return false;
-
-            foreach (SrPickerItem item in Items)
-            {
-                if (item.TheSR != null && item.TheSR.opaque_ref == defaultSR.opaque_ref && item.Enabled)
-                {
-                    SelectedItem = item;
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private bool SelectSR(SR sr)
-        {
-            if (sr == null)
-                return false;
-
-            foreach (SrPickerItem item in Items)
-            {
-                if (item.TheSR != null && item.TheSR.opaque_ref == sr.opaque_ref && item.Enabled)
-                {
-                    SelectedItem = item;
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private bool SelectAnySR()
-        {
-            foreach (SrPickerItem item in Items)
-            {
-                if (item != null && item.Enabled)
-                {
-                    SelectedItem = item;
-                    return true;
-                }
-            }
-
-            return false;
+            _connection.Cache.DeregisterCollectionChanged<SR>(_srCollectionChangedWithInvoke);
         }
 
         protected override void Dispose(bool disposing)

--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -177,10 +177,13 @@ namespace XenAdmin.Controls
 
     public abstract class SrPickerItem : CustomTreeNode, IComparable<SrPickerItem>
     {
+        private bool _scanning;
         public SR TheSR { get; }
         public bool Show { get; private set; } = true;
         protected readonly Host Affinity;
         protected VDI[] ExistingVDIs { get; private set; }
+
+        public event Action<SrPickerItem> ItemUpdated;
 
         protected SrPickerItem(SR sr, Host aff, VDI[] vdis)
         {
@@ -188,6 +191,16 @@ namespace XenAdmin.Controls
             TheSR = sr;
             Affinity = aff;
             Update();
+        }
+
+        public bool Scanning
+        {
+            get => _scanning;
+            set
+            {
+                _scanning = value;
+                Update();
+            }
         }
 
         protected virtual bool SupportsCurrentOperation => !TheSR.HBALunPerVDI();
@@ -200,7 +213,7 @@ namespace XenAdmin.Controls
             Update();
         }
 
-        private void Update()
+        public void Update()
         {
             Text = TheSR.Name();
             Image = Images.GetImage16For(TheSR);
@@ -212,7 +225,12 @@ namespace XenAdmin.Controls
                 return;
             }
 
-            if (CanBeEnabled(out var cannotEnableReason))
+            if (Scanning)
+            {
+                Description = Messages.SR_REFRESH_ACTION_TITLE_GENERIC;
+                Enabled = false;
+            }
+            else if (CanBeEnabled(out var cannotEnableReason))
             {
                 Description = string.Format(Messages.SRPICKER_DISK_FREE, Util.DiskSizeString(TheSR.FreeSpace(), 2),
                     Util.DiskSizeString(TheSR.physical_size, 2));
@@ -223,6 +241,8 @@ namespace XenAdmin.Controls
                 Description = cannotEnableReason;
                 Enabled = false;
             }
+
+            ItemUpdated?.Invoke(this);
         }
 
         protected bool IsCurrentLocation(out string cannotEnableReason)

--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -259,7 +259,7 @@ namespace XenAdmin.Controls
 
         protected bool IsBroken(out string cannotEnableReason)
         {
-            if (TheSR.IsBroken(false))
+            if (TheSR.IsBroken())
             {
                 cannotEnableReason = Messages.SR_IS_BROKEN;
                 return true;

--- a/XenAdmin/Core/HelpersGUI.cs
+++ b/XenAdmin/Core/HelpersGUI.cs
@@ -322,11 +322,10 @@ namespace XenAdmin.Core
             {
                 if (!a.IsCompleted)
                 {
-                    if (a is SrAction && a.SR == sr)
+                    if (a is SrAction && a.SR.opaque_ref == sr.opaque_ref)
                         return true;
 
-                    EnableHAAction haAction = a as EnableHAAction;
-                    if (haAction != null && haAction.HeartbeatSRs.Contains(sr))
+                    if (a is EnableHAAction haAction && haAction.HeartbeatSRs.Contains(sr))
                         return true;
                 }
 
@@ -334,18 +333,19 @@ namespace XenAdmin.Core
             return false;
         }
 
-        public static bool BeingScanned(SR sr)
+        public static bool BeingScanned(SR sr, out SrRefreshAction scanAction)
         {
             foreach (ActionBase a in ConnectionsManager.History)
+            {
+                if (!a.IsCompleted && a is SrRefreshAction refreshAction && a.SR.opaque_ref == sr.opaque_ref)
                 {
-                    if (!a.IsCompleted)
-                    {
-                        if (a is SrRefreshAction && a.SR == sr)
-                            return true;
-                    }
+                    scanAction = refreshAction;
+                    return true;
                 }
-                return false;
-            
+            }
+
+            scanAction = null;
+            return false;
         }
 
         /// <summary>

--- a/XenAdmin/Dialogs/CopyVMDialog.Designer.cs
+++ b/XenAdmin/Dialogs/CopyVMDialog.Designer.cs
@@ -42,6 +42,7 @@ namespace XenAdmin.Dialogs
             this.groupBox1 = new XenAdmin.Controls.DecentGroupBox();
             this.tableLayoutPanelSrPicker = new System.Windows.Forms.TableLayoutPanel();
             this.labelSrHint = new System.Windows.Forms.Label();
+            this.buttonRescan = new System.Windows.Forms.Button();
             this.toolTipContainer1 = new XenAdmin.Controls.ToolTipContainer();
             this.FastClonePanel = new System.Windows.Forms.Panel();
             this.groupBox1.SuspendLayout();
@@ -61,6 +62,7 @@ namespace XenAdmin.Dialogs
             this.srPicker1.ShowDescription = true;
             this.srPicker1.ShowImages = true;
             this.srPicker1.ShowRootLines = true;
+            this.srPicker1.CanBeScannedChanged += new System.Action(this.srPicker1_CanBeScannedChanged);
             this.srPicker1.SelectedIndexChanged += new System.EventHandler(this.srPicker1_SelectedIndexChanged);
             // 
             // CloseButton
@@ -120,7 +122,6 @@ namespace XenAdmin.Dialogs
             // FastCloneDescription
             // 
             resources.ApplyResources(this.FastCloneDescription, "FastCloneDescription");
-            this.FastCloneDescription.AutoEllipsis = true;
             this.FastCloneDescription.Name = "FastCloneDescription";
             // 
             // groupBox1
@@ -137,12 +138,21 @@ namespace XenAdmin.Dialogs
             resources.ApplyResources(this.tableLayoutPanelSrPicker, "tableLayoutPanelSrPicker");
             this.tableLayoutPanelSrPicker.Controls.Add(this.srPicker1, 0, 1);
             this.tableLayoutPanelSrPicker.Controls.Add(this.labelSrHint, 0, 0);
+            this.tableLayoutPanelSrPicker.Controls.Add(this.buttonRescan, 1, 1);
             this.tableLayoutPanelSrPicker.Name = "tableLayoutPanelSrPicker";
             // 
             // labelSrHint
             // 
             resources.ApplyResources(this.labelSrHint, "labelSrHint");
+            this.tableLayoutPanelSrPicker.SetColumnSpan(this.labelSrHint, 2);
             this.labelSrHint.Name = "labelSrHint";
+            // 
+            // buttonRescan
+            // 
+            resources.ApplyResources(this.buttonRescan, "buttonRescan");
+            this.buttonRescan.Name = "buttonRescan";
+            this.buttonRescan.UseVisualStyleBackColor = true;
+            this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
             // 
             // toolTipContainer1
             // 
@@ -202,5 +212,6 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.Panel FastClonePanel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelSrPicker;
         private System.Windows.Forms.Label labelSrHint;
+        private System.Windows.Forms.Button buttonRescan;
     }
 }

--- a/XenAdmin/Dialogs/CopyVMDialog.cs
+++ b/XenAdmin/Dialogs/CopyVMDialog.cs
@@ -99,13 +99,17 @@ namespace XenAdmin.Dialogs
                 where vdi != null
                 select vdi).ToArray();
 
-            srPicker1.PopulateAsync(SrPicker.SRPickerType.Copy, _vm.Connection,
-                _vm.Home(), null, vdis);
+            srPicker1.Populate(SrPicker.SRPickerType.Copy, _vm.Connection, _vm.Home(), null, vdis);
         }
 
         private void EnableMoveButton()
         {
             MoveButton.Enabled = NameTextBox.Text.Trim().Length > 0 && srPicker1.SR != null;
+        }
+
+        private void EnableRescanButton()
+        {
+            buttonRescan.Enabled = tableLayoutPanelSrPicker.Enabled && srPicker1.CanBeScanned;
         }
 
         private static string GetDefaultCopyName(VM vmToCopy)
@@ -117,6 +121,12 @@ namespace XenAdmin.Dialogs
 
         #region Control event handlers
 
+        private void srPicker1_CanBeScannedChanged()
+        {
+            EnableRescanButton();
+            EnableMoveButton();
+        }
+
         private void srPicker1_SelectedIndexChanged(object sender, EventArgs e)
         {
             EnableMoveButton();
@@ -125,6 +135,11 @@ namespace XenAdmin.Dialogs
         private void NameTextBox_TextChanged(object sender, EventArgs e)
         {
             EnableMoveButton();
+        }
+
+        private void buttonRescan_Click(object sender, EventArgs e)
+        {
+            srPicker1.ScanSRs();
         }
 
         private void CloseButton_Click(object sender, EventArgs e)
@@ -153,6 +168,7 @@ namespace XenAdmin.Dialogs
         private void CopyRadioButton_CheckedChanged(object sender, EventArgs e)
         {
             tableLayoutPanelSrPicker.Enabled = CopyRadioButton.Checked;
+            EnableRescanButton();
             // Since the radiobuttons aren't in the same panel, we have to do manual mutual exclusion
             CloneRadioButton.Checked = !CopyRadioButton.Checked;
         }

--- a/XenAdmin/Dialogs/CopyVMDialog.resx
+++ b/XenAdmin/Dialogs/CopyVMDialog.resx
@@ -135,11 +135,8 @@
   <data name="srPicker1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 18</value>
   </data>
-  <data name="srPicker1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 3</value>
-  </data>
   <data name="srPicker1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 107</value>
+    <value>318, 129</value>
   </data>
   <data name="srPicker1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -148,7 +145,7 @@
     <value>srPicker1</value>
   </data>
   <data name="&gt;&gt;srPicker1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SrPicker, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.SrPicker, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;srPicker1.Parent" xml:space="preserve">
     <value>tableLayoutPanelSrPicker</value>
@@ -163,7 +160,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="CloseButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 320</value>
+    <value>364, 342</value>
   </data>
   <data name="CloseButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -193,7 +190,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="MoveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>231, 320</value>
+    <value>283, 342</value>
   </data>
   <data name="MoveButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -256,7 +253,7 @@
     <value>79, 12</value>
   </data>
   <data name="NameTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>308, 23</value>
+    <value>369, 23</value>
   </data>
   <data name="NameTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -346,7 +343,7 @@
     <value>79, 38</value>
   </data>
   <data name="DescriptionTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>308, 23</value>
+    <value>369, 23</value>
   </data>
   <data name="DescriptionTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -399,6 +396,9 @@
   <data name="FastCloneDescription.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
+  <data name="FastCloneDescription.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="FastCloneDescription.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -406,13 +406,10 @@
     <value>NoControl</value>
   </data>
   <data name="FastCloneDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 20</value>
-  </data>
-  <data name="FastCloneDescription.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
+    <value>13, 22</value>
   </data>
   <data name="FastCloneDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>344, 31</value>
+    <value>370, 15</value>
   </data>
   <data name="FastCloneDescription.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -439,7 +436,7 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="tableLayoutPanelSrPicker.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="labelSrHint.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -453,11 +450,8 @@
   <data name="labelSrHint.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
-  <data name="labelSrHint.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 3</value>
-  </data>
   <data name="labelSrHint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 15</value>
+    <value>399, 15</value>
   </data>
   <data name="labelSrHint.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -477,6 +471,33 @@
   <data name="&gt;&gt;labelSrHint.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="buttonRescan.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonRescan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>327, 18</value>
+  </data>
+  <data name="buttonRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonRescan.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonRescan.Text" xml:space="preserve">
+    <value>&amp;Rescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Name" xml:space="preserve">
+    <value>buttonRescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Parent" xml:space="preserve">
+    <value>tableLayoutPanelSrPicker</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="tableLayoutPanelSrPicker.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -487,7 +508,7 @@
     <value>2</value>
   </data>
   <data name="tableLayoutPanelSrPicker.Size" type="System.Drawing.Size, System.Drawing">
-    <value>341, 128</value>
+    <value>405, 150</value>
   </data>
   <data name="tableLayoutPanelSrPicker.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -505,7 +526,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanelSrPicker.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="srPicker1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelSrHint" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="srPicker1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelSrHint" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="buttonRescan" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="toolTipContainer1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -520,7 +541,7 @@
     <value>0, 0</value>
   </data>
   <data name="FastClonePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 52</value>
+    <value>421, 52</value>
   </data>
   <data name="FastClonePanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -544,7 +565,7 @@
     <value>9, 19</value>
   </data>
   <data name="toolTipContainer1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 52</value>
+    <value>421, 52</value>
   </data>
   <data name="toolTipContainer1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -553,7 +574,7 @@
     <value>toolTipContainer1</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.ToolTipContainer, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -571,7 +592,7 @@
     <value>3, 10, 3, 10</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 236</value>
+    <value>436, 258</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -583,7 +604,7 @@
     <value>groupBox1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DecentGroupBox, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -598,13 +619,13 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>403, 359</value>
+    <value>464, 381</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>419, 398</value>
+    <value>480, 420</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Copy Virtual Machine</value>
@@ -613,6 +634,6 @@
     <value>CopyVMDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.Designer.cs
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.Designer.cs
@@ -36,6 +36,7 @@
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.labelBlurb = new System.Windows.Forms.Label();
+            this.buttonRescan = new System.Windows.Forms.Button();
             this.toolTipContainer2.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
@@ -61,19 +62,28 @@
             // 
             // srPicker1
             // 
+            this.tableLayoutPanel2.SetColumnSpan(this.srPicker1, 3);
             resources.ApplyResources(this.srPicker1, "srPicker1");
-            this.tableLayoutPanel2.SetColumnSpan(this.srPicker1, 2);
+            this.srPicker1.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.srPicker1.Name = "srPicker1";
-            this.srPicker1.SelectedIndexChanged += new System.EventHandler(this.srPicker1_SelectedIndexChanged);
+            this.srPicker1.NodeIndent = 3;
+            this.srPicker1.RootAlwaysExpanded = false;
+            this.srPicker1.ShowCheckboxes = false;
+            this.srPicker1.ShowDescription = true;
+            this.srPicker1.ShowImages = true;
+            this.srPicker1.ShowRootLines = true;
+            this.srPicker1.CanBeScannedChanged += new System.Action(this.srPicker1_CanBeScannedChanged);
             this.srPicker1.DoubleClickOnRow += new System.EventHandler(this.srPicker1_DoubleClickOnRow);
+            this.srPicker1.SelectedIndexChanged += new System.EventHandler(this.srPicker1_SelectedIndexChanged);
             // 
             // tableLayoutPanel2
             // 
             resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-            this.tableLayoutPanel2.Controls.Add(this.toolTipContainer2, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.buttonCancel, 1, 2);
+            this.tableLayoutPanel2.Controls.Add(this.buttonCancel, 2, 2);
             this.tableLayoutPanel2.Controls.Add(this.srPicker1, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.labelBlurb, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.toolTipContainer2, 1, 2);
+            this.tableLayoutPanel2.Controls.Add(this.buttonRescan, 0, 2);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
             // buttonCancel
@@ -87,8 +97,15 @@
             // labelBlurb
             // 
             resources.ApplyResources(this.labelBlurb, "labelBlurb");
-            this.tableLayoutPanel2.SetColumnSpan(this.labelBlurb, 2);
+            this.tableLayoutPanel2.SetColumnSpan(this.labelBlurb, 3);
             this.labelBlurb.Name = "labelBlurb";
+            // 
+            // buttonRescan
+            // 
+            resources.ApplyResources(this.buttonRescan, "buttonRescan");
+            this.buttonRescan.Name = "buttonRescan";
+            this.buttonRescan.UseVisualStyleBackColor = true;
+            this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
             // 
             // MoveVirtualDiskDialog
             // 
@@ -115,5 +132,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.Label labelBlurb;
         private System.Windows.Forms.Button buttonCancel;
+        private System.Windows.Forms.Button buttonRescan;
     }
 }

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.cs
@@ -65,9 +65,9 @@ namespace XenAdmin.Dialogs
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            
-            UpdateButtons();
-            srPicker1.PopulateAsync(SrPickerType, connection, null, null, _vdis.ToArray());
+
+            UpdateMoveButton();
+            srPicker1.Populate(SrPickerType, connection, null, null, _vdis.ToArray());
         }
 
         internal override string HelpName => "VDIMigrateDialog";
@@ -76,7 +76,7 @@ namespace XenAdmin.Dialogs
 
         protected virtual SrPicker.SRPickerType SrPickerType => SrPicker.SRPickerType.Move;
 
-        private void UpdateButtons()
+        private void UpdateMoveButton()
         {
             buttonMove.Enabled = srPicker1.SR != null;
         }
@@ -85,13 +85,24 @@ namespace XenAdmin.Dialogs
 
         private void srPicker1_SelectedIndexChanged(object sender, EventArgs e)
         {
-            UpdateButtons();
+            UpdateMoveButton();
         }
 
         private void srPicker1_DoubleClickOnRow(object sender, EventArgs e)
         {
             if (buttonMove.Enabled)
                 buttonMove.PerformClick();
+        }
+
+        private void srPicker1_CanBeScannedChanged()
+        {
+            buttonRescan.Enabled = srPicker1.CanBeScanned;
+            UpdateMoveButton();
+        }
+
+        private void buttonRescan_Click(object sender, EventArgs e)
+        {
+            srPicker1.ScanSRs();
         }
 
         private void buttonMove_Click(object sender, EventArgs e)

--- a/XenAdmin/Dialogs/MoveVirtualDiskDialog.resx
+++ b/XenAdmin/Dialogs/MoveVirtualDiskDialog.resx
@@ -214,25 +214,22 @@
     <value>75, 25</value>
   </data>
   <data name="toolTipContainer2.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;toolTipContainer2.Name" xml:space="preserve">
     <value>toolTipContainer2</value>
   </data>
   <data name="&gt;&gt;toolTipContainer2.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.ToolTipContainer, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;toolTipContainer2.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;toolTipContainer2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="srPicker1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="buttonCancel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -256,7 +253,7 @@
     <value>75, 25</value>
   </data>
   <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -271,7 +268,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="labelBlurb.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -288,11 +285,11 @@
   <data name="labelBlurb.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
-  <data name="labelBlurb.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 10</value>
+  <data name="labelBlurb.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 10</value>
   </data>
   <data name="labelBlurb.Size" type="System.Drawing.Size, System.Drawing">
-    <value>507, 25</value>
+    <value>507, 15</value>
   </data>
   <data name="labelBlurb.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -310,7 +307,34 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;labelBlurb.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>2</value>
+  </data>
+  <data name="buttonRescan.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonRescan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 218</value>
+  </data>
+  <data name="buttonRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonRescan.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonRescan.Text" xml:space="preserve">
+    <value>&amp;Rescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Name" xml:space="preserve">
+    <value>buttonRescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -343,19 +367,25 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="toolTipContainer2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonCancel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="srPicker1" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="labelBlurb" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="buttonCancel" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="srPicker1" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="labelBlurb" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="toolTipContainer2" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="buttonRescan" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="srPicker1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="srPicker1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <data name="srPicker1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 25</value>
+  <data name="srPicker1.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
-  <data name="srPicker1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 3</value>
+  <data name="srPicker1.ItemHeight" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="srPicker1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 28</value>
   </data>
   <data name="srPicker1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>507, 187</value>
+    <value>507, 184</value>
   </data>
   <data name="srPicker1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -364,13 +394,13 @@
     <value>srPicker1</value>
   </data>
   <data name="&gt;&gt;srPicker1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SrPicker, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.SrPicker, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;srPicker1.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;srPicker1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -397,6 +427,6 @@
     <value>MoveVirtualDiskDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/NewDiskDialog.Designer.cs
+++ b/XenAdmin/Dialogs/NewDiskDialog.Designer.cs
@@ -41,6 +41,7 @@ namespace XenAdmin.Dialogs
             this.label4 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.diskSpinner1 = new XenAdmin.Controls.DiskSpinner();
+            this.buttonRescan = new System.Windows.Forms.Button();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -56,6 +57,7 @@ namespace XenAdmin.Dialogs
             this.srPicker.ShowDescription = true;
             this.srPicker.ShowImages = true;
             this.srPicker.ShowRootLines = true;
+            this.srPicker.CanBeScannedChanged += new System.Action(this.srPicker_CanBeScannedChanged);
             this.srPicker.SelectedIndexChanged += new System.EventHandler(this.srListBox_SelectedIndexChanged);
             // 
             // CloseButton
@@ -117,6 +119,7 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel1.Controls.Add(this.label6, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.OkButton, 2, 6);
             this.tableLayoutPanel1.Controls.Add(this.diskSpinner1, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.buttonRescan, 1, 6);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // label4
@@ -136,6 +139,13 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel1.SetColumnSpan(this.diskSpinner1, 3);
             this.diskSpinner1.Name = "diskSpinner1";
             this.diskSpinner1.SelectedSizeChanged += new System.Action(this.diskSpinner1_SelectedSizeChanged);
+            // 
+            // buttonRescan
+            // 
+            resources.ApplyResources(this.buttonRescan, "buttonRescan");
+            this.buttonRescan.Name = "buttonRescan";
+            this.buttonRescan.UseVisualStyleBackColor = true;
+            this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
             // 
             // NewDiskDialog
             // 
@@ -166,5 +176,6 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label6;
         private Controls.DiskSpinner diskSpinner1;
+        private System.Windows.Forms.Button buttonRescan;
     }
 }

--- a/XenAdmin/Dialogs/NewDiskDialog.Designer.cs
+++ b/XenAdmin/Dialogs/NewDiskDialog.Designer.cs
@@ -29,7 +29,7 @@ namespace XenAdmin.Dialogs
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NewDiskDialog));
-            this.SrListBox = new XenAdmin.Controls.SrPicker();
+            this.srPicker = new XenAdmin.Controls.SrPicker();
             this.CloseButton = new System.Windows.Forms.Button();
             this.OkButton = new System.Windows.Forms.Button();
             this.NameTextBox = new System.Windows.Forms.TextBox();
@@ -44,19 +44,19 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // SrListBox
+            // srPicker
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.SrListBox, 3);
-            resources.ApplyResources(this.SrListBox, "SrListBox");
-            this.SrListBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-            this.SrListBox.Name = "SrListBox";
-            this.SrListBox.NodeIndent = 3;
-            this.SrListBox.RootAlwaysExpanded = false;
-            this.SrListBox.ShowCheckboxes = false;
-            this.SrListBox.ShowDescription = true;
-            this.SrListBox.ShowImages = true;
-            this.SrListBox.ShowRootLines = true;
-            this.SrListBox.SelectedIndexChanged += new System.EventHandler(this.srListBox_SelectedIndexChanged);
+            this.tableLayoutPanel1.SetColumnSpan(this.srPicker, 3);
+            resources.ApplyResources(this.srPicker, "srPicker");
+            this.srPicker.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.srPicker.Name = "srPicker";
+            this.srPicker.NodeIndent = 3;
+            this.srPicker.RootAlwaysExpanded = false;
+            this.srPicker.ShowCheckboxes = false;
+            this.srPicker.ShowDescription = true;
+            this.srPicker.ShowImages = true;
+            this.srPicker.ShowRootLines = true;
+            this.srPicker.SelectedIndexChanged += new System.EventHandler(this.srListBox_SelectedIndexChanged);
             // 
             // CloseButton
             // 
@@ -111,7 +111,7 @@ namespace XenAdmin.Dialogs
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.NameTextBox, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.DescriptionTextBox, 1, 3);
-            this.tableLayoutPanel1.Controls.Add(this.SrListBox, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.srPicker, 1, 5);
             this.tableLayoutPanel1.Controls.Add(this.label3, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.label4, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.label6, 0, 1);
@@ -157,7 +157,7 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label1;
-        private XenAdmin.Controls.SrPicker SrListBox;
+        private XenAdmin.Controls.SrPicker srPicker;
         private System.Windows.Forms.Button CloseButton;
         private System.Windows.Forms.Button OkButton;
         private System.Windows.Forms.TextBox NameTextBox;

--- a/XenAdmin/Dialogs/NewDiskDialog.resx
+++ b/XenAdmin/Dialogs/NewDiskDialog.resx
@@ -451,7 +451,7 @@
     <value>diskSpinner1</value>
   </data>
   <data name="&gt;&gt;diskSpinner1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DiskSpinner, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DiskSpinner, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;diskSpinner1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -490,42 +490,42 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CloseButton" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NameTextBox" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="DescriptionTextBox" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="SrListBox" Row="5" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="OkButton" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="diskSpinner1" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CloseButton" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NameTextBox" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="DescriptionTextBox" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="srPicker" Row="5" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="OkButton" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="diskSpinner1" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="SrListBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="srPicker.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="SrListBox.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="srPicker.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
-  <data name="SrListBox.IntegralHeight" type="System.Boolean, mscorlib">
+  <data name="srPicker.IntegralHeight" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="SrListBox.ItemHeight" type="System.Int32, mscorlib">
+  <data name="srPicker.ItemHeight" type="System.Int32, mscorlib">
     <value>17</value>
   </data>
-  <data name="SrListBox.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="srPicker.Location" type="System.Drawing.Point, System.Drawing">
     <value>79, 176</value>
   </data>
-  <data name="SrListBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="srPicker.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 6, 3, 3</value>
   </data>
-  <data name="SrListBox.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="srPicker.Size" type="System.Drawing.Size, System.Drawing">
     <value>545, 174</value>
   </data>
-  <data name="SrListBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="srPicker.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;SrListBox.Name" xml:space="preserve">
-    <value>SrListBox</value>
+  <data name="&gt;&gt;srPicker.Name" xml:space="preserve">
+    <value>srPicker</value>
   </data>
-  <data name="&gt;&gt;SrListBox.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SrPicker, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;srPicker.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.SrPicker, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;SrListBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;srPicker.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;SrListBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;srPicker.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -556,6 +556,6 @@
     <value>NewDiskDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Dialogs/NewDiskDialog.resx
+++ b/XenAdmin/Dialogs/NewDiskDialog.resx
@@ -142,7 +142,7 @@
     <value>75, 23</value>
   </data>
   <data name="CloseButton.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="CloseButton.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -406,7 +406,7 @@
     <value>75, 23</value>
   </data>
   <data name="OkButton.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="OkButton.Text" xml:space="preserve">
     <value>&amp;Add</value>
@@ -459,6 +459,33 @@
   <data name="&gt;&gt;diskSpinner1.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
+  <data name="buttonRescan.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonRescan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>79, 356</value>
+  </data>
+  <data name="buttonRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonRescan.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="buttonRescan.Text" xml:space="preserve">
+    <value>&amp;Rescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Name" xml:space="preserve">
+    <value>buttonRescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -490,7 +517,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CloseButton" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NameTextBox" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="DescriptionTextBox" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="srPicker" Row="5" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="OkButton" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="diskSpinner1" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CloseButton" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="NameTextBox" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="DescriptionTextBox" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="srPicker" Row="5" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="OkButton" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="diskSpinner1" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="buttonRescan" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100,AutoSize,0,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="srPicker.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.Designer.cs
+++ b/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.Designer.cs
@@ -35,6 +35,7 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.toolTipContainer1 = new XenAdmin.Controls.ToolTipContainer();
+            this.buttonRescan = new System.Windows.Forms.Button();
             this.tableLayoutPanel1.SuspendLayout();
             this.toolTipContainer1.SuspendLayout();
             this.SuspendLayout();
@@ -42,7 +43,15 @@
             // srPicker1
             // 
             resources.ApplyResources(this.srPicker1, "srPicker1");
+            this.srPicker1.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.srPicker1.Name = "srPicker1";
+            this.srPicker1.NodeIndent = 3;
+            this.srPicker1.RootAlwaysExpanded = false;
+            this.srPicker1.ShowCheckboxes = false;
+            this.srPicker1.ShowDescription = true;
+            this.srPicker1.ShowImages = true;
+            this.srPicker1.ShowRootLines = true;
+            this.srPicker1.CanBeScannedChanged += new System.Action(this.srPicker1_CanBeScannedChanged);
             this.srPicker1.DoubleClickOnRow += new System.EventHandler(this.srPicker1_DoubleClickOnRow);
             this.srPicker1.SelectedIndexChanged += new System.EventHandler(this.srPicker1_SelectedIndexChanged);
             // 
@@ -79,12 +88,20 @@
             this.toolTipContainer1.Controls.Add(this.buttonMove);
             this.toolTipContainer1.Name = "toolTipContainer1";
             // 
+            // buttonRescan
+            // 
+            resources.ApplyResources(this.buttonRescan, "buttonRescan");
+            this.buttonRescan.Name = "buttonRescan";
+            this.buttonRescan.UseVisualStyleBackColor = true;
+            this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
+            // 
             // MoveVMDialog
             // 
             this.AcceptButton = this.buttonMove;
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.buttonCancel;
+            this.Controls.Add(this.buttonRescan);
             this.Controls.Add(this.toolTipContainer1);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.buttonCancel);
@@ -104,5 +121,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label label1;
         private XenAdmin.Controls.ToolTipContainer toolTipContainer1;
+        private System.Windows.Forms.Button buttonRescan;
     }
 }

--- a/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
+++ b/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.cs
@@ -59,8 +59,7 @@ namespace XenAdmin.Dialogs.VMDialogs
                 where vdi != null
                 select vdi).ToArray();
 
-            srPicker1.PopulateAsync(SrPicker.SRPickerType.Move, vm.Connection,
-                vm.Home(), null, vdis);
+            srPicker1.Populate(SrPicker.SRPickerType.Move, vm.Connection, vm.Home(), null, vdis);
         }
 
         private void EnableMoveButton()
@@ -76,11 +75,22 @@ namespace XenAdmin.Dialogs.VMDialogs
                 buttonMove.PerformClick();
         }
 
+        private void buttonRescan_Click(object sender, EventArgs e)
+        {
+            srPicker1.ScanSRs();
+        }
+
         private void buttonMove_Click(object sender, EventArgs e)
         {
             var action = new VMMoveAction(vm, srPicker1.SR, vm.GetStorageHost(false));
             action.RunAsync();
             Close();
+        }
+
+        private void srPicker1_CanBeScannedChanged()
+        {
+            buttonRescan.Enabled = srPicker1.CanBeScanned;
+            EnableMoveButton();
         }
 
         private void srPicker1_SelectedIndexChanged(object sender, EventArgs e)

--- a/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.resx
+++ b/XenAdmin/Dialogs/VMDialogs/MoveVMDialog.resx
@@ -125,6 +125,13 @@
   <data name="srPicker1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="srPicker1.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="srPicker1.ItemHeight" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
   <data name="srPicker1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 25</value>
   </data>
@@ -134,7 +141,6 @@
   <data name="srPicker1.Size" type="System.Drawing.Size, System.Drawing">
     <value>495, 186</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="srPicker1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
@@ -142,7 +148,7 @@
     <value>srPicker1</value>
   </data>
   <data name="&gt;&gt;srPicker1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SrPicker, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.SrPicker, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;srPicker1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -193,7 +199,7 @@
     <value>75, 23</value>
   </data>
   <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -208,7 +214,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -277,7 +283,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="srPicker1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
@@ -295,18 +301,45 @@
     <value>77, 23</value>
   </data>
   <data name="toolTipContainer1.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.Name" xml:space="preserve">
     <value>toolTipContainer1</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.ToolTipContainer, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonRescan.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonRescan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 237</value>
+  </data>
+  <data name="buttonRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonRescan.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="buttonRescan.Text" xml:space="preserve">
+    <value>&amp;Rescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Name" xml:space="preserve">
+    <value>buttonRescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -331,6 +364,6 @@
     <value>MoveVMDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Dialogs.XenDialogBase, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/TabPages/SrStoragePage.cs
+++ b/XenAdmin/TabPages/SrStoragePage.cs
@@ -434,7 +434,7 @@ namespace XenAdmin.TabPages
                 buttonRescan.Enabled = false;
                 toolTipContainerRescan.SetToolTip(Messages.SR_DETACHED);
             }
-            else if (HelpersGUI.BeingScanned(sr))
+            else if (HelpersGUI.BeingScanned(sr, out _))
             {
                 buttonRescan.Enabled = false;
                 toolTipContainerRescan.SetToolTip(Messages.SCAN_IN_PROGRESS_TOOLTIP);

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.Designer.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.Designer.cs
@@ -44,6 +44,7 @@
             this.labelRubric = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
+            this.buttonRescan = new System.Windows.Forms.Button();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanelSrPicker.SuspendLayout();
@@ -89,17 +90,27 @@
             resources.ApplyResources(this.tableLayoutPanelSrPicker, "tableLayoutPanelSrPicker");
             this.tableLayoutPanelSrPicker.Controls.Add(this.srPicker1, 0, 1);
             this.tableLayoutPanelSrPicker.Controls.Add(this.labelSrHint, 0, 0);
+            this.tableLayoutPanelSrPicker.Controls.Add(this.buttonRescan, 1, 1);
             this.tableLayoutPanelSrPicker.Name = "tableLayoutPanelSrPicker";
             // 
             // srPicker1
             // 
             resources.ApplyResources(this.srPicker1, "srPicker1");
+            this.srPicker1.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.srPicker1.Name = "srPicker1";
+            this.srPicker1.NodeIndent = 3;
+            this.srPicker1.RootAlwaysExpanded = false;
+            this.srPicker1.ShowCheckboxes = false;
+            this.srPicker1.ShowDescription = true;
+            this.srPicker1.ShowImages = true;
+            this.srPicker1.ShowRootLines = true;
+            this.srPicker1.CanBeScannedChanged += new System.Action(this.srPicker1_CanBeScannedChanged);
             this.srPicker1.SelectedIndexChanged += new System.EventHandler(this.srPicker1_SelectedIndexChanged);
             // 
             // labelSrHint
             // 
             resources.ApplyResources(this.labelSrHint, "labelSrHint");
+            this.tableLayoutPanelSrPicker.SetColumnSpan(this.labelSrHint, 2);
             this.labelSrHint.Name = "labelSrHint";
             // 
             // toolTipContainer1
@@ -153,6 +164,13 @@
             resources.ApplyResources(this.label1, "label1");
             this.label1.Name = "label1";
             // 
+            // buttonRescan
+            // 
+            resources.ApplyResources(this.buttonRescan, "buttonRescan");
+            this.buttonRescan.Name = "buttonRescan";
+            this.buttonRescan.UseVisualStyleBackColor = true;
+            this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
+            // 
             // IntraPoolCopyPage
             // 
             resources.ApplyResources(this, "$this");
@@ -189,6 +207,7 @@
         private System.Windows.Forms.TextBox NameTextBox;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelSrPicker;
         private System.Windows.Forms.Label labelSrHint;
+        private System.Windows.Forms.Button buttonRescan;
     }
 }
 

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.resx
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/IntraPoolCopyPage.resx
@@ -181,22 +181,25 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="tableLayoutPanelSrPicker.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
-  <data name="srPicker1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+  <data name="srPicker1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="srPicker1.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
+  <data name="srPicker1.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="srPicker1.ItemHeight" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
   <data name="srPicker1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 18</value>
   </data>
-  <data name="srPicker1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 3</value>
-  </data>
   <data name="srPicker1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>430, 138</value>
+    <value>349, 138</value>
   </data>
   <data name="srPicker1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -205,7 +208,7 @@
     <value>srPicker1</value>
   </data>
   <data name="&gt;&gt;srPicker1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SrPicker, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.SrPicker, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;srPicker1.Parent" xml:space="preserve">
     <value>tableLayoutPanelSrPicker</value>
@@ -221,9 +224,6 @@
   </data>
   <data name="labelSrHint.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
-  </data>
-  <data name="labelSrHint.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 3</value>
   </data>
   <data name="labelSrHint.Size" type="System.Drawing.Size, System.Drawing">
     <value>430, 15</value>
@@ -245,6 +245,30 @@
   </data>
   <data name="&gt;&gt;labelSrHint.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="buttonRescan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>358, 18</value>
+  </data>
+  <data name="buttonRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonRescan.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonRescan.Text" xml:space="preserve">
+    <value>&amp;Rescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Name" xml:space="preserve">
+    <value>buttonRescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Parent" xml:space="preserve">
+    <value>tableLayoutPanelSrPicker</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="tableLayoutPanelSrPicker.Location" type="System.Drawing.Point, System.Drawing">
     <value>25, 102</value>
@@ -271,7 +295,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanelSrPicker.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="srPicker1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelSrHint" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="srPicker1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelSrHint" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="buttonRescan" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="toolTipContainer1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -388,7 +412,7 @@
     <value>toolTipContainer1</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.ToolTipContainer, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.ToolTipContainer, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;toolTipContainer1.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -451,7 +475,7 @@
     <value>groupBox1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DecentGroupBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DecentGroupBox, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -619,6 +643,6 @@
     <value>IntraPoolCopyPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Wizards/ImportWizard/StoragePickerPage.Designer.cs
+++ b/XenAdmin/Wizards/ImportWizard/StoragePickerPage.Designer.cs
@@ -32,6 +32,7 @@
             this.m_srPicker = new XenAdmin.Controls.SrPicker();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.labelSrHint = new System.Windows.Forms.Label();
+            this.buttonRescan = new System.Windows.Forms.Button();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -46,6 +47,7 @@
             this.m_srPicker.ShowDescription = true;
             this.m_srPicker.ShowImages = true;
             this.m_srPicker.ShowRootLines = true;
+            this.m_srPicker.CanBeScannedChanged += new System.Action(this.m_srPicker_CanBeScannedChanged);
             this.m_srPicker.SelectedIndexChanged += new System.EventHandler(this.m_srPicker_SelectedIndexChanged);
             // 
             // tableLayoutPanel1
@@ -53,12 +55,20 @@
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.labelSrHint, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.m_srPicker, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.buttonRescan, 0, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // labelSrHint
             // 
             resources.ApplyResources(this.labelSrHint, "labelSrHint");
             this.labelSrHint.Name = "labelSrHint";
+            // 
+            // buttonRescan
+            // 
+            resources.ApplyResources(this.buttonRescan, "buttonRescan");
+            this.buttonRescan.Name = "buttonRescan";
+            this.buttonRescan.UseVisualStyleBackColor = true;
+            this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
             // 
             // StoragePickerPage
             // 
@@ -77,5 +87,6 @@
         private XenAdmin.Controls.SrPicker m_srPicker;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label labelSrHint;
-	}
+        private System.Windows.Forms.Button buttonRescan;
+    }
 }

--- a/XenAdmin/Wizards/ImportWizard/StoragePickerPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/StoragePickerPage.cs
@@ -117,7 +117,7 @@ namespace XenAdmin.Wizards.ImportWizard
         public override void PopulatePage()
         {
             SetButtonNextEnabled(false);
-            m_srPicker.PopulateAsync(SrPicker.SRPickerType.VM, TargetConnection, TargetHost, null, null);
+            m_srPicker.Populate(SrPicker.SRPickerType.VM, TargetConnection, TargetHost, null, null);
             IsDirty = true;
         }
 
@@ -287,6 +287,17 @@ namespace XenAdmin.Wizards.ImportWizard
 			IsDirty = true;
 		}
 
-		#endregion
-	}
+        private void m_srPicker_CanBeScannedChanged()
+        {
+            buttonRescan.Enabled = m_srPicker.CanBeScanned;
+            SetButtonNextEnabled(m_srPicker.SR != null);
+        }
+
+        private void buttonRescan_Click(object sender, EventArgs e)
+        {
+            m_srPicker.ScanSRs();
+        }
+
+        #endregion
+    }
 }

--- a/XenAdmin/Wizards/ImportWizard/StoragePickerPage.resx
+++ b/XenAdmin/Wizards/ImportWizard/StoragePickerPage.resx
@@ -136,16 +136,16 @@
     <value>3, 52</value>
   </data>
   <data name="m_srPicker.Size" type="System.Drawing.Size, System.Drawing">
-    <value>566, 277</value>
+    <value>566, 248</value>
   </data>
   <data name="m_srPicker.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;m_srPicker.Name" xml:space="preserve">
     <value>m_srPicker</value>
   </data>
   <data name="&gt;&gt;m_srPicker.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SrPicker, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.SrPicker, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_srPicker.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -191,6 +191,30 @@ When you have finished, click "Import" to begin importing the VM and proceed to 
   <data name="&gt;&gt;labelSrHint.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="buttonRescan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 306</value>
+  </data>
+  <data name="buttonRescan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonRescan.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonRescan.Text" xml:space="preserve">
+    <value>&amp;Rescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Name" xml:space="preserve">
+    <value>buttonRescan</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonRescan.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -198,7 +222,7 @@ When you have finished, click "Import" to begin importing the VM and proceed to 
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>572, 332</value>
@@ -219,7 +243,7 @@ When you have finished, click "Import" to begin importing the VM and proceed to 
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelSrHint" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="m_srPicker" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelSrHint" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="m_srPicker" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonRescan" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -234,6 +258,6 @@ When you have finished, click "Import" to begin importing the VM and proceed to 
     <value>StoragePickerPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space]Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -35271,7 +35271,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This storage repository is broken.
+        ///   Looks up a localized string similar to This SR is broken or not fully attached..
         /// </summary>
         public static string SR_IS_BROKEN {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -23114,15 +23114,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to v{0} &amp;Release Notes.
-        /// </summary>
-        public static string MAINWINDOW_UPDATE_RELEASE {
-            get {
-                return ResourceManager.GetString("MAINWINDOW_UPDATE_RELEASE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &amp;Add....
         /// </summary>
         public static string MAINWINDOW_ADD_HOST {
@@ -24095,6 +24086,15 @@ namespace XenAdmin {
         public static string MAINWINDOW_TRIM_SR {
             get {
                 return ResourceManager.GetString("MAINWINDOW_TRIM_SR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to v{0} &amp;Release Notes.
+        /// </summary>
+        public static string MAINWINDOW_UPDATE_RELEASE {
+            get {
+                return ResourceManager.GetString("MAINWINDOW_UPDATE_RELEASE", resourceCulture);
             }
         }
         
@@ -35345,11 +35345,11 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Scanning available SRs ....
+        ///   Looks up a localized string similar to Scanning....
         /// </summary>
-        public static string SR_REFRESH_ACTION_TITLE_MANY {
+        public static string SR_REFRESH_ACTION_TITLE_GENERIC {
             get {
-                return ResourceManager.GetString("SR_REFRESH_ACTION_TITLE_MANY", resourceCulture);
+                return ResourceManager.GetString("SR_REFRESH_ACTION_TITLE_GENERIC", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12244,8 +12244,8 @@ The upper limit: SR size / {2}</value>
   <data name="SR_REFRESH_ACTION_TITLE" xml:space="preserve">
     <value>Scanning SR '{0}'</value>
   </data>
-  <data name="SR_REFRESH_ACTION_TITLE_MANY" xml:space="preserve">
-    <value>Scanning available SRs ...</value>
+  <data name="SR_REFRESH_ACTION_TITLE_GENERIC" xml:space="preserve">
+    <value>Scanning...</value>
   </data>
   <data name="SR_SHARE_REVERTED" xml:space="preserve">
     <value>Reverting {0} to unshared completed.</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12219,7 +12219,7 @@ Incremental allocation: {1}</value>
     <value>This SR contains running VMs.</value>
   </data>
   <data name="SR_IS_BROKEN" xml:space="preserve">
-    <value>This storage repository is broken</value>
+    <value>This SR is broken or not fully attached.</value>
   </data>
   <data name="SR_IS_LOCAL" xml:space="preserve">
     <value>VMs without a home server cannot have disks on local storage</value>


### PR DESCRIPTION
The scans run in parallel in batches of three to avoid flooding the session. Also, prevent firing the SelectedIndexChanged event multiple times when populating the NewDisk dialog. Renamed the SrPicker control on the latter (because SrListBox is a different type of control).