### PR TITLE
CA-375703: Remove leftover language mentions in `XenCenter.wxs`

### DIFF
--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -35,7 +35,7 @@
      xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
     <?include branding.wxi ?>
     <Product Id="$(var.ProductCode)" Name="$(var.BrandConsole)" Language="$(env.WixLangId)" Version="$(var.ProductVersion)" Manufacturer="$(var.CompanyNameLegal)" UpgradeCode="$(var.UpgradeCode)">
-        <Package Languages="1033,1041,2052,1028" Description="$(var.BrandConsole)" Comments="none." InstallerVersion="200" Compressed="yes" />
+        <Package Languages="1033" Description="$(var.BrandConsole)" Comments="none." InstallerVersion="200" Compressed="yes" />
         <Media Id="1" Cabinet="XenCenter.cab" EmbedCab="yes" />
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder">

--- a/scripts/xenadmin-build.sh
+++ b/scripts/xenadmin-build.sh
@@ -164,9 +164,6 @@ do
   cp ${WIX}/out${name}/${name}.msi ${WIX}
 done
 
-cd ${WIX} && cp ${BRANDING_BRAND_CONSOLE_NO_SPACE}.msi ${BRANDING_BRAND_CONSOLE_NO_SPACE}.zh-tw.msi
-cd ${WIX} && cscript CodePageChange.vbs ZH-TW ${BRANDING_BRAND_CONSOLE_NO_SPACE}.zh-tw.msi
-
 #copy and sign the combined installer
 
 if [ -f "${SIGN_BAT}" ] ; then


### PR DESCRIPTION
Tested with a Chinese (Simplified) W10 install and a Japanese one.