### PR TITLE
CP-41737: Add FCoE deprecation warnings

### DIFF
--- a/XenAdmin/Diagnostics/Checks/PoolHasDeprecatedSrsCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PoolHasDeprecatedSrsCheck.cs
@@ -1,6 +1,5 @@
-﻿/* Copyright (c) Citrix Systems, Inc. 
- * All rights reserved. 
- * 
+﻿/* Copyright (c) Cloud Software Group, Inc. 
+ *
  * Redistribution and use in source and binary forms, 
  * with or without modification, are permitted provided 
  * that the following conditions are met: 

--- a/XenAdmin/Diagnostics/Checks/PoolHasDeprecatedSrsCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PoolHasDeprecatedSrsCheck.cs
@@ -46,13 +46,11 @@ namespace XenAdmin.Diagnostics.Checks
         {
         }
 
-        public override bool CanRun() => !Helpers.Post82X(Host.Connection);
+        public override bool CanRun() => Host.Connection.Cache.SRs.Any(sr => sr.GetSRType(true) == SR.SRTypes.lvmofcoe);
 
         protected override Problem RunHostCheck()
         {
-            var hasFCoESr = Host.Connection.Cache.SRs.Any(sr => sr.GetSRType(true) == SR.SRTypes.lvmofcoe);
-            return !hasFCoESr ? null : new PoolHasFCoESrWarning(this, Helpers.GetPoolOfOne(Host.Connection), true);
+            return new PoolHasFCoESrWarning(this, Helpers.GetPoolOfOne(Host.Connection));
         }
-
     }
 }

--- a/XenAdmin/Diagnostics/Checks/PoolHasDeprecatedSrsCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/PoolHasDeprecatedSrsCheck.cs
@@ -1,0 +1,58 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Linq;
+using XenAdmin.Core;
+using XenAPI;
+using XenAdmin.Diagnostics.Problems;
+using XenAdmin.Diagnostics.Problems.PoolProblem;
+
+namespace XenAdmin.Diagnostics.Checks
+{
+    internal class PoolHasDeprecatedSrsCheck : HostPostLivenessCheck
+    {
+        public override string Description => string.Format(Messages.DEPRECATED_SRS_CHECK, Helpers.GetPoolOfOne(Host.Connection));
+
+        public PoolHasDeprecatedSrsCheck(Host host)
+            : base(host)
+        {
+        }
+
+        public override bool CanRun() => !Helpers.Post82X(Host.Connection);
+
+        protected override Problem RunHostCheck()
+        {
+            var hasFCoESr = Host.Connection.Cache.SRs.Any(sr => sr.GetSRType(true) == SR.SRTypes.lvmofcoe);
+            return !hasFCoESr ? null : new PoolHasFCoESrWarning(this, Helpers.GetPoolOfOne(Host.Connection), true);
+        }
+
+    }
+}

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
@@ -33,6 +33,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using XenAdmin.Actions;
+using XenAdmin.Core;
 using XenAdmin.Diagnostics.Checks;
 using XenAdmin.Dialogs;
 using XenAPI;
@@ -44,17 +45,23 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
     {
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
         private readonly Pool _pool;
+        private readonly bool _upgradingToVersionWithDeprecation;
 
         public override string Title => Check.Description;
         public override string HelpMessage => Messages.MORE_INFO;
         public override string LinkText => Messages.LEARN_MORE;
         public override string LinkData => InvisibleMessages.PV_GUESTS_CHECK_URL;
         public override string Message => string.Empty;
-        public override string Description => string.Format(Messages.POOL_HAS_DEPRECATED_FCOE_WARNING, _pool);
 
-        public PoolHasFCoESrWarning(Check check, Pool pool) : base(check)
+        public override string Description => string.Format(_upgradingToVersionWithDeprecation ? Messages.POOL_HAS_DEPRECATED_FCOE_WARNING : Messages.POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING,
+            _pool,
+            BrandManager.ProductVersionPost82
+        );
+
+        public PoolHasFCoESrWarning(Check check, Pool pool, bool upgradingToVersionWithDeprecation) : base(check)
         {
             _pool = pool;
+            _upgradingToVersionWithDeprecation = upgradingToVersionWithDeprecation;
         }
 
         protected override AsyncAction CreateAction(out bool cancelled)

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
@@ -28,13 +28,8 @@
  * SUCH DAMAGE.
  */
 
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using XenAdmin.Actions;
 using XenAdmin.Core;
 using XenAdmin.Diagnostics.Checks;
-using XenAdmin.Dialogs;
 using XenAPI;
 
 
@@ -42,44 +37,26 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
 {
     internal class PoolHasFCoESrWarning : WarningWithMoreInfo
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
         private readonly Pool _pool;
         private readonly bool _upgradingToVersionWithDeprecation;
 
-        public override string Title => Check.Description;
-        public override string HelpMessage => Messages.MORE_INFO;
+        public override string Title => Description;
         public override string LinkText => Messages.LEARN_MORE;
-        public override string LinkData => InvisibleMessages.PV_GUESTS_CHECK_URL;
-        public override string Message => string.Empty;
+        public override string LinkData => InvisibleMessages.FCOE_SR_DEPRECATION_URL;
 
-        public override string Description => string.Format(_upgradingToVersionWithDeprecation ? Messages.POOL_HAS_DEPRECATED_FCOE_WARNING : Messages.POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING,
-            _pool,
-            BrandManager.ProductVersionPost82
-        );
-        
-        public PoolHasFCoESrWarning(Check check, Pool pool, bool upgradingToVersionWithDeprecation) : base(check)
+        public override string Message => string.Format(_upgradingToVersionWithDeprecation
+                ? Messages.POOL_HAS_DEPRECATED_FCOE_WARNING
+                : Messages.POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING,
+            BrandManager.ProductVersionPost82);
+
+        public override string Description => string.Format(Messages.POOL_HAS_DEPRECATED_FCOE_SHORT,
+            _pool, BrandManager.ProductVersionPost82);
+
+        public PoolHasFCoESrWarning(Check check, Pool pool, bool upgradingToVersionWithDeprecation)
+            : base(check)
         {
             _pool = pool;
             _upgradingToVersionWithDeprecation = upgradingToVersionWithDeprecation;
-        }
-
-        protected override AsyncAction CreateAction(out bool cancelled)
-        {
-            try
-            {
-                Process.Start(InvisibleMessages.FCOE_SR_DEPRECATION_URL);
-            }
-            catch(Exception e)
-            {
-                Log.Error($"Error while attempting to open {InvisibleMessages.FCOE_SR_DEPRECATION_URL}.", e);
-                using (var dlg = new WarningDialog(string.Format(Messages.COULD_NOT_OPEN_URL, InvisibleMessages.FCOE_SR_DEPRECATION_URL)))
-                {
-                    dlg.Show();
-                }
-            }
-            
-            cancelled = true;
-            return null;
         }
     }
 }

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
@@ -1,0 +1,81 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using XenAdmin.Actions;
+using XenAdmin.Diagnostics.Checks;
+using XenAdmin.Dialogs;
+using XenAPI;
+
+
+namespace XenAdmin.Diagnostics.Problems.PoolProblem
+{
+    internal class PoolHasFCoESrWarning : WarningWithMoreInfo
+    {
+        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
+
+        private readonly bool _hasFCoESr;
+
+        private readonly Pool _pool;
+
+        public override string HelpMessage => "Details...";
+        public override string Message => string.Empty;
+        public override string Title => string.Empty;
+        public override string Description => _hasFCoESr ? string.Format(Messages.POOL_HAS_DEPRECATED_FCOE_WARNING, _pool) : null;
+
+        public PoolHasFCoESrWarning(Check check, Pool pool, bool hasFCoESr) : base(check)
+        {
+            _hasFCoESr = hasFCoESr;
+            _pool = pool;
+        }
+
+        protected override AsyncAction CreateAction(out bool cancelled)
+        {
+            try
+            {
+                Process.Start(InvisibleMessages.FCOE_SR_DEPRECATION_URL);
+            }
+            catch(Exception e)
+            {
+                Log.Error($"Error while attempting to open {InvisibleMessages.FCOE_SR_DEPRECATION_URL}.", e);
+                using (var dlg = new WarningDialog(string.Format(Messages.COULD_NOT_OPEN_URL, InvisibleMessages.FCOE_SR_DEPRECATION_URL)))
+                {
+                    dlg.Show();
+                }
+            }
+            
+            cancelled = true;
+            return null;
+        }
+    }
+}

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
@@ -45,9 +45,11 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
         private readonly Pool _pool;
 
-        public override string HelpMessage => "Details...";
+        public override string Title => Check.Description;
+        public override string HelpMessage => Messages.MORE_INFO;
+        public override string LinkText => Messages.LEARN_MORE;
+        public override string LinkData => InvisibleMessages.PV_GUESTS_CHECK_URL;
         public override string Message => string.Empty;
-        public override string Title => string.Empty;
         public override string Description => string.Format(Messages.POOL_HAS_DEPRECATED_FCOE_WARNING, _pool);
 
         public PoolHasFCoESrWarning(Check check, Pool pool) : base(check)

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
@@ -43,19 +43,15 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
     internal class PoolHasFCoESrWarning : WarningWithMoreInfo
     {
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
-
-        private readonly bool _hasFCoESr;
-
         private readonly Pool _pool;
 
         public override string HelpMessage => "Details...";
         public override string Message => string.Empty;
         public override string Title => string.Empty;
-        public override string Description => _hasFCoESr ? string.Format(Messages.POOL_HAS_DEPRECATED_FCOE_WARNING, _pool) : null;
+        public override string Description => string.Format(Messages.POOL_HAS_DEPRECATED_FCOE_WARNING, _pool);
 
-        public PoolHasFCoESrWarning(Check check, Pool pool, bool hasFCoESr) : base(check)
+        public PoolHasFCoESrWarning(Check check, Pool pool) : base(check)
         {
-            _hasFCoESr = hasFCoESr;
             _pool = pool;
         }
 

--- a/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
+++ b/XenAdmin/Diagnostics/Problems/PoolProblem/PoolHasFCoESrWarning.cs
@@ -1,6 +1,5 @@
-﻿/* Copyright (c) Citrix Systems, Inc. 
- * All rights reserved. 
- * 
+﻿/* Copyright (c) Cloud Software Group, Inc. 
+ *
  * Redistribution and use in source and binary forms, 
  * with or without modification, are permitted provided 
  * that the following conditions are met: 
@@ -57,7 +56,7 @@ namespace XenAdmin.Diagnostics.Problems.PoolProblem
             _pool,
             BrandManager.ProductVersionPost82
         );
-
+        
         public PoolHasFCoESrWarning(Check check, Pool pool, bool upgradingToVersionWithDeprecation) : base(check)
         {
             _pool = pool;

--- a/XenAdmin/Diagnostics/Problems/Problem.cs
+++ b/XenAdmin/Diagnostics/Problems/Problem.cs
@@ -93,7 +93,7 @@ namespace XenAdmin.Diagnostics.Problems
             return null;
         }
 
-        public int CompareTo(Problem other)
+        public virtual int CompareTo(Problem other)
         {
             if (other == null)
                 return 1;

--- a/XenAdmin/Diagnostics/Problems/Warning.cs
+++ b/XenAdmin/Diagnostics/Problems/Warning.cs
@@ -83,6 +83,16 @@ namespace XenAdmin.Diagnostics.Problems
         public override string Title => Check.Description;
         public virtual string LinkData => null;
         public virtual string LinkText => LinkData;
+
+        public override int CompareTo(Problem other)
+        {
+            if (!(other is WarningWithMoreInfo warning))
+                return 1;
+
+            var result = string.Compare(Message, warning.Message);
+
+            return result == 0 ? base.CompareTo(other) : result;
+        }
     }
 
 

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1891,7 +1891,7 @@ namespace XenAdmin.TabPages
             {
                 Banner.BannerType = DeprecationBanner.Type.Deprecation;
                 Banner.WarningMessage = string.Format(
-                    Messages.CONTAINER_FCOE_DEPRECATION_WARNING, string.Format(Messages.STRING_SPACE_STRING, BrandManager.ProductBrand, BrandManager.ProductVersionPost82));
+                    Messages.FCOE_DEPRECATION_WARNING, string.Format(Messages.STRING_SPACE_STRING, BrandManager.ProductBrand, BrandManager.ProductVersionPost82));
                 Banner.LinkText = Messages.PATCHING_WIZARD_WEBPAGE_CELL;
                 Banner.LinkUri = new Uri(InvisibleMessages.FCOE_SR_DEPRECATION_URL);
                 Banner.Visible = true;

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1887,6 +1887,15 @@ namespace XenAdmin.TabPages
                 Banner.LinkUri = new Uri(InvisibleMessages.DEPRECATION_URL);
                 Banner.Visible = true;
             }
+            else if (xenObject is SR sr && sr.GetSRType(true) == SR.SRTypes.lvmofcoe)
+            {
+                Banner.BannerType = DeprecationBanner.Type.Deprecation;
+                Banner.WarningMessage = string.Format(
+                    Messages.CONTAINER_FCOE_DEPRECATION_WARNING, string.Format(Messages.STRING_SPACE_STRING, BrandManager.ProductBrand, BrandManager.ProductVersionPost82));
+                Banner.LinkText = Messages.PATCHING_WIZARD_WEBPAGE_CELL;
+                Banner.LinkUri = new Uri(InvisibleMessages.FCOE_SR_DEPRECATION_URL);
+                Banner.Visible = true;
+            }
             else if (!Helpers.Post82X(xenObject.Connection))
             {
                 Banner.BannerType = DeprecationBanner.Type.Deprecation;

--- a/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.cs
@@ -81,7 +81,7 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
             else if (srWizardType is SrWizardType_Fcoe)
             {
                 deprecationBanner.AppliesToVersion = string.Format(Messages.STRING_SPACE_STRING,
-                    BrandManager.LegacyProduct, BrandManager.ProductVersionPost82);
+                    BrandManager.ProductBrand, BrandManager.ProductVersionPost82);
                 deprecationBanner.BannerType = DeprecationBanner.Type.Deprecation;
                 deprecationBanner.FeatureName = Messages.SOFTWARE_FCOE_STORAGE_REPOSITORIES;
                 deprecationBanner.LinkUri = new Uri(InvisibleMessages.FCOE_SR_DEPRECATION_URL);

--- a/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.cs
+++ b/XenAdmin/Wizards/NewSRWizard_Pages/ChooseSrTypePage.cs
@@ -68,9 +68,9 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
 
         }
 
-        private void SetupDeprecationBanner(bool visible)
+        private void SetupDeprecationBanner(SrWizardType srWizardType)
         {
-            if(visible)
+            if (srWizardType is SrWizardType_Cslg)
             {
                 deprecationBanner.AppliesToVersion = BrandManager.ProductVersion65;
                 deprecationBanner.BannerType = DeprecationBanner.Type.Removal;
@@ -78,8 +78,19 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
                 deprecationBanner.LinkUri = new Uri(InvisibleMessages.ISL_DEPRECATION_URL);
                 deprecationBanner.Visible = !HiddenFeatures.LinkLabelHidden;
             }
+            else if (srWizardType is SrWizardType_Fcoe)
+            {
+                deprecationBanner.AppliesToVersion = string.Format(Messages.STRING_SPACE_STRING,
+                    BrandManager.LegacyProduct, BrandManager.ProductVersionPost82);
+                deprecationBanner.BannerType = DeprecationBanner.Type.Deprecation;
+                deprecationBanner.FeatureName = Messages.SOFTWARE_FCOE_STORAGE_REPOSITORIES;
+                deprecationBanner.LinkUri = new Uri(InvisibleMessages.FCOE_SR_DEPRECATION_URL);
+                deprecationBanner.Visible = !HiddenFeatures.LinkLabelHidden;
+            }
             else
+            {
                 deprecationBanner.Visible = false;
+            }
         }
 
         #region XenTabPage overrides
@@ -249,9 +260,9 @@ namespace XenAdmin.Wizards.NewSRWizard_Pages
                 foreach (RadioButton rb in _radioButtons)
                     rb.Checked = rb == radioButton;
 
-                SrWizardType frontend = (SrWizardType)radioButton.Tag;
+                var frontend = (SrWizardType)radioButton.Tag;
 
-                SetupDeprecationBanner(frontend is SrWizardType_Cslg);
+                SetupDeprecationBanner(frontend);
 
                 if (frontend.IsEnhancedSR && Helpers.FeatureForbidden(Connection, Host.RestrictStorageChoices))
                 {

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -287,7 +287,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
             //Deprecated SRs checks 
             var deprecatedSRsChecks = (from Host host in SelectedCoordinators
-                let check = new PoolHasDeprecatedSrsCheck(host)
+                let check = new PoolHasDeprecatedSrsCheck(host, InstallMethodConfig, ManualUpgrade)
                 where check.CanRun()
                 select check as Check).ToList();
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -284,6 +284,15 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             if (gfs2Checks.Count > 0) 
                 groups.Add(new CheckGroup(Messages.CHECKING_CLUSTERING_STATUS, gfs2Checks));
 
+            //Deprecated SRs checks 
+            var deprecatedSRsChecks = (from Host host in SelectedCoordinators
+                let check = new PoolHasDeprecatedSrsCheck(host)
+                where check.CanRun()
+                select check as Check).ToList();
+
+            if (deprecatedSRsChecks.Count > 0)
+                groups.Add(new CheckGroup(Messages.CHECKING_DEPRECATED_SRS, deprecatedSRsChecks));
+
             return groups;
         }
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -53,19 +53,19 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
         private void AddEventHandlersToCoordinators()
         {
-            foreach (Host coordinator in SelectedCoordinators)
+            foreach (var c in SelectedCoordinators.Select(c => c.Connection))
             {
-                coordinator.Connection.ConnectionStateChanged += connection_ConnectionChanged;
-                coordinator.Connection.CachePopulated += connection_CachePopulated;
+                c.ConnectionStateChanged += connection_ConnectionChanged;
+                c.CachePopulated += connection_CachePopulated;
             }
         }
 
         private void RemoveEventHandlersToCoordinators()
         {
-            foreach (Host coordinator in SelectedCoordinators)
+            foreach (var c in SelectedCoordinators.Select(c => c.Connection))
             {
-                coordinator.Connection.ConnectionStateChanged -= connection_ConnectionChanged;
-                coordinator.Connection.CachePopulated -= connection_CachePopulated;
+                c.ConnectionStateChanged -= connection_ConnectionChanged;
+                c.CachePopulated -= connection_CachePopulated;
             }
         }
 
@@ -89,16 +89,15 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             var selectedCoordinators = new List<Host>(SelectedCoordinators);
             RemoveEventHandlersToCoordinators();
             SelectedServers.Clear();
-            foreach (Host selectedCoordinator in selectedCoordinators)
+            foreach (var selectedCoordinator in selectedCoordinators)
             {
-                Host coordinator = selectedCoordinator;
-                if (coordinator != null)
+                if (selectedCoordinator != null)
                 {
-                    Pool pool = Helpers.GetPoolOfOne(coordinator.Connection);
+                    var pool = Helpers.GetPoolOfOne(selectedCoordinator.Connection);
                     if (pool != null)
                         SelectedServers.AddRange(pool.HostsToUpgrade());
                     else
-                        SelectedServers.Add(coordinator);
+                        SelectedServers.Add(selectedCoordinator);
                 }
             }
             AddEventHandlersToCoordinators();
@@ -119,26 +118,11 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             RemoveEventHandlersToCoordinators();
         }
 
-        public override string PageTitle
-        {
-            get
-            {
-                return Messages.UPGRADE_PRECHECKS_TITLE;
-            }
-        }
+        public override string PageTitle => Messages.UPGRADE_PRECHECKS_TITLE;
 
-        public override string Text
-        {
-            get
-            {
-                return Messages.UPGRADE_PRECHECKS_TEXT;
-            }
-        }
+        public override string Text => Messages.UPGRADE_PRECHECKS_TEXT;
 
-        public override string HelpID
-        {
-            get { return "Upgradeprechecks"; }
-        }
+        public override string HelpID => "Upgradeprechecks";
 
         public override string NextText(bool isLastPage)
         {
@@ -149,11 +133,10 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
         {
             var groups = new List<CheckGroup>();
 
-            List<Host> hostsToUpgrade = new List<Host>();
-            List<Host> hostsToUpgradeOrUpdate = new List<Host>();
-            foreach (var pool in SelectedPools)
+            var hostsToUpgrade = new List<Host>();
+            var hostsToUpgradeOrUpdate = new List<Host>();
+            foreach (var poolHostsToUpgrade in SelectedPools.Select(pool => pool.HostsToUpgrade()))
             {
-                var poolHostsToUpgrade = pool.HostsToUpgrade();
                 hostsToUpgrade.AddRange(poolHostsToUpgrade);
                 hostsToUpgradeOrUpdate.AddRange(poolHostsToUpgrade);
             }
@@ -169,7 +152,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
             //HostMaintenanceModeCheck checks - for hosts that will be upgraded or updated
             var livenessChecks = new List<Check>();
-            foreach (Host host in hostsToUpgradeOrUpdate)
+            foreach (var host in hostsToUpgradeOrUpdate)
                 livenessChecks.Add(new HostLivenessCheck(host, hostsToUpgrade.Contains(host)));
             groups.Add(new CheckGroup(Messages.CHECKING_HOST_LIVENESS_STATUS, livenessChecks));
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -135,8 +135,9 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
             var hostsToUpgrade = new List<Host>();
             var hostsToUpgradeOrUpdate = new List<Host>();
-            foreach (var poolHostsToUpgrade in SelectedPools.Select(pool => pool.HostsToUpgrade()))
+            foreach (var pool in SelectedPools)
             {
+                var poolHostsToUpgrade = pool.HostsToUpgrade();
                 hostsToUpgrade.AddRange(poolHostsToUpgrade);
                 hostsToUpgradeOrUpdate.AddRange(poolHostsToUpgrade);
             }

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Diagnostics\Checks\AutomatedUpdatesLicenseCheck.cs" />
     <Compile Include="Diagnostics\Checks\DiskSpaceForBatchUpdatesCheck.cs" />
     <Compile Include="Diagnostics\Checks\HealthCheckServiceCheck.cs" />
+    <Compile Include="Diagnostics\Checks\PoolHasDeprecatedSrsCheck.cs" />
     <Compile Include="Diagnostics\Checks\PowerOniLoCheck.cs" />
     <Compile Include="Diagnostics\Checks\PoolLegacySslCheck.cs" />
     <Compile Include="Diagnostics\Checks\PrepareToUpgradeCheck.cs" />
@@ -254,6 +255,7 @@
     <Compile Include="Diagnostics\Problems\HostProblem\PowerOniLoProblem.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\HealthCheckServiceProblem.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\LegacySslProblem.cs" />
+    <Compile Include="Diagnostics\Problems\PoolProblem\PoolHasFCoESrWarning.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\PoolHasVmsWithDmcProblem.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\PoolHasPVGuestWarningUrl.cs" />
     <Compile Include="Diagnostics\Problems\HostProblem\HostMemoryPostUpgradeWarning.cs" />

--- a/XenModel/InvisibleMessages.Designer.cs
+++ b/XenModel/InvisibleMessages.Designer.cs
@@ -97,6 +97,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to https://docs.citrix.com/en-us/citrix-hypervisor/CH-0011.html.
+        /// </summary>
+        public static string FCOE_SR_DEPRECATION_URL {
+            get {
+                return ResourceManager.GetString("FCOE_SR_DEPRECATION_URL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ?utm_campaign={0}&amp;utm_medium=ui_link&amp;utm_source={1}.
         /// </summary>
         public static string HELP_URL_QUERY {

--- a/XenModel/InvisibleMessages.resx
+++ b/XenModel/InvisibleMessages.resx
@@ -129,6 +129,9 @@
   <data name="DOCS_URL" xml:space="preserve">
     <value>http://docs.citrix.com/en-us/</value>
   </data>
+  <data name="FCOE_SR_DEPRECATION_URL" xml:space="preserve">
+    <value>https://docs.citrix.com/en-us/citrix-hypervisor/CH-0011.html</value>
+  </data>
   <data name="HELP_URL_QUERY" xml:space="preserve">
     <value>?utm_campaign={0}&amp;utm_medium=ui_link&amp;utm_source={1}</value>
   </data>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -7620,7 +7620,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Checking deprecated storage repositories.
+        ///   Looks up a localized string similar to Checking for deprecated storage repositories.
         /// </summary>
         public static string CHECKING_DEPRECATED_SRS {
             get {
@@ -9455,15 +9455,6 @@ namespace XenAdmin {
         public static string CONTAINER_CREATED {
             get {
                 return ResourceManager.GetString("CONTAINER_CREATED", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Support for software FCoE storage repositories has been deprecated as of {0}..
-        /// </summary>
-        public static string CONTAINER_FCOE_DEPRECATION_WARNING {
-            get {
-                return ResourceManager.GetString("CONTAINER_FCOE_DEPRECATION_WARNING", resourceCulture);
             }
         }
         
@@ -17103,6 +17094,15 @@ namespace XenAdmin {
         public static string FAST_CLONE_UNAVAILABLE {
             get {
                 return ResourceManager.GetString("FAST_CLONE_UNAVAILABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Support for Software FCoE storage repositories has been deprecated as of {0}..
+        /// </summary>
+        public static string FCOE_DEPRECATION_WARNING {
+            get {
+                return ResourceManager.GetString("FCOE_DEPRECATION_WARNING", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -9459,6 +9459,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Support for software FCoE storage repositories has been deprecated as of {0}..
+        /// </summary>
+        public static string CONTAINER_FCOE_DEPRECATION_WARNING {
+            get {
+                return ResourceManager.GetString("CONTAINER_FCOE_DEPRECATION_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Container General Properties.
         /// </summary>
         public static string CONTAINER_GENERAL_TAB_TITLE {
@@ -34729,6 +34738,15 @@ namespace XenAdmin {
         public static string SNAPSHOTTING {
             get {
                 return ResourceManager.GetString("SNAPSHOTTING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Software FCoE storage repositories.
+        /// </summary>
+        public static string SOFTWARE_FCOE_STORAGE_REPOSITORIES {
+            get {
+                return ResourceManager.GetString("SOFTWARE_FCOE_STORAGE_REPOSITORIES", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -30805,7 +30805,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: Support for Software FCoE SRs has been deprecated.
+        ///   Looks up a localized string similar to {0}: Support for Software FCoE SRs has been deprecated in {1}.
         /// </summary>
         public static string POOL_HAS_DEPRECATED_FCOE_WARNING {
             get {
@@ -30940,6 +30940,15 @@ namespace XenAdmin {
         public static string POOL_LICENSE {
             get {
                 return ResourceManager.GetString("POOL_LICENSE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: If you are upgrading to {1}, support for Software FCoE SRs has been deprecated.
+        /// </summary>
+        public static string POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING {
+            get {
+                return ResourceManager.GetString("POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -7620,6 +7620,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking deprecated storage repositories.
+        /// </summary>
+        public static string CHECKING_DEPRECATED_SRS {
+            get {
+                return ResourceManager.GetString("CHECKING_DEPRECATED_SRS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Checking for pending restart.
         /// </summary>
         public static string CHECKING_FOR_PENDING_RESTART {
@@ -12651,6 +12660,15 @@ namespace XenAdmin {
         public static string DELETING_VMSS {
             get {
                 return ResourceManager.GetString("DELETING_VMSS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SR deprecation check.
+        /// </summary>
+        public static string DEPRECATED_SRS_CHECK {
+            get {
+                return ResourceManager.GetString("DEPRECATED_SRS_CHECK", resourceCulture);
             }
         }
         
@@ -30774,6 +30792,15 @@ namespace XenAdmin {
         public static string POOL_GONE {
             get {
                 return ResourceManager.GetString("POOL_GONE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: Support for Software FCoE SRs has been deprecated.
+        /// </summary>
+        public static string POOL_HAS_DEPRECATED_FCOE_WARNING {
+            get {
+                return ResourceManager.GetString("POOL_HAS_DEPRECATED_FCOE_WARNING", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -30807,6 +30807,15 @@ namespace XenAdmin {
         /// <summary>
         ///   Looks up a localized string similar to {0}: Support for Software FCoE SRs has been deprecated in {1}.
         /// </summary>
+        public static string POOL_HAS_DEPRECATED_FCOE_SHORT {
+            get {
+                return ResourceManager.GetString("POOL_HAS_DEPRECATED_FCOE_SHORT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Support for Software FCoE SRs has been deprecated in {0} and will be removed in a future release. It is recommended that you move your VMs to a different type of storage and remove Software FCoE SRs from your systems as soon as possible..
+        /// </summary>
         public static string POOL_HAS_DEPRECATED_FCOE_WARNING {
             get {
                 return ResourceManager.GetString("POOL_HAS_DEPRECATED_FCOE_WARNING", resourceCulture);
@@ -30944,7 +30953,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: If you are upgrading to {1}, support for Software FCoE SRs has been deprecated.
+        ///   Looks up a localized string similar to Support for Software FCoE SRs has been deprecated in {0} and will be removed in a future release. If you are upgrading to this version, it is recommended that you move your VMs to a different type of storage and remove Software FCoE SRs from your system as soon as possible..
         /// </summary>
         public static string POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -10695,8 +10695,11 @@ Please reconnect the host and try again</value>
   <data name="POOL_GONE" xml:space="preserve">
     <value>Could not find the pool in {0}'s cache.</value>
   </data>
-  <data name="POOL_HAS_DEPRECATED_FCOE_WARNING" xml:space="preserve">
+  <data name="POOL_HAS_DEPRECATED_FCOE_SHORT" xml:space="preserve">
     <value>{0}: Support for Software FCoE SRs has been deprecated in {1}</value>
+  </data>
+  <data name="POOL_HAS_DEPRECATED_FCOE_WARNING" xml:space="preserve">
+    <value>Support for Software FCoE SRs has been deprecated in {0} and will be removed in a future release. It is recommended that you move your VMs to a different type of storage and remove Software FCoE SRs from your systems as soon as possible.</value>
   </data>
   <data name="POOL_HAS_MIXED_LICENSES" xml:space="preserve">
     <value>This pool has hosts with different types of license.</value>
@@ -10745,7 +10748,7 @@ Support for PV guests has been removed in {1}. Click Learn more to see the list 
     <value>Pool License</value>
   </data>
   <data name="POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING" xml:space="preserve">
-    <value>{0}: If you are upgrading to {1}, support for Software FCoE SRs has been deprecated</value>
+    <value>Support for Software FCoE SRs has been deprecated in {0} and will be removed in a future release. If you are upgrading to this version, it is recommended that you move your VMs to a different type of storage and remove Software FCoE SRs from your system as soon as possible.</value>
   </data>
   <data name="POOL_NAME_EMPTY" xml:space="preserve">
     <value>Pool name cannot be empty</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -10696,7 +10696,7 @@ Please reconnect the host and try again</value>
     <value>Could not find the pool in {0}'s cache.</value>
   </data>
   <data name="POOL_HAS_DEPRECATED_FCOE_WARNING" xml:space="preserve">
-    <value>{0}: Support for Software FCoE SRs has been deprecated</value>
+    <value>{0}: Support for Software FCoE SRs has been deprecated in {1}</value>
   </data>
   <data name="POOL_HAS_MIXED_LICENSES" xml:space="preserve">
     <value>This pool has hosts with different types of license.</value>
@@ -10743,6 +10743,9 @@ Support for PV guests has been removed in {1}. Click Learn more to see the list 
   </data>
   <data name="POOL_LICENSE" xml:space="preserve">
     <value>Pool License</value>
+  </data>
+  <data name="POOL_MAY_HAVE_DEPRECATED_FCOE_WARNING" xml:space="preserve">
+    <value>{0}: If you are upgrading to {1}, support for Software FCoE SRs has been deprecated</value>
   </data>
   <data name="POOL_NAME_EMPTY" xml:space="preserve">
     <value>Pool name cannot be empty</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3413,6 +3413,9 @@ Would you like to carry out the operation at this time?</value>
   <data name="CONTAINER_CREATED" xml:space="preserve">
     <value>Created</value>
   </data>
+  <data name="CONTAINER_FCOE_DEPRECATION_WARNING" xml:space="preserve">
+    <value>Support for software FCoE storage repositories has been deprecated as of {0}.</value>
+  </data>
   <data name="CONTAINER_GENERAL_TAB_TITLE" xml:space="preserve">
     <value>Container General Properties</value>
   </data>
@@ -12039,6 +12042,9 @@ Reverting to this snapshot will revert the VM back to the point in time that the
   </data>
   <data name="SNAPSHOTTING" xml:space="preserve">
     <value>Creating a snapshot...</value>
+  </data>
+  <data name="SOFTWARE_FCOE_STORAGE_REPOSITORIES" xml:space="preserve">
+    <value>Software FCoE storage repositories</value>
   </data>
   <data name="SOFTWARE_VERSION_BUILD_NUMBER" xml:space="preserve">
     <value>Build number</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2757,7 +2757,7 @@ Do you want to assign these VMs to the schedule '{0}' instead?</value>
     <value>Checking clustering status</value>
   </data>
   <data name="CHECKING_DEPRECATED_SRS" xml:space="preserve">
-    <value>Checking deprecated storage repositories</value>
+    <value>Checking for deprecated storage repositories</value>
   </data>
   <data name="CHECKING_FOR_PENDING_RESTART" xml:space="preserve">
     <value>Checking for pending restart</value>
@@ -3412,9 +3412,6 @@ Would you like to carry out the operation at this time?</value>
   </data>
   <data name="CONTAINER_CREATED" xml:space="preserve">
     <value>Created</value>
-  </data>
-  <data name="CONTAINER_FCOE_DEPRECATION_WARNING" xml:space="preserve">
-    <value>Support for software FCoE storage repositories has been deprecated as of {0}.</value>
   </data>
   <data name="CONTAINER_GENERAL_TAB_TITLE" xml:space="preserve">
     <value>Container General Properties</value>
@@ -5996,6 +5993,9 @@ Would you like to eject these ISOs before continuing?</value>
   </data>
   <data name="FAST_CLONE_UNAVAILABLE" xml:space="preserve">
     <value>Fast clone is not supported by this storage type</value>
+  </data>
+  <data name="FCOE_DEPRECATION_WARNING" xml:space="preserve">
+    <value>Support for Software FCoE storage repositories has been deprecated as of {0}.</value>
   </data>
   <data name="FEATURE_DISABLED" xml:space="preserve">
     <value>'{0}' feature is disabled due to license restrictions on the server.</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -2756,6 +2756,9 @@ Do you want to assign these VMs to the schedule '{0}' instead?</value>
   <data name="CHECKING_CLUSTERING_STATUS" xml:space="preserve">
     <value>Checking clustering status</value>
   </data>
+  <data name="CHECKING_DEPRECATED_SRS" xml:space="preserve">
+    <value>Checking deprecated storage repositories</value>
+  </data>
   <data name="CHECKING_FOR_PENDING_RESTART" xml:space="preserve">
     <value>Checking for pending restart</value>
   </data>
@@ -4490,6 +4493,9 @@ This will also delete subfolders.</value>
   </data>
   <data name="DELETING_VMSS" xml:space="preserve">
     <value>Deleting snapshot schedule '{0}'</value>
+  </data>
+  <data name="DEPRECATED_SRS_CHECK" xml:space="preserve">
+    <value>SR deprecation check</value>
   </data>
   <data name="DESCRIPTION" xml:space="preserve">
     <value>Description</value>
@@ -10685,6 +10691,9 @@ Please reconnect the host and try again</value>
   </data>
   <data name="POOL_GONE" xml:space="preserve">
     <value>Could not find the pool in {0}'s cache.</value>
+  </data>
+  <data name="POOL_HAS_DEPRECATED_FCOE_WARNING" xml:space="preserve">
+    <value>{0}: Support for Software FCoE SRs has been deprecated</value>
   </data>
   <data name="POOL_HAS_MIXED_LICENSES" xml:space="preserve">
     <value>This pool has hosts with different types of license.</value>

--- a/XenModel/Utils/Helpers.Versions.cs
+++ b/XenModel/Utils/Helpers.Versions.cs
@@ -170,7 +170,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool DundeeOrGreater(IXenConnection conn)
         {
-            return conn == null || DundeeOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || DundeeOrGreater(GetCoordinator(conn));
         }
 
         /// Dundee is ver. 2.0.0
@@ -192,7 +192,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool ElyOrGreater(IXenConnection conn)
         {
-            return conn == null || ElyOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || ElyOrGreater(GetCoordinator(conn));
         }
 
         /// Ely is ver. 2.1.1
@@ -208,7 +208,7 @@ namespace XenAdmin.Core
 
         public static bool HavanaOrGreater(IXenConnection conn)
         {
-            return conn == null || HavanaOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || HavanaOrGreater(GetCoordinator(conn));
         }
 
         /// As Havana platform version is same with Ely and Honolulu, so use product version here
@@ -228,7 +228,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool FalconOrGreater(IXenConnection conn)
         {
-            return conn == null || FalconOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || FalconOrGreater(GetCoordinator(conn));
         }
 
         /// Falcon is ver. 2.3.0
@@ -245,7 +245,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool InvernessOrGreater(IXenConnection conn)
         {
-            return conn == null || InvernessOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || InvernessOrGreater(GetCoordinator(conn));
         }
 
         /// Inverness is ver. 2.4.0
@@ -262,7 +262,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool JuraOrGreater(IXenConnection conn)
         {
-            return conn == null || JuraOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || JuraOrGreater(GetCoordinator(conn));
         }
 
         /// Jura is ver. 2.5.0
@@ -279,7 +279,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool KolkataOrGreater(IXenConnection conn)
         {
-            return conn == null || KolkataOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || KolkataOrGreater(GetCoordinator(conn));
         }
 
         /// Kolkata platform version is 2.6.0
@@ -296,7 +296,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool LimaOrGreater(IXenConnection conn)
         {
-            return conn == null || LimaOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || LimaOrGreater(GetCoordinator(conn));
         }
 
         /// Lima platform version is 2.7.0
@@ -349,7 +349,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool StockholmOrGreater(IXenConnection conn)
         {
-            return conn == null || StockholmOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || StockholmOrGreater(GetCoordinator(conn));
         }
 
         /// <param name="host">May be null, in which case true is returned.</param>
@@ -367,7 +367,7 @@ namespace XenAdmin.Core
         /// <param name="conn">May be null, in which case true is returned.</param>
         public static bool YangtzeOrGreater(IXenConnection conn)
         {
-            return conn == null || YangtzeOrGreater(Helpers.GetCoordinator(conn));
+            return conn == null || YangtzeOrGreater(GetCoordinator(conn));
         }
 
         /// <param name="host">May be null, in which case true is returned.</param>


### PR DESCRIPTION
There's some tidy-up code here, I suggest you review one commit at a time.

Warnings added to
- RPU wizard from pre-82x
- New SR wizard
- General tab of SR

Note that the XC warning for pre-cloud connections is superseded by this new one. This is by design as there are planned changes to that warning. This is temporary as we will be making changes to that piece of logic, but should enable testing of the feature.

I am redirecting to a vanity link, this will be updated by the docs team once the deprecation has its own page.