### PR TITLE
CA-375346: Point to Wix Shell instead of executable when launching XenCenter

### DIFF
--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -274,11 +274,11 @@
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.XenCenter_Launch) $(var.BrandConsole)" />
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
         <Property Id="WixShellExecTarget" Value="[#XenCenterEXE]" />
-        <CustomAction Id="LaunchApplication" 
-            FileKey="XenCenterEXE"
-            ExeCommand="/X"  
+        <CustomAction Id="LaunchApplication"
+            BinaryKey="WixCA"
+            DllEntry="WixShellExec"
             Impersonate="yes"
-            Return="asyncNoWait" />
+        />
         <Icon Id="XenCenterICO" SourceFile="$(env.RepoRoot)\Branding\Images\AppIcon.ico" />
     </Product>
 </Wix>


### PR DESCRIPTION
FYI: While reviewing, you can use the example used in the ticket to check if the MSI has the correct permissions, since this branch doesn't contain 39b84bbcc5bfa282e0baf2deb73e07b2f076936e.

_________________

The XenCenter executable was started with elevated privileges even with use of `Impersonate = "yes"`, and `WixShellExecTarget` was actually ignored.


What helped debug the issue was the [wix 3 docs](https://wixtoolset.org/docs/v3/howtos/ui_and_localization/run_program_after_install/#step-3-include-the-custom-action), which point to the use of the `WixCA:WixShellExec` function, with the executable being its target.

> "Why did XenCenter.exe run under elevated privileges even if `Impersonate` was set to `"yes"`"

I do not know. The [`CustomAction` docs](https://wixtoolset.org/docs/v3/xsd/wix/customaction/) seem to suggest this should be a valid way to run an executable with user level privileges:


Name | Type | Description | Required
-- | -- | -- | --
Impersonate | YesNoType | This attribute specifies whether the  Windows Installer, which executes as LocalSystem,                                  should impersonate the user context of the installing user  when executing this custom action.                                  Typically the value should be 'yes', except when the custom action needs  elevated privileges                                 to apply changes to  the machine. |

Clearly that was not the case. I'm not sure if that's expected when pointing to executables rather than functions in specific DLLs, which was the case here. Either way, this seems to do the job.

> "Can we keep `Return="asyncNoWait"`?"

Even though the docs mention it, the following error is shown when the value is set:

```
error CNDL0038 : The CustomAction/@Return attribute's value, 'asyncNoWait', cannot be specified without attribute ExeCommand present.
```