### PR TITLE
Reordered templates on the NewVM wizard:

### DIFF
--- a/XenAdmin/Wizards/NewVMWizard/Page_Template.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Template.cs
@@ -161,7 +161,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             TemplatesGridView.ResumeLayout();
             RowsChanged();
 
-            TemplatesGridView.Sort(new Sorter());
+            TemplatesGridView.Sort(new TemplateSorter());
         }
 
         private void RefreshRows()
@@ -232,7 +232,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
         }
 
-        private class Sorter : IComparer
+        private class TemplateSorter : IComparer
         {
             public int Compare(object x, object y)
             {
@@ -249,8 +249,9 @@ namespace XenAdmin.Wizards.NewVMWizard
                 int result = xItem.SortOrder - yItem.SortOrder;
                 if (result != 0)
                     return result;
-                
-                result = StringUtility.NaturalCompare(xItem.Template.Name(), yItem.Template.Name());
+
+                //reverse alphabetical order so most recent version appears first
+                result = -StringUtility.NaturalCompare(xItem.Template.Name(), yItem.Template.Name());
                 if (result != 0)
                     return result;
                 
@@ -291,7 +292,10 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             switch (templateType)
             {
+                case VM.VmTemplateType.Custom:
+                    return Messages.NEWVMWIZARD_TEMPLATEPAGE_CUSTOM;
                 case VM.VmTemplateType.Windows:
+                case VM.VmTemplateType.WindowsServer:
                 case VM.VmTemplateType.LegacyWindows:
                     return Messages.NEWVMWIZARD_TEMPLATEPAGE_WINDOWS;
                 case VM.VmTemplateType.Centos:
@@ -344,6 +348,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                     return Images.StaticImages._000_UserTemplate_h32bit_16;
                 case VM.VmTemplateType.Windows:
                 case VM.VmTemplateType.LegacyWindows:
+                case VM.VmTemplateType.WindowsServer:
                     return Images.StaticImages.windows_h32bit_16;
                 case VM.VmTemplateType.Centos:
                     return Images.StaticImages.centos_16x;

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -842,28 +842,29 @@ namespace XenAPI
             NoTemplate = 0,//it's not a template
             Custom = 1,
             Windows = 2,
-            LegacyWindows = 3,
-            Asianux  = 4,
-            Centos = 5,
-            CoreOS = 6,
-            Debian = 7,
-            Gooroom = 8,
-            Linx = 9,
-            NeoKylin = 10,
-            Oracle = 11,
-            RedHat = 12,
-            Rocky = 13,
-            SciLinux = 14,
-            Suse = 15,
-            Turbo = 16,
-            Ubuntu = 17,
-            YinheKylin = 18,
-            Citrix = 19,
-            Solaris = 20,
-            Misc = 21,
-            Snapshot = 22,
-            SnapshotFromVmpp = 23,
-            Count = 24  //bump this if values are added
+            WindowsServer = 3,
+            LegacyWindows = 4,
+            Asianux  = 5,
+            Centos = 6,
+            CoreOS = 7,
+            Debian = 8,
+            Gooroom = 9,
+            Linx = 10,
+            NeoKylin = 11,
+            Oracle = 12,
+            RedHat = 13,
+            Rocky = 14,
+            SciLinux = 15,
+            Suse = 16,
+            Turbo = 17,
+            Ubuntu = 18,
+            YinheKylin = 19,
+            Citrix = 20,
+            Solaris = 21,
+            Misc = 22,
+            Snapshot = 23,
+            SnapshotFromVmpp = 24,
+            Count = 25  //bump this if values are added
         }
 
         public VmTemplateType TemplateType()
@@ -914,6 +915,9 @@ namespace XenAPI
 
             if (os.Contains("legacy windows"))
                 return VmTemplateType.LegacyWindows;
+
+            if (os.Contains("windows") && os.Contains("server"))
+                return VmTemplateType.WindowsServer;
 
             if (os.Contains("windows"))
                 return VmTemplateType.Windows;


### PR DESCRIPTION
- Moved Windows Server templates to a different category.
- Show templates in reverse alphabetical (typically release) order.