### PR TITLE
CA-375668: Report bytes uncompressed instead of percentage when uncompressing a gzip.

### DIFF
--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -21031,7 +21031,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uncompressing file {0}, please wait....
+        ///   Looks up a localized string similar to Uncompressing file {0} ({1} done)....
         /// </summary>
         public static string IMPORT_WIZARD_UNCOMPRESSING {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7337,7 +7337,7 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Select the storage repository for the imported template.</value>
   </data>
   <data name="IMPORT_WIZARD_UNCOMPRESSING" xml:space="preserve">
-    <value>Uncompressing file {0}, please wait...</value>
+    <value>Uncompressing file {0} ({1} done)...</value>
   </data>
   <data name="IMPORT_WIZARD_VM_SELECTION_INTRODUCTION" xml:space="preserve">
     <value>&amp;Virtual network interfaces in imported VMs:</value>


### PR DESCRIPTION
The original code was crashing because we switched to .NET framework's compression classes and GZipStream is a bit basic and does not support Position.

I tried to find an alternative method of reporting progress, however, I could not see a reliable way of knowing the uncompressed file size, particularly for the huge gzips handled by the application. The compression ratio depends on the data being compressed and the method and library that was used, which are generally unknown. One solution I thought of was to try to approximate the progress by assuming a compression ratio between 2:1 and 5:1 (typically offered by zlib), but in the end I thought best to just display bytes uncompressed without showing percentage. Let me know what you think.