### PR TITLE
[master] Do not prepend empty lines with a timestamp in `AutomatedUpdatesBasePage`

### DIFF
--- a/XenAdmin/Core/ExtensionMethods.cs
+++ b/XenAdmin/Core/ExtensionMethods.cs
@@ -164,7 +164,14 @@ namespace XenAdmin.Core
             var timestampString = HelpersGUI.DateTimeToString(timestamp, Messages.DATEFORMAT_DM_HMS, localize);
             // normalise all line endings before splitting
             var lines = value.Replace(Environment.NewLine, "\n").Split('\n');
-            return string.Join(Environment.NewLine, lines.Select(line => $"{timestampString} | {line}"));
+            return string.Join(Environment.NewLine, lines.Select(line =>
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    return line;
+                }
+                return $"{timestampString} | {line}";
+            }));
         }
     }
 }


### PR DESCRIPTION
`value` can sometimes be fed as a multiline string, in which case timestamps were added to empty lines, causing confusion.

Signed-off-by: Danilo Del Busso <danilo.delbusso@cloud.com>