### PR TITLE
[master] CA-375556: Pass non-compressed file stream to `HTTP.CopyStream`

### DIFF
--- a/XenModel/Actions/OvfActions/Import.cs
+++ b/XenModel/Actions/OvfActions/Import.cs
@@ -330,7 +330,7 @@ namespace XenAdmin.Actions.OvfActions
                         return null;
                     }
 
-                    dataStream = File.OpenRead(filePath);
+                    dataStream = File.OpenRead(sourcefile);
                     dataLength = virtualSize = dataStream.Length;
                 }
                 else if (VirtualDisk.SupportedDiskFormats.Any(f => ext.ToLower().EndsWith(f.ToLower())))

--- a/XenModel/Actions/OvfActions/Import.cs
+++ b/XenModel/Actions/OvfActions/Import.cs
@@ -318,7 +318,7 @@ namespace XenAdmin.Actions.OvfActions
                 {
                     vhdDisk = VirtualDisk.OpenDisk(sourcefile, FileAccess.Read);
                     virtualSize = vhdDisk.Capacity;
-                    dataStream = File.OpenRead(filePath);
+                    dataStream = File.OpenRead(sourcefile);
                     dataLength = dataStream.Length;
                     format = "&format=vhd";
                 }


### PR DESCRIPTION
Looks like we had been passing compressed streams for a while. However, they were working before passing the `format` parameter to the `import_raw_vdi` call. My guess is that [`vhd-tool`](https://github.com/xapi-project/vhd-tool) is decompressing it, but I haven't gotten that far yet.

Either way, this solution seems to work for all VHDs (compressed or otherwise), and doesn't regress the fix that was introduced to ignore zero bytes when importing disks.