### PR TITLE
(LCM) CA-375173: Create the VDI and VBD records before closing the new disk dialog

### DIFF
--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -180,6 +180,25 @@ namespace XenAdmin.Controls
                 _refreshQueue.Add(scanAction);
             }
             AddNode(item);
+
+            if (!item.Scanning)
+            {
+                if (_preselectedSr != null)
+                {
+                    if (item.TheSR.opaque_ref == _preselectedSr.opaque_ref)
+                        SelectedItem = item;
+                }
+                else if (_defaultSr != null)
+                {
+                    if (item.TheSR.opaque_ref == _defaultSr.opaque_ref)
+                        SelectedItem = item;
+                }
+                else if (SelectedItem == null)
+                {
+                    SelectedItem = item;
+                }
+            }
+
             OnCanBeScannedChanged();
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
@@ -379,7 +379,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 if (dialog.ShowDialog() != DialogResult.OK)
                     return;
 
-                DisksGridView.Rows.Add(new DiskGridRowItem(Connection, dialog.NewDisk(), dialog.NewDevice(), DiskSource.New));
+                DisksGridView.Rows.Add(new DiskGridRowItem(Connection, dialog.Disk, dialog.Device, DiskSource.New));
                 UpdateStatusForEachDisk();
                 UpdateEnablement();
             }
@@ -409,7 +409,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 if (dialog.ShowDialog(ParentForm) != DialogResult.OK)
                     return;
 
-                selectedItem.Disk = dialog.NewDisk();
+                selectedItem.Disk = dialog.Disk;
                 selectedItem.UpdateDetails();
                 UpdateStatusForEachDisk();
                 UpdateEnablement();


### PR DESCRIPTION
Also fixed issue where the SR was not preselected when editing an existing disk and no scans were taking place.