### PR TITLE
CA-375282: Insert sanitised TARs into Temp folder

### DIFF
--- a/XenModel/Actions/ZipStatusReportAction.cs
+++ b/XenModel/Actions/ZipStatusReportAction.cs
@@ -100,7 +100,7 @@ namespace XenAdmin.Actions
                             outFilename = Path.GetRandomFileName();
                         string outputDir = Path.Combine(_extractTempDir, Path.GetFileName(outFilename));
 
-                        string sanitizedTar = Path.GetRandomFileName();
+                        string sanitizedTar = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                         TarSanitization.SanitizeTarForWindows(inputFile, sanitizedTar, CheckCancellation);
 
                         using (FileStream fs = File.OpenRead(sanitizedTar))


### PR DESCRIPTION
Regression introduced on line [103](https://github.com/xenserver/xenadmin/blob/master/XenModel/Actions/ZipStatusReportAction.cs#L103) as part of #3087. Built application was trying to insert file in the installation directory, for which it had no permission.