### PR TITLE
CP-40157: Updates to `GraphDetailsDialog`

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/DataSet.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataSet.cs
@@ -62,11 +62,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         public DataSet(IXenObject xo, bool hide, string datasourceName, List<Data_source> datasources)
         {
             XenObject = xo;
-            Hide = datasourceName == "xapi_open_fds" ||
-                   datasourceName == "pool_task_count" ||
-                   datasourceName == "pool_session_count" ||
-                   datasourceName == "memory" ||
-                   datasourceName == "memory_total_kib" || hide;
+            Hide = datasourceName == "memory" || datasourceName == "memory_total_kib" || hide;
 
             DataSourceName = datasourceName;
 

--- a/XenAdmin/Controls/CustomDataGraph/DataSet.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataSet.cs
@@ -97,6 +97,8 @@ namespace XenAdmin.Controls.CustomDataGraph
                     CustomYRange = new DataRange(1, 0, 1, Unit.MegaHertz, RangeScaleMode.Auto);
                     break;
                 case "requests/s":
+                case "hits/s":
+                case "misses/s":
                 case "err/s":
                     CustomYRange = new DataRange(1, 0, 1, Unit.CountsPerSecond, RangeScaleMode.Auto);
                     break;

--- a/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
+++ b/XenAdmin/Controls/CustomDataGraph/GraphHelpers.cs
@@ -179,7 +179,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
             foreach (Data_source dataSource in dataSources)
             {
-                if (dataSource.name_label == "memory_total_kib" || dataSource.name_label == "memory" || dataSource.name_label == "xapi_open_fds" || dataSource.name_label == "pool_task_count" || dataSource.name_label == "pool_session_count")
+                if (dataSource.name_label == "memory_total_kib" || dataSource.name_label == "memory")
                     continue;
 
                 string friendlyName;

--- a/XenAdmin/Dialogs/GraphDetailsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.Designer.cs
@@ -53,9 +53,9 @@
             this.buttonEnable = new System.Windows.Forms.Button();
             this.ColumnDisplayOnGraph = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnEnabled = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnColour = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
@@ -106,9 +106,9 @@
             this.dataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ColumnDisplayOnGraph,
             this.ColumnName,
+            this.Description,
             this.ColumnType,
             this.ColumnEnabled,
-            this.Description,
             this.ColumnColour});
             resources.ApplyResources(this.dataGridView, "dataGridView");
             this.dataGridView.MultiSelect = false;
@@ -255,6 +255,13 @@
             this.ColumnName.Name = "ColumnName";
             this.ColumnName.ReadOnly = true;
             // 
+            // Description
+            // 
+            this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            resources.ApplyResources(this.Description, "Description");
+            this.Description.Name = "Description";
+            this.Description.ReadOnly = true;
+            // 
             // ColumnType
             // 
             this.ColumnType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
@@ -267,12 +274,6 @@
             resources.ApplyResources(this.ColumnEnabled, "ColumnEnabled");
             this.ColumnEnabled.Name = "ColumnEnabled";
             this.ColumnEnabled.ReadOnly = true;
-            // 
-            // Description
-            // 
-            resources.ApplyResources(this.Description, "Description");
-            this.Description.Name = "Description";
-            this.Description.ReadOnly = true;
             // 
             // ColumnColour
             // 
@@ -331,9 +332,9 @@
         private System.Windows.Forms.Button buttonClearAll;
         private System.Windows.Forms.DataGridViewCheckBoxColumn ColumnDisplayOnGraph;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnType;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnEnabled;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnColour;
     }
 }

--- a/XenAdmin/Dialogs/GraphDetailsDialog.Designer.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.Designer.cs
@@ -37,11 +37,6 @@
             this.CloseButton = new System.Windows.Forms.Button();
             this.GraphNameTextBox = new System.Windows.Forms.TextBox();
             this.dataGridView = new System.Windows.Forms.DataGridView();
-            this.ColumnDisplayOnGraph = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnEnabled = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnColour = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.pictureBoxProgress = new System.Windows.Forms.PictureBox();
             this.labelProgress = new System.Windows.Forms.Label();
@@ -56,6 +51,12 @@
             this.toolStripMenuItemDisabled = new System.Windows.Forms.ToolStripMenuItem();
             this.buttonClearAll = new System.Windows.Forms.Button();
             this.buttonEnable = new System.Windows.Forms.Button();
+            this.ColumnDisplayOnGraph = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.ColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnEnabled = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnColour = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxProgress)).BeginInit();
@@ -107,6 +108,7 @@
             this.ColumnName,
             this.ColumnType,
             this.ColumnEnabled,
+            this.Description,
             this.ColumnColour});
             resources.ApplyResources(this.dataGridView, "dataGridView");
             this.dataGridView.MultiSelect = false;
@@ -123,48 +125,6 @@
             this.dataGridView.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.datasourcesGridView_CellPainting);
             this.dataGridView.SelectionChanged += new System.EventHandler(this.dataGridView_SelectionChanged);
             this.dataGridView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridView_SortCompare);
-            // 
-            // ColumnDisplayOnGraph
-            // 
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle1.NullValue = false;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.ColumnDisplayOnGraph.DefaultCellStyle = dataGridViewCellStyle1;
-            resources.ApplyResources(this.ColumnDisplayOnGraph, "ColumnDisplayOnGraph");
-            this.ColumnDisplayOnGraph.Name = "ColumnDisplayOnGraph";
-            this.ColumnDisplayOnGraph.ReadOnly = true;
-            this.ColumnDisplayOnGraph.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.ColumnDisplayOnGraph.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            // 
-            // ColumnName
-            // 
-            this.ColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            resources.ApplyResources(this.ColumnName, "ColumnName");
-            this.ColumnName.Name = "ColumnName";
-            this.ColumnName.ReadOnly = true;
-            // 
-            // ColumnType
-            // 
-            this.ColumnType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            resources.ApplyResources(this.ColumnType, "ColumnType");
-            this.ColumnType.Name = "ColumnType";
-            this.ColumnType.ReadOnly = true;
-            // 
-            // ColumnEnabled
-            // 
-            resources.ApplyResources(this.ColumnEnabled, "ColumnEnabled");
-            this.ColumnEnabled.Name = "ColumnEnabled";
-            this.ColumnEnabled.ReadOnly = true;
-            // 
-            // ColumnColour
-            // 
-            this.ColumnColour.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            resources.ApplyResources(this.ColumnColour, "ColumnColour");
-            this.ColumnColour.Name = "ColumnColour";
-            this.ColumnColour.ReadOnly = true;
-            this.ColumnColour.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.ColumnColour.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
             // 
             // tableLayoutPanel1
             // 
@@ -275,6 +235,54 @@
             this.buttonEnable.UseVisualStyleBackColor = true;
             this.buttonEnable.Click += new System.EventHandler(this.buttonEnable_Click);
             // 
+            // ColumnDisplayOnGraph
+            // 
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle1.NullValue = false;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
+            this.ColumnDisplayOnGraph.DefaultCellStyle = dataGridViewCellStyle1;
+            resources.ApplyResources(this.ColumnDisplayOnGraph, "ColumnDisplayOnGraph");
+            this.ColumnDisplayOnGraph.Name = "ColumnDisplayOnGraph";
+            this.ColumnDisplayOnGraph.ReadOnly = true;
+            this.ColumnDisplayOnGraph.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.ColumnDisplayOnGraph.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            // 
+            // ColumnName
+            // 
+            this.ColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            resources.ApplyResources(this.ColumnName, "ColumnName");
+            this.ColumnName.Name = "ColumnName";
+            this.ColumnName.ReadOnly = true;
+            // 
+            // ColumnType
+            // 
+            this.ColumnType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            resources.ApplyResources(this.ColumnType, "ColumnType");
+            this.ColumnType.Name = "ColumnType";
+            this.ColumnType.ReadOnly = true;
+            // 
+            // ColumnEnabled
+            // 
+            resources.ApplyResources(this.ColumnEnabled, "ColumnEnabled");
+            this.ColumnEnabled.Name = "ColumnEnabled";
+            this.ColumnEnabled.ReadOnly = true;
+            // 
+            // Description
+            // 
+            resources.ApplyResources(this.Description, "Description");
+            this.Description.Name = "Description";
+            this.Description.ReadOnly = true;
+            // 
+            // ColumnColour
+            // 
+            this.ColumnColour.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            resources.ApplyResources(this.ColumnColour, "ColumnColour");
+            this.ColumnColour.Name = "ColumnColour";
+            this.ColumnColour.ReadOnly = true;
+            this.ColumnColour.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.ColumnColour.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
             // GraphDetailsDialog
             // 
             this.AcceptButton = this.SaveButton;
@@ -325,6 +333,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnName;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnType;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnEnabled;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnColour;
     }
 }

--- a/XenAdmin/Dialogs/GraphDetailsDialog.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.cs
@@ -402,6 +402,7 @@ namespace XenAdmin.Dialogs
             private readonly DataGridViewTextBoxCell _datasourceCell = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _typeCell = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _enabledCell = new DataGridViewTextBoxCell();
+            private readonly DataGridViewTextBoxCell _nameDescription = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _colourCell = new DataGridViewTextBoxCell();
 
             public DataSourceGridViewRow(DataSourceItem dataSourceItem, bool displayOnGraph)
@@ -412,8 +413,10 @@ namespace XenAdmin.Dialogs
                 _datasourceCell.Value = Dsi.ToString();
                 _typeCell.Value = Dsi.Category.ToStringI18N();
                 _enabledCell.Value = Dsi.Enabled.ToYesNoStringI18n();
+                _nameDescription.Value = Dsi.DataSource.name_description;
                 _colourCell.Value = Dsi.Color;
-                Cells.AddRange(_checkBoxCell, _datasourceCell, _typeCell, _enabledCell, _colourCell);
+
+                Cells.AddRange(_checkBoxCell, _datasourceCell, _typeCell, _enabledCell, _nameDescription, _colourCell);
 
                 if (Dsi.Hidden)
                     base.DefaultCellStyle = new DataGridViewCellStyle

--- a/XenAdmin/Dialogs/GraphDetailsDialog.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.cs
@@ -399,9 +399,9 @@ namespace XenAdmin.Dialogs
         {
             private readonly DataGridViewCheckBoxCell _checkBoxCell = new DataGridViewCheckBoxCell();
             private readonly DataGridViewTextBoxCell _dataSourceCell = new DataGridViewTextBoxCell();
+            private readonly DataGridViewTextBoxCell _nameDescription = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _typeCell = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _enabledCell = new DataGridViewTextBoxCell();
-            private readonly DataGridViewTextBoxCell _nameDescription = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _colorCell = new DataGridViewTextBoxCell();
 
             public DataSourceGridViewRow(DataSourceItem dataSourceItem, bool displayOnGraph)
@@ -410,12 +410,12 @@ namespace XenAdmin.Dialogs
 
                 _checkBoxCell.Value = displayOnGraph;
                 _dataSourceCell.Value = Dsi.ToString();
+                _nameDescription.Value = Dsi.DataSource.name_description;
                 _typeCell.Value = Dsi.Category.ToStringI18N();
                 _enabledCell.Value = Dsi.Enabled.ToYesNoStringI18n();
-                _nameDescription.Value = Dsi.DataSource.name_description;
                 _colorCell.Value = Dsi.Color;
 
-                Cells.AddRange(_checkBoxCell, _dataSourceCell, _typeCell, _enabledCell, _nameDescription, _colorCell);
+                Cells.AddRange(_checkBoxCell, _dataSourceCell, _nameDescription, _typeCell, _enabledCell, _colorCell);
 
                 if (Dsi.Hidden)
                     DefaultCellStyle = new DataGridViewCellStyle

--- a/XenAdmin/Dialogs/GraphDetailsDialog.cs
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.cs
@@ -40,16 +40,15 @@ using XenAdmin.Controls.CustomDataGraph;
 using XenAdmin.Core;
 using XenCenterLib;
 
-
 namespace XenAdmin.Dialogs
 {
     public partial class GraphDetailsDialog : XenDialogBase
     {
-        private const int ColorSquareSize = 12;
+        private const int COLOR_SQUARE_SIZE = 12;
 
-        private readonly DesignedGraph designedGraph;
-        private readonly GraphList graphList;
-        private readonly bool isNew;
+        private readonly DesignedGraph _designedGraph;
+        private readonly GraphList _graphList;
+        private readonly bool _isNew;
         private bool _updating;
         private List<DataSourceItem> _dataSourceItems = new List<DataSourceItem>();
 
@@ -59,53 +58,41 @@ namespace XenAdmin.Dialogs
             InitializeComponent();
             tableLayoutPanel1.Visible = false;
 
-            this.graphList = graphList;
+            _graphList = graphList;
 
             if (designedGraph == null)
             {
-                isNew = true;
-                this.designedGraph = new DesignedGraph();
-                // Generate an unique suggested name for the graph
-                this.designedGraph.DisplayName = Helpers.MakeUniqueName(Messages.GRAPH_NAME, graphList.DisplayNames);
+                _isNew = true;
+                _designedGraph = new DesignedGraph
+                {
+                    // Generate an unique suggested name for the graph
+                    DisplayName = Helpers.MakeUniqueName(Messages.GRAPH_NAME, graphList.DisplayNames)
+                };
                 base.Text = Messages.GRAPHS_NEW_TITLE;
             }
             else
             {
-                this.designedGraph = new DesignedGraph(designedGraph);
-                base.Text = string.Format(Messages.GRAPHS_EDIT_TITLE, this.designedGraph.DisplayName);
+                _designedGraph = new DesignedGraph(designedGraph);
+                base.Text = string.Format(Messages.GRAPHS_EDIT_TITLE, _designedGraph.DisplayName);
             }
 
             ActiveControl = GraphNameTextBox;
-            GraphNameTextBox.Text = this.designedGraph.DisplayName;
+            GraphNameTextBox.Text = _designedGraph.DisplayName;
             EnableControlsAfterCheckChanged();
             EnableControlsAfterSelectionChanged();
         }
 
         private void LoadDataSources()
         {
-            if (graphList.XenObject == null)
+            if (_graphList.XenObject == null)
                 return;
 
             tableLayoutPanel1.Visible = true;
             searchTextBox.Enabled = false;
 
-            var action = new GetDataSourcesAction(graphList.XenObject);
+            var action = new GetDataSourcesAction(_graphList.XenObject);
             action.Completed += getDataSourcesAction_Completed;
             action.RunAsync();
-        }
-
-        private void getDataSourcesAction_Completed(ActionBase sender)
-        {
-            if (!(sender is GetDataSourcesAction action))
-                return;
-
-            Program.Invoke(this, () =>
-            {
-                tableLayoutPanel1.Visible = false;
-                _dataSourceItems = DataSourceItemList.BuildList(action.XenObject, action.DataSources);
-                PopulateDataGridView();
-                searchTextBox.Enabled = true;
-            });
         }
 
         private void PopulateDataGridView()
@@ -118,7 +105,7 @@ namespace XenAdmin.Dialogs
 
                 var rowList = new List<DataSourceGridViewRow>();
 
-                foreach (DataSourceItem dataSourceItem in _dataSourceItems)
+                foreach (var dataSourceItem in _dataSourceItems)
                 {
                     if (!toolStripMenuItemHidden.Checked && dataSourceItem.Hidden)
                         continue;
@@ -129,7 +116,7 @@ namespace XenAdmin.Dialogs
                     if (!searchTextBox.Matches(dataSourceItem.ToString()))
                         continue;
 
-                    bool displayOnGraph = designedGraph.DataSourceItems.Contains(dataSourceItem);
+                    var displayOnGraph = _designedGraph.DataSourceItems.Contains(dataSourceItem);
                     rowList.Add(new DataSourceGridViewRow(dataSourceItem, displayOnGraph));
                 }
 
@@ -151,7 +138,7 @@ namespace XenAdmin.Dialogs
 
         private void EnableControlsAfterCheckChanged()
         {
-            int checkedRowCount = dataGridView.Rows.Cast<DataSourceGridViewRow>().Count(row => row.IsChecked);
+            var checkedRowCount = dataGridView.Rows.Cast<DataSourceGridViewRow>().Count(row => row.IsChecked);
             buttonClearAll.Enabled = checkedRowCount > 0;
             SaveButton.Enabled = checkedRowCount > 0;
         }
@@ -175,7 +162,7 @@ namespace XenAdmin.Dialogs
                         continue;
 
                     dsRow.ClearCheck();
-                    designedGraph.DataSourceItems.Remove(dsRow.Dsi);
+                    _designedGraph.DataSourceItems.Remove(dsRow.Dsi);
                 }
             }
             finally
@@ -184,9 +171,9 @@ namespace XenAdmin.Dialogs
             }
         }
 
-        private void EnableDatasource()
+        private void EnableDataSource()
         {
-            if (graphList.XenObject?.Connection == null || dataGridView.SelectedRows.Count != 1)
+            if (_graphList.XenObject?.Connection == null || dataGridView.SelectedRows.Count != 1)
                 return;
 
             if (!(dataGridView.SelectedRows[0] is DataSourceGridViewRow row))
@@ -197,7 +184,7 @@ namespace XenAdmin.Dialogs
                 return;
 
             buttonEnable.Enabled = false;
-            var action = new EnableDataSourceAction(graphList.XenObject, dataSource, row.Dsi.ToString());
+            var action = new EnableDataSourceAction(_graphList.XenObject, dataSource, row.Dsi.ToString());
 
             using (var dialog = new ActionProgressDialog(action, ProgressBarStyle.Marquee)
             {
@@ -220,18 +207,32 @@ namespace XenAdmin.Dialogs
 
         #region Event handlers
 
+        private void getDataSourcesAction_Completed(ActionBase sender)
+        {
+            if (!(sender is GetDataSourcesAction action))
+                return;
+
+            Program.Invoke(this, () =>
+            {
+                tableLayoutPanel1.Visible = false;
+                _dataSourceItems = DataSourceItemList.BuildList(action.XenObject, action.DataSources);
+                PopulateDataGridView();
+                searchTextBox.Enabled = true;
+            });
+        }
+
         private void datasourcesGridView_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)
         {
             if (e.ColumnIndex == ColumnColour.Index && 0 <= e.RowIndex && e.RowIndex <= dataGridView.RowCount -1)
             {   
-                Rectangle rect = dataGridView.GetCellDisplayRectangle(e.ColumnIndex, e.RowIndex, true);
+                var rect = dataGridView.GetCellDisplayRectangle(e.ColumnIndex, e.RowIndex, true);
                 e.PaintBackground(rect, true);
 
                 rect.X += 3;
                 rect.Y += 5;
                 
-                rect.Width = ColorSquareSize;
-                rect.Height = ColorSquareSize;
+                rect.Width = COLOR_SQUARE_SIZE;
+                rect.Height = COLOR_SQUARE_SIZE;
 
                 using (var brush = new SolidBrush((Color)e.Value))
                     e.Graphics.FillRectangle(brush, rect);
@@ -250,8 +251,7 @@ namespace XenAdmin.Dialogs
             if (e.RowIndex < 0 || e.RowIndex > dataGridView.RowCount - 1)
                 return;
 
-            var row = dataGridView.Rows[e.RowIndex] as DataSourceGridViewRow;
-            if (row == null)
+            if (!(dataGridView.Rows[e.RowIndex] is DataSourceGridViewRow row))
                 return;
 
             if (e.ColumnIndex == ColumnDisplayOnGraph.Index)
@@ -259,12 +259,12 @@ namespace XenAdmin.Dialogs
                 if (row.IsChecked)
                 {
                     row.ClearCheck();
-                    designedGraph.DataSourceItems.Remove(row.Dsi);
+                    _designedGraph.DataSourceItems.Remove(row.Dsi);
                 }
                 else
                 {
                     row.Check();
-                    designedGraph.DataSourceItems.Add(row.Dsi);
+                    _designedGraph.DataSourceItems.Add(row.Dsi);
                 }
 
                 EnableControlsAfterCheckChanged();
@@ -273,7 +273,7 @@ namespace XenAdmin.Dialogs
             {
                 using (var cd = new ColorDialog
                 {
-                    Color = row.Colour,
+                    Color = row.Color,
                     AllowFullOpen = true,
                     AnyColor = true,
                     FullOpen = true,
@@ -281,7 +281,7 @@ namespace XenAdmin.Dialogs
                 })
                 {
                     if (cd.ShowDialog() == DialogResult.OK)
-                        row.Colour = cd.Color;
+                        row.Color = cd.Color;
                 }
             }
         }
@@ -362,21 +362,20 @@ namespace XenAdmin.Dialogs
         
         private void buttonEnable_Click(object sender, EventArgs e)
         {
-            EnableDatasource();
+            EnableDataSource();
         }
-
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            if (graphList.XenObject == null)
+            if (_graphList.XenObject == null)
                 return;
 
-            designedGraph.DisplayName = GraphNameTextBox.Text;
+            _designedGraph.DisplayName = GraphNameTextBox.Text;
             
-            if (isNew)
-                graphList.AddGraph(designedGraph);
+            if (_isNew)
+                _graphList.AddGraph(_designedGraph);
             else
-                graphList.ReplaceGraphAt(graphList.SelectedGraphIndex, designedGraph);
+                _graphList.ReplaceGraphAt(_graphList.SelectedGraphIndex, _designedGraph);
 
             var dataSourceItems = new List<DataSourceItem>();
             foreach (DataGridViewRow row in dataGridView.Rows)
@@ -385,10 +384,10 @@ namespace XenAdmin.Dialogs
                     continue;
 
                 if (dsRow.Dsi.ColorChanged)
-                    Palette.SetCustomColor(Palette.GetUuid(dsRow.Dsi.DataSource.name_label, graphList.XenObject), dsRow.Dsi.Color);
+                    Palette.SetCustomColor(Palette.GetUuid(dsRow.Dsi.DataSource.name_label, _graphList.XenObject), dsRow.Dsi.Color);
                 dataSourceItems.Add(dsRow.Dsi);
             }
-            graphList.SaveGraphs(dataSourceItems);
+            _graphList.SaveGraphs(dataSourceItems);
         }
 
         #endregion
@@ -396,30 +395,30 @@ namespace XenAdmin.Dialogs
 
         #region Nested classes
 
-        private class DataSourceGridViewRow : DataGridViewRow
+        private sealed class DataSourceGridViewRow : DataGridViewRow
         {
             private readonly DataGridViewCheckBoxCell _checkBoxCell = new DataGridViewCheckBoxCell();
-            private readonly DataGridViewTextBoxCell _datasourceCell = new DataGridViewTextBoxCell();
+            private readonly DataGridViewTextBoxCell _dataSourceCell = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _typeCell = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _enabledCell = new DataGridViewTextBoxCell();
             private readonly DataGridViewTextBoxCell _nameDescription = new DataGridViewTextBoxCell();
-            private readonly DataGridViewTextBoxCell _colourCell = new DataGridViewTextBoxCell();
+            private readonly DataGridViewTextBoxCell _colorCell = new DataGridViewTextBoxCell();
 
             public DataSourceGridViewRow(DataSourceItem dataSourceItem, bool displayOnGraph)
             {
                 Dsi = dataSourceItem;
 
                 _checkBoxCell.Value = displayOnGraph;
-                _datasourceCell.Value = Dsi.ToString();
+                _dataSourceCell.Value = Dsi.ToString();
                 _typeCell.Value = Dsi.Category.ToStringI18N();
                 _enabledCell.Value = Dsi.Enabled.ToYesNoStringI18n();
                 _nameDescription.Value = Dsi.DataSource.name_description;
-                _colourCell.Value = Dsi.Color;
+                _colorCell.Value = Dsi.Color;
 
-                Cells.AddRange(_checkBoxCell, _datasourceCell, _typeCell, _enabledCell, _nameDescription, _colourCell);
+                Cells.AddRange(_checkBoxCell, _dataSourceCell, _typeCell, _enabledCell, _nameDescription, _colorCell);
 
                 if (Dsi.Hidden)
-                    base.DefaultCellStyle = new DataGridViewCellStyle
+                    DefaultCellStyle = new DataGridViewCellStyle
                     {
                         ForeColor = SystemColors.GrayText,
                         SelectionForeColor = SystemColors.GrayText,
@@ -429,14 +428,14 @@ namespace XenAdmin.Dialogs
 
             internal DataSourceItem Dsi { get; }
 
-            internal Color Colour
+            internal Color Color
             {
-                get => (Color)_colourCell.Value;
+                get => (Color)_colorCell.Value;
                 set
                 {
                     Dsi.ColorChanged = Dsi.Color != value;
                     Dsi.Color = value;
-                    _colourCell.Value = value;
+                    _colorCell.Value = value;
                 }
             }
 
@@ -471,14 +470,13 @@ namespace XenAdmin.Dialogs
                 if (index == _checkBoxCell.ColumnIndex)
                     return -IsChecked.CompareTo(other.IsChecked);
 
-                if (_checkBoxCell.ColumnIndex < index && index < _colourCell.ColumnIndex)
+                if (_checkBoxCell.ColumnIndex < index && index < _colorCell.ColumnIndex)
                     return StringUtility.NaturalCompare(Cells[index].Value.ToString(),
                         other.Cells[index].Value.ToString());
 
                 return 0;
             }
         }
-
 
         #endregion
     }

--- a/XenAdmin/Dialogs/GraphDetailsDialog.resx
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.resx
@@ -169,7 +169,7 @@
     <value>NoControl</value>
   </data>
   <data name="SaveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>345, 433</value>
+    <value>496, 433</value>
   </data>
   <data name="SaveButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -208,7 +208,7 @@
     <value>NoControl</value>
   </data>
   <data name="CloseButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>426, 433</value>
+    <value>577, 433</value>
   </data>
   <data name="CloseButton.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -244,7 +244,7 @@
     <value>51, 3</value>
   </data>
   <data name="GraphNameTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 23</value>
+    <value>601, 23</value>
   </data>
   <data name="GraphNameTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -337,7 +337,7 @@
     <value>3, 3, 3, 6</value>
   </data>
   <data name="dataGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>498, 290</value>
+    <value>649, 290</value>
   </data>
   <data name="dataGridView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -442,7 +442,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 121</value>
+    <value>235, 121</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
@@ -490,7 +490,7 @@
     <value>3, 0, 3, 15</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>498, 15</value>
+    <value>649, 15</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -535,7 +535,7 @@
     <value>1</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>504, 29</value>
+    <value>655, 29</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -565,7 +565,7 @@
     <value>3, 107</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>498, 290</value>
+    <value>649, 290</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -703,7 +703,7 @@
     <value>6</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>504, 461</value>
+    <value>655, 461</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -730,7 +730,7 @@
     <value>3, 72</value>
   </data>
   <data name="searchTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>498, 29</value>
+    <value>649, 29</value>
   </data>
   <data name="searchTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -757,7 +757,7 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>524, 481</value>
+    <value>675, 481</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/XenAdmin/Dialogs/GraphDetailsDialog.resx
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.resx
@@ -282,6 +282,15 @@
   <data name="ColumnName.MinimumWidth" type="System.Int32, mscorlib">
     <value>100</value>
   </data>
+  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="Description.HeaderText" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Description.MinimumWidth" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
   <metadata name="ColumnType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -302,15 +311,6 @@
   </data>
   <data name="ColumnEnabled.Width" type="System.Int32, mscorlib">
     <value>74</value>
-  </data>
-  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="Description.HeaderText" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="Description.Width" type="System.Int32, mscorlib">
-    <value>92</value>
   </data>
   <metadata name="ColumnColour.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -798,6 +798,12 @@
   <data name="&gt;&gt;ColumnName.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;Description.Name" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="&gt;&gt;Description.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;ColumnType.Name" xml:space="preserve">
     <value>ColumnType</value>
   </data>
@@ -808,12 +814,6 @@
     <value>ColumnEnabled</value>
   </data>
   <data name="&gt;&gt;ColumnEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Description.Name" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="&gt;&gt;Description.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ColumnColour.Name" xml:space="preserve">

--- a/XenAdmin/Dialogs/GraphDetailsDialog.resx
+++ b/XenAdmin/Dialogs/GraphDetailsDialog.resx
@@ -303,6 +303,15 @@
   <data name="ColumnEnabled.Width" type="System.Int32, mscorlib">
     <value>74</value>
   </data>
+  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="Description.HeaderText" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Description.Width" type="System.Int32, mscorlib">
+    <value>92</value>
+  </data>
   <metadata name="ColumnColour.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -765,6 +774,18 @@
   <data name="$this.Text" xml:space="preserve">
     <value>Graph Details</value>
   </data>
+  <data name="&gt;&gt;toolStripMenuItemHidden.Name" xml:space="preserve">
+    <value>toolStripMenuItemHidden</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemHidden.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemDisabled.Name" xml:space="preserve">
+    <value>toolStripMenuItemDisabled</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItemDisabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;ColumnDisplayOnGraph.Name" xml:space="preserve">
     <value>ColumnDisplayOnGraph</value>
   </data>
@@ -789,23 +810,17 @@
   <data name="&gt;&gt;ColumnEnabled.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;Description.Name" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="&gt;&gt;Description.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;ColumnColour.Name" xml:space="preserve">
     <value>ColumnColour</value>
   </data>
   <data name="&gt;&gt;ColumnColour.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItemHidden.Name" xml:space="preserve">
-    <value>toolStripMenuItemHidden</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItemHidden.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItemDisabled.Name" xml:space="preserve">
-    <value>toolStripMenuItemDisabled</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItemDisabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>GraphDetailsDialog</value>

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class FriendlyNames {
@@ -2455,7 +2455,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Number of open file descriptors.
+        ///   Looks up a localized string similar to Agent open file descriptors.
         /// </summary>
         public static string Label_performance_xapi_open_fds {
             get {

--- a/XenModel/FriendlyNames.ja.resx
+++ b/XenModel/FriendlyNames.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element msdata:IsDataSet="true" name="root">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" name="value" type="xsd:string" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
-                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string" />
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string" />
               </xsd:sequence>
-              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
-              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
-              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required" />
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string" />
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -936,9 +936,6 @@
   <data name="Label-performance.xenbr_tx_errors" xml:space="preserve">
     <value>{0} 送信エラー</value>
   </data>
-  <data name="Label-pool.ha_enabled" xml:space="preserve">
-    <value>プールの高可用性が有効</value>
-  </data>
   <data name="Label-Pool_patch.applied" xml:space="preserve">
     <value>適用済み</value>
   </data>
@@ -953,6 +950,9 @@
   </data>
   <data name="Label-Pool_patch.required-updates" xml:space="preserve">
     <value>必要なアップデート</value>
+  </data>
+  <data name="Label-pool.ha_enabled" xml:space="preserve">
+    <value>プールの高可用性が有効</value>
   </data>
   <data name="Label-pvsaccelerator" xml:space="preserve">
     <value>PVS アクセラレータ</value>

--- a/XenModel/FriendlyNames.ja.resx
+++ b/XenModel/FriendlyNames.ja.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -936,6 +936,9 @@
   <data name="Label-performance.xenbr_tx_errors" xml:space="preserve">
     <value>{0} 送信エラー</value>
   </data>
+  <data name="Label-pool.ha_enabled" xml:space="preserve">
+    <value>プールの高可用性が有効</value>
+  </data>
   <data name="Label-Pool_patch.applied" xml:space="preserve">
     <value>適用済み</value>
   </data>
@@ -950,9 +953,6 @@
   </data>
   <data name="Label-Pool_patch.required-updates" xml:space="preserve">
     <value>必要なアップデート</value>
-  </data>
-  <data name="Label-pool.ha_enabled" xml:space="preserve">
-    <value>プールの高可用性が有効</value>
   </data>
   <data name="Label-pvsaccelerator" xml:space="preserve">
     <value>PVS アクセラレータ</value>

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -942,6 +942,9 @@
   <data name="Label-performance.xenbr_tx_errors" xml:space="preserve">
     <value>{0} Send Errors</value>
   </data>
+  <data name="Label-pool.ha_enabled" xml:space="preserve">
+    <value>Pool HA enabled</value>
+  </data>
   <data name="Label-Pool_patch.applied" xml:space="preserve">
     <value>Applied</value>
   </data>
@@ -956,9 +959,6 @@
   </data>
   <data name="Label-Pool_patch.required-updates" xml:space="preserve">
     <value>Required Updates</value>
-  </data>
-  <data name="Label-pool.ha_enabled" xml:space="preserve">
-    <value>Pool HA enabled</value>
   </data>
   <data name="Label-pvsaccelerator" xml:space="preserve">
     <value>PVS-Accelerator</value>

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -916,7 +916,7 @@
     <value>Agent Memory Usage</value>
   </data>
   <data name="Label-performance.xapi_open_fds" xml:space="preserve">
-    <value>Number of open file descriptors</value>
+    <value>Agent open file descriptors</value>
   </data>
   <data name="Label-performance.xapi_rx" xml:space="preserve">
     <value>&lt;Internal&gt; Network {0} Receive</value>
@@ -942,9 +942,6 @@
   <data name="Label-performance.xenbr_tx_errors" xml:space="preserve">
     <value>{0} Send Errors</value>
   </data>
-  <data name="Label-pool.ha_enabled" xml:space="preserve">
-    <value>Pool HA enabled</value>
-  </data>
   <data name="Label-Pool_patch.applied" xml:space="preserve">
     <value>Applied</value>
   </data>
@@ -959,6 +956,9 @@
   </data>
   <data name="Label-Pool_patch.required-updates" xml:space="preserve">
     <value>Required Updates</value>
+  </data>
+  <data name="Label-pool.ha_enabled" xml:space="preserve">
+    <value>Pool HA enabled</value>
   </data>
   <data name="Label-pvsaccelerator" xml:space="preserve">
     <value>PVS-Accelerator</value>

--- a/XenModel/FriendlyNames.zh-CN.resx
+++ b/XenModel/FriendlyNames.zh-CN.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element msdata:IsDataSet="true" name="root">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" name="value" type="xsd:string" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
-                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string" />
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string" />
               </xsd:sequence>
-              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
-              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
-              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required" />
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string" />
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -936,9 +936,6 @@
   <data name="Label-performance.xenbr_tx_errors" xml:space="preserve">
     <value>{0} 发送错误</value>
   </data>
-  <data name="Label-pool.ha_enabled" xml:space="preserve">
-    <value>池高可用性已启用</value>
-  </data>
   <data name="Label-Pool_patch.applied" xml:space="preserve">
     <value>已应用</value>
   </data>
@@ -953,6 +950,9 @@
   </data>
   <data name="Label-Pool_patch.required-updates" xml:space="preserve">
     <value>必需的更新</value>
+  </data>
+  <data name="Label-pool.ha_enabled" xml:space="preserve">
+    <value>池高可用性已启用</value>
   </data>
   <data name="Label-pvsaccelerator" xml:space="preserve">
     <value>PVS 加速器</value>

--- a/XenModel/FriendlyNames.zh-CN.resx
+++ b/XenModel/FriendlyNames.zh-CN.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -936,6 +936,9 @@
   <data name="Label-performance.xenbr_tx_errors" xml:space="preserve">
     <value>{0} 发送错误</value>
   </data>
+  <data name="Label-pool.ha_enabled" xml:space="preserve">
+    <value>池高可用性已启用</value>
+  </data>
   <data name="Label-Pool_patch.applied" xml:space="preserve">
     <value>已应用</value>
   </data>
@@ -950,9 +953,6 @@
   </data>
   <data name="Label-Pool_patch.required-updates" xml:space="preserve">
     <value>必需的更新</value>
-  </data>
-  <data name="Label-pool.ha_enabled" xml:space="preserve">
-    <value>池高可用性已启用</value>
   </data>
   <data name="Label-pvsaccelerator" xml:space="preserve">
     <value>PVS 加速器</value>


### PR DESCRIPTION
- Expose some hidden data sources to UI 
- Update friendly name for xapi_open_fds data source
    - Also apply string sorting
- Add data source description as column in GraphDetailsDialog
- Increase default GraphDetailsDialog width to accomodate new column

Also:

Tidy up source in GraphDetailsDialog
- Rename fields
- Reorder methods
- Rename methods
- Add `sealed` to `DataSourceGridViewRow`


_________________

This PR also fixes #3080 