### PR TITLE
CA-375532, CA-336510, and CP-41825: Add warnings when user selects too many vCPUs

### DIFF
--- a/XenAdmin/Commands/VappStartCommand.cs
+++ b/XenAdmin/Commands/VappStartCommand.cs
@@ -87,8 +87,22 @@ namespace XenAdmin.Commands
                 appsToStart.Add(firstVm.Connection.Resolve(firstVm.appliance));
             }
 
+            if (appsToStart.Count == 0)
+            {
+                return;
+            }
+
+            var maxVCpusCount = appsToStart.First()
+                .Connection
+                .ResolveAll(appsToStart.SelectMany(app => app.VMs))
+                .Select(vm => vm.VCPUs_at_startup)
+                .Max();
+
             foreach (var app in appsToStart)
+            {
+                
                 (new StartApplianceAction(app, false)).RunAsync();
+            }
         }
 
         private bool CanStartAppliance(VM_appliance app)

--- a/XenAdmin/Commands/VappStartCommand.cs
+++ b/XenAdmin/Commands/VappStartCommand.cs
@@ -91,17 +91,10 @@ namespace XenAdmin.Commands
             {
                 return;
             }
-
-            var maxVCpusCount = appsToStart.First()
-                .Connection
-                .ResolveAll(appsToStart.SelectMany(app => app.VMs))
-                .Select(vm => vm.VCPUs_at_startup)
-                .Max();
-
+            
             foreach (var app in appsToStart)
             {
-                
-                (new StartApplianceAction(app, false)).RunAsync();
+                new StartApplianceAction(app, false).RunAsync();
             }
         }
 

--- a/XenAdmin/Commands/VappStartCommand.cs
+++ b/XenAdmin/Commands/VappStartCommand.cs
@@ -87,11 +87,6 @@ namespace XenAdmin.Commands
                 appsToStart.Add(firstVm.Connection.Resolve(firstVm.appliance));
             }
 
-            if (appsToStart.Count == 0)
-            {
-                return;
-            }
-            
             foreach (var app in appsToStart)
             {
                 new StartApplianceAction(app, false).RunAsync();

--- a/XenAdmin/Controls/Ballooning/MemorySpinner.cs
+++ b/XenAdmin/Controls/Ballooning/MemorySpinner.cs
@@ -47,20 +47,12 @@ namespace XenAdmin.Controls.Ballooning
             previousUnitsValue = Messages.VAL_GIGB;
         }
 
-        public void Initialize(double amount, double static_max, string units = null)
+        public void Initialize(double amount, double static_max)
         {
             amount = Util.CorrectRoundingErrors(amount);
 
+            Units = static_max <= Util.BINARY_GIGA ? Messages.VAL_MEGB : Messages.VAL_GIGB;
 
-            if (units != Messages.VAL_MEGB && units != Messages.VAL_GIGB)
-            {
-                Units = Units = static_max <= Util.BINARY_GIGA ? Messages.VAL_MEGB : Messages.VAL_GIGB;
-            }
-            else
-            {
-                Units = units;
-            }
-            
             ChangeSpinnerSettings();
             previousUnitsValue = Units;
             Initialize(amount, RoundingBehaviour.None);

--- a/XenAdmin/Controls/Ballooning/MemorySpinner.cs
+++ b/XenAdmin/Controls/Ballooning/MemorySpinner.cs
@@ -47,11 +47,20 @@ namespace XenAdmin.Controls.Ballooning
             previousUnitsValue = Messages.VAL_GIGB;
         }
 
-        public void Initialize(double amount, double static_max)
+        public void Initialize(double amount, double static_max, string units = null)
         {
             amount = Util.CorrectRoundingErrors(amount);
 
-            Units = static_max <= Util.BINARY_GIGA ? Messages.VAL_MEGB : Messages.VAL_GIGB;
+
+            if (units != Messages.VAL_MEGB && units != Messages.VAL_GIGB)
+            {
+                Units = Units = static_max <= Util.BINARY_GIGA ? Messages.VAL_MEGB : Messages.VAL_GIGB;
+            }
+            else
+            {
+                Units = units;
+            }
+            
             ChangeSpinnerSettings();
             previousUnitsValue = Units;
             Initialize(amount, RoundingBehaviour.None);

--- a/XenAdmin/Dialogs/PropertiesDialog.cs
+++ b/XenAdmin/Dialogs/PropertiesDialog.cs
@@ -49,7 +49,7 @@ namespace XenAdmin.Dialogs
     public partial class PropertiesDialog : VerticallyTabbedDialog
     {
         #region Tabs
-        private CPUMemoryEditPage VCpuMemoryEditPage;
+        private CpuMemoryEditPage VCpuMemoryEditPage;
         private HostMultipathPage hostMultipathPage1;
         private CustomFieldsDisplayPage CustomFieldsEditPage;
         private LogDestinationEditPage LogDestinationEditPage;
@@ -149,7 +149,7 @@ namespace XenAdmin.Dialogs
 
                 if (is_vm)
                 {
-                    ShowTab(VCpuMemoryEditPage = new CPUMemoryEditPage());
+                    ShowTab(VCpuMemoryEditPage = new CpuMemoryEditPage());
                     ShowTab(StartupOptionsEditPage = new BootOptionsEditPage());
                     VMHAEditPage = new VMHAEditPage();
                     VMHAEditPage.Populated += EditPage_Populated;

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -212,7 +212,7 @@ namespace XenAdmin.SettingsPanels
             this.lblVcpuWarning.LinkColor = System.Drawing.SystemColors.ActiveCaption;
             this.lblVcpuWarning.Name = "lblVcpuWarning";
             this.lblVcpuWarning.TabStop = true;
-            this.lblVcpuWarning.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lblVcpuWarning_LinkClicked);
+            this.lblVcpuWarning.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lblVCpuWarning_LinkClicked);
             // 
             // lblMemory
             // 

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -37,28 +37,27 @@ namespace XenAdmin.SettingsPanels
             this.warningsTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.cpuWarningPictureBox = new System.Windows.Forms.PictureBox();
             this.cpuWarningLabel = new System.Windows.Forms.Label();
-            this.memoryWarningLabel = new System.Windows.Forms.Label();
             this.topologyWarningLabel = new System.Windows.Forms.Label();
-            this.memoryPictureBox = new System.Windows.Forms.PictureBox();
             this.topologyPictureBox = new System.Windows.Forms.PictureBox();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
             this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
             this.labelTopology = new System.Windows.Forms.Label();
-            this.MemWarningLabel = new System.Windows.Forms.Label();
-            this.memorySpinner = new XenAdmin.Controls.Ballooning.MemorySpinner();
             this.panel1 = new System.Windows.Forms.Panel();
             this.transparentTrackBar1 = new XenAdmin.Controls.TransparentTrackBar();
             this.lblVCPUs = new System.Windows.Forms.Label();
-            this.lblMemory = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
+            this.tableLayoutPanelInfo = new System.Windows.Forms.TableLayoutPanel();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.labelInfo = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.warningsTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).BeginInit();
             this.panel1.SuspendLayout();
+            this.tableLayoutPanelInfo.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.SuspendLayout();
             // 
             // lblSliderHighest
@@ -79,37 +78,33 @@ namespace XenAdmin.SettingsPanels
             // lblPriority
             // 
             resources.ApplyResources(this.lblPriority, "lblPriority");
-            this.tableLayoutPanel1.SetColumnSpan(this.lblPriority, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.lblPriority, 3);
             this.lblPriority.Name = "lblPriority";
             // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.BackColor = System.Drawing.Color.Transparent;
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 12);
-            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.MemWarningLabel, 3, 10);
-            this.tableLayoutPanel1.Controls.Add(this.memorySpinner, 1, 10);
-            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 9);
-            this.tableLayoutPanel1.Controls.Add(this.lblPriority, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.lblPriority, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.lblVCPUs, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.lblMemory, 0, 10);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxVCPUs, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanelInfo, 0, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // warningsTableLayoutPanel
             // 
             resources.ApplyResources(this.warningsTableLayoutPanel, "warningsTableLayoutPanel");
-            this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 3);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningPictureBox, 0, 0);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningLabel, 1, 0);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 1);
             this.warningsTableLayoutPanel.Controls.Add(this.topologyWarningLabel, 0, 2);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 1);
             this.warningsTableLayoutPanel.Controls.Add(this.topologyPictureBox, 0, 2);
             this.warningsTableLayoutPanel.Name = "warningsTableLayoutPanel";
             // 
@@ -125,22 +120,10 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.cpuWarningLabel, "cpuWarningLabel");
             this.cpuWarningLabel.Name = "cpuWarningLabel";
             // 
-            // memoryWarningLabel
-            // 
-            resources.ApplyResources(this.memoryWarningLabel, "memoryWarningLabel");
-            this.memoryWarningLabel.Name = "memoryWarningLabel";
-            // 
             // topologyWarningLabel
             // 
             resources.ApplyResources(this.topologyWarningLabel, "topologyWarningLabel");
             this.topologyWarningLabel.Name = "topologyWarningLabel";
-            // 
-            // memoryPictureBox
-            // 
-            this.memoryPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
-            resources.ApplyResources(this.memoryPictureBox, "memoryPictureBox");
-            this.memoryPictureBox.Name = "memoryPictureBox";
-            this.memoryPictureBox.TabStop = false;
             // 
             // topologyPictureBox
             // 
@@ -164,7 +147,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // comboBoxTopology
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 2);
             this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
             this.comboBoxTopology.FormattingEnabled = true;
@@ -176,25 +159,10 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.labelTopology, "labelTopology");
             this.labelTopology.Name = "labelTopology";
             // 
-            // MemWarningLabel
-            // 
-            resources.ApplyResources(this.MemWarningLabel, "MemWarningLabel");
-            this.MemWarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.MemWarningLabel.Name = "MemWarningLabel";
-            this.tableLayoutPanel1.SetRowSpan(this.MemWarningLabel, 2);
-            // 
-            // memorySpinner
-            // 
-            resources.ApplyResources(this.memorySpinner, "memorySpinner");
-            this.tableLayoutPanel1.SetColumnSpan(this.memorySpinner, 2);
-            this.memorySpinner.Increment = 0.1D;
-            this.memorySpinner.Name = "memorySpinner";
-            this.memorySpinner.SpinnerValueChanged += new System.EventHandler(this.memorySpinner_SpinnerValueChanged);
-            // 
             // panel1
             // 
             resources.ApplyResources(this.panel1, "panel1");
-            this.tableLayoutPanel1.SetColumnSpan(this.panel1, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.panel1, 3);
             this.panel1.Controls.Add(this.lblSliderHighest);
             this.panel1.Controls.Add(this.lblSliderNormal);
             this.panel1.Controls.Add(this.lblSliderLowest);
@@ -213,15 +181,10 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.lblVCPUs, "lblVCPUs");
             this.lblVCPUs.Name = "lblVCPUs";
             // 
-            // lblMemory
-            // 
-            resources.ApplyResources(this.lblMemory, "lblMemory");
-            this.lblMemory.Name = "lblMemory";
-            // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
-            this.tableLayoutPanel1.SetColumnSpan(this.label1, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.label1, 3);
             this.label1.Name = "label1";
             // 
             // comboBoxVCPUs
@@ -231,6 +194,26 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.comboBoxVCPUs, "comboBoxVCPUs");
             this.comboBoxVCPUs.Name = "comboBoxVCPUs";
             this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxVCPUs_SelectedIndexChanged);
+            // 
+            // tableLayoutPanelInfo
+            // 
+            resources.ApplyResources(this.tableLayoutPanelInfo, "tableLayoutPanelInfo");
+            this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutPanelInfo, 3);
+            this.tableLayoutPanelInfo.Controls.Add(this.pictureBox1, 0, 0);
+            this.tableLayoutPanelInfo.Controls.Add(this.labelInfo, 1, 0);
+            this.tableLayoutPanelInfo.Name = "tableLayoutPanelInfo";
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
+            resources.ApplyResources(this.pictureBox1, "pictureBox1");
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.TabStop = false;
+            // 
+            // labelInfo
+            // 
+            resources.ApplyResources(this.labelInfo, "labelInfo");
+            this.labelInfo.Name = "labelInfo";
             // 
             // CpuMemoryEditPage
             // 
@@ -246,10 +229,12 @@ namespace XenAdmin.SettingsPanels
             this.warningsTableLayoutPanel.ResumeLayout(false);
             this.warningsTableLayoutPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
+            this.tableLayoutPanelInfo.ResumeLayout(false);
+            this.tableLayoutPanelInfo.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -263,9 +248,7 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.Label lblSliderLowest;
         private System.Windows.Forms.Label lblPriority;
         private System.Windows.Forms.Label lblVCPUs;
-        private System.Windows.Forms.Label lblMemory;
         private XenAdmin.Controls.TransparentTrackBar transparentTrackBar1;
-        private System.Windows.Forms.Label MemWarningLabel;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label labelTopology;
         private XenAdmin.Controls.CPUTopologyComboBox comboBoxTopology;
@@ -275,10 +258,10 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.TableLayoutPanel warningsTableLayoutPanel;
         private System.Windows.Forms.PictureBox cpuWarningPictureBox;
         private System.Windows.Forms.Label cpuWarningLabel;
-        private System.Windows.Forms.Label memoryWarningLabel;
-        private System.Windows.Forms.PictureBox memoryPictureBox;
         private System.Windows.Forms.Label topologyWarningLabel;
         private System.Windows.Forms.PictureBox topologyPictureBox;
-        private Controls.Ballooning.MemorySpinner memorySpinner;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelInfo;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label labelInfo;
     }
 }

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -34,6 +34,7 @@ namespace XenAdmin.SettingsPanels
             this.lblSliderLowest = new System.Windows.Forms.Label();
             this.lblPriority = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.initialVCPUWarningLabel = new System.Windows.Forms.Label();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
             this.labelInvalidVCPUWarning = new System.Windows.Forms.Label();
@@ -51,7 +52,6 @@ namespace XenAdmin.SettingsPanels
             this.VCPUWarningLabel = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
-            this.initialVCPUWarningLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudMemory)).BeginInit();
@@ -100,6 +100,13 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxVCPUs, 1, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // initialVCPUWarningLabel
+            // 
+            resources.ApplyResources(this.initialVCPUWarningLabel, "initialVCPUWarningLabel");
+            this.tableLayoutPanel1.SetColumnSpan(this.initialVCPUWarningLabel, 2);
+            this.initialVCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
+            this.initialVCPUWarningLabel.Name = "initialVCPUWarningLabel";
             // 
             // comboBoxInitialVCPUs
             // 
@@ -233,13 +240,6 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.comboBoxVCPUs, "comboBoxVCPUs");
             this.comboBoxVCPUs.Name = "comboBoxVCPUs";
             this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxVCPUs_SelectedIndexChanged);
-            // 
-            // initialVCPUWarningLabel
-            // 
-            resources.ApplyResources(this.initialVCPUWarningLabel, "initialVCPUWarningLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.initialVCPUWarningLabel, 2);
-            this.initialVCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.initialVCPUWarningLabel.Name = "initialVCPUWarningLabel";
             // 
             // CPUMemoryEditPage
             // 

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -43,19 +43,18 @@ namespace XenAdmin.SettingsPanels
             this.topologyPictureBox = new System.Windows.Forms.PictureBox();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
-            this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
             this.labelTopology = new System.Windows.Forms.Label();
             this.MemWarningLabel = new System.Windows.Forms.Label();
             this.panel2 = new System.Windows.Forms.Panel();
             this.lblMB = new System.Windows.Forms.Label();
             this.nudMemory = new System.Windows.Forms.NumericUpDown();
             this.panel1 = new System.Windows.Forms.Panel();
-            this.transparentTrackBar1 = new XenAdmin.Controls.TransparentTrackBar();
             this.lblVCPUs = new System.Windows.Forms.Label();
-            this.lblVcpuWarning = new System.Windows.Forms.LinkLabel();
             this.lblMemory = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
+            this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
+            this.transparentTrackBar1 = new XenAdmin.Controls.TransparentTrackBar();
             this.tableLayoutPanel1.SuspendLayout();
             this.warningsTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
@@ -101,7 +100,6 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 9);
             this.tableLayoutPanel1.Controls.Add(this.lblPriority, 0, 8);
             this.tableLayoutPanel1.Controls.Add(this.lblVCPUs, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.lblVcpuWarning, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.lblMemory, 0, 10);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxVCPUs, 1, 2);
@@ -168,15 +166,6 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.labelInitialVCPUs, "labelInitialVCPUs");
             this.labelInitialVCPUs.Name = "labelInitialVCPUs";
             // 
-            // comboBoxTopology
-            // 
-            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
-            this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
-            this.comboBoxTopology.FormattingEnabled = true;
-            this.comboBoxTopology.Name = "comboBoxTopology";
-            this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
-            // 
             // labelTopology
             // 
             resources.ApplyResources(this.labelTopology, "labelTopology");
@@ -233,26 +222,10 @@ namespace XenAdmin.SettingsPanels
             this.panel1.Controls.Add(this.transparentTrackBar1);
             this.panel1.Name = "panel1";
             // 
-            // transparentTrackBar1
-            // 
-            resources.ApplyResources(this.transparentTrackBar1, "transparentTrackBar1");
-            this.transparentTrackBar1.BackColor = System.Drawing.Color.Transparent;
-            this.transparentTrackBar1.Name = "transparentTrackBar1";
-            this.transparentTrackBar1.TabStop = false;
-            // 
             // lblVCPUs
             // 
             resources.ApplyResources(this.lblVCPUs, "lblVCPUs");
             this.lblVCPUs.Name = "lblVCPUs";
-            // 
-            // lblVcpuWarning
-            // 
-            resources.ApplyResources(this.lblVcpuWarning, "lblVcpuWarning");
-            this.tableLayoutPanel1.SetColumnSpan(this.lblVcpuWarning, 4);
-            this.lblVcpuWarning.LinkColor = System.Drawing.SystemColors.ActiveCaption;
-            this.lblVcpuWarning.Name = "lblVcpuWarning";
-            this.lblVcpuWarning.TabStop = true;
-            this.lblVcpuWarning.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lblVCpuWarning_LinkClicked);
             // 
             // lblMemory
             // 
@@ -272,6 +245,22 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.comboBoxVCPUs, "comboBoxVCPUs");
             this.comboBoxVCPUs.Name = "comboBoxVCPUs";
             this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxVCPUs_SelectedIndexChanged);
+            // 
+            // comboBoxTopology
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
+            this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
+            this.comboBoxTopology.FormattingEnabled = true;
+            this.comboBoxTopology.Name = "comboBoxTopology";
+            this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
+            // 
+            // transparentTrackBar1
+            // 
+            resources.ApplyResources(this.transparentTrackBar1, "transparentTrackBar1");
+            this.transparentTrackBar1.BackColor = System.Drawing.Color.Transparent;
+            this.transparentTrackBar1.Name = "transparentTrackBar1";
+            this.transparentTrackBar1.TabStop = false;
             // 
             // CpuMemoryEditPage
             // 
@@ -310,7 +299,6 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.Label lblPriority;
         private System.Windows.Forms.Label lblVCPUs;
         private System.Windows.Forms.Label lblMemory;
-        private System.Windows.Forms.LinkLabel lblVcpuWarning;
         private XenAdmin.Controls.TransparentTrackBar transparentTrackBar1;
         private System.Windows.Forms.Panel panel2;
         private System.Windows.Forms.Label MemWarningLabel;

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -34,10 +34,15 @@ namespace XenAdmin.SettingsPanels
             this.lblSliderLowest = new System.Windows.Forms.Label();
             this.lblPriority = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.initialVCPUWarningLabel = new System.Windows.Forms.Label();
+            this.warningsTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.cpuWarningPictureBox = new System.Windows.Forms.PictureBox();
+            this.cpuWarningLabel = new System.Windows.Forms.Label();
+            this.memoryWarningLabel = new System.Windows.Forms.Label();
+            this.topologyWarningLabel = new System.Windows.Forms.Label();
+            this.memoryPictureBox = new System.Windows.Forms.PictureBox();
+            this.topologyPictureBox = new System.Windows.Forms.PictureBox();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
-            this.labelInvalidVCPUWarning = new System.Windows.Forms.Label();
             this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
             this.labelTopology = new System.Windows.Forms.Label();
             this.MemWarningLabel = new System.Windows.Forms.Label();
@@ -49,10 +54,13 @@ namespace XenAdmin.SettingsPanels
             this.lblVCPUs = new System.Windows.Forms.Label();
             this.lblVcpuWarning = new System.Windows.Forms.LinkLabel();
             this.lblMemory = new System.Windows.Forms.Label();
-            this.VCPUWarningLabel = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
             this.tableLayoutPanel1.SuspendLayout();
+            this.warningsTableLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).BeginInit();
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudMemory)).BeginInit();
             this.panel1.SuspendLayout();
@@ -83,10 +91,9 @@ namespace XenAdmin.SettingsPanels
             // 
             this.tableLayoutPanel1.BackColor = System.Drawing.Color.Transparent;
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.initialVCPUWarningLabel, 2, 6);
+            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 12);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 6);
             this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelInvalidVCPUWarning, 1, 5);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 4);
             this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.MemWarningLabel, 3, 10);
@@ -96,17 +103,57 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanel1.Controls.Add(this.lblVCPUs, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.lblVcpuWarning, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.lblMemory, 0, 10);
-            this.tableLayoutPanel1.Controls.Add(this.VCPUWarningLabel, 2, 2);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxVCPUs, 1, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
-            // initialVCPUWarningLabel
+            // warningsTableLayoutPanel
             // 
-            resources.ApplyResources(this.initialVCPUWarningLabel, "initialVCPUWarningLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.initialVCPUWarningLabel, 2);
-            this.initialVCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.initialVCPUWarningLabel.Name = "initialVCPUWarningLabel";
+            resources.ApplyResources(this.warningsTableLayoutPanel, "warningsTableLayoutPanel");
+            this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningPictureBox, 0, 0);
+            this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningLabel, 1, 0);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 1);
+            this.warningsTableLayoutPanel.Controls.Add(this.topologyWarningLabel, 0, 2);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 1);
+            this.warningsTableLayoutPanel.Controls.Add(this.topologyPictureBox, 0, 2);
+            this.warningsTableLayoutPanel.Name = "warningsTableLayoutPanel";
+            // 
+            // cpuWarningPictureBox
+            // 
+            this.cpuWarningPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.cpuWarningPictureBox, "cpuWarningPictureBox");
+            this.cpuWarningPictureBox.Name = "cpuWarningPictureBox";
+            this.cpuWarningPictureBox.TabStop = false;
+            // 
+            // cpuWarningLabel
+            // 
+            resources.ApplyResources(this.cpuWarningLabel, "cpuWarningLabel");
+            this.cpuWarningLabel.Name = "cpuWarningLabel";
+            // 
+            // memoryWarningLabel
+            // 
+            resources.ApplyResources(this.memoryWarningLabel, "memoryWarningLabel");
+            this.memoryWarningLabel.Name = "memoryWarningLabel";
+            // 
+            // topologyWarningLabel
+            // 
+            resources.ApplyResources(this.topologyWarningLabel, "topologyWarningLabel");
+            this.topologyWarningLabel.Name = "topologyWarningLabel";
+            // 
+            // memoryPictureBox
+            // 
+            this.memoryPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.memoryPictureBox, "memoryPictureBox");
+            this.memoryPictureBox.Name = "memoryPictureBox";
+            this.memoryPictureBox.TabStop = false;
+            // 
+            // topologyPictureBox
+            // 
+            this.topologyPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.topologyPictureBox, "topologyPictureBox");
+            this.topologyPictureBox.Name = "topologyPictureBox";
+            this.topologyPictureBox.TabStop = false;
             // 
             // comboBoxInitialVCPUs
             // 
@@ -120,13 +167,6 @@ namespace XenAdmin.SettingsPanels
             // 
             resources.ApplyResources(this.labelInitialVCPUs, "labelInitialVCPUs");
             this.labelInitialVCPUs.Name = "labelInitialVCPUs";
-            // 
-            // labelInvalidVCPUWarning
-            // 
-            resources.ApplyResources(this.labelInvalidVCPUWarning, "labelInvalidVCPUWarning");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelInvalidVCPUWarning, 3);
-            this.labelInvalidVCPUWarning.ForeColor = System.Drawing.Color.Red;
-            this.labelInvalidVCPUWarning.Name = "labelInvalidVCPUWarning";
             // 
             // comboBoxTopology
             // 
@@ -219,14 +259,6 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.lblMemory, "lblMemory");
             this.lblMemory.Name = "lblMemory";
             // 
-            // VCPUWarningLabel
-            // 
-            resources.ApplyResources(this.VCPUWarningLabel, "VCPUWarningLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.VCPUWarningLabel, 2);
-            this.VCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.VCPUWarningLabel.Name = "VCPUWarningLabel";
-            this.tableLayoutPanel1.SetRowSpan(this.VCPUWarningLabel, 2);
-            // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
@@ -241,7 +273,7 @@ namespace XenAdmin.SettingsPanels
             this.comboBoxVCPUs.Name = "comboBoxVCPUs";
             this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxVCPUs_SelectedIndexChanged);
             // 
-            // CPUMemoryEditPage
+            // CpuMemoryEditPage
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
@@ -252,6 +284,11 @@ namespace XenAdmin.SettingsPanels
             this.Name = "CpuMemoryEditPage";
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.warningsTableLayoutPanel.ResumeLayout(false);
+            this.warningsTableLayoutPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).EndInit();
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudMemory)).EndInit();
@@ -276,15 +313,19 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.LinkLabel lblVcpuWarning;
         private XenAdmin.Controls.TransparentTrackBar transparentTrackBar1;
         private System.Windows.Forms.Panel panel2;
-        private System.Windows.Forms.Label VCPUWarningLabel;
         private System.Windows.Forms.Label MemWarningLabel;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label labelTopology;
         private XenAdmin.Controls.CPUTopologyComboBox comboBoxTopology;
-        private System.Windows.Forms.Label labelInvalidVCPUWarning;
         private System.Windows.Forms.ComboBox comboBoxVCPUs;
         private System.Windows.Forms.ComboBox comboBoxInitialVCPUs;
         private System.Windows.Forms.Label labelInitialVCPUs;
-        private System.Windows.Forms.Label initialVCPUWarningLabel;
+        private System.Windows.Forms.TableLayoutPanel warningsTableLayoutPanel;
+        private System.Windows.Forms.PictureBox cpuWarningPictureBox;
+        private System.Windows.Forms.Label cpuWarningLabel;
+        private System.Windows.Forms.Label memoryWarningLabel;
+        private System.Windows.Forms.PictureBox memoryPictureBox;
+        private System.Windows.Forms.Label topologyWarningLabel;
+        private System.Windows.Forms.PictureBox topologyPictureBox;
     }
 }

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -1,6 +1,6 @@
 namespace XenAdmin.SettingsPanels
 {
-    partial class CPUMemoryEditPage
+    partial class CpuMemoryEditPage
     {
         /// <summary> 
         /// Required designer variable.
@@ -28,7 +28,7 @@ namespace XenAdmin.SettingsPanels
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CPUMemoryEditPage));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CpuMemoryEditPage));
             this.lblSliderHighest = new System.Windows.Forms.Label();
             this.lblSliderNormal = new System.Windows.Forms.Label();
             this.lblSliderLowest = new System.Windows.Forms.Label();
@@ -249,7 +249,7 @@ namespace XenAdmin.SettingsPanels
             this.Controls.Add(this.tableLayoutPanel1);
             this.DoubleBuffered = true;
             this.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.Name = "CPUMemoryEditPage";
+            this.Name = "CpuMemoryEditPage";
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.panel2.ResumeLayout(false);

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -43,25 +43,21 @@ namespace XenAdmin.SettingsPanels
             this.topologyPictureBox = new System.Windows.Forms.PictureBox();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
+            this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
             this.labelTopology = new System.Windows.Forms.Label();
             this.MemWarningLabel = new System.Windows.Forms.Label();
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.lblMB = new System.Windows.Forms.Label();
-            this.nudMemory = new System.Windows.Forms.NumericUpDown();
+            this.memorySpinner = new XenAdmin.Controls.Ballooning.MemorySpinner();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.transparentTrackBar1 = new XenAdmin.Controls.TransparentTrackBar();
             this.lblVCPUs = new System.Windows.Forms.Label();
             this.lblMemory = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
-            this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
-            this.transparentTrackBar1 = new XenAdmin.Controls.TransparentTrackBar();
             this.tableLayoutPanel1.SuspendLayout();
             this.warningsTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).BeginInit();
-            this.panel2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMemory)).BeginInit();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -96,7 +92,7 @@ namespace XenAdmin.SettingsPanels
             this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 4);
             this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.MemWarningLabel, 3, 10);
-            this.tableLayoutPanel1.Controls.Add(this.panel2, 1, 10);
+            this.tableLayoutPanel1.Controls.Add(this.memorySpinner, 1, 10);
             this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 9);
             this.tableLayoutPanel1.Controls.Add(this.lblPriority, 0, 8);
             this.tableLayoutPanel1.Controls.Add(this.lblVCPUs, 0, 2);
@@ -166,6 +162,15 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.labelInitialVCPUs, "labelInitialVCPUs");
             this.labelInitialVCPUs.Name = "labelInitialVCPUs";
             // 
+            // comboBoxTopology
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
+            this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
+            this.comboBoxTopology.FormattingEnabled = true;
+            this.comboBoxTopology.Name = "comboBoxTopology";
+            this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
+            // 
             // labelTopology
             // 
             resources.ApplyResources(this.labelTopology, "labelTopology");
@@ -178,39 +183,13 @@ namespace XenAdmin.SettingsPanels
             this.MemWarningLabel.Name = "MemWarningLabel";
             this.tableLayoutPanel1.SetRowSpan(this.MemWarningLabel, 2);
             // 
-            // panel2
+            // memorySpinner
             // 
-            resources.ApplyResources(this.panel2, "panel2");
-            this.tableLayoutPanel1.SetColumnSpan(this.panel2, 2);
-            this.panel2.Controls.Add(this.lblMB);
-            this.panel2.Controls.Add(this.nudMemory);
-            this.panel2.Name = "panel2";
-            // 
-            // lblMB
-            // 
-            resources.ApplyResources(this.lblMB, "lblMB");
-            this.lblMB.Name = "lblMB";
-            // 
-            // nudMemory
-            // 
-            resources.ApplyResources(this.nudMemory, "nudMemory");
-            this.nudMemory.Maximum = new decimal(new int[] {
-            1048576,
-            0,
-            0,
-            0});
-            this.nudMemory.Minimum = new decimal(new int[] {
-            64,
-            0,
-            0,
-            0});
-            this.nudMemory.Name = "nudMemory";
-            this.nudMemory.Value = new decimal(new int[] {
-            64,
-            0,
-            0,
-            0});
-            this.nudMemory.ValueChanged += new System.EventHandler(this.nudMemory_ValueChanged);
+            resources.ApplyResources(this.memorySpinner, "memorySpinner");
+            this.tableLayoutPanel1.SetColumnSpan(this.memorySpinner, 2);
+            this.memorySpinner.Increment = 0.1D;
+            this.memorySpinner.Name = "memorySpinner";
+            this.memorySpinner.SpinnerValueChanged += new System.EventHandler(this.memorySpinner_SpinnerValueChanged);
             // 
             // panel1
             // 
@@ -221,6 +200,13 @@ namespace XenAdmin.SettingsPanels
             this.panel1.Controls.Add(this.lblSliderLowest);
             this.panel1.Controls.Add(this.transparentTrackBar1);
             this.panel1.Name = "panel1";
+            // 
+            // transparentTrackBar1
+            // 
+            resources.ApplyResources(this.transparentTrackBar1, "transparentTrackBar1");
+            this.transparentTrackBar1.BackColor = System.Drawing.Color.Transparent;
+            this.transparentTrackBar1.Name = "transparentTrackBar1";
+            this.transparentTrackBar1.TabStop = false;
             // 
             // lblVCPUs
             // 
@@ -246,22 +232,6 @@ namespace XenAdmin.SettingsPanels
             this.comboBoxVCPUs.Name = "comboBoxVCPUs";
             this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxVCPUs_SelectedIndexChanged);
             // 
-            // comboBoxTopology
-            // 
-            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
-            this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
-            this.comboBoxTopology.FormattingEnabled = true;
-            this.comboBoxTopology.Name = "comboBoxTopology";
-            this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
-            // 
-            // transparentTrackBar1
-            // 
-            resources.ApplyResources(this.transparentTrackBar1, "transparentTrackBar1");
-            this.transparentTrackBar1.BackColor = System.Drawing.Color.Transparent;
-            this.transparentTrackBar1.Name = "transparentTrackBar1";
-            this.transparentTrackBar1.TabStop = false;
-            // 
             // CpuMemoryEditPage
             // 
             resources.ApplyResources(this, "$this");
@@ -278,9 +248,6 @@ namespace XenAdmin.SettingsPanels
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).EndInit();
-            this.panel2.ResumeLayout(false);
-            this.panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMemory)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.ResumeLayout(false);
@@ -290,8 +257,6 @@ namespace XenAdmin.SettingsPanels
         #endregion
 
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.NumericUpDown nudMemory;
-        private System.Windows.Forms.Label lblMB;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Label lblSliderHighest;
         private System.Windows.Forms.Label lblSliderNormal;
@@ -300,7 +265,6 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.Label lblVCPUs;
         private System.Windows.Forms.Label lblMemory;
         private XenAdmin.Controls.TransparentTrackBar transparentTrackBar1;
-        private System.Windows.Forms.Panel panel2;
         private System.Windows.Forms.Label MemWarningLabel;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label labelTopology;
@@ -315,5 +279,6 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.PictureBox memoryPictureBox;
         private System.Windows.Forms.Label topologyWarningLabel;
         private System.Windows.Forms.PictureBox topologyPictureBox;
+        private Controls.Ballooning.MemorySpinner memorySpinner;
     }
 }

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -216,7 +216,7 @@ namespace XenAdmin.SettingsPanels
                 // Show the performance warning about vCPUs > pCPUs.
                 // Don't show if the VM isn't running, since we don't know which server it will
                 // run on (and so can't count the number of pCPUs).
-                if ( vm.power_state == vm_power_state.Running
+                if (vm.power_state == vm_power_state.Running
                     && vm.VCPUs_at_startup > currentHost.host_CPUs.Count
                     && !vm.GetIgnoreExcessiveVcpus())
                 {
@@ -249,7 +249,7 @@ namespace XenAdmin.SettingsPanels
             _currentVCpuWeight = Convert.ToDecimal(vm.GetVcpuWeight());
 
             InitializeVCpuControls();
-            
+
             _validToSave = true;
         }
 
@@ -262,7 +262,7 @@ namespace XenAdmin.SettingsPanels
             labelInitialVCPUs.Text = _vm.power_state == vm_power_state.Halted
                 ? Messages.VM_CPUMEMPAGE_INITIAL_VCPUS_LABEL
                 : Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_LABEL;
-            
+
             labelInitialVCPUs.Visible = comboBoxInitialVCPUs.Visible = _isVCpuHotplugSupported;
             comboBoxInitialVCPUs.Enabled = _isVCpuHotplugSupported &&
                                            (_vm.power_state == vm_power_state.Halted ||
@@ -368,8 +368,8 @@ namespace XenAdmin.SettingsPanels
             {
                 _vm.SetCoresPerSocket(comboBoxTopology.CoresPerSocket);
             }
-			
-			if (HasMemoryChanged)
+
+            if (HasMemoryChanged)
             {
                 actions.Add(_memoryAction);  // Calculated in ValidToSave
             }
@@ -542,7 +542,7 @@ namespace XenAdmin.SettingsPanels
                 // If VcpusAtStartup and VcpusMax are equal, and VcpusMax is changed, then VcpusAtStartup is changed to match
                 // But if the numbers are unequal, and VcpusMax is changed but is still higher than VcpusAtStartup, then VcpusAtStartup is unchanged
                 var newValue = SelectedVCpusAtStartup;
-               
+
                 if (SelectedVCpusMax < SelectedVCpusAtStartup)
                     newValue = SelectedVCpusMax;
                 else if (SelectedVCpusAtStartup == _prevVCpusMax && SelectedVCpusMax != _prevVCpusMax)

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -44,34 +44,34 @@ using XenAdmin.Dialogs;
 
 namespace XenAdmin.SettingsPanels
 {
-    public partial class CPUMemoryEditPage : UserControl, IEditPage
+    public partial class CpuMemoryEditPage : UserControl, IEditPage
     {
-        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private VM vm;
-        bool ShowMemory = false;       // If this VM has DMC, we don't show the memory controls on this page.
+        private VM _vm;
+        bool _showMemory = false;       // If this VM has DMC, we don't show the memory controls on this page.
 
-        private bool _ValidToSave = true;
-        private decimal _OrigMemory;
-        private long _OrigVCPUs;
-        private long _OrigVCPUsMax;
-        private long _OrigVCPUsAtStartup;
-        private decimal _OrigVCPUWeight;
-        private decimal _CurrentVCPUWeight;
-        private bool isVcpuHotplugSupported;
-        private int minVCPUs;
+        private bool _validToSave = true;
+        private decimal _origMemory;
+        private long _origVcpUs;
+        private long _origVcpUsMax;
+        private long _origVcpUsAtStartup;
+        private decimal _origVcpuWeight;
+        private decimal _currentVcpuWeight;
+        private bool _isVcpuHotplugSupported;
+        private int _minVcpUs;
 
         // Please note that the comboBoxVCPUs control can represent two different VM properties, depending whether the VM supports vCPU hotplug or not: 
         // If vCPU hotplug is supported, comboBoxVCPUs represents the maximum number of vCPUs (VCPUs_max). And the initial number of vCPUs is represented in comboBoxInitialVCPUs (which is only visible in this case) 
         // If vCPU hotplug is not supported, comboBoxVCPUs represents the initial number of vCPUs (VCPUs_at_startup). In this case we will also set the VM property VCPUs_max to the same value.
         // We use the _OrigVCPUs variable to store the original value that populates this combo box (VCPUs_max if hotplug is allowed, otherwise VCPUs_at_startup)
 
-        private ChangeMemorySettingsAction memoryAction;
+        private ChangeMemorySettingsAction _memoryAction;
         public bool ValidToSave
         {
             get
             {
-                if (!_ValidToSave)
+                if (!_validToSave)
                     return false;
 
                 // Also confirm whether the user wants to save memory changes.
@@ -79,8 +79,8 @@ namespace XenAdmin.SettingsPanels
                 if (HasMemoryChanged)
                 {
                     long mem = Convert.ToInt64(this.nudMemory.Value * Util.BINARY_MEGA);
-                    memoryAction = ConfirmAndCalcActions(mem);
-                    if (memoryAction == null)
+                    _memoryAction = ConfirmAndCalcActions(mem);
+                    if (_memoryAction == null)
                         return false;
                 }
 
@@ -90,14 +90,14 @@ namespace XenAdmin.SettingsPanels
 
         private ChangeMemorySettingsAction ConfirmAndCalcActions(long mem)
         {
-            if (vm.memory_static_max / Util.BINARY_MEGA == mem / Util.BINARY_MEGA)
+            if (_vm.memory_static_max / Util.BINARY_MEGA == mem / Util.BINARY_MEGA)
             {
                 // don't want to show warning dialog just for rounding errors
-                mem = vm.memory_static_max;
+                mem = _vm.memory_static_max;
             }
-            else if (vm.power_state != vm_power_state.Halted)
+            else if (_vm.power_state != vm_power_state.Halted)
             {
-                var msg = vm.SupportsBallooning() && !Helpers.FeatureForbidden(vm, Host.RestrictDMC)
+                var msg = _vm.SupportsBallooning() && !Helpers.FeatureForbidden(_vm, Host.RestrictDMC)
                     ? Messages.CONFIRM_CHANGE_MEMORY_MAX_SINGULAR
                     : Messages.CONFIRM_CHANGE_MEMORY_SINGULAR;
 
@@ -109,13 +109,13 @@ namespace XenAdmin.SettingsPanels
                 }
             }
 
-            return new ChangeMemorySettingsAction(vm,
-                string.Format(Messages.ACTION_CHANGE_MEMORY_SETTINGS, vm.Name()),
-                vm.memory_static_min, mem, mem, mem,
+            return new ChangeMemorySettingsAction(_vm,
+                string.Format(Messages.ACTION_CHANGE_MEMORY_SETTINGS, _vm.Name()),
+                _vm.memory_static_min, mem, mem, mem,
                 VMOperationCommand.WarningDialogHAInvalidConfig, VMOperationCommand.StartDiagnosisForm, true);
         }
 
-        public CPUMemoryEditPage()
+        public CpuMemoryEditPage()
         {
             InitializeComponent();
 
@@ -131,7 +131,7 @@ namespace XenAdmin.SettingsPanels
 
         void nudMemory_LostFocus(object sender, EventArgs e)
         {
-            ValidateNud(nudMemory, (decimal)vm.memory_static_max / Util.BINARY_MEGA);
+            ValidateNud(nudMemory, (decimal)_vm.memory_static_max / Util.BINARY_MEGA);
         }
 
         private void ValidateNud(NumericUpDown nud, Decimal defaultValue)
@@ -159,19 +159,19 @@ namespace XenAdmin.SettingsPanels
             }
             if (this.nudMemory.Text == "")
             {
-                _ValidToSave = false;
+                _validToSave = false;
             }
             else
             {
-                _ValidToSave = true;
+                _validToSave = true;
             }
         }
 
         private void tbPriority_Scroll(object sender, EventArgs e)
         {
-            _CurrentVCPUWeight = Convert.ToDecimal(Math.Pow(4.0d, Convert.ToDouble(transparentTrackBar1.Value)));
+            _currentVcpuWeight = Convert.ToDecimal(Math.Pow(4.0d, Convert.ToDouble(transparentTrackBar1.Value)));
             if (transparentTrackBar1.Value == transparentTrackBar1.Max)
-                _CurrentVCPUWeight--;
+                _currentVcpuWeight--;
         }
 
         /// <summary>
@@ -179,17 +179,17 @@ namespace XenAdmin.SettingsPanels
         /// </summary>
         public void SetXenObjects(IXenObject orig, IXenObject clone)
         {
-            vm = (VM)clone;
-            ShowMemory = Helpers.FeatureForbidden(vm, Host.RestrictDMC);
+            _vm = (VM)clone;
+            _showMemory = Helpers.FeatureForbidden(_vm, Host.RestrictDMC);
             Repopulate();
         }
 
         public void Repopulate()
         {
-            VM vm = this.vm;
+            VM vm = this._vm;
 
-            Text = ShowMemory ? Messages.CPU_AND_MEMORY : Messages.CPU;
-            if (!ShowMemory)
+            Text = _showMemory ? Messages.CPU_AND_MEMORY : Messages.CPU;
+            if (!_showMemory)
                 lblMemory.Visible = panel2.Visible = MemWarningLabel.Visible = false;
             else if (vm.power_state != vm_power_state.Halted && vm.power_state != vm_power_state.Running)
             {
@@ -217,7 +217,7 @@ namespace XenAdmin.SettingsPanels
                 this.nudMemory.Text = (this.nudMemory.Value = value).ToString();
             }
 
-            Host currentHost = Helpers.GetCoordinator(this.vm.Connection);
+            Host currentHost = Helpers.GetCoordinator(this._vm.Connection);
             if (currentHost != null)
             {
                 // Show the performance warning about vCPUs > pCPUs.
@@ -241,59 +241,59 @@ namespace XenAdmin.SettingsPanels
                 lblVcpuWarning.Visible = false;
             }
 
-            isVcpuHotplugSupported = vm.SupportsVcpuHotplug();
-            minVCPUs = vm.MinVCPUs();
+            _isVcpuHotplugSupported = vm.SupportsVcpuHotplug();
+            _minVcpUs = vm.MinVCPUs();
 
             label1.Text = GetRubric();
 
-            _OrigMemory = nudMemory.Value;
-            _OrigVCPUsMax = vm.VCPUs_max > 0 ? vm.VCPUs_max : 1;
-            _OrigVCPUsAtStartup = vm.VCPUs_at_startup > 0 ? vm.VCPUs_at_startup : 1;
-            _OrigVCPUWeight = _CurrentVCPUWeight;
-            _OrigVCPUs = isVcpuHotplugSupported ? _OrigVCPUsMax : _OrigVCPUsAtStartup;
-            _prevVCPUsMax = _OrigVCPUsMax;  // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
+            _origMemory = nudMemory.Value;
+            _origVcpUsMax = vm.VCPUs_max > 0 ? vm.VCPUs_max : 1;
+            _origVcpUsAtStartup = vm.VCPUs_at_startup > 0 ? vm.VCPUs_at_startup : 1;
+            _origVcpuWeight = _currentVcpuWeight;
+            _origVcpUs = _isVcpuHotplugSupported ? _origVcpUsMax : _origVcpUsAtStartup;
+            _prevVcpUsMax = _origVcpUsMax;  // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
 
-            _CurrentVCPUWeight = Convert.ToDecimal(vm.GetVcpuWeight());
+            _currentVcpuWeight = Convert.ToDecimal(vm.GetVcpuWeight());
 
             InitializeVcpuControls();
             
-            _ValidToSave = true;
+            _validToSave = true;
         }
 
         private void InitializeVcpuControls()
         {
-            lblVCPUs.Text = isVcpuHotplugSupported
+            lblVCPUs.Text = _isVcpuHotplugSupported
                 ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_LABEL
                 : Messages.VM_CPUMEMPAGE_VCPUS_LABEL;
 
-            labelInitialVCPUs.Text = vm.power_state == vm_power_state.Halted
+            labelInitialVCPUs.Text = _vm.power_state == vm_power_state.Halted
                 ? Messages.VM_CPUMEMPAGE_INITIAL_VCPUS_LABEL
                 : Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_LABEL;
             
-            labelInitialVCPUs.Visible = comboBoxInitialVCPUs.Visible = isVcpuHotplugSupported;
-            comboBoxInitialVCPUs.Enabled = isVcpuHotplugSupported &&
-                                           (vm.power_state == vm_power_state.Halted ||
-                                            vm.power_state == vm_power_state.Running);
+            labelInitialVCPUs.Visible = comboBoxInitialVCPUs.Visible = _isVcpuHotplugSupported;
+            comboBoxInitialVCPUs.Enabled = _isVcpuHotplugSupported &&
+                                           (_vm.power_state == vm_power_state.Halted ||
+                                            _vm.power_state == vm_power_state.Running);
 
-            comboBoxVCPUs.Enabled = comboBoxTopology.Enabled = vm.power_state == vm_power_state.Halted;
+            comboBoxVCPUs.Enabled = comboBoxTopology.Enabled = _vm.power_state == vm_power_state.Halted;
 
-            comboBoxTopology.Populate(vm.VCPUs_at_startup, vm.VCPUs_max, vm.GetCoresPerSocket(), vm.MaxCoresPerSocket());
+            comboBoxTopology.Populate(_vm.VCPUs_at_startup, _vm.VCPUs_max, _vm.GetCoresPerSocket(), _vm.MaxCoresPerSocket());
 
             // CA-12941 
             // We set a sensible maximum based on the template, but if the user sets something higher 
             // from the CLI then use that as the maximum.
-            var maxAllowed = vm.MaxVCPUsAllowed();
-            long maxVCPUs = maxAllowed < _OrigVCPUs ? _OrigVCPUs : maxAllowed;
-            PopulateVCPUs(maxVCPUs, _OrigVCPUs);
+            var maxAllowed = _vm.MaxVCPUsAllowed();
+            long maxVcpUs = maxAllowed < _origVcpUs ? _origVcpUs : maxAllowed;
+            PopulateVcpUs(maxVcpUs, _origVcpUs);
 
-            if (isVcpuHotplugSupported)
-                PopulateVCPUsAtStartup(_OrigVCPUsMax, _OrigVCPUsAtStartup);
+            if (_isVcpuHotplugSupported)
+                PopulateVcpUsAtStartup(_origVcpUsMax, _origVcpUsAtStartup);
 
-            transparentTrackBar1.Value = Convert.ToInt32(Math.Log(Convert.ToDouble(vm.GetVcpuWeight())) / Math.Log(4.0d));
-            panel1.Enabled = vm.power_state == vm_power_state.Halted;
+            transparentTrackBar1.Value = Convert.ToInt32(Math.Log(Convert.ToDouble(_vm.GetVcpuWeight())) / Math.Log(4.0d));
+            panel1.Enabled = _vm.power_state == vm_power_state.Halted;
         }
 
-        private void PopulateVCPUComboBox(ComboBox comboBox, long min, long max, long currentValue, Predicate<long> isValid)
+        private void PopulateVcpuComboBox(ComboBox comboBox, long min, long max, long currentValue, Predicate<long> isValid)
         {
             comboBox.BeginUpdate();
             comboBox.Items.Clear();
@@ -308,15 +308,15 @@ namespace XenAdmin.SettingsPanels
             comboBox.EndUpdate();
         }
 
-        private void PopulateVCPUs(long maxVCPUs, long currentVCPUs)
+        private void PopulateVcpUs(long maxVcpUs, long currentVcpUs)
         {
-            PopulateVCPUComboBox(comboBoxVCPUs, 1, maxVCPUs, currentVCPUs, i => comboBoxTopology.IsValidVCPU(i));
+            PopulateVcpuComboBox(comboBoxVCPUs, 1, maxVcpUs, currentVcpUs, i => comboBoxTopology.IsValidVCPU(i));
         }
 
-        private void PopulateVCPUsAtStartup(long max, long currentValue)
+        private void PopulateVcpUsAtStartup(long max, long currentValue)
         {
-            long min = vm.power_state == vm_power_state.Halted ? 1 : _OrigVCPUsAtStartup;
-            PopulateVCPUComboBox(comboBoxInitialVCPUs, min, max, currentValue, i => true);
+            long min = _vm.power_state == vm_power_state.Halted ? 1 : _origVcpUsAtStartup;
+            PopulateVcpuComboBox(comboBoxInitialVCPUs, min, max, currentValue, i => true);
         }
 
         private string GetRubric()
@@ -324,17 +324,17 @@ namespace XenAdmin.SettingsPanels
             StringBuilder sb = new StringBuilder();
             sb.Append(Messages.VM_CPUMEMPAGE_RUBRIC);
             // add hotplug text
-            if (isVcpuHotplugSupported)
+            if (_isVcpuHotplugSupported)
                 sb.Append(Messages.VM_CPUMEMPAGE_RUBRIC_HOTPLUG);
             // add power state warning
-            if (vm.power_state != vm_power_state.Halted)
+            if (_vm.power_state != vm_power_state.Halted)
             {
                 sb.AppendLine();
                 sb.AppendLine();
-                sb.Append(isVcpuHotplugSupported ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY : Messages.VCPU_ONLY_WHEN_HALTED);
+                sb.Append(_isVcpuHotplugSupported ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY : Messages.VCPU_ONLY_WHEN_HALTED);
             }
             // add power state warning for Current number of vCPUs
-            if (isVcpuHotplugSupported && vm.power_state != vm_power_state.Halted && vm.power_state != vm_power_state.Running)
+            if (_isVcpuHotplugSupported && _vm.power_state != vm_power_state.Halted && _vm.power_state != vm_power_state.Running)
             {
                 sb.Append(Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_READONLY);
             }
@@ -343,38 +343,38 @@ namespace XenAdmin.SettingsPanels
 
         public bool HasChanged
         {
-            get { return HasVCPUChanged || HasMemoryChanged || HasTopologyChanged || HasVCPUsAtStartupChanged || HasVCPUWeightChanged; }
+            get { return HasVcpuChanged || HasMemoryChanged || HasTopologyChanged || HasVcpUsAtStartupChanged || HasVcpuWeightChanged; }
         }
 
         private bool HasMemoryChanged
         {
             get
             {
-                return _OrigMemory != nudMemory.Value;
+                return _origMemory != nudMemory.Value;
             }
         }
 
-        private bool HasVCPUChanged
+        private bool HasVcpuChanged
         {
             get
             {
-                return _OrigVCPUs != (long)comboBoxVCPUs.SelectedItem;
+                return _origVcpUs != (long)comboBoxVCPUs.SelectedItem;
             }
         }
 
-        private bool HasVCPUWeightChanged
+        private bool HasVcpuWeightChanged
         {
             get
             {
-                return _OrigVCPUWeight != _CurrentVCPUWeight;
+                return _origVcpuWeight != _currentVcpuWeight;
             }
         }
 
-        private bool HasVCPUsAtStartupChanged
+        private bool HasVcpUsAtStartupChanged
         {
             get
             {
-                return isVcpuHotplugSupported && _OrigVCPUsAtStartup != (long)comboBoxInitialVCPUs.SelectedItem;
+                return _isVcpuHotplugSupported && _origVcpUsAtStartup != (long)comboBoxInitialVCPUs.SelectedItem;
             }
         }
 
@@ -382,7 +382,7 @@ namespace XenAdmin.SettingsPanels
         {
             get
             {
-                return vm.GetCoresPerSocket() != comboBoxTopology.CoresPerSocket;
+                return _vm.GetCoresPerSocket() != comboBoxTopology.CoresPerSocket;
             }
         }
 
@@ -398,7 +398,7 @@ namespace XenAdmin.SettingsPanels
         {
             get
             {
-                return isVcpuHotplugSupported ? (long)comboBoxInitialVCPUs.SelectedItem : (long)comboBoxVCPUs.SelectedItem;
+                return _isVcpuHotplugSupported ? (long)comboBoxInitialVCPUs.SelectedItem : (long)comboBoxVCPUs.SelectedItem;
             }
         }
 
@@ -406,24 +406,24 @@ namespace XenAdmin.SettingsPanels
         {
             List<AsyncAction> actions = new List<AsyncAction>();
 
-            if (HasVCPUWeightChanged)
+            if (HasVcpuWeightChanged)
             {
-                vm.SetVcpuWeight(Convert.ToInt32(_CurrentVCPUWeight));
+                _vm.SetVcpuWeight(Convert.ToInt32(_currentVcpuWeight));
             }
 
-            if (HasVCPUChanged || HasVCPUsAtStartupChanged)
+            if (HasVcpuChanged || HasVcpUsAtStartupChanged)
             {
-                actions.Add(new ChangeVCPUSettingsAction(vm, SelectedVcpusMax, SelectedVcpusAtStartup));
+                actions.Add(new ChangeVCPUSettingsAction(_vm, SelectedVcpusMax, SelectedVcpusAtStartup));
             }
 
             if (HasTopologyChanged)
             {
-                vm.SetCoresPerSocket(comboBoxTopology.CoresPerSocket);
+                _vm.SetCoresPerSocket(comboBoxTopology.CoresPerSocket);
             }
 			
 			if (HasMemoryChanged)
             {
-                actions.Add(memoryAction);  // Calculated in ValidToSave
+                actions.Add(_memoryAction);  // Calculated in ValidToSave
             }
 
             if (actions.Count == 0)
@@ -432,7 +432,7 @@ namespace XenAdmin.SettingsPanels
                 return actions[0];
             else
             {
-                MultipleAction multipleAction = new MultipleAction(vm.Connection, "", "", "", actions, true);
+                MultipleAction multipleAction = new MultipleAction(_vm.Connection, "", "", "", actions, true);
                 return multipleAction;
             }
         }
@@ -450,7 +450,7 @@ namespace XenAdmin.SettingsPanels
         /// </summary>
         private void lblVcpuWarning_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            if (vm == null)
+            if (_vm == null)
             {
                 System.Diagnostics.Trace.Assert(false, "Selected object should be a vm");
                 return;
@@ -467,22 +467,22 @@ namespace XenAdmin.SettingsPanels
                 if (dialog.IsCheckBoxChecked)
                 {
                     // User clicked 'ignore': set flag in VM.
-                    log.DebugFormat("Setting IgnoreExcessiveVcpus flag to true for VM {0}", vm.Name());
+                    Log.DebugFormat("Setting IgnoreExcessiveVcpus flag to true for VM {0}", _vm.Name());
 
-                    VM copyVm = (VM)vm.Clone();
+                    VM copyVm = (VM)_vm.Clone();
                     copyVm.SetIgnoreExcessiveVcpus(true);
 
                     try
                     {
-                        vm.Locked = true;
-                        copyVm.SaveChanges(vm.Connection.Session);
+                        _vm.Locked = true;
+                        copyVm.SaveChanges(_vm.Connection.Session);
                     }
                     finally
                     {
-                        vm.Locked = false;
+                        _vm.Locked = false;
                     }
                 }
-                else if (Program.MainWindow.SelectObjectInTree(vm))
+                else if (Program.MainWindow.SelectObjectInTree(_vm))
                 {
                     Program.MainWindow.SwitchToTab(MainWindow.Tab.General);
                 }
@@ -498,14 +498,14 @@ namespace XenAdmin.SettingsPanels
 
         private void ShowMemError(bool showAlways, bool testValue)
         {
-            if (vm == null || !ShowMemory)
+            if (_vm == null || !_showMemory)
                 return;
 
-            Host selectedAffinity = vm.Connection.Resolve<Host>(vm.power_state == vm_power_state.Running ? vm.resident_on : vm.affinity);
+            Host selectedAffinity = _vm.Connection.Resolve<Host>(_vm.power_state == vm_power_state.Running ? _vm.resident_on : _vm.affinity);
             if (selectedAffinity != null)
             {
-                Host_metrics host_metrics = vm.Connection.Resolve<Host_metrics>(selectedAffinity.metrics);
-                if ((showAlways || (testValue && (host_metrics != null && (double)host_metrics.memory_total < (double)nudMemory.Value * (double)Util.BINARY_MEGA))))
+                Host_metrics hostMetrics = _vm.Connection.Resolve<Host_metrics>(selectedAffinity.metrics);
+                if ((showAlways || (testValue && (hostMetrics != null && (double)hostMetrics.memory_total < (double)nudMemory.Value * (double)Util.BINARY_MEGA))))
                 {
                     MemWarningLabel.Visible = true;
                 }
@@ -518,18 +518,18 @@ namespace XenAdmin.SettingsPanels
 
         private void comboBoxVCPUs_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ValidateVCPUSettings();
+            ValidateVcpuSettings();
             comboBoxTopology.Update((long)comboBoxVCPUs.SelectedItem);
             ValidateTopologySettings();
-            RefreshCurrentVCPUs();
+            RefreshCurrentVcpUs();
         }
 
-        private void ValidateVCPUSettings()
+        private void ValidateVcpuSettings()
         {
-            if (vm == null || !comboBoxVCPUs.Enabled)
+            if (_vm == null || !comboBoxVCPUs.Enabled)
                 return;
-            var homeHost = vm.Home();
-            var maxPhysicalCpus = vm.Connection.Cache.Hosts.Select(h => h.host_CPUs.Count).Max();
+            var homeHost = _vm.Home();
+            var maxPhysicalCpus = _vm.Connection.Cache.Hosts.Select(h => h.host_CPUs.Count).Max();
             var homeHostPhysicalCpus = homeHost?.host_CPUs.Count;
 
 
@@ -550,9 +550,9 @@ namespace XenAdmin.SettingsPanels
                     VCPUWarningLabel.Visible = false;
                 }
             }
-            else if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax < minVCPUs)
+            else if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax < _minVcpUs)
             {
-                VCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, minVCPUs);
+                VCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVcpUs);
                 VCPUWarningLabel.Visible = true;
             }
             else if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
@@ -565,9 +565,9 @@ namespace XenAdmin.SettingsPanels
                 VCPUWarningLabel.Visible = false;
             }
 
-            if (comboBoxInitialVCPUs.SelectedItem != null && SelectedVcpusAtStartup < minVCPUs)
+            if (comboBoxInitialVCPUs.SelectedItem != null && SelectedVcpusAtStartup < _minVcpUs)
             {
-                initialVCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, minVCPUs);
+                initialVCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVcpUs);
                 initialVCPUWarningLabel.Visible = true;
             }
             else
@@ -582,9 +582,9 @@ namespace XenAdmin.SettingsPanels
                 labelInvalidVCPUWarning.Text = VM.ValidVCPUConfiguration((long)comboBoxVCPUs.SelectedItem, comboBoxTopology.CoresPerSocket);
         }
 
-        private long _prevVCPUsMax;
+        private long _prevVcpUsMax;
 
-        private void RefreshCurrentVCPUs()
+        private void RefreshCurrentVcpUs()
         {
             // refresh comboBoxInitialVCPUs if it's visible and populated
             if (comboBoxInitialVCPUs.Visible && comboBoxInitialVCPUs.Items.Count > 0)
@@ -597,11 +597,11 @@ namespace XenAdmin.SettingsPanels
                
                 if (SelectedVcpusMax < SelectedVcpusAtStartup)
                     newValue = SelectedVcpusMax;
-                else if (SelectedVcpusAtStartup == _prevVCPUsMax && SelectedVcpusMax != _prevVCPUsMax)
+                else if (SelectedVcpusAtStartup == _prevVcpUsMax && SelectedVcpusMax != _prevVcpUsMax)
                     newValue = SelectedVcpusMax;
 
-                PopulateVCPUsAtStartup(SelectedVcpusMax, newValue);
-                _prevVCPUsMax = SelectedVcpusMax;
+                PopulateVcpUsAtStartup(SelectedVcpusMax, newValue);
+                _prevVcpUsMax = SelectedVcpusMax;
             }
         }
 
@@ -609,7 +609,7 @@ namespace XenAdmin.SettingsPanels
         {
             get
             {
-                return ShowMemory ?
+                return _showMemory ?
                     String.Format(Messages.CPU_AND_MEMORY_SUB, SelectedVcpusAtStartup, nudMemory.Value) :
                     String.Format(Messages.CPU_SUB, SelectedVcpusAtStartup);
             }
@@ -622,7 +622,7 @@ namespace XenAdmin.SettingsPanels
 
         private void comboBoxInitialVCPUs_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ValidateVCPUSettings();
+            ValidateVcpuSettings();
         }
     }
 }

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -331,11 +331,11 @@ namespace XenAdmin.SettingsPanels
                     warnings.Add(Messages.VM_CPUMEMPAGE_VCPU_WARNING);
                 }
             }
-            else if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax < _minVCpus)
+            if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax < _minVCpus)
             {
                 warnings.Add(string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVCpus));
             }
-            else if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
+            if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
                 warnings.Add(string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand));
             }

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -555,6 +555,11 @@ namespace XenAdmin.SettingsPanels
                 VCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, minVCPUs);
                 VCPUWarningLabel.Visible = true;
             }
+            else if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
+            {
+                VCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS);
+                VCPUWarningLabel.Visible = true;
+            }
             else
             {
                 VCPUWarningLabel.Visible = false;

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -46,10 +46,11 @@ namespace XenAdmin.SettingsPanels
 {
     public partial class CpuMemoryEditPage : UserControl, IEditPage
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly log4net.ILog Log =
+            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         private VM _vm;
-        private bool _showMemory;       // If this VM has DMC, we don't show the memory controls on this page.
+        private bool _showMemory; // If this VM has DMC, we don't show the memory controls on this page.
 
         private bool _validToSave = true;
         private decimal _origMemory;
@@ -67,6 +68,7 @@ namespace XenAdmin.SettingsPanels
         // We use the _OrigVCPUs variable to store the original value that populates this combo box (VCPUs_max if hotplug is allowed, otherwise VCPUs_at_startup)
 
         private ChangeMemorySettingsAction _memoryAction;
+
         public bool ValidToSave
         {
             get
@@ -102,7 +104,7 @@ namespace XenAdmin.SettingsPanels
                     : Messages.CONFIRM_CHANGE_MEMORY_SINGULAR;
 
                 using (var dlg = new WarningDialog(msg,
-                    ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo))
+                           ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo))
                 {
                     if (dlg.ShowDialog(this) != DialogResult.Yes)
                         return null;
@@ -139,8 +141,7 @@ namespace XenAdmin.SettingsPanels
             if (!string.IsNullOrEmpty(nud.Text.Trim()))
                 return;
 
-            nud.Value = defaultValue >= nud.Minimum && defaultValue <= nud.Maximum ?
-                defaultValue : nud.Maximum;
+            nud.Value = defaultValue >= nud.Minimum && defaultValue <= nud.Maximum ? defaultValue : nud.Maximum;
 
             nud.Text = nud.Value.ToString(CultureInfo.InvariantCulture);
         }
@@ -244,7 +245,8 @@ namespace XenAdmin.SettingsPanels
             _origVCpusAtStartup = vm.VCPUs_at_startup > 0 ? vm.VCPUs_at_startup : 1;
             _origVCpuWeight = _currentVCpuWeight;
             _origVCpus = _isVCpuHotplugSupported ? _origVCpusMax : _origVCpusAtStartup;
-            _prevVCpusMax = _origVCpusMax;  // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
+            _prevVCpusMax =
+                _origVCpusMax; // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
 
             _currentVCpuWeight = Convert.ToDecimal(vm.GetVcpuWeight());
 
@@ -270,7 +272,8 @@ namespace XenAdmin.SettingsPanels
 
             comboBoxVCPUs.Enabled = comboBoxTopology.Enabled = _vm.power_state == vm_power_state.Halted;
 
-            comboBoxTopology.Populate(_vm.VCPUs_at_startup, _vm.VCPUs_max, _vm.GetCoresPerSocket(), _vm.MaxCoresPerSocket());
+            comboBoxTopology.Populate(_vm.VCPUs_at_startup, _vm.VCPUs_max, _vm.GetCoresPerSocket(),
+                _vm.MaxCoresPerSocket());
 
             // CA-12941 
             // We set a sensible maximum based on the template, but if the user sets something higher 
@@ -282,11 +285,13 @@ namespace XenAdmin.SettingsPanels
             if (_isVCpuHotplugSupported)
                 PopulateVCpusAtStartup(_origVCpusMax, _origVCpusAtStartup);
 
-            transparentTrackBar1.Value = Convert.ToInt32(Math.Log(Convert.ToDouble(_vm.GetVcpuWeight())) / Math.Log(4.0d));
+            transparentTrackBar1.Value =
+                Convert.ToInt32(Math.Log(Convert.ToDouble(_vm.GetVcpuWeight())) / Math.Log(4.0d));
             panel1.Enabled = _vm.power_state == vm_power_state.Halted;
         }
 
-        private void PopulateVCpuComboBox(ComboBox comboBox, long min, long max, long currentValue, Predicate<long> isValid)
+        private void PopulateVCpuComboBox(ComboBox comboBox, long min, long max, long currentValue,
+            Predicate<long> isValid)
         {
             comboBox.BeginUpdate();
             comboBox.Items.Clear();
@@ -295,6 +300,7 @@ namespace XenAdmin.SettingsPanels
                 if (i == currentValue || isValid(i))
                     comboBox.Items.Add(i);
             }
+
             if (currentValue > max)
                 comboBox.Items.Add(currentValue);
             comboBox.SelectedItem = currentValue;
@@ -324,17 +330,23 @@ namespace XenAdmin.SettingsPanels
             {
                 sb.AppendLine();
                 sb.AppendLine();
-                sb.Append(_isVCpuHotplugSupported ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY : Messages.VCPU_ONLY_WHEN_HALTED);
+                sb.Append(_isVCpuHotplugSupported
+                    ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY
+                    : Messages.VCPU_ONLY_WHEN_HALTED);
             }
+
             // add power state warning for Current number of vCPUs
-            if (_isVCpuHotplugSupported && _vm.power_state != vm_power_state.Halted && _vm.power_state != vm_power_state.Running)
+            if (_isVCpuHotplugSupported && _vm.power_state != vm_power_state.Halted &&
+                _vm.power_state != vm_power_state.Running)
             {
                 sb.Append(Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_READONLY);
             }
+
             return sb.ToString();
         }
 
-        public bool HasChanged => HasVCpuChanged || HasMemoryChanged || HasTopologyChanged || HasVCpusAtStartupChanged || HasVCpuWeightChanged;
+        public bool HasChanged => HasVCpuChanged || HasMemoryChanged || HasTopologyChanged ||
+                                  HasVCpusAtStartupChanged || HasVCpuWeightChanged;
 
         private bool HasMemoryChanged => _origMemory != nudMemory.Value;
 
@@ -342,13 +354,16 @@ namespace XenAdmin.SettingsPanels
 
         private bool HasVCpuWeightChanged => _origVCpuWeight != _currentVCpuWeight;
 
-        private bool HasVCpusAtStartupChanged => _isVCpuHotplugSupported && _origVCpusAtStartup != (long)comboBoxInitialVCPUs.SelectedItem;
+        private bool HasVCpusAtStartupChanged =>
+            _isVCpuHotplugSupported && _origVCpusAtStartup != (long)comboBoxInitialVCPUs.SelectedItem;
 
         private bool HasTopologyChanged => _vm.GetCoresPerSocket() != comboBoxTopology.CoresPerSocket;
 
         private long SelectedVCpusMax => (long)comboBoxVCPUs.SelectedItem;
 
-        private long SelectedVCpusAtStartup => _isVCpuHotplugSupported ? (long)comboBoxInitialVCPUs.SelectedItem : (long)comboBoxVCPUs.SelectedItem;
+        private long SelectedVCpusAtStartup => _isVCpuHotplugSupported
+            ? (long)comboBoxInitialVCPUs.SelectedItem
+            : (long)comboBoxVCPUs.SelectedItem;
 
         public AsyncAction SaveSettings()
         {
@@ -371,7 +386,7 @@ namespace XenAdmin.SettingsPanels
 
             if (HasMemoryChanged)
             {
-                actions.Add(_memoryAction);  // Calculated in ValidToSave
+                actions.Add(_memoryAction); // Calculated in ValidToSave
             }
 
             if (actions.Count == 0)
@@ -386,12 +401,18 @@ namespace XenAdmin.SettingsPanels
         }
 
         /** Show local validation balloon tooltips */
-        public void ShowLocalValidationMessages() { }
+        public void ShowLocalValidationMessages()
+        {
+        }
 
-        public void HideLocalValidationMessages() { }
+        public void HideLocalValidationMessages()
+        {
+        }
 
         /** Unregister listeners, dispose balloon tooltips, etc. */
-        public void Cleanup() { }
+        public void Cleanup()
+        {
+        }
 
         /// <summary>
         /// Shows the warning dialog about vCPUs > pCPUs.
@@ -405,10 +426,10 @@ namespace XenAdmin.SettingsPanels
             }
 
             using (var dialog = new WarningDialog(Messages.VCPUS_MORE_THAN_PCPUS)
-            {
-                ShowCheckbox = true,
-                CheckboxCaption = Messages.DO_NOT_SHOW_THIS_MESSAGE
-            })
+                   {
+                       ShowCheckbox = true,
+                       CheckboxCaption = Messages.DO_NOT_SHOW_THIS_MESSAGE
+                   })
             {
                 dialog.ShowDialog(this);
 
@@ -449,11 +470,14 @@ namespace XenAdmin.SettingsPanels
             if (_vm == null || !_showMemory)
                 return;
 
-            var selectedAffinity = _vm.Connection.Resolve(_vm.power_state == vm_power_state.Running ? _vm.resident_on : _vm.affinity);
+            var selectedAffinity =
+                _vm.Connection.Resolve(_vm.power_state == vm_power_state.Running ? _vm.resident_on : _vm.affinity);
             if (selectedAffinity != null)
             {
                 var hostMetrics = _vm.Connection.Resolve(selectedAffinity.metrics);
-                if ((showAlways || (testValue && (hostMetrics != null && hostMetrics.memory_total < (double)nudMemory.Value * Util.BINARY_MEGA))))
+                if ((showAlways || (testValue && (hostMetrics != null &&
+                                                  hostMetrics.memory_total <
+                                                  (double)nudMemory.Value * Util.BINARY_MEGA))))
                 {
                     MemWarningLabel.Visible = true;
                 }
@@ -483,7 +507,8 @@ namespace XenAdmin.SettingsPanels
 
             if (comboBoxVCPUs.SelectedItem != null && maxPhysicalCpus < SelectedVCpusMax)
             {
-                if (homeHostPhysicalCpus != null && homeHostPhysicalCpus < SelectedVCpusMax && maxPhysicalCpus >= SelectedVCpusMax)
+                if (homeHostPhysicalCpus != null && homeHostPhysicalCpus < SelectedVCpusMax &&
+                    maxPhysicalCpus >= SelectedVCpusMax)
                 {
                     VCPUWarningLabel.Text = Messages.VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING;
                     VCPUWarningLabel.Visible = true;
@@ -505,7 +530,8 @@ namespace XenAdmin.SettingsPanels
             }
             else if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
-                VCPUWarningLabel.Text = string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
+                VCPUWarningLabel.Text = string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING,
+                    VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
                 VCPUWarningLabel.Visible = true;
             }
             else
@@ -527,7 +553,8 @@ namespace XenAdmin.SettingsPanels
         private void ValidateTopologySettings()
         {
             if (comboBoxVCPUs.SelectedItem != null)
-                labelInvalidVCPUWarning.Text = VM.ValidVCPUConfiguration((long)comboBoxVCPUs.SelectedItem, comboBoxTopology.CoresPerSocket);
+                labelInvalidVCPUWarning.Text =
+                    VM.ValidVCPUConfiguration((long)comboBoxVCPUs.SelectedItem, comboBoxTopology.CoresPerSocket);
         }
 
         private long _prevVCpusMax;
@@ -554,9 +581,9 @@ namespace XenAdmin.SettingsPanels
         }
 
         public string SubText =>
-            _showMemory ?
-                string.Format(Messages.CPU_AND_MEMORY_SUB, SelectedVCpusAtStartup, nudMemory.Value) :
-                string.Format(Messages.CPU_SUB, SelectedVCpusAtStartup);
+            _showMemory
+                ? string.Format(Messages.CPU_AND_MEMORY_SUB, SelectedVCpusAtStartup, nudMemory.Value)
+                : string.Format(Messages.CPU_SUB, SelectedVCpusAtStartup);
 
         private void comboBoxTopology_SelectedIndexChanged(object sender, EventArgs e)
         {

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -557,7 +557,7 @@ namespace XenAdmin.SettingsPanels
             }
             else if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
-                VCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS);
+                VCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
                 VCPUWarningLabel.Visible = true;
             }
             else

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -356,7 +356,7 @@ namespace XenAdmin.SettingsPanels
                 var topologyWarning = VM.ValidVCPUConfiguration((long)comboBoxVCPUs.SelectedItem, comboBoxTopology.CoresPerSocket);
                 if (!string.IsNullOrEmpty(topologyWarning))
                 {
-                    warnings.Add(topologyWarning);
+                    warnings.Add($"{topologyWarning}.");
                 }
             }
             ShowTopologyWarnings(warnings);

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -557,7 +557,7 @@ namespace XenAdmin.SettingsPanels
             }
             else if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
-                VCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
+                VCPUWarningLabel.Text = string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
                 VCPUWarningLabel.Visible = true;
             }
             else

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -31,6 +31,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 
@@ -527,14 +528,27 @@ namespace XenAdmin.SettingsPanels
         {
             if (vm == null || !comboBoxVCPUs.Enabled)
                 return;
-            Host selectedAffinity = vm.Home();
-            if (selectedAffinity == null && vm.Connection.Cache.Hosts.Length == 1)
-                selectedAffinity = vm.Connection.Cache.Hosts[0];
+            var homeHost = vm.Home();
+            var maxPhysicalCpus = vm.Connection.Cache.Hosts.Select(h => h.host_CPUs.Count).Max();
+            var homeHostPhysicalCpus = homeHost?.host_CPUs.Count;
 
-            if (selectedAffinity != null && comboBoxVCPUs.SelectedItem != null && selectedAffinity.host_CPUs.Count < SelectedVcpusMax)
+
+            if (comboBoxVCPUs.SelectedItem != null && maxPhysicalCpus < SelectedVcpusMax)
             {
-                VCPUWarningLabel.Text = Messages.VM_CPUMEMPAGE_VCPU_WARNING;
-                VCPUWarningLabel.Visible = true;
+                if (homeHostPhysicalCpus != null && homeHostPhysicalCpus < SelectedVcpusMax && maxPhysicalCpus >= SelectedVcpusMax)
+                {
+                    VCPUWarningLabel.Text = Messages.VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING;
+                    VCPUWarningLabel.Visible = true;
+                }
+                else if (maxPhysicalCpus < SelectedVcpusMax)
+                {
+                    VCPUWarningLabel.Text = Messages.VM_CPUMEMPAGE_VCPU_WARNING;
+                    VCPUWarningLabel.Visible = true;
+                }
+                else
+                {
+                    VCPUWarningLabel.Visible = false;
+                }
             }
             else if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax < minVCPUs)
             {

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -49,7 +49,7 @@ namespace XenAdmin.SettingsPanels
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         private VM _vm;
-        bool _showMemory = false;       // If this VM has DMC, we don't show the memory controls on this page.
+        private bool _showMemory = false;       // If this VM has DMC, we don't show the memory controls on this page.
 
         private bool _validToSave = true;
         private decimal _origMemory;
@@ -129,7 +129,7 @@ namespace XenAdmin.SettingsPanels
 
         public Image Image => Images.StaticImages._000_CPU_h32bit_16;
 
-        void nudMemory_LostFocus(object sender, EventArgs e)
+        private void nudMemory_LostFocus(object sender, EventArgs e)
         {
             ValidateNud(nudMemory, (decimal)_vm.memory_static_max / Util.BINARY_MEGA);
         }
@@ -145,7 +145,7 @@ namespace XenAdmin.SettingsPanels
             nud.Text = nud.Value.ToString();
         }
 
-        void nudMemory_TextChanged(object sender, EventArgs e)
+        private void nudMemory_TextChanged(object sender, EventArgs e)
         {
             decimal val;
             if (decimal.TryParse(nudMemory.Text, out val))

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -32,13 +32,10 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using XenAdmin.Actions;
-using XenAdmin.Commands;
 using XenAdmin.Core;
 using XenAPI;
-using XenAdmin.Dialogs;
 
 namespace XenAdmin.SettingsPanels
 {
@@ -47,9 +44,7 @@ namespace XenAdmin.SettingsPanels
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
 
         private VM _vm;
-        private bool _showMemory; // If this VM has DMC, we don't show the memory controls on this page.
         private bool _validToSave = true;
-        private double _origMemory;
         private long _origVCpus;
         private long _origVCpusMax;
         private long _origVCpusAtStartup;
@@ -63,10 +58,6 @@ namespace XenAdmin.SettingsPanels
         // If vCPU hotplug is supported, comboBoxVCPUs represents the maximum number of vCPUs (VCPUs_max). And the initial number of vCPUs is represented in comboBoxInitialVCPUs (which is only visible in this case) 
         // If vCPU hotplug is not supported, comboBoxVCPUs represents the initial number of vCPUs (VCPUs_at_startup). In this case we will also set the VM property VCPUs_max to the same value.
         // We use the _OrigVCPUs variable to store the original value that populates this combo box (VCPUs_max if hotplug is allowed, otherwise VCPUs_at_startup)
-
-        private ChangeMemorySettingsAction _memoryAction;
-
-        private bool HasMemoryChanged => _origMemory != memorySpinner.Value;
 
         private bool HasVCpuChanged => _origVCpus != (long)comboBoxVCPUs.SelectedItem;
 
@@ -85,18 +76,13 @@ namespace XenAdmin.SettingsPanels
 
         public Image Image => Images.StaticImages._000_CPU_h32bit_16;
 
-        public string SubText =>
-            _showMemory
-                ? string.Format(Messages.CPU_AND_MEMORY_SUB, SelectedVCpusAtStartup, memorySpinner.Value / Util.BINARY_MEGA)
-                : string.Format(Messages.CPU_SUB, SelectedVCpusAtStartup);
+        public string SubText => string.Format(Messages.CPU_SUB, SelectedVCpusAtStartup);
 
         public CpuMemoryEditPage()
         {
             InitializeComponent();
-
-            Text = Messages.CPU_AND_MEMORY;
-
-            transparentTrackBar1.Scroll += new EventHandler(tbPriority_Scroll);
+            transparentTrackBar1.Scroll += tbPriority_Scroll;
+            Text = Messages.CPU;
         }
 
         private void InitializeVCpuControls()
@@ -134,48 +120,44 @@ namespace XenAdmin.SettingsPanels
             panel1.Enabled = _vm.power_state == vm_power_state.Halted;
         }
 
-        public void Repopulate()
+        private void Repopulate()
         {
             var vm = _vm;
-
-            Text = _showMemory ? Messages.CPU_AND_MEMORY : Messages.CPU;
-            if (!_showMemory)
-                lblMemory.Visible = memorySpinner.Visible = MemWarningLabel.Visible = false;
-            else if (vm.power_state != vm_power_state.Halted && vm.power_state != vm_power_state.Running)
-            {
-                memorySpinner.Enabled = false;
-            }
-
-            // Since updates come in dribs and drabs, avoid error if new max and min arrive
-            // out of sync and maximum < minimum.
-            if (vm.memory_dynamic_max >= vm.memory_dynamic_min &&
-                vm.memory_static_max >= vm.memory_static_min)
-            {
-                var min = vm.memory_static_min;
-                var max = vm.MaxMemAllowed();
-                var value = vm.memory_static_max;
-                // Avoid setting the range to exclude the current value: CA-40041
-                if (value > max)
-                    max = value;
-                if (value < min)
-                    min = value;
-                memorySpinner.Initialize(value, max, Messages.VAL_MEGB);
-                memorySpinner.SetRange(min, max);
-                ValidateMemorySettings();
-            }
 
             _isVCpuHotplugSupported = vm.SupportsVcpuHotplug();
             _minVCpus = vm.MinVCPUs();
 
-            label1.Text = GetRubric();
+            label1.Text = Messages.VM_CPUMEMPAGE_RUBRIC;
 
-            _origMemory = memorySpinner.Value;
+            if (_isVCpuHotplugSupported)
+                label1.Text += Messages.VM_CPUMEMPAGE_RUBRIC_HOTPLUG;
+
+            if (_vm.power_state != vm_power_state.Halted)
+            {
+                if (_isVCpuHotplugSupported)
+                {
+                    labelInfo.Text = Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY;
+
+                    if (_vm.power_state != vm_power_state.Running)
+                        labelInfo.Text += Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_READONLY;
+                }
+                else
+                {
+                    labelInfo.Text = Messages.VCPU_ONLY_WHEN_HALTED;
+                }
+
+                tableLayoutPanelInfo.Visible = true;
+            }
+            else
+            {
+                tableLayoutPanelInfo.Visible = false;
+            }
+
             _origVCpusMax = vm.VCPUs_max > 0 ? vm.VCPUs_max : 1;
             _origVCpusAtStartup = vm.VCPUs_at_startup > 0 ? vm.VCPUs_at_startup : 1;
             _origVCpuWeight = _currentVCpuWeight;
             _origVCpus = _isVCpuHotplugSupported ? _origVCpusMax : _origVCpusAtStartup;
-            _prevVCpusMax =
-                _origVCpusMax; // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
+            _prevVCpusMax = _origVCpusMax; // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
 
             _currentVCpuWeight = Convert.ToDecimal(vm.GetVcpuWeight());
 
@@ -212,51 +194,17 @@ namespace XenAdmin.SettingsPanels
             PopulateVCpuComboBox(comboBoxInitialVCPUs, min, max, currentValue, i => true);
         }
 
-        private string GetRubric()
-        {
-            var sb = new StringBuilder();
-            sb.Append(Messages.VM_CPUMEMPAGE_RUBRIC);
-            // add hotplug text
-            if (_isVCpuHotplugSupported)
-                sb.Append(Messages.VM_CPUMEMPAGE_RUBRIC_HOTPLUG);
-            // add power state warning
-            if (_vm.power_state != vm_power_state.Halted)
-            {
-                sb.AppendLine();
-                sb.AppendLine();
-                sb.Append(_isVCpuHotplugSupported
-                    ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY
-                    : Messages.VCPU_ONLY_WHEN_HALTED);
-            }
-
-            // add power state warning for Current number of vCPUs
-            if (_isVCpuHotplugSupported && _vm.power_state != vm_power_state.Halted &&
-                _vm.power_state != vm_power_state.Running)
-            {
-                sb.Append(Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_READONLY);
-            }
-
-            return sb.ToString();
-        }
-
-        private void ShowMemoryWarnings(IReadOnlyCollection<string> warnings)
-        {
-            var show = warnings.Count > 0;
-            memoryWarningLabel.Text = show ? string.Join(Environment.NewLine, warnings) : null;
-            memoryPictureBox.Visible = memoryWarningLabel.Visible = show;
-        }
-
         private void ShowCpuWarnings(IReadOnlyCollection<string> warnings)
         {
             var show = warnings.Count > 0;
-            cpuWarningLabel.Text = show ? string.Join(Environment.NewLine, warnings) : null;
+            cpuWarningLabel.Text = show ? string.Join($"{Environment.NewLine}{Environment.NewLine}", warnings) : null;
             cpuWarningPictureBox.Visible = cpuWarningLabel.Visible = show;
         }
 
         private void ShowTopologyWarnings(IReadOnlyCollection<string> warnings)
         {
             var show = warnings.Count > 0;
-            topologyWarningLabel.Text = show ? string.Join(Environment.NewLine, warnings) : null;
+            topologyWarningLabel.Text = show ? string.Join($"{Environment.NewLine}{Environment.NewLine}", warnings) : null;
             topologyPictureBox.Visible = topologyWarningLabel.Visible = show;
         }
 
@@ -264,6 +212,7 @@ namespace XenAdmin.SettingsPanels
         {
             if (_vm == null || !comboBoxVCPUs.Enabled)
                 return;
+
             var homeHost = _vm.Home();
             var maxPhysicalCpus = _vm.Connection.Cache.Hosts.Select(h => h.host_CPUs.Count).Max();
             var homeHostPhysicalCpus = homeHost?.host_CPUs.Count;
@@ -282,10 +231,12 @@ namespace XenAdmin.SettingsPanels
                     warnings.Add(Messages.VM_CPUMEMPAGE_VCPU_WARNING);
                 }
             }
+
             if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax < _minVCpus)
             {
                 warnings.Add(string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVCpus));
             }
+
             if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
                 warnings.Add(string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand));
@@ -305,62 +256,13 @@ namespace XenAdmin.SettingsPanels
             if (comboBoxVCPUs.SelectedItem != null)
             {
                 var topologyWarning = VM.ValidVCPUConfiguration((long)comboBoxVCPUs.SelectedItem, comboBoxTopology.CoresPerSocket);
+
                 if (!string.IsNullOrEmpty(topologyWarning))
                 {
                     warnings.Add($"{topologyWarning}.");
                 }
             }
             ShowTopologyWarnings(warnings);
-        }
-
-        private void ValidateMemorySettings()
-        {
-            var warnings = new List<string>();
-            if (_vm != null && _showMemory)
-            {
-                if (_vm.power_state != vm_power_state.Halted && _vm.power_state != vm_power_state.Running)
-                {
-                    warnings.Add(Messages.MEM_NOT_WHEN_SUSPENDED);
-                }
-
-                var selectedAffinity =
-                    _vm.Connection.Resolve(_vm.power_state == vm_power_state.Running ? _vm.resident_on : _vm.affinity);
-                if (selectedAffinity != null)
-                {
-                    var hostMetrics = _vm.Connection.Resolve(selectedAffinity.metrics);
-                    if (hostMetrics != null && hostMetrics.memory_total < memorySpinner.Value)
-                    {
-                        warnings.Add(Messages.VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_HOST);
-                    }
-                }
-                else
-                {
-                    var hosts = _vm.Connection.Cache.Hosts;
-                    var hostHasEnoughMemory = false;
-                    foreach (var host in hosts)
-                    {
-                        if (host == null)
-                        {
-                            log.Warn($"One of the hosts cached for VM {_vm.Name()} is null. Cannot check its metrics.");
-                            continue;
-                        }
-
-                        var hostMetrics = _vm.Connection.Resolve(host.metrics);
-                        if (hostMetrics.memory_total < memorySpinner.Value)
-                        {
-                            continue;
-                        }
-                        hostHasEnoughMemory = true;
-                        break;
-                    }
-
-                    if (!hostHasEnoughMemory)
-                    {
-                        warnings.Add(Messages.VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_POOL);
-                    }
-                }
-            }
-            ShowMemoryWarnings(warnings);
         }
 
         private void RefreshCurrentVCpus()
@@ -384,27 +286,6 @@ namespace XenAdmin.SettingsPanels
             }
         }
 
-        private ChangeMemorySettingsAction ConfirmAndCalculateActions(long memoryBytes)
-        {
-            if (_vm.power_state != vm_power_state.Halted)
-            {
-                var msg = _vm.SupportsBallooning() && !Helpers.FeatureForbidden(_vm, Host.RestrictDMC)
-                    ? Messages.CONFIRM_CHANGE_MEMORY_MAX_SINGULAR
-                    : Messages.CONFIRM_CHANGE_MEMORY_SINGULAR;
-
-                using (var dlg = new WarningDialog(msg,
-                           ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo))
-                {
-                    if (dlg.ShowDialog(this) != DialogResult.Yes)
-                        return null;
-                }
-            }
-
-            return new ChangeMemorySettingsAction(_vm,
-                string.Format(Messages.ACTION_CHANGE_MEMORY_SETTINGS, _vm.Name()), _vm.memory_static_min, memoryBytes, memoryBytes, memoryBytes,
-                VMOperationCommand.WarningDialogHAInvalidConfig, VMOperationCommand.StartDiagnosisForm, true);
-        }
-
         #region IEditPage
 
         public AsyncAction SaveSettings()
@@ -424,11 +305,6 @@ namespace XenAdmin.SettingsPanels
             if (HasTopologyChanged)
             {
                 _vm.SetCoresPerSocket(comboBoxTopology.CoresPerSocket);
-            }
-
-            if (HasMemoryChanged)
-            {
-                actions.Add(_memoryAction); // Calculated in ValidToSave
             }
 
             switch (actions.Count)
@@ -451,30 +327,10 @@ namespace XenAdmin.SettingsPanels
         public void SetXenObjects(IXenObject orig, IXenObject clone)
         {
             _vm = (VM)clone;
-            _showMemory = Helpers.FeatureForbidden(_vm, Host.RestrictDMC);
             Repopulate();
         }
 
-        public bool ValidToSave
-        {
-            get
-            {
-                if (!_validToSave)
-                    return false;
-
-                // Also confirm whether the user wants to save memory changes.
-                // If not, don't close the properties dialog.
-                if (HasMemoryChanged)
-                {
-                    var mem = Convert.ToInt64(memorySpinner.Value);
-                    _memoryAction = ConfirmAndCalculateActions(mem);
-                    if (_memoryAction == null)
-                        return false;
-                }
-
-                return true;
-            }
-        }
+        public bool ValidToSave => _validToSave;
 
         /** Show local validation balloon tooltips */
         public void ShowLocalValidationMessages()
@@ -493,7 +349,7 @@ namespace XenAdmin.SettingsPanels
             // not applicable
         }
 
-        public bool HasChanged => HasVCpuChanged || HasMemoryChanged || HasTopologyChanged ||
+        public bool HasChanged => HasVCpuChanged || HasTopologyChanged ||
                                   HasVCpusAtStartupChanged || HasVCpuWeightChanged;
 
         #endregion
@@ -523,10 +379,6 @@ namespace XenAdmin.SettingsPanels
             _currentVCpuWeight = Convert.ToDecimal(Math.Pow(4.0d, Convert.ToDouble(transparentTrackBar1.Value)));
             if (transparentTrackBar1.Value == transparentTrackBar1.Max)
                 _currentVCpuWeight--;
-        }
-        private void memorySpinner_SpinnerValueChanged(object sender, EventArgs e)
-        {
-            ValidateMemorySettings();
         }
 
         #endregion

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.ja.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.ja.resx
@@ -898,7 +898,7 @@
     <value>500, 500</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>CPUMemoryEditPage</value>
+    <value>CpuMemoryEditPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -439,7 +439,7 @@
     <value>Top</value>
   </data>
   <data name="warningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 282</value>
+    <value>0, 263</value>
   </data>
   <data name="warningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 0, 3</value>
@@ -469,7 +469,7 @@
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="comboBoxInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 117</value>
+    <value>129, 98</value>
   </data>
   <data name="comboBoxInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
@@ -499,7 +499,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 117</value>
+    <value>3, 98</value>
   </data>
   <data name="labelInitialVCPUs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -532,7 +532,7 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="comboBoxTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 90</value>
+    <value>129, 71</value>
   </data>
   <data name="comboBoxTopology.Size" type="System.Drawing.Size, System.Drawing">
     <value>250, 21</value>
@@ -562,7 +562,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 90</value>
+    <value>3, 71</value>
   </data>
   <data name="labelTopology.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -601,7 +601,7 @@
     <value>NoControl</value>
   </data>
   <data name="MemWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>230, 253</value>
+    <value>230, 234</value>
   </data>
   <data name="MemWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>267, 26</value>
@@ -700,7 +700,7 @@
     <value>Fill</value>
   </data>
   <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 256</value>
+    <value>126, 237</value>
   </data>
   <data name="panel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 0, 3</value>
@@ -751,7 +751,7 @@
     <value>3</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 187</value>
+    <value>3, 168</value>
   </data>
   <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 24</value>
@@ -787,7 +787,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 63</value>
+    <value>3, 44</value>
   </data>
   <data name="lblVCPUs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -816,42 +816,6 @@
   <data name="&gt;&gt;lblVCPUs.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="lblVcpuWarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblVcpuWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblVcpuWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 41</value>
-  </data>
-  <data name="lblVcpuWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 6</value>
-  </data>
-  <data name="lblVcpuWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>183, 13</value>
-  </data>
-  <data name="lblVcpuWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="lblVcpuWarning.Text" xml:space="preserve">
-    <value>How can I improve VM performance?</value>
-  </data>
-  <data name="lblVcpuWarning.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblVcpuWarning.Name" xml:space="preserve">
-    <value>lblVcpuWarning</value>
-  </data>
-  <data name="&gt;&gt;lblVcpuWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVcpuWarning.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;lblVcpuWarning.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
   <data name="lblMemory.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -862,7 +826,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblMemory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 256</value>
+    <value>3, 237</value>
   </data>
   <data name="lblMemory.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -889,7 +853,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblMemory.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -925,10 +889,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>11</value>
   </data>
   <data name="comboBoxVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 63</value>
+    <value>129, 44</value>
   </data>
   <data name="comboBoxVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
@@ -946,7 +910,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>12</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -979,13 +943,13 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="panel2" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblVcpuWarning" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="panel2" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="lblPriority.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="lblPriority.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 161</value>
+    <value>3, 142</value>
   </data>
   <data name="lblPriority.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 10, 0, 0</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -228,44 +228,248 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="initialVCPUWarningLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="warningsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="initialVCPUWarningLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="warningsTableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <data name="initialVCPUWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="warningsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="cpuWarningPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="initialVCPUWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 133</value>
+  <data name="cpuWarningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 3</value>
   </data>
-  <data name="initialVCPUWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>312, 27</value>
+  <data name="cpuWarningPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
   </data>
-  <data name="initialVCPUWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+  <data name="cpuWarningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 16</value>
   </data>
-  <data name="initialVCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
+  <data name="cpuWarningPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
   </data>
-  <data name="initialVCPUWarningLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;initialVCPUWarningLabel.Name" xml:space="preserve">
-    <value>initialVCPUWarningLabel</value>
-  </data>
-  <data name="&gt;&gt;initialVCPUWarningLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;initialVCPUWarningLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;initialVCPUWarningLabel.ZOrder" xml:space="preserve">
+  <data name="cpuWarningPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
+  <data name="cpuWarningPictureBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningPictureBox.Name" xml:space="preserve">
+    <value>cpuWarningPictureBox</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningPictureBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningPictureBox.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningPictureBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cpuWarningLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cpuWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cpuWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 3</value>
+  </data>
+  <data name="cpuWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="cpuWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="cpuWarningLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="cpuWarningLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.Name" xml:space="preserve">
+    <value>cpuWarningLabel</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="memoryWarningLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="memoryWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="memoryWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="memoryWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="memoryWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="memoryWarningLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="memoryWarningLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.Name" xml:space="preserve">
+    <value>memoryWarningLabel</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="topologyWarningLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="topologyWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="topologyWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 47</value>
+  </data>
+  <data name="topologyWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="topologyWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="topologyWarningLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="topologyWarningLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;topologyWarningLabel.Name" xml:space="preserve">
+    <value>topologyWarningLabel</value>
+  </data>
+  <data name="&gt;&gt;topologyWarningLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;topologyWarningLabel.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;topologyWarningLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="memoryPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="memoryPictureBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="memoryPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="memoryPictureBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 16</value>
+  </data>
+  <data name="memoryPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
+  </data>
+  <data name="memoryPictureBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="memoryPictureBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.Name" xml:space="preserve">
+    <value>memoryPictureBox</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="topologyPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="topologyPictureBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 47</value>
+  </data>
+  <data name="topologyPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="topologyPictureBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 14</value>
+  </data>
+  <data name="topologyPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
+  </data>
+  <data name="topologyPictureBox.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="topologyPictureBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;topologyPictureBox.Name" xml:space="preserve">
+    <value>topologyPictureBox</value>
+  </data>
+  <data name="&gt;&gt;topologyPictureBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;topologyPictureBox.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;topologyPictureBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 282</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="warningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>500, 64</value>
+  </data>
+  <data name="warningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.Name" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="warningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
   <data name="comboBoxInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 136</value>
+    <value>129, 117</value>
   </data>
   <data name="comboBoxInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
@@ -295,7 +499,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 136</value>
+    <value>3, 117</value>
   </data>
   <data name="labelInitialVCPUs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -324,39 +528,6 @@
   <data name="&gt;&gt;labelInitialVCPUs.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="labelInvalidVCPUWarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 114</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 6</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>368, 13</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Name" xml:space="preserve">
-    <value>labelInvalidVCPUWarning</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="comboBoxTopology.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
   </data>
@@ -379,7 +550,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="labelTopology.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -418,7 +589,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelTopology.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="MemWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -430,7 +601,7 @@
     <value>NoControl</value>
   </data>
   <data name="MemWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>230, 272</value>
+    <value>230, 253</value>
   </data>
   <data name="MemWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>267, 26</value>
@@ -457,7 +628,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;MemWarningLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="panel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -529,7 +700,7 @@
     <value>Fill</value>
   </data>
   <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 275</value>
+    <value>126, 256</value>
   </data>
   <data name="panel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 0, 3</value>
@@ -550,7 +721,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -580,7 +751,7 @@
     <value>3</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 206</value>
+    <value>3, 187</value>
   </data>
   <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 24</value>
@@ -604,7 +775,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="lblVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -643,7 +814,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblVCPUs.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="lblVcpuWarning.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -679,7 +850,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblVcpuWarning.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
   </data>
   <data name="lblMemory.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -691,7 +862,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblMemory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 275</value>
+    <value>3, 256</value>
   </data>
   <data name="lblMemory.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -718,43 +889,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblMemory.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="VCPUWarningLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="VCPUWarningLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="VCPUWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="VCPUWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 60</value>
-  </data>
-  <data name="VCPUWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>312, 27</value>
-  </data>
-  <data name="VCPUWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="VCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="VCPUWarningLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;VCPUWarningLabel.Name" xml:space="preserve">
-    <value>VCPUWarningLabel</value>
-  </data>
-  <data name="&gt;&gt;VCPUWarningLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;VCPUWarningLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;VCPUWarningLabel.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>11</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -790,7 +925,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>12</value>
   </data>
   <data name="comboBoxVCPUs.Location" type="System.Drawing.Point, System.Drawing">
     <value>129, 63</value>
@@ -811,7 +946,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>13</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -844,13 +979,13 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="initialVCPUWarningLabel" Row="6" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInvalidVCPUWarning" Row="5" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="panel2" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblVcpuWarning" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="VCPUWarningLabel" Row="2" RowSpan="2" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="panel2" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblVcpuWarning" Row="1" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="lblPriority.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="lblPriority.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 180</value>
+    <value>3, 161</value>
   </data>
   <data name="lblPriority.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 10, 0, 0</value>
@@ -877,7 +1012,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblPriority.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>8</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -739,7 +739,7 @@
     <value>4</value>
   </data>
   <data name="VCPUWarningLabel.Text" xml:space="preserve">
-    <value>More vCPUs than physical CPUs may lead to reduced VM performance</value>
+    <value>You cannot start VMs with more vCPUs than there are physical CPUs on any host in the pool</value>
   </data>
   <data name="VCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -895,7 +895,7 @@
     <value>500, 500</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>CPUMemoryEditPage</value>
+    <value>CpuMemoryEditPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -466,7 +466,7 @@
     <value>0</value>
   </data>
   <data name="warningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="comboBoxInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
     <value>129, 98</value>
@@ -630,97 +630,34 @@
   <data name="&gt;&gt;MemWarningLabel.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="panel2.AutoSize" type="System.Boolean, mscorlib">
+  <data name="memorySpinner.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="panel2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+  <data name="memorySpinner.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
-  <data name="lblMB.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="memorySpinner.Location" type="System.Drawing.Point, System.Drawing">
+    <value>126, 234</value>
   </data>
-  <data name="lblMB.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblMB.Location" type="System.Drawing.Point, System.Drawing">
-    <value>72, 3</value>
-  </data>
-  <data name="lblMB.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="lblMB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 13</value>
-  </data>
-  <data name="lblMB.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="lblMB.Text" xml:space="preserve">
-    <value>MB</value>
-  </data>
-  <data name="lblMB.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblMB.Name" xml:space="preserve">
-    <value>lblMB</value>
-  </data>
-  <data name="&gt;&gt;lblMB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMB.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;lblMB.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="nudMemory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1, 0</value>
-  </data>
-  <data name="nudMemory.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="memorySpinner.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="nudMemory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 20</value>
+  <data name="memorySpinner.Size" type="System.Drawing.Size, System.Drawing">
+    <value>98, 26</value>
   </data>
-  <data name="nudMemory.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="memorySpinner.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
   </data>
-  <data name="&gt;&gt;nudMemory.Name" xml:space="preserve">
-    <value>nudMemory</value>
+  <data name="&gt;&gt;memorySpinner.Name" xml:space="preserve">
+    <value>memorySpinner</value>
   </data>
-  <data name="&gt;&gt;nudMemory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;memorySpinner.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.Ballooning.MemorySpinner, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;nudMemory.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;nudMemory.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 237</value>
-  </data>
-  <data name="panel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
-  </data>
-  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 20</value>
-  </data>
-  <data name="panel2.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
+  <data name="&gt;&gt;memorySpinner.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;memorySpinner.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
   <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -943,7 +880,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="panel2" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="memorySpinner" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="lblPriority.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -226,7 +226,7 @@
     <value>True</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="warningsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -241,16 +241,10 @@
     <value>NoControl</value>
   </data>
   <data name="cpuWarningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 3</value>
-  </data>
-  <data name="cpuWarningPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 3</value>
   </data>
   <data name="cpuWarningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="cpuWarningPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="cpuWarningPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -270,6 +264,9 @@
   <data name="&gt;&gt;cpuWarningPictureBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="cpuWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="cpuWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -277,16 +274,13 @@
     <value>NoControl</value>
   </data>
   <data name="cpuWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 3</value>
-  </data>
-  <data name="cpuWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 4</value>
   </data>
   <data name="cpuWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="cpuWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="cpuWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -303,38 +297,8 @@
   <data name="&gt;&gt;cpuWarningLabel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="memoryWarningLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="memoryWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="memoryWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="memoryWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
-  </data>
-  <data name="memoryWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 13</value>
-  </data>
-  <data name="memoryWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="memoryWarningLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.Name" xml:space="preserve">
-    <value>memoryWarningLabel</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.Parent" xml:space="preserve">
-    <value>warningsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="topologyWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="topologyWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -343,16 +307,13 @@
     <value>NoControl</value>
   </data>
   <data name="topologyWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 47</value>
-  </data>
-  <data name="topologyWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 32</value>
   </data>
   <data name="topologyWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="topologyWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="topologyWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -367,55 +328,16 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;topologyWarningLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="memoryPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="memoryPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="memoryPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
-  </data>
-  <data name="memoryPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="memoryPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
-  </data>
-  <data name="memoryPictureBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="memoryPictureBox.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.Name" xml:space="preserve">
-    <value>memoryPictureBox</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.Parent" xml:space="preserve">
-    <value>warningsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="topologyPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="topologyPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 47</value>
-  </data>
-  <data name="topologyPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 31</value>
   </data>
   <data name="topologyPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 14</value>
-  </data>
-  <data name="topologyPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="topologyPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -433,25 +355,25 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;topologyPictureBox.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="warningsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="warningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 263</value>
+    <value>0, 255</value>
   </data>
   <data name="warningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>0, 20, 0, 0</value>
   </data>
   <data name="warningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="warningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 64</value>
+    <value>500, 50</value>
   </data>
   <data name="warningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;warningsTableLayoutPanel.Name" xml:space="preserve">
     <value>warningsTableLayoutPanel</value>
@@ -466,16 +388,16 @@
     <value>0</value>
   </data>
   <data name="warningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,6,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="comboBoxInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 98</value>
+    <value>129, 130</value>
   </data>
   <data name="comboBoxInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
   </data>
   <data name="comboBoxInitialVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;comboBoxInitialVCPUs.Name" xml:space="preserve">
     <value>comboBoxInitialVCPUs</value>
@@ -489,32 +411,26 @@
   <data name="&gt;&gt;comboBoxInitialVCPUs.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="labelInitialVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="labelInitialVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelInitialVCPUs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="labelInitialVCPUs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 98</value>
-  </data>
-  <data name="labelInitialVCPUs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>3, 134</value>
   </data>
   <data name="labelInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+    <value>120, 13</value>
   </data>
   <data name="labelInitialVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>5</value>
   </data>
   <data name="labelInitialVCPUs.Text" xml:space="preserve">
     <value>Initial number of v&amp;CPUs:</value>
-  </data>
-  <data name="labelInitialVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelInitialVCPUs.Name" xml:space="preserve">
     <value>labelInitialVCPUs</value>
@@ -532,13 +448,13 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="comboBoxTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 71</value>
+    <value>129, 103</value>
   </data>
   <data name="comboBoxTopology.Size" type="System.Drawing.Size, System.Drawing">
     <value>250, 21</value>
   </data>
   <data name="comboBoxTopology.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.Name" xml:space="preserve">
     <value>comboBoxTopology</value>
@@ -552,32 +468,26 @@
   <data name="&gt;&gt;comboBoxTopology.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="labelTopology.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="labelTopology.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelTopology.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="labelTopology.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 71</value>
-  </data>
-  <data name="labelTopology.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>3, 107</value>
   </data>
   <data name="labelTopology.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+    <value>54, 13</value>
   </data>
   <data name="labelTopology.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="labelTopology.Text" xml:space="preserve">
     <value>&amp;Topology:</value>
-  </data>
-  <data name="labelTopology.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelTopology.Name" xml:space="preserve">
     <value>labelTopology</value>
@@ -590,75 +500,6 @@
   </data>
   <data name="&gt;&gt;labelTopology.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="MemWarningLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="MemWarningLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="MemWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="MemWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>230, 234</value>
-  </data>
-  <data name="MemWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 26</value>
-  </data>
-  <data name="MemWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="MemWarningLabel.Text" xml:space="preserve">
-    <value>The amount of physical memory allocated to this VM is greater than the total memory of its home server</value>
-  </data>
-  <data name="MemWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="MemWarningLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.Name" xml:space="preserve">
-    <value>MemWarningLabel</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="memorySpinner.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="memorySpinner.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="memorySpinner.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 234</value>
-  </data>
-  <data name="memorySpinner.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="memorySpinner.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 26</value>
-  </data>
-  <data name="memorySpinner.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.Name" xml:space="preserve">
-    <value>memorySpinner</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.Ballooning.MemorySpinner, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -688,10 +529,7 @@
     <value>3</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 168</value>
-  </data>
-  <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 24</value>
+    <value>3, 190</value>
   </data>
   <data name="panel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 6</value>
@@ -700,7 +538,7 @@
     <value>494, 42</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;panel1.Name" xml:space="preserve">
     <value>panel1</value>
@@ -712,34 +550,28 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>5</value>
+  </data>
+  <data name="lblVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="lblVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="lblVCPUs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="lblVCPUs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="lblVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 44</value>
-  </data>
-  <data name="lblVCPUs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>3, 80</value>
   </data>
   <data name="lblVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+    <value>95, 13</value>
   </data>
   <data name="lblVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="lblVCPUs.Text" xml:space="preserve">
     <value>&amp;Number of vCPUs:</value>
-  </data>
-  <data name="lblVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;lblVCPUs.Name" xml:space="preserve">
     <value>lblVCPUs</value>
@@ -751,46 +583,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblVCPUs.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="lblMemory.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblMemory.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="lblMemory.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblMemory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 237</value>
-  </data>
-  <data name="lblMemory.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="lblMemory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="lblMemory.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="lblMemory.Text" xml:space="preserve">
-    <value>&amp;VM memory:</value>
-  </data>
-  <data name="lblMemory.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.Name" xml:space="preserve">
-    <value>lblMemory</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>7</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -804,11 +597,11 @@
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
-  <data name="label1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 15</value>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 15</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 41</value>
+    <value>494, 26</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -826,16 +619,16 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>8</value>
   </data>
   <data name="comboBoxVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 44</value>
+    <value>129, 76</value>
   </data>
   <data name="comboBoxVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
   </data>
   <data name="comboBoxVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.Name" xml:space="preserve">
     <value>comboBoxVCPUs</value>
@@ -847,7 +640,97 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="tableLayoutPanelInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanelInfo.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanelInfo.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>tableLayoutPanelInfo</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="labelInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 4</value>
+  </data>
+  <data name="labelInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="labelInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.Name" xml:space="preserve">
+    <value>labelInfo</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanelInfo</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 41</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 10</value>
+  </data>
+  <data name="tableLayoutPanelInfo.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>500, 22</value>
+  </data>
+  <data name="tableLayoutPanelInfo.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.Name" xml:space="preserve">
+    <value>tableLayoutPanelInfo</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="tableLayoutPanelInfo.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInfo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -859,10 +742,10 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>8</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 500</value>
+    <value>500, 400</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -880,22 +763,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="memorySpinner" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="panel1" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="lblPriority" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanelInfo" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="lblPriority.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="lblPriority.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 142</value>
+    <value>3, 174</value>
   </data>
-  <data name="lblPriority.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 10, 0, 0</value>
+  <data name="lblPriority.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 20, 3, 0</value>
   </data>
   <data name="lblPriority.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 23</value>
+    <value>179, 13</value>
   </data>
   <data name="lblPriority.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="lblPriority.Text" xml:space="preserve">
     <value>vCPU priority for this virtual machine:</value>
@@ -913,7 +796,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblPriority.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>6</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -925,10 +808,10 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>500, 500</value>
+    <value>500, 400</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 500</value>
+    <value>500, 400</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>CpuMemoryEditPage</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -373,7 +373,7 @@
     <value>comboBoxTopology</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.CPUTopologyComboBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.CPUTopologyComboBox, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -571,7 +571,7 @@
     <value>transparentTrackBar1</value>
   </data>
   <data name="&gt;&gt;transparentTrackBar1.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.TransparentTrackBar, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.TransparentTrackBar, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;transparentTrackBar1.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -737,9 +737,6 @@
   </data>
   <data name="VCPUWarningLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
-  </data>
-  <data name="VCPUWarningLabel.Text" xml:space="preserve">
-    <value>You cannot start VMs with more vCPUs than there are physical CPUs on any host in the pool</value>
   </data>
   <data name="VCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.zh-CN.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.zh-CN.resx
@@ -898,7 +898,7 @@
     <value>500, 500</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>CPUMemoryEditPage</value>
+    <value>CpuMemoryEditPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
@@ -469,7 +469,6 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                     summary = new VmTitleSummary(summary, pair.Value);
 
                 summary = new DestinationPoolSummary(summary, pair.Value, TargetConnection);
-                summary = new TargetServerSummary(summary, pair.Value, TargetConnection);
                 summary = new TransferNetworkSummary(summary, m_pageTransferNetwork.NetworkUuid.Value);
                 summary = new StorageSummary(summary, pair.Value, xenConnection);
                 summary = new NetworkSummary(summary, pair.Value, xenConnection);

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.Designer.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.Designer.cs
@@ -129,8 +129,8 @@
             // 
             // pictureBox1
             // 
-            resources.ApplyResources(this.pictureBox1, "pictureBox1");
             this.pictureBox1.Image = global::XenAdmin.Properties.Resources._000_WarningAlert_h32bit_32;
+            resources.ApplyResources(this.pictureBox1, "pictureBox1");
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.TabStop = false;
             // 

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -208,15 +208,15 @@ namespace XenAdmin.Wizards.GenericPages
             {
                 foreach (DataGridViewRow row in m_dataGridView.Rows)
                 {
-                    string sysId = (string)row.Cells[0].Tag;
+                    var sysId = (string)row.Cells[0].Tag;
 
                     if (m_vmMappings.ContainsKey(sysId))
                     {
                         var mapping = m_vmMappings[sysId];
-                        DataGridViewEnableableComboBoxCell cbCell = row.Cells[m_colTarget.Index] as DataGridViewEnableableComboBoxCell;
+                        var cbCell = row.Cells[m_colTarget.Index] as DataGridViewEnableableComboBoxCell;
                         System.Diagnostics.Debug.Assert(cbCell != null, "ComboBox cell was not found");
 
-                        IEnableableXenObjectComboBoxItem selectedItem = cbCell.Value as IEnableableXenObjectComboBoxItem;
+                        var selectedItem = cbCell.Value as IEnableableXenObjectComboBoxItem;
                         System.Diagnostics.Debug.Assert(selectedItem != null, "Vm has no target mapped");
                         var type = selectedItem.Item.GetType();
 
@@ -231,7 +231,7 @@ namespace XenAdmin.Wizards.GenericPages
 
                 return m_vmMappings;
             }
-            set { m_vmMappings = value; }
+            set => m_vmMappings = value;
         }
 
         #endregion
@@ -257,8 +257,7 @@ namespace XenAdmin.Wizards.GenericPages
 
             foreach (var item in m_comboBoxConnection.Items)
             {
-                DelayLoadingOptionComboBoxItem tempItem = item as DelayLoadingOptionComboBoxItem;
-                if (tempItem != null)
+                if (item is DelayLoadingOptionComboBoxItem tempItem)
                     tempItem.ReasonUpdated -= DelayLoadedComboBoxItem_ReasonChanged;
             }
             m_comboBoxConnection.Items.Clear();
@@ -290,11 +289,11 @@ namespace XenAdmin.Wizards.GenericPages
             {
                 DelayLoadingOptionComboBoxItem item = null;
 
-                Pool pool = Helpers.GetPool(xenConnection);
+                var pool = Helpers.GetPool(xenConnection);
 
                 if (pool == null)
                 {
-                    Host host = Helpers.GetCoordinator(xenConnection);
+                    var host = Helpers.GetCoordinator(xenConnection);
 
                     if (host != null)
                     {
@@ -345,7 +344,7 @@ namespace XenAdmin.Wizards.GenericPages
         {
             foreach (DataGridViewRow row in m_dataGridView.Rows)
             {
-                string sysId = (string)row.Cells[m_colVmName.Index].Tag;
+                var sysId = (string)row.Cells[m_colVmName.Index].Tag;
 
                 if (m_vmMappings.TryGetValue(sysId, out var mapping) &&
                     row.Cells[m_colTarget.Index] is DataGridViewEnableableComboBoxCell cbCell)
@@ -485,17 +484,16 @@ namespace XenAdmin.Wizards.GenericPages
 
             Program.Invoke(this, () =>
             {
-                int index = m_comboBoxConnection.Items.IndexOf(item);
+                var index = m_comboBoxConnection.Items.IndexOf(item);
                 if (index < 0 || index >= m_comboBoxConnection.Items.Count)
                     return;
 
                 if (updatingDestinationCombobox || updatingHomeServerList)
                     return;
 
-                int selectedIndex = m_comboBoxConnection.SelectedIndex;
+                var selectedIndex = m_comboBoxConnection.SelectedIndex;
 
-                var tempItem = m_comboBoxConnection.Items[index] as DelayLoadingOptionComboBoxItem;
-                if (tempItem == null)
+                if (!(m_comboBoxConnection.Items[index] is DelayLoadingOptionComboBoxItem tempItem))
                     throw new NullReferenceException("Trying to update delay loaded reason but failed to extract reason");
 
                 tempItem.CopyFrom(item);
@@ -527,8 +525,7 @@ namespace XenAdmin.Wizards.GenericPages
             if (item == null)
                 throw new NullReferenceException("Trying to update delay loaded reason but failed to extract reason");
 
-            var cb = item.ParentComboBox as DataGridViewEnableableComboBoxCell;
-            if (cb == null)
+            if (!(item.ParentComboBox is DataGridViewEnableableComboBoxCell cb))
                 return;
 
             Program.Invoke(this, () =>
@@ -595,7 +592,7 @@ namespace XenAdmin.Wizards.GenericPages
 
             //If the item is delay loading and them item is disabled, null the selection made 
             //and clear the table containing server data
-            IEnableableXenObjectComboBoxItem item = m_comboBoxConnection.SelectedItem as IEnableableXenObjectComboBoxItem;
+            var item = m_comboBoxConnection.SelectedItem as IEnableableXenObjectComboBoxItem;
             if (item != null && !item.Enabled)
             {
                 m_comboBoxConnection.SelectedIndex = -1;
@@ -604,8 +601,7 @@ namespace XenAdmin.Wizards.GenericPages
                 return;
             }
 
-            AddHostRunningComboBoxItem exeItem = m_comboBoxConnection.SelectedItem as AddHostRunningComboBoxItem;
-            if (exeItem != null && !updatingDestinationCombobox)
+            if (m_comboBoxConnection.SelectedItem is AddHostRunningComboBoxItem exeItem && !updatingDestinationCombobox)
                 exeItem.RunCommand(this);
 
             else if (!updatingDestinationCombobox)
@@ -643,8 +639,7 @@ namespace XenAdmin.Wizards.GenericPages
 
             m_dataGridView.BeginEdit(false);
 
-            var editingControl = m_dataGridView.EditingControl as ComboBox;
-            if (editingControl != null)
+            if (m_dataGridView.EditingControl is ComboBox editingControl)
                 editingControl.DroppedDown = true;
         }
 
@@ -699,8 +694,7 @@ namespace XenAdmin.Wizards.GenericPages
         {
             foreach (var item in m_comboBoxConnection.Items)
             {
-                DelayLoadingOptionComboBoxItem comboBoxItem = item as DelayLoadingOptionComboBoxItem;
-                if (comboBoxItem != null)
+                if (item is DelayLoadingOptionComboBoxItem comboBoxItem)
                     comboBoxItem.CancelFilters();
             }
         }

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -49,7 +49,6 @@ namespace XenAdmin.Wizards.GenericPages
     internal abstract partial class SelectMultipleVMDestinationPage : XenTabPage
     {
         private Dictionary<string, VmMapping> m_vmMappings;
-        public IXenObject SelectedTarget { get; set; }
         private bool updatingDestinationCombobox;
         private bool restoreGridHomeServerSelection;
         private bool updatingHomeServerList;
@@ -58,6 +57,7 @@ namespace XenAdmin.Wizards.GenericPages
         private readonly CollectionChangeEventHandler Host_CollectionChangedWithInvoke;
         private string _preferredHomeRef;
         private IXenObject _selectedTargetPool;
+        private IXenObject _selectedTarget;
 
         #region Nested classes
 
@@ -121,8 +121,24 @@ namespace XenAdmin.Wizards.GenericPages
             get => _selectedTargetPool;
             private set
             {
+                var oldTargetPool = _selectedTargetPool;
                 _selectedTargetPool = value;
-                OnChosenItemChanged();
+
+                if (oldTargetPool?.opaque_ref != _selectedTargetPool?.opaque_ref)
+                    OnSelectedTargetPoolChanged();
+            }
+        }
+
+        public IXenObject SelectedTarget
+        {
+            get => _selectedTarget;
+            set
+            {
+                var oldTarget = _selectedTarget;
+                _selectedTarget = value;
+
+                if (oldTarget?.opaque_ref != SelectedTarget?.opaque_ref)
+                    OnSelectedTargetChanged();
             }
         }
 
@@ -143,8 +159,13 @@ namespace XenAdmin.Wizards.GenericPages
         /// </summary>
         protected abstract string TargetServerSelectionIntroText { get; }
 
-        protected virtual void OnChosenItemChanged()
+        protected virtual void OnSelectedTargetPoolChanged()
         { }
+
+        protected virtual void OnSelectedTargetChanged()
+        {
+
+        }
 
         protected void ShowWarning(string warningText)
         {

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.resx
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.resx
@@ -300,9 +300,6 @@
   <data name="tableLayoutPanelWarning.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="pictureBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>

--- a/XenAdmin/Wizards/GenericPages/VMMappingSummary.cs
+++ b/XenAdmin/Wizards/GenericPages/VMMappingSummary.cs
@@ -166,46 +166,6 @@ namespace XenAdmin.Wizards.GenericPages
         }
     }
 
-    public class TargetServerSummary : MappingSummaryDecorator
-    {
-        private readonly VmMapping mapping;
-        private readonly IXenConnection connection;
-
-        public TargetServerSummary(MappingSummary summary, VmMapping mapping, IXenConnection connection)
-            : base(summary)
-        {
-            this.mapping = mapping;
-            this.connection = connection;
-        }
-
-        public override List<SummaryDetails> Details
-        {
-            get
-            {
-                List<SummaryDetails> decoratedSummary = summary.Details;
-                decoratedSummary.Add(new SummaryDetails(Messages.CPM_SUMMARY_KEY_HOME_SERVER, ResolveLabel()));
-                return decoratedSummary;
-            }
-        }
-
-        private string ResolveLabel()
-        {
-            if (mapping.XenRef is XenRef<Host>)
-            {
-                Host targetHost = connection.Resolve(mapping.XenRef as XenRef<Host>);
-
-                if (targetHost == null)
-                {
-                    return Messages.UNKNOWN;
-                }
-
-                return mapping.TargetName;
-            }
-
-            return Messages.CPM_SUMMARY_UNSET;
-        }
-    }
-
     public class StorageSummary : MappingSummaryDecorator
     {
         private readonly VmMapping mapping;
@@ -355,9 +315,6 @@ namespace XenAdmin.Wizards.GenericPages
             this.summary = summary;
         }
  
-        public override List<SummaryDetails> Details
-        {
-            get { return summary != null ? summary.Details : new List<SummaryDetails>(); }
-        }
+        public override List<SummaryDetails> Details => summary != null ? summary.Details : new List<SummaryDetails>();
     }
 }

--- a/XenAdmin/Wizards/ImportWizard/ImportFinishPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportFinishPage.cs
@@ -91,15 +91,7 @@ namespace XenAdmin.Wizards.ImportWizard
         public bool CanStartVmsAutomatically
         {
             get => _canStartVmsAutomatically;
-            set
-            {
-                m_checkBoxStartVms.Enabled = value;
-                if (!value)
-                {
-                    m_checkBoxStartVms.Checked = false;
-                }
-                _canStartVmsAutomatically = value;
-            }
+            set => _canStartVmsAutomatically = m_checkBoxStartVms.Enabled = m_checkBoxStartVms.Checked = value;
         }
 
         /// <summary>

--- a/XenAdmin/Wizards/ImportWizard/ImportFinishPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportFinishPage.cs
@@ -87,10 +87,25 @@ namespace XenAdmin.Wizards.ImportWizard
 
         public Func<IEnumerable<KeyValuePair<string, string>>> SummaryRetriever { private get; set; }
 
+        private bool _canStartVmsAutomatically = true;
+        public bool CanStartVmsAutomatically
+        {
+            get => _canStartVmsAutomatically;
+            set
+            {
+                m_checkBoxStartVms.Enabled = value;
+                if (!value)
+                {
+                    m_checkBoxStartVms.Checked = false;
+                }
+                _canStartVmsAutomatically = value;
+            }
+        }
+
         /// <summary>
 		/// Do the action described after the import/export has finished?
 		/// </summary>
-		public bool StartVmsAutomatically => m_checkBoxStartVms.Visible && m_checkBoxStartVms.Checked;
+		public bool StartVmsAutomatically => CanStartVmsAutomatically && m_checkBoxStartVms.Visible && m_checkBoxStartVms.Checked;
 
         public bool ShowStartVmsGroupBox
         {

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -175,10 +175,10 @@ namespace XenAdmin.Wizards.ImportWizard
                 {
                     warnings.Add(string.Format(Messages.IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING, ovfCountsAboveLimit, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand));
                 }
-
-                if (!CheckDestinationHasEnoughPhysicalCpus(out var warningMessage))
-                    warnings.Add(warningMessage);
             }
+
+            if (!CheckDestinationHasEnoughPhysicalCpus(out var warningMessage))
+                warnings.Add(warningMessage);
 
             ShowWarning(string.Join("\n\n", warnings));
 

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -127,29 +127,35 @@ namespace XenAdmin.Wizards.ImportWizard
                             }
                         }
                         // Memory
-                        if (rasdType.ResourceType.Value == 4 && long.TryParse(rasdType.VirtualQuantity.Value.ToString(), out var memory))
+                        if (rasdType.ResourceType.Value == 4 && double.TryParse(rasdType.VirtualQuantity.Value.ToString(), out var memory))
                         {
                             //The default memory unit is MB (2^20), however, the RASD may contain a different
                             //one with format byte*memoryBase^memoryPower (byte being a literal string)
 
-                            double memoryPower = 20.0;
                             double memoryBase = 2.0;
+                            double memoryPower = 20.0;
 
                             if (rasdType.AllocationUnits.Value.ToLower().StartsWith("byte"))
                             {
                                 string[] a1 = rasdType.AllocationUnits.Value.Split('*', '^');
+
                                 if (a1.Length == 3)
                                 {
-                                    memoryBase = Convert.ToDouble(a1[1].Trim());
-                                    memoryPower = Convert.ToDouble(a1[2].Trim());
+                                    if (!double.TryParse(a1[1].Trim(), out memoryBase))
+                                        memoryBase = 2.0;
+                                    if (!double.TryParse(a1[2].Trim(), out memoryPower))
+                                        memoryPower = 20.0;
                                 }
                             }
 
                             double memoryMultiplier = Math.Pow(memoryBase, memoryPower);
-                            memory *= (long)memoryMultiplier;
+                            memory *= memoryMultiplier;
+
+                            if (memory > long.MaxValue)
+                                memory = long.MaxValue;
 
                             if (_ovfMemory < memory)
-                                _ovfMemory = memory;
+                                _ovfMemory = (long)memory;
                         }
                     }
 

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -234,6 +234,10 @@ namespace XenAdmin.Wizards.ImportWizard
             return true;
         }
 
+        /// <summary>
+        /// Check if the appliance can be started on the selected host or pool. Note that if the user selects
+        /// a shared SR in other pages, the VM could still start.
+        /// </summary>
         public bool ApplianceCanBeStarted => _ovfMaxVCpusCount == null ||
                                              GetPhysicalCpus(SelectedTarget ?? SelectedTargetPool) < 0 ||
                                              GetPhysicalCpus(SelectedTarget ?? SelectedTargetPool) >= _ovfMaxVCpusCount;

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -31,7 +31,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using XenAdmin.Actions.OvfActions;
 using XenAdmin.Core;
@@ -41,7 +40,6 @@ using XenAdmin.Wizards.ImportWizard.Filters;
 using XenAPI;
 using XenOvf;
 using XenOvf.Definitions;
-using static XenAdmin.ServerDBs.Db;
 
 
 namespace XenAdmin.Wizards.ImportWizard

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -173,7 +173,7 @@ namespace XenAdmin.Wizards.ImportWizard
                 var ovfCountsAboveLimit = _ovfVCpusCount.Count(vCpusCount => vCpusCount > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS);
                 if (ovfCountsAboveLimit > 0)
                 {
-                    warnings.Add(string.Format(Messages.IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING, ovfCountsAboveLimit, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS));
+                    warnings.Add(string.Format(Messages.IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING, ovfCountsAboveLimit, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand));
                 }
 
                 if (!CheckDestinationHasEnoughPhysicalCpus(out var warningMessage))

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -223,17 +223,21 @@ namespace XenAdmin.Wizards.ImportWizard
             return true;
         }
 
+        public bool ApplianceCanBeStarted => _ovfMaxVCpusCount == null ||
+                                             GetPhysicalCpus(SelectedTarget ?? SelectedTargetPool) < 0 ||
+                                             GetPhysicalCpus(SelectedTarget ?? SelectedTargetPool) >= _ovfMaxVCpusCount;
+
         private bool CheckDestinationHasEnoughPhysicalCpus(out string warningMessage)
         {
             warningMessage = string.Empty;
             
-            if (_ovfMaxVCpusCount == null)
+            if (ApplianceCanBeStarted)
                 return true;
 
             var selectedTarget = SelectedTarget ?? SelectedTargetPool;
             var physicalCpusCount = GetPhysicalCpus(selectedTarget);
 
-            if (physicalCpusCount < 0)
+            if (physicalCpusCount < 0 || physicalCpusCount >= _ovfMaxVCpusCount)
                 return true;
 
             if (selectedTarget is Pool)

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -310,7 +310,7 @@ namespace XenAdmin.Wizards.ImportWizard
                 _targetConnection = m_pageHost.SelectedTargetPool?.Connection;
                 var oldHostSelection = m_vmMappings.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.TargetName);
                 m_vmMappings = m_pageHost.VmMappings;
-
+                m_pageFinish.CanStartVmsAutomatically = m_pageHost.ApplianceCanBeStarted;
                 if (oldTargetConnection != _targetConnection)
                 {
                     RemovePage(m_pageRbac);
@@ -329,7 +329,7 @@ namespace XenAdmin.Wizards.ImportWizard
 
                 if (oldTargetConnection != _targetConnection ||
                     oldHostSelection.Any(kvp=> !m_vmMappings.TryGetValue(kvp.Key, out var map) || map == null || map.TargetName != kvp.Value))
-                    NotifyNextPagesOfChange(m_pageStorage, m_pageNetwork, m_pageOptions);
+                    NotifyNextPagesOfChange(m_pageStorage, m_pageNetwork, m_pageOptions, m_pageFinish);
             }
             else if (type == typeof(ImportBootOptionPage))
             {

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -647,11 +647,9 @@ namespace XenAdmin.Wizards.ImportWizard
 
             foreach (var mapping in m_vmMappings.Values)
             {
-                var targetLbl = m_vmMappings.Count == 1 ? Messages.FINISH_PAGE_TARGET : string.Format(Messages.FINISH_PAGE_TARGET_FOR_VM, mapping.VmNameLabel);
                 var storageLbl = m_vmMappings.Count == 1 ? Messages.FINISH_PAGE_STORAGE : string.Format(Messages.FINISH_PAGE_STORAGE_FOR_VM, mapping.VmNameLabel);
                 var networkLbl = m_vmMappings.Count == 1 ? Messages.FINISH_PAGE_NETWORK : string.Format(Messages.FINISH_PAGE_NETWORK_FOR_VM, mapping.VmNameLabel);
 
-                temp.Add(new Tuple(targetLbl, mapping.TargetName));
                 bool first = true;
                 foreach (var sr in mapping.Storage)
                 {

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -582,7 +582,7 @@ namespace XenAdmin.Wizards.ImportWizard
         {
             var temp = new List<Tuple>();
             temp.Add(new Tuple(Messages.FINISH_PAGE_VMNAME, m_pageXvaStorage.ImportedVm.Name()));
-            temp.Add(new Tuple(Messages.FINISH_PAGE_TARGET, m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection.Name : m_pageXvaHost.SelectedHost.Name()));
+            temp.Add(new Tuple(Messages.FINISH_PAGE_TARGET_FOR_VM, m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection.Name : m_pageXvaHost.SelectedHost.Name()));
             temp.Add(new Tuple(Messages.FINISH_PAGE_STORAGE, m_pageXvaStorage.SR.Name()));
 
             var con = m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection : m_pageXvaHost.SelectedHost.Connection;

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -131,7 +131,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
             #endregion
 
-            page_8_Finish.SummaryRetreiver = GetSummary;
+            page_8_Finish.SummaryRetriever = GetSummary;
 
             AddPages(page_1_Template, page_2_Name, page_3_InstallationMedia, page_4_HomeServer,
                      page_5_CpuMem, page_6_Storage, page_7_Networking, page_8_Finish);
@@ -286,7 +286,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
             else if (prevPageType == typeof(Page_CpuMem))
             {
-                page_8_Finish.CanStartImmediately = page_5_CpuMem.CanStartVM;
+                page_8_Finish.CanStartImmediately = page_5_CpuMem.CanStartVm;
             }
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -52,7 +52,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private readonly Page_Name page_2_Name;
         private readonly Page_InstallationMedia page_3_InstallationMedia;
         private readonly Page_HomeServer page_4_HomeServer;
-        private readonly PageCpuMem page_5_CpuMem;
+        private readonly Page_CpuMem page_5_CpuMem;
         private readonly Page_Storage page_6_Storage;
         private readonly Page_Networking page_7_Networking;
         private readonly Page_Finish page_8_Finish;
@@ -77,7 +77,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             page_2_Name = new Page_Name();
             page_3_InstallationMedia = new Page_InstallationMedia();
             page_4_HomeServer = new Page_HomeServer();
-            page_5_CpuMem = new PageCpuMem();
+            page_5_CpuMem = new Page_CpuMem();
             page_6_Storage = new Page_Storage();
             page_7_Networking = new Page_Networking();
             page_8_Finish = new Page_Finish();
@@ -283,6 +283,10 @@ namespace XenAdmin.Wizards.NewVMWizard
                     page_6b_LunPerVdi.DisksToMap = page_6_Storage.SelectedDisks;
                     AddAfterPage(page_6_Storage, page_6b_LunPerVdi);
                 }
+            }
+            else if (prevPageType == typeof(Page_CpuMem))
+            {
+                page_8_Finish.CanStartImmediately = page_5_CpuMem.CanStartVM;
             }
         }
 

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -52,7 +52,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private readonly Page_Name page_2_Name;
         private readonly Page_InstallationMedia page_3_InstallationMedia;
         private readonly Page_HomeServer page_4_HomeServer;
-        private readonly Page_CpuMem page_5_CpuMem;
+        private readonly PageCpuMem page_5_CpuMem;
         private readonly Page_Storage page_6_Storage;
         private readonly Page_Networking page_7_Networking;
         private readonly Page_Finish page_8_Finish;
@@ -77,7 +77,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             page_2_Name = new Page_Name();
             page_3_InstallationMedia = new Page_InstallationMedia();
             page_4_HomeServer = new Page_HomeServer();
-            page_5_CpuMem = new Page_CpuMem();
+            page_5_CpuMem = new PageCpuMem();
             page_6_Storage = new Page_Storage();
             page_7_Networking = new Page_Networking();
             page_8_Finish = new Page_Finish();
@@ -161,8 +161,8 @@ namespace XenAdmin.Wizards.NewVMWizard
                                         page_3_InstallationMedia.SelectedUrl,
                                         page_3_InstallationMedia.SelectedBootMode,
                                         m_affinity,
-                                        page_5_CpuMem.SelectedVcpusMax,
-                                        page_5_CpuMem.SelectedVcpusAtStartup,
+                                        page_5_CpuMem.SelectedVCpusMax,
+                                        page_5_CpuMem.SelectedVCpusAtStartup,
                                         (long)page_5_CpuMem.SelectedMemoryDynamicMin,
                                         (long)page_5_CpuMem.SelectedMemoryDynamicMax,
                                         (long)page_5_CpuMem.SelectedMemoryStaticMax,

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
@@ -29,63 +29,100 @@ namespace XenAdmin.Wizards.NewVMWizard
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_CpuMem));
-            this.labelVCPUs = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.warningPictureBox = new System.Windows.Forms.PictureBox();
-            this.ErrorLabel = new System.Windows.Forms.Label();
-            this.ErrorPanel = new System.Windows.Forms.Panel();
-            this.spinnerDynMin = new XenAdmin.Controls.Ballooning.MemorySpinner();
-            this.spinnerDynMax = new XenAdmin.Controls.Ballooning.MemorySpinner();
-            this.spinnerStatMax = new XenAdmin.Controls.Ballooning.MemorySpinner();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.vCPUWarningLabel = new System.Windows.Forms.Label();
-            this.initialVCPUWarningLabel = new System.Windows.Forms.Label();
-            this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
-            this.labelInitialVCPUs = new System.Windows.Forms.Label();
-            this.labelInvalidVCPUWarning = new System.Windows.Forms.Label();
-            this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
-            this.labelTopology = new System.Windows.Forms.Label();
-            this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
-            this.labelDynMin = new System.Windows.Forms.Label();
-            this.labelDynMax = new System.Windows.Forms.Label();
-            this.labelStatMax = new System.Windows.Forms.Label();
-            this.labelDynMinInfo = new System.Windows.Forms.Label();
-            this.labelDynMaxInfo = new System.Windows.Forms.Label();
+            this.warningsTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.cpuWarningPictureBox = new System.Windows.Forms.PictureBox();
+            this.cpuWarningLabel = new System.Windows.Forms.Label();
+            this.memoryWarningLabel = new System.Windows.Forms.Label();
+            this.memoryPictureBox = new System.Windows.Forms.PictureBox();
             this.labelStatMaxInfo = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.warningPictureBox)).BeginInit();
-            this.ErrorPanel.SuspendLayout();
+            this.labelDynMaxInfo = new System.Windows.Forms.Label();
+            this.labelDynMinInfo = new System.Windows.Forms.Label();
+            this.labelStatMax = new System.Windows.Forms.Label();
+            this.labelDynMax = new System.Windows.Forms.Label();
+            this.labelDynMin = new System.Windows.Forms.Label();
+            this.spinnerDynMin = new XenAdmin.Controls.Ballooning.MemorySpinner();
+            this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
+            this.labelTopology = new System.Windows.Forms.Label();
+            this.spinnerDynMax = new XenAdmin.Controls.Ballooning.MemorySpinner();
+            this.labelVCPUs = new System.Windows.Forms.Label();
+            this.spinnerStatMax = new XenAdmin.Controls.Ballooning.MemorySpinner();
+            this.label5 = new System.Windows.Forms.Label();
+            this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
+            this.labelInvalidVCPUWarning = new System.Windows.Forms.Label();
+            this.labelInitialVCPUs = new System.Windows.Forms.Label();
+            this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
+            this.initialVCPUWarningLabel = new System.Windows.Forms.Label();
+            this.vCPUWarningLabel = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.warningsTableLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // labelVCPUs
+            // warningsTableLayoutPanel
             // 
-            resources.ApplyResources(this.labelVCPUs, "labelVCPUs");
-            this.labelVCPUs.Name = "labelVCPUs";
+            resources.ApplyResources(this.warningsTableLayoutPanel, "warningsTableLayoutPanel");
+            this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningPictureBox, 0, 0);
+            this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningLabel, 1, 0);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 1);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 1);
+            this.warningsTableLayoutPanel.Name = "warningsTableLayoutPanel";
             // 
-            // label5
+            // cpuWarningPictureBox
             // 
-            resources.ApplyResources(this.label5, "label5");
-            this.tableLayoutPanel1.SetColumnSpan(this.label5, 4);
-            this.label5.Name = "label5";
+            this.cpuWarningPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.cpuWarningPictureBox, "cpuWarningPictureBox");
+            this.cpuWarningPictureBox.Name = "cpuWarningPictureBox";
+            this.cpuWarningPictureBox.TabStop = false;
             // 
-            // warningPictureBox
+            // cpuWarningLabel
             // 
-            this.warningPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
-            resources.ApplyResources(this.warningPictureBox, "warningPictureBox");
-            this.warningPictureBox.Name = "warningPictureBox";
-            this.warningPictureBox.TabStop = false;
+            resources.ApplyResources(this.cpuWarningLabel, "cpuWarningLabel");
+            this.cpuWarningLabel.Name = "cpuWarningLabel";
             // 
-            // ErrorLabel
+            // memoryWarningLabel
             // 
-            resources.ApplyResources(this.ErrorLabel, "ErrorLabel");
-            this.ErrorLabel.Name = "ErrorLabel";
+            resources.ApplyResources(this.memoryWarningLabel, "memoryWarningLabel");
+            this.memoryWarningLabel.Name = "memoryWarningLabel";
             // 
-            // ErrorPanel
+            // memoryPictureBox
             // 
-            this.ErrorPanel.Controls.Add(this.ErrorLabel);
-            this.ErrorPanel.Controls.Add(this.warningPictureBox);
-            resources.ApplyResources(this.ErrorPanel, "ErrorPanel");
-            this.ErrorPanel.Name = "ErrorPanel";
+            this.memoryPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.memoryPictureBox, "memoryPictureBox");
+            this.memoryPictureBox.Name = "memoryPictureBox";
+            this.memoryPictureBox.TabStop = false;
+            // 
+            // labelStatMaxInfo
+            // 
+            resources.ApplyResources(this.labelStatMaxInfo, "labelStatMaxInfo");
+            this.labelStatMaxInfo.Name = "labelStatMaxInfo";
+            // 
+            // labelDynMaxInfo
+            // 
+            resources.ApplyResources(this.labelDynMaxInfo, "labelDynMaxInfo");
+            this.labelDynMaxInfo.Name = "labelDynMaxInfo";
+            // 
+            // labelDynMinInfo
+            // 
+            resources.ApplyResources(this.labelDynMinInfo, "labelDynMinInfo");
+            this.labelDynMinInfo.Name = "labelDynMinInfo";
+            // 
+            // labelStatMax
+            // 
+            resources.ApplyResources(this.labelStatMax, "labelStatMax");
+            this.labelStatMax.Name = "labelStatMax";
+            // 
+            // labelDynMax
+            // 
+            resources.ApplyResources(this.labelDynMax, "labelDynMax");
+            this.labelDynMax.Name = "labelDynMax";
+            // 
+            // labelDynMin
+            // 
+            resources.ApplyResources(this.labelDynMin, "labelDynMin");
+            this.labelDynMin.Name = "labelDynMin";
             // 
             // spinnerDynMin
             // 
@@ -95,6 +132,19 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.spinnerDynMin.Name = "spinnerDynMin";
             this.spinnerDynMin.SpinnerValueChanged += new System.EventHandler(this.memory_ValueChanged);
             // 
+            // comboBoxVCPUs
+            // 
+            this.comboBoxVCPUs.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxVCPUs.FormattingEnabled = true;
+            resources.ApplyResources(this.comboBoxVCPUs, "comboBoxVCPUs");
+            this.comboBoxVCPUs.Name = "comboBoxVCPUs";
+            this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.vCPU_ValueChanged);
+            // 
+            // labelTopology
+            // 
+            resources.ApplyResources(this.labelTopology, "labelTopology");
+            this.labelTopology.Name = "labelTopology";
+            // 
             // spinnerDynMax
             // 
             resources.ApplyResources(this.spinnerDynMax, "spinnerDynMax");
@@ -103,6 +153,11 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.spinnerDynMax.Name = "spinnerDynMax";
             this.spinnerDynMax.SpinnerValueChanged += new System.EventHandler(this.memory_ValueChanged);
             // 
+            // labelVCPUs
+            // 
+            resources.ApplyResources(this.labelVCPUs, "labelVCPUs");
+            this.labelVCPUs.Name = "labelVCPUs";
+            // 
             // spinnerStatMax
             // 
             resources.ApplyResources(this.spinnerStatMax, "spinnerStatMax");
@@ -110,6 +165,55 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.spinnerStatMax.Increment = 0.1D;
             this.spinnerStatMax.Name = "spinnerStatMax";
             this.spinnerStatMax.SpinnerValueChanged += new System.EventHandler(this.memory_ValueChanged);
+            // 
+            // label5
+            // 
+            resources.ApplyResources(this.label5, "label5");
+            this.tableLayoutPanel1.SetColumnSpan(this.label5, 4);
+            this.label5.Name = "label5";
+            // 
+            // comboBoxTopology
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
+            this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
+            this.comboBoxTopology.FormattingEnabled = true;
+            this.comboBoxTopology.Name = "comboBoxTopology";
+            this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
+            // 
+            // labelInvalidVCPUWarning
+            // 
+            resources.ApplyResources(this.labelInvalidVCPUWarning, "labelInvalidVCPUWarning");
+            this.tableLayoutPanel1.SetColumnSpan(this.labelInvalidVCPUWarning, 3);
+            this.labelInvalidVCPUWarning.ForeColor = System.Drawing.Color.Red;
+            this.labelInvalidVCPUWarning.Name = "labelInvalidVCPUWarning";
+            // 
+            // labelInitialVCPUs
+            // 
+            resources.ApplyResources(this.labelInitialVCPUs, "labelInitialVCPUs");
+            this.labelInitialVCPUs.Name = "labelInitialVCPUs";
+            // 
+            // comboBoxInitialVCPUs
+            // 
+            this.comboBoxInitialVCPUs.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxInitialVCPUs.FormattingEnabled = true;
+            resources.ApplyResources(this.comboBoxInitialVCPUs, "comboBoxInitialVCPUs");
+            this.comboBoxInitialVCPUs.Name = "comboBoxInitialVCPUs";
+            this.comboBoxInitialVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxInitialVCPUs_SelectedIndexChanged);
+            // 
+            // initialVCPUWarningLabel
+            // 
+            resources.ApplyResources(this.initialVCPUWarningLabel, "initialVCPUWarningLabel");
+            this.tableLayoutPanel1.SetColumnSpan(this.initialVCPUWarningLabel, 2);
+            this.initialVCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
+            this.initialVCPUWarningLabel.Name = "initialVCPUWarningLabel";
+            // 
+            // vCPUWarningLabel
+            // 
+            resources.ApplyResources(this.vCPUWarningLabel, "vCPUWarningLabel");
+            this.tableLayoutPanel1.SetColumnSpan(this.vCPUWarningLabel, 2);
+            this.vCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
+            this.vCPUWarningLabel.Name = "vCPUWarningLabel";
             // 
             // tableLayoutPanel1
             // 
@@ -133,103 +237,19 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.tableLayoutPanel1.Controls.Add(this.labelDynMinInfo, 3, 6);
             this.tableLayoutPanel1.Controls.Add(this.labelDynMaxInfo, 3, 7);
             this.tableLayoutPanel1.Controls.Add(this.labelStatMaxInfo, 3, 8);
+            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 9);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // vCPUWarningLabel
-            // 
-            resources.ApplyResources(this.vCPUWarningLabel, "vCPUWarningLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.vCPUWarningLabel, 2);
-            this.vCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.vCPUWarningLabel.Name = "vCPUWarningLabel";
-            // 
-            // initialVCPUWarningLabel
-            // 
-            resources.ApplyResources(this.initialVCPUWarningLabel, "initialVCPUWarningLabel");
-            this.tableLayoutPanel1.SetColumnSpan(this.initialVCPUWarningLabel, 2);
-            this.initialVCPUWarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.initialVCPUWarningLabel.Name = "initialVCPUWarningLabel";
-            // 
-            // comboBoxInitialVCPUs
-            // 
-            this.comboBoxInitialVCPUs.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxInitialVCPUs.FormattingEnabled = true;
-            resources.ApplyResources(this.comboBoxInitialVCPUs, "comboBoxInitialVCPUs");
-            this.comboBoxInitialVCPUs.Name = "comboBoxInitialVCPUs";
-            this.comboBoxInitialVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxInitialVCPUs_SelectedIndexChanged);
-            // 
-            // labelInitialVCPUs
-            // 
-            resources.ApplyResources(this.labelInitialVCPUs, "labelInitialVCPUs");
-            this.labelInitialVCPUs.Name = "labelInitialVCPUs";
-            // 
-            // labelInvalidVCPUWarning
-            // 
-            resources.ApplyResources(this.labelInvalidVCPUWarning, "labelInvalidVCPUWarning");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelInvalidVCPUWarning, 3);
-            this.labelInvalidVCPUWarning.ForeColor = System.Drawing.Color.Red;
-            this.labelInvalidVCPUWarning.Name = "labelInvalidVCPUWarning";
-            // 
-            // comboBoxTopology
-            // 
-            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
-            this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
-            this.comboBoxTopology.FormattingEnabled = true;
-            this.comboBoxTopology.Name = "comboBoxTopology";
-            this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
-            // 
-            // labelTopology
-            // 
-            resources.ApplyResources(this.labelTopology, "labelTopology");
-            this.labelTopology.Name = "labelTopology";
-            // 
-            // comboBoxVCPUs
-            // 
-            this.comboBoxVCPUs.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxVCPUs.FormattingEnabled = true;
-            resources.ApplyResources(this.comboBoxVCPUs, "comboBoxVCPUs");
-            this.comboBoxVCPUs.Name = "comboBoxVCPUs";
-            this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.vCPU_ValueChanged);
-            // 
-            // labelDynMin
-            // 
-            resources.ApplyResources(this.labelDynMin, "labelDynMin");
-            this.labelDynMin.Name = "labelDynMin";
-            // 
-            // labelDynMax
-            // 
-            resources.ApplyResources(this.labelDynMax, "labelDynMax");
-            this.labelDynMax.Name = "labelDynMax";
-            // 
-            // labelStatMax
-            // 
-            resources.ApplyResources(this.labelStatMax, "labelStatMax");
-            this.labelStatMax.Name = "labelStatMax";
-            // 
-            // labelDynMinInfo
-            // 
-            resources.ApplyResources(this.labelDynMinInfo, "labelDynMinInfo");
-            this.labelDynMinInfo.Name = "labelDynMinInfo";
-            // 
-            // labelDynMaxInfo
-            // 
-            resources.ApplyResources(this.labelDynMaxInfo, "labelDynMaxInfo");
-            this.labelDynMaxInfo.Name = "labelDynMaxInfo";
-            // 
-            // labelStatMaxInfo
-            // 
-            resources.ApplyResources(this.labelStatMaxInfo, "labelStatMaxInfo");
-            this.labelStatMaxInfo.Name = "labelStatMaxInfo";
             // 
             // Page_CpuMem
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Controls.Add(this.ErrorPanel);
             this.Name = "Page_CpuMem";
-            ((System.ComponentModel.ISupportInitialize)(this.warningPictureBox)).EndInit();
-            this.ErrorPanel.ResumeLayout(false);
+            this.warningsTableLayoutPanel.ResumeLayout(false);
+            this.warningsTableLayoutPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).EndInit();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
@@ -238,28 +258,30 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         #endregion
 
-        private System.Windows.Forms.Label labelVCPUs;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.PictureBox warningPictureBox;
-        private System.Windows.Forms.Label ErrorLabel;
-        private System.Windows.Forms.Panel ErrorPanel;
-        private XenAdmin.Controls.Ballooning.MemorySpinner spinnerDynMin;
-        private XenAdmin.Controls.Ballooning.MemorySpinner spinnerDynMax;
-        private XenAdmin.Controls.Ballooning.MemorySpinner spinnerStatMax;
+        private System.Windows.Forms.TableLayoutPanel warningsTableLayoutPanel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Label labelTopology;
-        private Controls.CPUTopologyComboBox comboBoxTopology;
-        private System.Windows.Forms.ComboBox comboBoxVCPUs;
+        private System.Windows.Forms.Label vCPUWarningLabel;
+        private System.Windows.Forms.Label initialVCPUWarningLabel;
         private System.Windows.Forms.ComboBox comboBoxInitialVCPUs;
         private System.Windows.Forms.Label labelInitialVCPUs;
         private System.Windows.Forms.Label labelInvalidVCPUWarning;
+        private Controls.CPUTopologyComboBox comboBoxTopology;
+        private System.Windows.Forms.Label label5;
+        private Controls.Ballooning.MemorySpinner spinnerStatMax;
+        private System.Windows.Forms.Label labelVCPUs;
+        private Controls.Ballooning.MemorySpinner spinnerDynMax;
+        private System.Windows.Forms.Label labelTopology;
+        private System.Windows.Forms.ComboBox comboBoxVCPUs;
+        private Controls.Ballooning.MemorySpinner spinnerDynMin;
         private System.Windows.Forms.Label labelDynMin;
         private System.Windows.Forms.Label labelDynMax;
         private System.Windows.Forms.Label labelStatMax;
         private System.Windows.Forms.Label labelDynMinInfo;
         private System.Windows.Forms.Label labelDynMaxInfo;
         private System.Windows.Forms.Label labelStatMaxInfo;
-        private System.Windows.Forms.Label vCPUWarningLabel;
-        private System.Windows.Forms.Label initialVCPUWarningLabel;
+        private System.Windows.Forms.PictureBox cpuWarningPictureBox;
+        private System.Windows.Forms.Label cpuWarningLabel;
+        private System.Windows.Forms.Label memoryWarningLabel;
+        private System.Windows.Forms.PictureBox memoryPictureBox;
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
@@ -48,26 +48,30 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.spinnerStatMax = new XenAdmin.Controls.Ballooning.MemorySpinner();
             this.label5 = new System.Windows.Forms.Label();
             this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
-            this.labelInvalidVCPUWarning = new System.Windows.Forms.Label();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.initialVCPUWarningLabel = new System.Windows.Forms.Label();
             this.vCPUWarningLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.pictureBoxTopology = new System.Windows.Forms.PictureBox();
+            this.labelTopologyWarning = new System.Windows.Forms.Label();
             this.warningsTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxTopology)).BeginInit();
             this.SuspendLayout();
             // 
             // warningsTableLayoutPanel
             // 
             resources.ApplyResources(this.warningsTableLayoutPanel, "warningsTableLayoutPanel");
             this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.pictureBoxTopology, 0, 2);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningPictureBox, 0, 0);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningLabel, 1, 0);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 1);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 1);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.labelTopologyWarning, 1, 2);
             this.warningsTableLayoutPanel.Name = "warningsTableLayoutPanel";
             // 
             // cpuWarningPictureBox
@@ -181,13 +185,6 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.comboBoxTopology.Name = "comboBoxTopology";
             this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
             // 
-            // labelInvalidVCPUWarning
-            // 
-            resources.ApplyResources(this.labelInvalidVCPUWarning, "labelInvalidVCPUWarning");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelInvalidVCPUWarning, 3);
-            this.labelInvalidVCPUWarning.ForeColor = System.Drawing.Color.Red;
-            this.labelInvalidVCPUWarning.Name = "labelInvalidVCPUWarning";
-            // 
             // labelInitialVCPUs
             // 
             resources.ApplyResources(this.labelInitialVCPUs, "labelInitialVCPUs");
@@ -219,26 +216,37 @@ namespace XenAdmin.Wizards.NewVMWizard
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.vCPUWarningLabel, 2, 1);
-            this.tableLayoutPanel1.Controls.Add(this.initialVCPUWarningLabel, 2, 4);
-            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.labelInvalidVCPUWarning, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.initialVCPUWarningLabel, 2, 3);
+            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.label5, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.spinnerStatMax, 1, 8);
+            this.tableLayoutPanel1.Controls.Add(this.spinnerStatMax, 1, 7);
             this.tableLayoutPanel1.Controls.Add(this.labelVCPUs, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMax, 1, 7);
+            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMax, 1, 6);
             this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxVCPUs, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMin, 1, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMin, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMax, 0, 7);
-            this.tableLayoutPanel1.Controls.Add(this.labelStatMax, 0, 8);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMinInfo, 3, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMaxInfo, 3, 7);
-            this.tableLayoutPanel1.Controls.Add(this.labelStatMaxInfo, 3, 8);
-            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 9);
+            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMin, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMin, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMax, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.labelStatMax, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMinInfo, 3, 5);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMaxInfo, 3, 6);
+            this.tableLayoutPanel1.Controls.Add(this.labelStatMaxInfo, 3, 7);
+            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 8);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // pictureBoxTopology
+            // 
+            this.pictureBoxTopology.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.pictureBoxTopology, "pictureBoxTopology");
+            this.pictureBoxTopology.Name = "pictureBoxTopology";
+            this.pictureBoxTopology.TabStop = false;
+            // 
+            // labelTopologyWarning
+            // 
+            resources.ApplyResources(this.labelTopologyWarning, "labelTopologyWarning");
+            this.labelTopologyWarning.Name = "labelTopologyWarning";
             // 
             // Page_CpuMem
             // 
@@ -252,6 +260,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).EndInit();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxTopology)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -264,7 +273,6 @@ namespace XenAdmin.Wizards.NewVMWizard
         private System.Windows.Forms.Label initialVCPUWarningLabel;
         private System.Windows.Forms.ComboBox comboBoxInitialVCPUs;
         private System.Windows.Forms.Label labelInitialVCPUs;
-        private System.Windows.Forms.Label labelInvalidVCPUWarning;
         private Controls.CPUTopologyComboBox comboBoxTopology;
         private System.Windows.Forms.Label label5;
         private Controls.Ballooning.MemorySpinner spinnerStatMax;
@@ -283,5 +291,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private System.Windows.Forms.Label cpuWarningLabel;
         private System.Windows.Forms.Label memoryWarningLabel;
         private System.Windows.Forms.PictureBox memoryPictureBox;
+        private System.Windows.Forms.PictureBox pictureBoxTopology;
+        private System.Windows.Forms.Label labelTopologyWarning;
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
@@ -31,7 +31,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_CpuMem));
             this.labelVCPUs = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.warningPictureBox = new System.Windows.Forms.PictureBox();
             this.ErrorLabel = new System.Windows.Forms.Label();
             this.ErrorPanel = new System.Windows.Forms.Panel();
             this.spinnerDynMin = new XenAdmin.Controls.Ballooning.MemorySpinner();
@@ -52,7 +52,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.labelDynMinInfo = new System.Windows.Forms.Label();
             this.labelDynMaxInfo = new System.Windows.Forms.Label();
             this.labelStatMaxInfo = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.warningPictureBox)).BeginInit();
             this.ErrorPanel.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
@@ -68,12 +68,12 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.tableLayoutPanel1.SetColumnSpan(this.label5, 4);
             this.label5.Name = "label5";
             // 
-            // pictureBox1
+            // warningPictureBox
             // 
-            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
-            resources.ApplyResources(this.pictureBox1, "pictureBox1");
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.TabStop = false;
+            this.warningPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.warningPictureBox, "warningPictureBox");
+            this.warningPictureBox.Name = "warningPictureBox";
+            this.warningPictureBox.TabStop = false;
             // 
             // ErrorLabel
             // 
@@ -83,7 +83,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             // ErrorPanel
             // 
             this.ErrorPanel.Controls.Add(this.ErrorLabel);
-            this.ErrorPanel.Controls.Add(this.pictureBox1);
+            this.ErrorPanel.Controls.Add(this.warningPictureBox);
             resources.ApplyResources(this.ErrorPanel, "ErrorPanel");
             this.ErrorPanel.Name = "ErrorPanel";
             // 
@@ -228,9 +228,8 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.ErrorPanel);
             this.Name = "Page_CpuMem";
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.warningPictureBox)).EndInit();
             this.ErrorPanel.ResumeLayout(false);
-            this.ErrorPanel.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
@@ -241,7 +240,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private System.Windows.Forms.Label labelVCPUs;
         private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.PictureBox warningPictureBox;
         private System.Windows.Forms.Label ErrorLabel;
         private System.Windows.Forms.Panel ErrorPanel;
         private XenAdmin.Controls.Ballooning.MemorySpinner spinnerDynMin;

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
@@ -1,6 +1,6 @@
 namespace XenAdmin.Wizards.NewVMWizard
 {
-    partial class PageCpuMem
+    partial class Page_CpuMem
     {
         /// <summary> 
         /// Required designer variable.
@@ -28,7 +28,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PageCpuMem));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_CpuMem));
             this.labelVCPUs = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
@@ -227,7 +227,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.ErrorPanel);
-            this.Name = "PageCpuMem";
+            this.Name = "Page_CpuMem";
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ErrorPanel.ResumeLayout(false);
             this.ErrorPanel.PerformLayout();

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
@@ -1,6 +1,6 @@
 namespace XenAdmin.Wizards.NewVMWizard
 {
-    partial class Page_CpuMem
+    partial class PageCpuMem
     {
         /// <summary> 
         /// Required designer variable.
@@ -28,7 +28,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_CpuMem));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PageCpuMem));
             this.labelVCPUs = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
@@ -227,7 +227,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.ErrorPanel);
-            this.Name = "Page_CpuMem";
+            this.Name = "PageCpuMem";
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ErrorPanel.ResumeLayout(false);
             this.ErrorPanel.PerformLayout();

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -341,28 +341,46 @@ namespace XenAdmin.Wizards.NewVMWizard
 
             if (maxMemTotalHost != null && SelectedMemoryDynamicMin > maxMemTotal)
             {
-                ErrorPanel.Visible = true;
-                ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1, Helpers.GetName(maxMemTotalHost).Ellipsise(50), Util.MemorySizeStringSuitableUnits(maxMemTotal, false));
+                ShowMemoryWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1, Helpers.GetName(maxMemTotalHost).Ellipsise(50), Util.MemorySizeStringSuitableUnits(maxMemTotal, false)));
             }
             else if (maxMemFreeHost != null && SelectedMemoryDynamicMin > maxMemFree)
             {
-                ErrorPanel.Visible = true;
-                ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2, Helpers.GetName(maxMemFreeHost).Ellipsise(50), Util.MemorySizeStringSuitableUnits(maxMemFree, false));
-            }
-            else if (maxVcpusHost != null && SelectedVCpusMax > _maxVCpus)
-            {
-                ErrorPanel.Visible = true;
-                ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN, Helpers.GetName(maxVcpusHost).Ellipsise(50), _maxVCpus);
-            }
-            else if (SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
-            {
-                ErrorPanel.Visible = true;
-                ErrorLabel.Text = string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
+                ShowMemoryWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2,
+                    Helpers.GetName(maxMemFreeHost).Ellipsise(50),
+                    Util.MemorySizeStringSuitableUnits(maxMemFree, false)));
             }
             else
             {
-                ErrorPanel.Visible = false;
+                ShowMemoryWarning();
             }
+            
+            if (maxVcpusHost != null && SelectedVCpusMax > _maxVCpus)
+            {
+                ShowCpuWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN, Helpers.GetName(maxVcpusHost).Ellipsise(50), _maxVCpus));
+            }
+            else if (SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
+            {
+                ShowCpuWarning(string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand));
+            }
+            else
+            {
+                ShowCpuWarning();
+            }
+        }
+
+        private void ShowMemoryWarning(string text = null)
+        {
+            var show = !string.IsNullOrEmpty(text);
+
+            memoryWarningLabel.Text = show ? text : null;
+            memoryPictureBox.Visible = memoryWarningLabel.Visible = show;
+        }
+
+        private void ShowCpuWarning(string text = null)
+        {
+            var show = !string.IsNullOrEmpty(text);
+            cpuWarningLabel.Text = show ? text : null;
+            cpuWarningPictureBox.Visible = cpuWarningLabel.Visible = show;
         }
 
         private void ShowMemoryMinMaxInformation(Label label, double min, double max)

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -151,8 +151,8 @@ namespace XenAdmin.Wizards.NewVMWizard
             InitialiseVCpuControls();
             SetSpinnerLimitsAndIncrement();
             ValidateMemorySettings();
-            ValidateVcpuSettings();
-            ValidateInitialVcpuSettings();
+            ValidateVCpuSettings();
+            ValidateInitialVCpuSettings();
             OnPageUpdated();
 
             _initializing = false;
@@ -344,9 +344,9 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
         }
 
-        private void ValidateVcpuSettings()
+        private void ValidateVCpuSettings()
         {
-            Host maxVcpusHost = null;
+            Host maxVCpusHost = null;
             _maxVCpus = 0;
 
             var warnings = new List<string>();
@@ -364,13 +364,13 @@ namespace XenAdmin.Wizards.NewVMWizard
                 if (hostCpus > _maxVCpus)
                 {
                     _maxVCpus = hostCpus;
-                    maxVcpusHost = host;
+                    maxVCpusHost = host;
                 }
             }
 
-            if (maxVcpusHost != null && SelectedVCpusMax > _maxVCpus)
+            if (maxVCpusHost != null && SelectedVCpusMax > _maxVCpus)
             {
-                var isStandAloneHost = Helpers.GetPool(maxVcpusHost.Connection) == null;
+                var isStandAloneHost = Helpers.GetPool(maxVCpusHost.Connection) == null;
                 if (isStandAloneHost)
                 {
                     warnings.Add(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST, SelectedVCpusMax, _maxVCpus));
@@ -399,7 +399,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
         }
 
-        private void ValidateInitialVcpuSettings()
+        private void ValidateInitialVCpuSettings()
         {
             if (SelectedVCpusAtStartup < _minVCpus)
             {
@@ -457,7 +457,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private void vCPU_ValueChanged(object sender, EventArgs e)
         {
             comboBoxTopology.Update((long)comboBoxVCPUs.SelectedItem);
-            ValidateVcpuSettings();
+            ValidateVCpuSettings();
             RefreshCurrentVCpus();
             OnPageUpdated();
         }
@@ -500,7 +500,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void comboBoxInitialVCPUs_SelectedIndexChanged(object sender, EventArgs e)
         {
-           ValidateInitialVcpuSettings();
+            ValidateInitialVCpuSettings();
         }
 
         #endregion

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -356,7 +356,16 @@ namespace XenAdmin.Wizards.NewVMWizard
             
             if (maxVcpusHost != null && SelectedVCpusMax > _maxVCpus)
             {
-                ShowCpuWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN, _maxVCpus));
+                var isStandAloneHost = Helpers.GetPool(maxVcpusHost.Connection) == null;
+                if (isStandAloneHost)
+                {
+                    ShowCpuWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST, SelectedVCpusMax, _maxVCpus));
+                }
+                else
+                {
+                    ShowCpuWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_POOL, SelectedVCpusMax, _maxVCpus));
+                }
+                
             }
             else if (SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -151,7 +151,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             comboBox.BeginUpdate();
             comboBox.Items.Clear();
-            for (long i = min; i <= max; ++i)
+            for (var i = min; i <= max; ++i)
             {
                 if (i == currentValue || isValid(i))
                     comboBox.Items.Add(i);
@@ -174,7 +174,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private string GetRubric()
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             sb.Append(Messages.NEWVMWIZARD_CPUMEMPAGE_RUBRIC);
             // add hotplug text
             if (_isVcpuHotplugSupported)
@@ -190,15 +190,15 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             get
             {
-                long msm = _template.memory_static_max;
-                long mma = _template.MaxMemAllowed();
+                var msm = _template.memory_static_max;
+                var mma = _template.MaxMemAllowed();
                 return (msm > mma ? msm : mma);
             }
         }
 
         private void FreeSpinnerLimits()
         {
-            long maxMemAllowed = MaxMemAllowed;
+            var maxMemAllowed = MaxMemAllowed;
             spinnerDynMin.SetRange(0, maxMemAllowed);
             spinnerDynMax.SetRange(0, maxMemAllowed);
             spinnerStatMax.SetRange(0, maxMemAllowed);
@@ -208,7 +208,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             spinnerDynMin.Increment = spinnerDynMax.Increment = spinnerStatMax.Increment = VMMemoryControlsEdit.CalcIncrement(_template.memory_static_max, spinnerDynMin.Units);
             
-            long maxMemAllowed = MaxMemAllowed;
+            var maxMemAllowed = MaxMemAllowed;
             double min = _template.memory_static_min;
             if (_memoryMode == MemoryMode.JustMemory)
             {
@@ -216,10 +216,10 @@ namespace XenAdmin.Wizards.NewVMWizard
                 ShowMemoryMinMaxInformation(labelDynMinInfo, min, maxMemAllowed);
                 return;
             }
-            long min2 = (long)(SelectedMemoryStaticMax * _memoryRatio);
+            var min2 = (long)(SelectedMemoryStaticMax * _memoryRatio);
             if (min < min2)
                 min = min2;
-            double max = SelectedMemoryDynamicMax;
+            var max = SelectedMemoryDynamicMax;
             if (max < min)
                 max = min;
             spinnerDynMin.SetRange(min, max);
@@ -260,7 +260,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             get
             {
-                List<KeyValuePair<string, string>> sum = new List<KeyValuePair<string, string>>();
+                var sum = new List<KeyValuePair<string, string>>();
 
                 if (_isVcpuHotplugSupported)
                 {
@@ -300,17 +300,17 @@ namespace XenAdmin.Wizards.NewVMWizard
             Host maxMemFreeHost = null;
             Host maxVcpusHost = null;
 
-            foreach (Host host in Connection.Cache.Hosts)
+            foreach (var host in Connection.Cache.Hosts)
             {
                 long hostCpus = 0;
 
-                foreach (Host_cpu cpu in Connection.Cache.Host_cpus)
+                foreach (var cpu in Connection.Cache.Host_cpus)
                 {
                     if (cpu.host.opaque_ref.Equals(host.opaque_ref))
                         hostCpus++;
                 }
 
-                Host_metrics metrics = Connection.Resolve(host.metrics);
+                var metrics = Connection.Resolve(host.metrics);
 
                 if (hostCpus > maxVcpus)
                 {
@@ -328,7 +328,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 // plus however much we can squeeze down the existing VMs. This assumes
                 // that the overhead won't increase when we create the new VM, so it
                 // has false negatives.
-                long memoryFree = host.memory_available_calc();
+                var memoryFree = host.memory_available_calc();
 
                 if (metrics != null && memoryFree > maxMemFree)
                 {

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -44,16 +44,17 @@ namespace XenAdmin.Wizards.NewVMWizard
         private VM _template;
 
         // number of spinners to show
-        enum MemoryMode
+        private enum MemoryMode
         {
             JustMemory = 1,
             MinimumAndMaximum = 2,
             MinimumMaximumAndStaticMax = 3
         }
-        MemoryMode _memoryMode = MemoryMode.JustMemory;
 
-        double _memoryRatio = 0.0;  // the permitted ratio of dynamic_min / static_max
-        bool _initialising = true;
+        private MemoryMode _memoryMode = MemoryMode.JustMemory;
+
+        private double _memoryRatio = 0.0;  // the permitted ratio of dynamic_min / static_max
+        private bool _initialising = true;
         private bool _isVcpuHotplugSupported;
         private int _minVcpUs;
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -53,10 +53,10 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private MemoryMode _memoryMode = MemoryMode.JustMemory;
 
-        private double _memoryRatio = 0.0;  // the permitted ratio of dynamic_min / static_max
+        private double _memoryRatio;  // the permitted ratio of dynamic_min / static_max
         private bool _initializing = true;
-        private bool _isVcpuHotplugSupported;
-        private int _minVcpUs;
+        private bool _isVCpuHotplugSupported;
+        private int _minVCpus;
 
         // Please note that the comboBoxVCPUs control can represent two different VM properties, depending whether the VM supports vCPU hotplug or not: 
         // When vCPU hotplug is not supported, comboBoxVCPUs represents the initial number of vCPUs (VCPUs_at_startup). In this case we will also set the VM property VCPUs_max to the same value.
@@ -110,14 +110,14 @@ namespace XenAdmin.Wizards.NewVMWizard
             labelDynMaxInfo.Visible = labelDynMax.Visible = spinnerDynMax.Visible = _memoryMode == MemoryMode.MinimumAndMaximum || _memoryMode == MemoryMode.MinimumMaximumAndStaticMax;
             labelStatMaxInfo.Visible = labelStatMax.Visible = spinnerStatMax.Visible = _memoryMode == MemoryMode.MinimumMaximumAndStaticMax;
 
-            _isVcpuHotplugSupported = _template.SupportsVcpuHotplug();
-            _minVcpUs = _template.MinVCPUs();
+            _isVCpuHotplugSupported = _template.SupportsVcpuHotplug();
+            _minVCpus = _template.MinVCPUs();
 
             _prevVcpUsMax = _template.VCPUs_max;  // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
 
             label5.Text = GetRubric();
 
-            InitialiseVcpuControls();
+            InitialiseVCpuControls();
 
             SetSpinnerLimitsAndIncrement();
 
@@ -131,23 +131,23 @@ namespace XenAdmin.Wizards.NewVMWizard
             comboBoxVCPUs.Select();
         }
 
-        private void InitialiseVcpuControls()
+        private void InitialiseVCpuControls()
         {
-            labelVCPUs.Text = _isVcpuHotplugSupported
+            labelVCPUs.Text = _isVCpuHotplugSupported
                 ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_LABEL
                 : Messages.VM_CPUMEMPAGE_VCPUS_LABEL;
 
             labelInitialVCPUs.Text = Messages.VM_CPUMEMPAGE_INITIAL_VCPUS_LABEL;
-            labelInitialVCPUs.Visible = comboBoxInitialVCPUs.Visible = _isVcpuHotplugSupported;
+            labelInitialVCPUs.Visible = comboBoxInitialVCPUs.Visible = _isVCpuHotplugSupported;
 
             comboBoxTopology.Populate(_template.VCPUs_at_startup, _template.VCPUs_max, _template.GetCoresPerSocket(), _template.MaxCoresPerSocket());
-            PopulateVcpUs(_template.MaxVCPUsAllowed(), _isVcpuHotplugSupported ? _template.VCPUs_max : _template.VCPUs_at_startup);
+            PopulateVcpUs(_template.MaxVCPUsAllowed(), _isVCpuHotplugSupported ? _template.VCPUs_max : _template.VCPUs_at_startup);
 
-            if (_isVcpuHotplugSupported)
+            if (_isVCpuHotplugSupported)
                 PopulateVcpUsAtStartup(_template.VCPUs_max, _template.VCPUs_at_startup);
         }
 
-        private void PopulateVcpuComboBox(ComboBox comboBox, long min, long max, long currentValue, Predicate<long> isValid)
+        private void PopulateVCpuComboBox(ComboBox comboBox, long min, long max, long currentValue, Predicate<long> isValid)
         {
             comboBox.BeginUpdate();
             comboBox.Items.Clear();
@@ -164,12 +164,12 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void PopulateVcpUs(long maxVcpUs, long currentVcpUs)
         {
-            PopulateVcpuComboBox(comboBoxVCPUs, 1, maxVcpUs, currentVcpUs, i => comboBoxTopology.IsValidVCPU(i));
+            PopulateVCpuComboBox(comboBoxVCPUs, 1, maxVcpUs, currentVcpUs, i => comboBoxTopology.IsValidVCPU(i));
         }
 
         private void PopulateVcpUsAtStartup(long max, long currentValue)
         {
-            PopulateVcpuComboBox(comboBoxInitialVCPUs, 1, max, currentValue, i => true);
+            PopulateVCpuComboBox(comboBoxInitialVCPUs, 1, max, currentValue, i => true);
         }
 
         private string GetRubric()
@@ -177,7 +177,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             var sb = new StringBuilder();
             sb.Append(Messages.NEWVMWIZARD_CPUMEMPAGE_RUBRIC);
             // add hotplug text
-            if (_isVcpuHotplugSupported)
+            if (_isVCpuHotplugSupported)
                 sb.Append(Messages.VM_CPUMEMPAGE_RUBRIC_HOTPLUG);
             return sb.ToString();
         }
@@ -250,9 +250,9 @@ namespace XenAdmin.Wizards.NewVMWizard
             _memoryMode == MemoryMode.MinimumAndMaximum ? spinnerDynMax.Value :
             spinnerStatMax.Value;
 
-        public long SelectedVcpusMax => (long)comboBoxVCPUs.SelectedItem;
+        public long SelectedVCpusMax => (long)comboBoxVCPUs.SelectedItem;
 
-        public long SelectedVcpusAtStartup => _isVcpuHotplugSupported ? (long)comboBoxInitialVCPUs.SelectedItem : (long)comboBoxVCPUs.SelectedItem;
+        public long SelectedVCpusAtStartup => _isVCpuHotplugSupported ? (long)comboBoxInitialVCPUs.SelectedItem : (long)comboBoxVCPUs.SelectedItem;
 
         public long SelectedCoresPerSocket => comboBoxTopology.CoresPerSocket;
 
@@ -262,14 +262,14 @@ namespace XenAdmin.Wizards.NewVMWizard
             {
                 var sum = new List<KeyValuePair<string, string>>();
 
-                if (_isVcpuHotplugSupported)
+                if (_isVCpuHotplugSupported)
                 {
-                    sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_CPUMEMPAGE_MAX_VCPUS, SelectedVcpusMax.ToString()));
-                    sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_CPUMEMPAGE_INITIAL_VCPUS, SelectedVcpusAtStartup.ToString()));
+                    sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_CPUMEMPAGE_MAX_VCPUS, SelectedVCpusMax.ToString()));
+                    sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_CPUMEMPAGE_INITIAL_VCPUS, SelectedVCpusAtStartup.ToString()));
                 }
                 else
                 {
-                    sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUS, SelectedVcpusAtStartup.ToString()));
+                    sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUS, SelectedVCpusAtStartup.ToString()));
                 }
                 sum.Add(new KeyValuePair<string, string>(Messages.NEWVMWIZARD_CPUMEMPAGE_TOPOLOGY, comboBoxTopology.Text));
                 if (_memoryMode == MemoryMode.JustMemory)
@@ -347,7 +347,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 ErrorPanel.Visible = true;
                 ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2, Helpers.GetName(maxMemFreeHost).Ellipsise(50), Util.MemorySizeStringSuitableUnits(maxMemFree, false));
             }
-            else if (maxVcpusHost != null && SelectedVcpusMax > maxVcpus)
+            else if (maxVcpusHost != null && SelectedVCpusMax > maxVcpus)
             {
                 ErrorPanel.Visible = true;
                 ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN, Helpers.GetName(maxVcpusHost).Ellipsise(50), maxVcpus);
@@ -375,7 +375,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             comboBoxTopology.Update((long)comboBoxVCPUs.SelectedItem);
             ValuesUpdated();
-            ValidateVcpuSettings();
+            ValidateVCpuSettings();
             RefreshCurrentVcpUs();
         }
 
@@ -388,11 +388,11 @@ namespace XenAdmin.Wizards.NewVMWizard
             ValuesUpdated();
         }
         
-        private void ValidateVcpuSettings()
+        private void ValidateVCpuSettings()
         {
-            if (comboBoxVCPUs.SelectedItem != null && SelectedVcpusMax < _minVcpUs)
+            if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax < _minVCpus)
             {
-                vCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVcpUs);
+                vCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVCpus);
                 vCPUWarningLabel.Visible = true;
             }
             else
@@ -400,9 +400,9 @@ namespace XenAdmin.Wizards.NewVMWizard
                 vCPUWarningLabel.Visible = false;
             }
 
-            if (comboBoxInitialVCPUs.SelectedItem != null && SelectedVcpusAtStartup < _minVcpUs)
+            if (comboBoxInitialVCPUs.SelectedItem != null && SelectedVCpusAtStartup < _minVCpus)
             {
-                initialVCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVcpUs);
+                initialVCPUWarningLabel.Text = string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVCpus);
                 initialVCPUWarningLabel.Visible = true;
             }
             else
@@ -428,15 +428,15 @@ namespace XenAdmin.Wizards.NewVMWizard
                 // So if VcpusMax is decreased below VcpusAtStartup, then VcpusAtStartup is decreased to that number too
                 // If VcpusAtStartup and VcpusMax are equal, and VcpusMax is changed, then VcpusAtStartup is changed to match
                 // But if the numbers are unequal, and VcpusMax is changed but is still higher than VcpusAtStartup, then VcpusAtStartup is unchanged
-                var newValue = SelectedVcpusAtStartup;
+                var newValue = SelectedVCpusAtStartup;
 
-                if (SelectedVcpusMax < SelectedVcpusAtStartup)
-                    newValue = SelectedVcpusMax;
-                else if (SelectedVcpusAtStartup == _prevVcpUsMax && SelectedVcpusMax != _prevVcpUsMax)
-                    newValue = SelectedVcpusMax;
+                if (SelectedVCpusMax < SelectedVCpusAtStartup)
+                    newValue = SelectedVCpusMax;
+                else if (SelectedVCpusAtStartup == _prevVcpUsMax && SelectedVCpusMax != _prevVcpUsMax)
+                    newValue = SelectedVCpusMax;
 
-                PopulateVcpUsAtStartup(SelectedVcpusMax, newValue);
-                _prevVcpUsMax = SelectedVcpusMax;
+                PopulateVcpUsAtStartup(SelectedVCpusMax, newValue);
+                _prevVcpUsMax = SelectedVCpusMax;
             }
         }
 
@@ -447,7 +447,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void comboBoxInitialVCPUs_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ValidateVcpuSettings();
+            ValidateVCpuSettings();
         }
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -80,7 +80,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         public double SelectedMemoryDynamicMax => _memoryMode == MemoryMode.JustMemory ? spinnerDynMin.Value : spinnerDynMax.Value;
 
-        public bool CanStartVM => _maxVCpus > 0 && SelectedVCpusMax <= _maxVCpus;
+        public bool CanStartVm => _maxVCpus > 0 && SelectedVCpusMax <= _maxVCpus;
 
         public double SelectedMemoryStaticMax =>
             _memoryMode == MemoryMode.JustMemory ? spinnerDynMin.Value :

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -357,7 +357,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             else if (SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
                 ErrorPanel.Visible = true;
-                ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
+                ErrorLabel.Text = string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
             }
             else
             {

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -54,7 +54,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private MemoryMode _memoryMode = MemoryMode.JustMemory;
 
         private double _memoryRatio = 0.0;  // the permitted ratio of dynamic_min / static_max
-        private bool _initialising = true;
+        private bool _initializing = true;
         private bool _isVcpuHotplugSupported;
         private int _minVcpUs;
 
@@ -78,7 +78,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             if (SelectedTemplate ==  _template)
                 return;
 
-            _initialising = true;
+            _initializing = true;
 
             _template = SelectedTemplate;
             if (_template.SupportsBallooning() && !Helpers.FeatureForbidden(_template, Host.RestrictDMC))
@@ -123,7 +123,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
             ValuesUpdated();
 
-            _initialising = false;
+            _initializing = false;
         }
 
         public override void SelectDefaultControl()
@@ -381,7 +381,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void memory_ValueChanged(object sender, EventArgs e)
         {
-            if (_initialising)
+            if (_initializing)
                 return;
 
             SetSpinnerLimitsAndIncrement();

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -354,6 +354,11 @@ namespace XenAdmin.Wizards.NewVMWizard
                 ErrorPanel.Visible = true;
                 ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN, Helpers.GetName(maxVcpusHost).Ellipsise(50), _maxVCpus);
             }
+            else if (SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
+            {
+                ErrorPanel.Visible = true;
+                ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS);
+            }
             else
             {
                 ErrorPanel.Visible = false;

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -39,7 +39,7 @@ using XenAPI;
 
 namespace XenAdmin.Wizards.NewVMWizard
 {
-    public partial class PageCpuMem : XenTabPage
+    public partial class Page_CpuMem : XenTabPage
     {
         private VM _template;
 
@@ -64,7 +64,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         // When vCPU hotplug is not supported, comboBoxVCPUs represents the initial number of vCPUs (VCPUs_at_startup). In this case we will also set the VM property VCPUs_max to the same value.
         // When vCPU hotplug is supported, comboBoxVCPUs represents the maximum number of vCPUs (VCPUs_max). And the initial number of vCPUs is represented in comboBoxInitialVCPUs (which is only visible in this case) 
 
-        public PageCpuMem()
+        public Page_CpuMem()
         {
             InitializeComponent();
         }
@@ -158,10 +158,10 @@ namespace XenAdmin.Wizards.NewVMWizard
             labelInitialVCPUs.Visible = comboBoxInitialVCPUs.Visible = _isVCpuHotplugSupported;
 
             comboBoxTopology.Populate(_template.VCPUs_at_startup, _template.VCPUs_max, _template.GetCoresPerSocket(), _template.MaxCoresPerSocket());
-            PopulateVcpUs(_template.MaxVCPUsAllowed(), _isVCpuHotplugSupported ? _template.VCPUs_max : _template.VCPUs_at_startup);
+            PopulateVCpus(_template.MaxVCPUsAllowed(), _isVCpuHotplugSupported ? _template.VCPUs_max : _template.VCPUs_at_startup);
 
             if (_isVCpuHotplugSupported)
-                PopulateVcpUsAtStartup(_template.VCPUs_max, _template.VCPUs_at_startup);
+                PopulateVCpusAtStartup(_template.VCPUs_max, _template.VCPUs_at_startup);
         }
 
         private void PopulateVCpuComboBox(ComboBox comboBox, long min, long max, long currentValue, Predicate<long> isValid)
@@ -179,12 +179,12 @@ namespace XenAdmin.Wizards.NewVMWizard
             comboBox.EndUpdate();
         }
 
-        private void PopulateVcpUs(long maxVcpUs, long currentVcpUs)
+        private void PopulateVCpus(long maxVCpus, long currentVCpus)
         {
-            PopulateVCpuComboBox(comboBoxVCPUs, 1, maxVcpUs, currentVcpUs, i => comboBoxTopology.IsValidVCPU(i));
+            PopulateVCpuComboBox(comboBoxVCPUs, 1, maxVCpus, currentVCpus, i => comboBoxTopology.IsValidVCPU(i));
         }
 
-        private void PopulateVcpUsAtStartup(long max, long currentValue)
+        private void PopulateVCpusAtStartup(long max, long currentValue)
         {
             PopulateVCpuComboBox(comboBoxInitialVCPUs, 1, max, currentValue, i => true);
         }
@@ -376,7 +376,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             comboBoxTopology.Update((long)comboBoxVCPUs.SelectedItem);
             ValuesUpdated();
             ValidateVCpuSettings();
-            RefreshCurrentVcpUs();
+            RefreshCurrentVCpus();
         }
 
         private void memory_ValueChanged(object sender, EventArgs e)
@@ -417,7 +417,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 labelInvalidVCPUWarning.Text = VM.ValidVCPUConfiguration((long)comboBoxVCPUs.SelectedItem, comboBoxTopology.CoresPerSocket);
         }
 
-        private void RefreshCurrentVcpUs()
+        private void RefreshCurrentVCpus()
         {
             // refresh comboBoxInitialVCPUs if it's visible and populated
             if (comboBoxInitialVCPUs.Visible && comboBoxInitialVCPUs.Items.Count > 0)
@@ -433,7 +433,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                 else if (SelectedVCpusAtStartup == _prevVCpusMax && SelectedVCpusMax != _prevVCpusMax)
                     newValue = SelectedVCpusMax;
 
-                PopulateVcpUsAtStartup(SelectedVCpusMax, newValue);
+                PopulateVCpusAtStartup(SelectedVCpusMax, newValue);
                 _prevVCpusMax = SelectedVCpusMax;
             }
         }

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -66,20 +66,11 @@ namespace XenAdmin.Wizards.NewVMWizard
             InitializeComponent();
         }
 
-        public override string Text
-        {
-            get { return Messages.NEWVMWIZARD_CPUMEMPAGE_NAME; }
-        }
+        public override string Text => Messages.NEWVMWIZARD_CPUMEMPAGE_NAME;
 
-        public override string PageTitle
-        {
-            get { return Messages.NEWVMWIZARD_CPUMEMPAGE_TITLE; }
-        }
+        public override string PageTitle => Messages.NEWVMWIZARD_CPUMEMPAGE_TITLE;
 
-        public override string HelpID
-        {
-            get { return "CPU&Memory"; }
-        }
+        public override string HelpID => "CPU&Memory";
 
         protected override void PageLoadedCore(PageLoadedDirection direction)
         {
@@ -249,56 +240,20 @@ namespace XenAdmin.Wizards.NewVMWizard
             spinnerStatMax.Enabled = false;
         }
 
-        public double SelectedMemoryDynamicMin
-        {
-            get
-            {
-                return spinnerDynMin.Value;
-            }
-        }
+        public double SelectedMemoryDynamicMin => spinnerDynMin.Value;
 
-        public double SelectedMemoryDynamicMax
-        {
-            get
-            {
-                return memoryMode == MemoryMode.JustMemory ? spinnerDynMin.Value : spinnerDynMax.Value;
-            }
-        }
+        public double SelectedMemoryDynamicMax => memoryMode == MemoryMode.JustMemory ? spinnerDynMin.Value : spinnerDynMax.Value;
 
-        public double SelectedMemoryStaticMax
-        {
-            get
-            {
-                return
-                    memoryMode == MemoryMode.JustMemory ? spinnerDynMin.Value :
-                    memoryMode == MemoryMode.MinimumAndMaximum ? spinnerDynMax.Value :
-                    spinnerStatMax.Value;
-            }
-        }
+        public double SelectedMemoryStaticMax =>
+            memoryMode == MemoryMode.JustMemory ? spinnerDynMin.Value :
+            memoryMode == MemoryMode.MinimumAndMaximum ? spinnerDynMax.Value :
+            spinnerStatMax.Value;
 
-        public long SelectedVcpusMax
-        {
-            get
-            {
-                return (long)comboBoxVCPUs.SelectedItem;
-            }
-        }
+        public long SelectedVcpusMax => (long)comboBoxVCPUs.SelectedItem;
 
-        public long SelectedVcpusAtStartup
-        {
-            get
-            {
-                return isVcpuHotplugSupported ? (long)comboBoxInitialVCPUs.SelectedItem : (long)comboBoxVCPUs.SelectedItem;
-            }
-        }
+        public long SelectedVcpusAtStartup => isVcpuHotplugSupported ? (long)comboBoxInitialVCPUs.SelectedItem : (long)comboBoxVCPUs.SelectedItem;
 
-        public long SelectedCoresPerSocket
-        {
-            get
-            {
-                return comboBoxTopology.CoresPerSocket;
-            }
-        }
+        public long SelectedCoresPerSocket => comboBoxTopology.CoresPerSocket;
 
         public override List<KeyValuePair<string, string>> PageSummary
         {

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -357,7 +357,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             else if (SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
                 ErrorPanel.Visible = true;
-                ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS);
+                ErrorLabel.Text = string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand);
             }
             else
             {

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -341,13 +341,11 @@ namespace XenAdmin.Wizards.NewVMWizard
 
             if (maxMemTotalHost != null && SelectedMemoryDynamicMin > maxMemTotal)
             {
-                ShowMemoryWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1, Helpers.GetName(maxMemTotalHost).Ellipsise(50), Util.MemorySizeStringSuitableUnits(maxMemTotal, false)));
+                ShowMemoryWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1, Util.MemorySizeStringSuitableUnits(maxMemTotal, false)));
             }
             else if (maxMemFreeHost != null && SelectedMemoryDynamicMin > maxMemFree)
             {
-                ShowMemoryWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2,
-                    Helpers.GetName(maxMemFreeHost).Ellipsise(50),
-                    Util.MemorySizeStringSuitableUnits(maxMemFree, false)));
+                ShowMemoryWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2, Util.MemorySizeStringSuitableUnits(maxMemFree, false)));
             }
             else
             {
@@ -356,7 +354,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             
             if (maxVcpusHost != null && SelectedVCpusMax > _maxVCpus)
             {
-                ShowCpuWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN, Helpers.GetName(maxVcpusHost).Ellipsise(50), _maxVCpus));
+                ShowCpuWarning(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN, _maxVCpus));
             }
             else if (SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.ja.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.ja.resx
@@ -826,7 +826,7 @@
     <value>515, 367</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Page_CpuMem</value>
+    <value>PageCpuMem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.ja.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.ja.resx
@@ -826,7 +826,7 @@
     <value>515, 367</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>PageCpuMem</value>
+    <value>Page_CpuMem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
@@ -117,47 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="labelVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="labelVCPUs.AutoSize" type="System.Boolean, mscorlib">
+  <data name="warningsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelVCPUs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="warningsTableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="labelVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 47</value>
-  </data>
-  <data name="labelVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 13</value>
-  </data>
-  <data name="labelVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="labelVCPUs.Text" xml:space="preserve">
-    <value>&amp;Number of vCPUs:</value>
-  </data>
-  <data name="labelVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;labelVCPUs.Name" xml:space="preserve">
-    <value>labelVCPUs</value>
-  </data>
-  <data name="&gt;&gt;labelVCPUs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelVCPUs.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelVCPUs.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="warningsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>4</value>
@@ -171,6 +140,7 @@
   <data name="vCPUWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="vCPUWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>185, 40</value>
   </data>
@@ -348,6 +318,42 @@
   <data name="&gt;&gt;comboBoxTopology.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 14</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>509, 26</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>Specify the number of virtual CPUs, their topology and the amount of memory that will be initially allocated to the new virtual machine.</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <data name="spinnerStatMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -377,6 +383,42 @@
   </data>
   <data name="&gt;&gt;spinnerStatMax.ZOrder" xml:space="preserve">
     <value>7</value>
+  </data>
+  <data name="labelVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="labelVCPUs.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelVCPUs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelVCPUs.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 47</value>
+  </data>
+  <data name="labelVCPUs.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 13</value>
+  </data>
+  <data name="labelVCPUs.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelVCPUs.Text" xml:space="preserve">
+    <value>&amp;Number of vCPUs:</value>
+  </data>
+  <data name="labelVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;labelVCPUs.Name" xml:space="preserve">
+    <value>labelVCPUs</value>
+  </data>
+  <data name="&gt;&gt;labelVCPUs.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelVCPUs.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;labelVCPUs.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="spinnerDynMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -501,6 +543,9 @@
   <data name="labelDynMin.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="labelDynMin.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="labelDynMin.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 166</value>
   </data>
@@ -530,6 +575,9 @@
   </data>
   <data name="labelDynMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="labelDynMax.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="labelDynMax.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 192</value>
@@ -561,6 +609,9 @@
   <data name="labelStatMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="labelStatMax.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="labelStatMax.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 218</value>
   </data>
@@ -590,6 +641,9 @@
   </data>
   <data name="labelDynMinInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="labelDynMinInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="labelDynMinInfo.Location" type="System.Drawing.Point, System.Drawing">
     <value>226, 166</value>
@@ -621,6 +675,9 @@
   <data name="labelDynMaxInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="labelDynMaxInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="labelDynMaxInfo.Location" type="System.Drawing.Point, System.Drawing">
     <value>226, 192</value>
   </data>
@@ -650,6 +707,9 @@
   </data>
   <data name="labelStatMaxInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="labelStatMaxInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="labelStatMaxInfo.Location" type="System.Drawing.Point, System.Drawing">
     <value>226, 218</value>
@@ -685,7 +745,7 @@
     <value>10</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>515, 255</value>
+    <value>515, 367</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -703,115 +763,172 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="vCPUWarningLabel" Row="1" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="initialVCPUWarningLabel" Row="4" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInvalidVCPUWarning" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxTopology" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="spinnerStatMax" Row="8" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelVCPUs" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMax" Row="7" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxVCPUs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMin" Row="6" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelDynMin" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMax" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMax" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMinInfo" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMaxInfo" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMaxInfo" Row="8" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,41,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="vCPUWarningLabel" Row="1" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="initialVCPUWarningLabel" Row="4" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInvalidVCPUWarning" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxTopology" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="spinnerStatMax" Row="8" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelVCPUs" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMax" Row="7" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxVCPUs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMin" Row="6" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelDynMin" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMax" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMax" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMinInfo" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMaxInfo" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMaxInfo" Row="8" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="warningsTableLayoutPanel" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,41,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
-  </data>
-  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 14</value>
-  </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>509, 26</value>
-  </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>Specify the number of virtual CPUs, their topology and the amount of memory that will be initially allocated to the new virtual machine.</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="warningPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="cpuWarningPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="warningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 6</value>
+  <data name="cpuWarningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 3</value>
   </data>
-  <data name="warningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 16</value>
+  <data name="cpuWarningPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
   </data>
-  <data name="warningPictureBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="cpuWarningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 16</value>
+  </data>
+  <data name="cpuWarningPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
+  </data>
+  <data name="cpuWarningPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;warningPictureBox.Name" xml:space="preserve">
-    <value>warningPictureBox</value>
-  </data>
-  <data name="&gt;&gt;warningPictureBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;warningPictureBox.Parent" xml:space="preserve">
-    <value>ErrorPanel</value>
-  </data>
-  <data name="&gt;&gt;warningPictureBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ErrorLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="ErrorLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ErrorLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>25, 6</value>
-  </data>
-  <data name="ErrorLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>487, 106</value>
-  </data>
-  <data name="ErrorLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ErrorLabel.Name" xml:space="preserve">
-    <value>ErrorLabel</value>
-  </data>
-  <data name="&gt;&gt;ErrorLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ErrorLabel.Parent" xml:space="preserve">
-    <value>ErrorPanel</value>
-  </data>
-  <data name="&gt;&gt;ErrorLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ErrorPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="ErrorPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 255</value>
-  </data>
-  <data name="ErrorPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>515, 112</value>
-  </data>
-  <data name="ErrorPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="ErrorPanel.Visible" type="System.Boolean, mscorlib">
+  <data name="cpuWarningPictureBox.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;ErrorPanel.Name" xml:space="preserve">
-    <value>ErrorPanel</value>
+  <data name="&gt;&gt;cpuWarningPictureBox.Name" xml:space="preserve">
+    <value>cpuWarningPictureBox</value>
   </data>
-  <data name="&gt;&gt;ErrorPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cpuWarningPictureBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;ErrorPanel.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;cpuWarningPictureBox.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;ErrorPanel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;cpuWarningPictureBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cpuWarningLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cpuWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cpuWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 3</value>
+  </data>
+  <data name="cpuWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="cpuWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="cpuWarningLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="cpuWarningLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.Name" xml:space="preserve">
+    <value>cpuWarningLabel</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cpuWarningLabel.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="memoryWarningLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="memoryWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="memoryWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 25</value>
+  </data>
+  <data name="memoryWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="memoryWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="memoryWarningLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="memoryWarningLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.Name" xml:space="preserve">
+    <value>memoryWarningLabel</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;memoryWarningLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="memoryPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="memoryPictureBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="memoryPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="memoryPictureBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 16</value>
+  </data>
+  <data name="memoryPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
+  </data>
+  <data name="memoryPictureBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="memoryPictureBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.Name" xml:space="preserve">
+    <value>memoryPictureBox</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;memoryPictureBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 320</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="warningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="warningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>515, 44</value>
+  </data>
+  <data name="warningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.Name" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;warningsTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="warningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
@@ -826,7 +826,7 @@
     <value>515, 367</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Page_CpuMem</value>
+    <value>PageCpuMem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
@@ -735,31 +735,28 @@
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="warningPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="warningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 6</value>
   </data>
-  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="warningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>16, 16</value>
   </data>
-  <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>AutoSize</value>
-  </data>
-  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+  <data name="warningPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
-    <value>pictureBox1</value>
+  <data name="&gt;&gt;warningPictureBox.Name" xml:space="preserve">
+    <value>warningPictureBox</value>
   </data>
-  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+  <data name="&gt;&gt;warningPictureBox.Type" xml:space="preserve">
     <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;warningPictureBox.Parent" xml:space="preserve">
     <value>ErrorPanel</value>
   </data>
-  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;warningPictureBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="ErrorLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
@@ -142,13 +142,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="vCPUWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 40</value>
+    <value>185, 38</value>
   </data>
   <data name="vCPUWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>327, 27</value>
   </data>
   <data name="vCPUWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+    <value>2</value>
   </data>
   <data name="vCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -178,13 +178,13 @@
     <value>NoControl</value>
   </data>
   <data name="initialVCPUWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 113</value>
+    <value>185, 92</value>
   </data>
   <data name="initialVCPUWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>327, 27</value>
   </data>
   <data name="initialVCPUWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>7</value>
   </data>
   <data name="initialVCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -205,7 +205,7 @@
     <value>1</value>
   </data>
   <data name="comboBoxInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 116</value>
+    <value>129, 95</value>
   </data>
   <data name="comboBoxInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
@@ -235,7 +235,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 120</value>
+    <value>3, 99</value>
   </data>
   <data name="labelInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 13</value>
@@ -245,9 +245,6 @@
   </data>
   <data name="labelInitialVCPUs.Text" xml:space="preserve">
     <value>Initial number of v&amp;CPUs:</value>
-  </data>
-  <data name="labelInitialVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelInitialVCPUs.Name" xml:space="preserve">
     <value>labelInitialVCPUs</value>
@@ -261,44 +258,11 @@
   <data name="&gt;&gt;labelInitialVCPUs.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="labelInvalidVCPUWarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 94</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 6</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>383, 13</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Name" xml:space="preserve">
-    <value>labelInvalidVCPUWarning</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="comboBoxTopology.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
   </data>
   <data name="comboBoxTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 70</value>
+    <value>129, 68</value>
   </data>
   <data name="comboBoxTopology.Size" type="System.Drawing.Size, System.Drawing">
     <value>250, 21</value>
@@ -316,7 +280,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -331,7 +295,7 @@
     <value>3, 0</value>
   </data>
   <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 14</value>
+    <value>3, 0, 3, 12</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
     <value>509, 26</value>
@@ -352,7 +316,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="spinnerStatMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -361,7 +325,7 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="spinnerStatMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 212</value>
+    <value>126, 191</value>
   </data>
   <data name="spinnerStatMax.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -370,7 +334,7 @@
     <value>97, 26</value>
   </data>
   <data name="spinnerStatMax.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;spinnerStatMax.Name" xml:space="preserve">
     <value>spinnerStatMax</value>
@@ -382,7 +346,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;spinnerStatMax.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="labelVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -394,7 +358,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 47</value>
+    <value>3, 45</value>
   </data>
   <data name="labelVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>95, 13</value>
@@ -404,9 +368,6 @@
   </data>
   <data name="labelVCPUs.Text" xml:space="preserve">
     <value>&amp;Number of vCPUs:</value>
-  </data>
-  <data name="labelVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelVCPUs.Name" xml:space="preserve">
     <value>labelVCPUs</value>
@@ -418,7 +379,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelVCPUs.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="spinnerDynMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -427,7 +388,7 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="spinnerDynMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 186</value>
+    <value>126, 165</value>
   </data>
   <data name="spinnerDynMax.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -436,7 +397,7 @@
     <value>97, 26</value>
   </data>
   <data name="spinnerDynMax.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="&gt;&gt;spinnerDynMax.Name" xml:space="preserve">
     <value>spinnerDynMax</value>
@@ -448,7 +409,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;spinnerDynMax.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>8</value>
   </data>
   <data name="labelTopology.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -460,7 +421,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 74</value>
+    <value>3, 72</value>
   </data>
   <data name="labelTopology.Size" type="System.Drawing.Size, System.Drawing">
     <value>54, 13</value>
@@ -470,9 +431,6 @@
   </data>
   <data name="labelTopology.Text" xml:space="preserve">
     <value>&amp;Topology:</value>
-  </data>
-  <data name="labelTopology.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelTopology.Name" xml:space="preserve">
     <value>labelTopology</value>
@@ -484,16 +442,16 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelTopology.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="comboBoxVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 43</value>
+    <value>129, 41</value>
   </data>
   <data name="comboBoxVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
   </data>
   <data name="comboBoxVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.Name" xml:space="preserve">
     <value>comboBoxVCPUs</value>
@@ -505,7 +463,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
   </data>
   <data name="spinnerDynMin.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -514,7 +472,7 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="spinnerDynMin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 160</value>
+    <value>126, 139</value>
   </data>
   <data name="spinnerDynMin.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -523,7 +481,7 @@
     <value>97, 26</value>
   </data>
   <data name="spinnerDynMin.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;spinnerDynMin.Name" xml:space="preserve">
     <value>spinnerDynMin</value>
@@ -535,7 +493,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;spinnerDynMin.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>11</value>
   </data>
   <data name="labelDynMin.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -547,13 +505,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 166</value>
+    <value>3, 145</value>
   </data>
   <data name="labelDynMin.Size" type="System.Drawing.Size, System.Drawing">
     <value>90, 13</value>
   </data>
   <data name="labelDynMin.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="labelDynMin.Text" xml:space="preserve">
     <value>&amp;Minimum memory:</value>
@@ -568,7 +526,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMin.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>12</value>
   </data>
   <data name="labelDynMax.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -580,13 +538,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 192</value>
+    <value>3, 171</value>
   </data>
   <data name="labelDynMax.Size" type="System.Drawing.Size, System.Drawing">
     <value>93, 13</value>
   </data>
   <data name="labelDynMax.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="labelDynMax.Text" xml:space="preserve">
     <value>Ma&amp;ximum memory:</value>
@@ -601,7 +559,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMax.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>13</value>
   </data>
   <data name="labelStatMax.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -613,13 +571,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelStatMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 218</value>
+    <value>3, 197</value>
   </data>
   <data name="labelStatMax.Size" type="System.Drawing.Size, System.Drawing">
     <value>83, 13</value>
   </data>
   <data name="labelStatMax.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>14</value>
   </data>
   <data name="labelStatMax.Text" xml:space="preserve">
     <value>&amp;Static maximum:</value>
@@ -634,7 +592,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelStatMax.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>14</value>
   </data>
   <data name="labelDynMinInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -646,13 +604,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMinInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>226, 166</value>
+    <value>226, 145</value>
   </data>
   <data name="labelDynMinInfo.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 13</value>
   </data>
   <data name="labelDynMinInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>10</value>
   </data>
   <data name="labelDynMinInfo.Text" xml:space="preserve">
     <value>Minimum maximum placeholder.</value>
@@ -667,7 +625,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMinInfo.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>15</value>
   </data>
   <data name="labelDynMaxInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -679,13 +637,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMaxInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>226, 192</value>
+    <value>226, 171</value>
   </data>
   <data name="labelDynMaxInfo.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 13</value>
   </data>
   <data name="labelDynMaxInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>13</value>
   </data>
   <data name="labelDynMaxInfo.Text" xml:space="preserve">
     <value>Minimum maximum placeholder.</value>
@@ -700,7 +658,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMaxInfo.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>16</value>
   </data>
   <data name="labelStatMaxInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -712,7 +670,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelStatMaxInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>226, 218</value>
+    <value>226, 197</value>
   </data>
   <data name="labelStatMaxInfo.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 13</value>
@@ -733,7 +691,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelStatMaxInfo.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>17</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -742,7 +700,7 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>515, 367</value>
@@ -763,22 +721,43 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="vCPUWarningLabel" Row="1" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="initialVCPUWarningLabel" Row="4" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInvalidVCPUWarning" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxTopology" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="spinnerStatMax" Row="8" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelVCPUs" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMax" Row="7" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxVCPUs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMin" Row="6" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelDynMin" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMax" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMax" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMinInfo" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMaxInfo" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMaxInfo" Row="8" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="warningsTableLayoutPanel" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,41,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="vCPUWarningLabel" Row="1" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="initialVCPUWarningLabel" Row="3" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="spinnerStatMax" Row="7" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelVCPUs" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMax" Row="6" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxVCPUs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMin" Row="5" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelDynMin" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMax" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMax" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMinInfo" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMaxInfo" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMaxInfo" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="warningsTableLayoutPanel" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,41,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="pictureBoxTopology.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBoxTopology.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 31</value>
+  </data>
+  <data name="pictureBoxTopology.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBoxTopology.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="pictureBoxTopology.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.Name" xml:space="preserve">
+    <value>pictureBoxTopology</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cpuWarningPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="cpuWarningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 3</value>
-  </data>
-  <data name="cpuWarningPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 3</value>
   </data>
   <data name="cpuWarningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="cpuWarningPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="cpuWarningPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -796,7 +775,10 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cpuWarningPictureBox.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
+  </data>
+  <data name="cpuWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="cpuWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -805,16 +787,13 @@
     <value>NoControl</value>
   </data>
   <data name="cpuWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 3</value>
-  </data>
-  <data name="cpuWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 4</value>
   </data>
   <data name="cpuWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="cpuWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="cpuWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -829,7 +808,10 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cpuWarningLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
+  </data>
+  <data name="memoryWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="memoryWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -838,16 +820,13 @@
     <value>NoControl</value>
   </data>
   <data name="memoryWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="memoryWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 60</value>
   </data>
   <data name="memoryWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="memoryWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="memoryWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -862,22 +841,16 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;memoryWarningLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="memoryPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="memoryPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="memoryPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 59</value>
   </data>
   <data name="memoryPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="memoryPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="memoryPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -895,25 +868,55 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;memoryPictureBox.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
+  </data>
+  <data name="labelTopologyWarning.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="labelTopologyWarning.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelTopologyWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 32</value>
+  </data>
+  <data name="labelTopologyWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="labelTopologyWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelTopologyWarning.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.Name" xml:space="preserve">
+    <value>labelTopologyWarning</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="warningsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
+    <value>Top</value>
   </data>
   <data name="warningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 320</value>
+    <value>0, 237</value>
   </data>
   <data name="warningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>0, 20, 0, 0</value>
   </data>
   <data name="warningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="warningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>515, 44</value>
+    <value>515, 78</value>
   </data>
   <data name="warningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>17</value>
   </data>
   <data name="&gt;&gt;warningsTableLayoutPanel.Name" xml:space="preserve">
     <value>warningsTableLayoutPanel</value>
@@ -925,10 +928,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;warningsTableLayoutPanel.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>18</value>
   </data>
   <data name="warningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBoxTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelTopologyWarning" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,6,AutoSize,0,Absolute,6,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
@@ -826,7 +826,7 @@
     <value>515, 367</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>PageCpuMem</value>
+    <value>Page_CpuMem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
@@ -340,7 +340,7 @@
     <value>comboBoxTopology</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.CPUTopologyComboBox, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.CPUTopologyComboBox, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -370,7 +370,7 @@
     <value>spinnerStatMax</value>
   </data>
   <data name="&gt;&gt;spinnerStatMax.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.Ballooning.MemorySpinner, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.Ballooning.MemorySpinner, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;spinnerStatMax.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -400,7 +400,7 @@
     <value>spinnerDynMax</value>
   </data>
   <data name="&gt;&gt;spinnerDynMax.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.Ballooning.MemorySpinner, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.Ballooning.MemorySpinner, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;spinnerDynMax.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -487,7 +487,7 @@
     <value>spinnerDynMin</value>
   </data>
   <data name="&gt;&gt;spinnerDynMin.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.Ballooning.MemorySpinner, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.Ballooning.MemorySpinner, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;spinnerDynMin.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -829,6 +829,6 @@
     <value>Page_CpuMem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.zh-CN.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.zh-CN.resx
@@ -826,7 +826,7 @@
     <value>515, 367</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Page_CpuMem</value>
+    <value>PageCpuMem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.zh-CN.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.zh-CN.resx
@@ -826,7 +826,7 @@
     <value>515, 367</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>PageCpuMem</value>
+    <value>Page_CpuMem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.Designer.cs
@@ -31,21 +31,15 @@ namespace XenAdmin.Wizards.NewVMWizard
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_Finish));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.richTextBox1 = new System.Windows.Forms.RichTextBox();
             this.AutoStartCheckBox = new System.Windows.Forms.CheckBox();
             this.SummaryGridView = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
             this.PropertyColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ValueColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.SummaryGridView)).BeginInit();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // richTextBox1
-            // 
-            resources.ApplyResources(this.richTextBox1, "richTextBox1");
-            this.richTextBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.richTextBox1.Name = "richTextBox1";
-            this.richTextBox1.ReadOnly = true;
-            this.richTextBox1.TabStop = false;
             // 
             // AutoStartCheckBox
             // 
@@ -57,9 +51,9 @@ namespace XenAdmin.Wizards.NewVMWizard
             // 
             // SummaryGridView
             // 
-            resources.ApplyResources(this.SummaryGridView, "SummaryGridView");
             this.SummaryGridView.BackgroundColor = System.Drawing.SystemColors.Control;
             this.SummaryGridView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
+            this.SummaryGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.SummaryGridView.ColumnHeadersVisible = false;
             this.SummaryGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.PropertyColumn,
@@ -72,6 +66,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.SummaryGridView.DefaultCellStyle = dataGridViewCellStyle1;
+            resources.ApplyResources(this.SummaryGridView, "SummaryGridView");
             this.SummaryGridView.Name = "SummaryGridView";
             this.SummaryGridView.ReadOnly = true;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Control;
@@ -94,26 +89,38 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.ValueColumn.Name = "ValueColumn";
             this.ValueColumn.ReadOnly = true;
             // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.AutoStartCheckBox, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.SummaryGridView, 0, 1);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
+            // 
             // Page_Finish
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.SummaryGridView);
-            this.Controls.Add(this.AutoStartCheckBox);
-            this.Controls.Add(this.richTextBox1);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "Page_Finish";
             ((System.ComponentModel.ISupportInitialize)(this.SummaryGridView)).EndInit();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.RichTextBox richTextBox1;
         private System.Windows.Forms.CheckBox AutoStartCheckBox;
         private XenAdmin.Controls.DataGridViewEx.DataGridViewEx SummaryGridView;
         private System.Windows.Forms.DataGridViewTextBoxColumn PropertyColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn ValueColumn;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
@@ -81,11 +81,11 @@ namespace XenAdmin.Wizards.NewVMWizard
         {
             SummaryGridView.Rows.Clear();
             
-            if (SummaryRetreiver == null)
+            if (SummaryRetriever == null)
                 return;
 
-            var entries = SummaryRetreiver.Invoke();
-            foreach (KeyValuePair<string, string> pair in entries)
+            var entries = SummaryRetriever.Invoke();
+            foreach (var pair in entries)
                 SummaryGridView.Rows.Add(pair.Key, pair.Value);
         }
 
@@ -95,6 +95,6 @@ namespace XenAdmin.Wizards.NewVMWizard
                 AutoStartCheckBox.Select();
         }
 
-        public Func<IEnumerable<KeyValuePair<string, string>>> SummaryRetreiver { private get; set; }
+        public Func<IEnumerable<KeyValuePair<string, string>>> SummaryRetriever { private get; set; }
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
@@ -61,20 +61,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         public bool CanStartImmediately
         {
             get => _canStartImmediately;
-            set
-            {
-                if (!value)
-                {
-                    AutoStartCheckBox.Checked = false;
-                    AutoStartCheckBox.Enabled = false;
-                }
-                else
-                {
-                    AutoStartCheckBox.Enabled = true;
-                }
-
-                _canStartImmediately = value;
-            }
+            set => _canStartImmediately = AutoStartCheckBox.Checked = AutoStartCheckBox.Enabled = value;
         }
 
         protected override void PageLoadedCore(PageLoadedDirection direction)

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
@@ -71,6 +71,27 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
         }
 
+        private bool _canStartImmediately = true;
+
+        public bool CanStartImmediately
+        {
+            get => _canStartImmediately;
+            set
+            {
+                if (!value)
+                {
+                    AutoStartCheckBox.Checked = false;
+                    AutoStartCheckBox.Enabled = false;
+                }
+                else
+                {
+                    AutoStartCheckBox.Enabled = true;
+                }
+
+                _canStartImmediately = value;
+            }
+        }
+
         protected override void PageLoadedCore(PageLoadedDirection direction)
         {
             SummaryGridView.Rows.Clear();
@@ -85,7 +106,8 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         public override void SelectDefaultControl()
         {
-            AutoStartCheckBox.Select();
+            if(CanStartImmediately)
+                AutoStartCheckBox.Select();
         }
 
         public Func<IEnumerable<KeyValuePair<string, string>>> SummaryRetreiver { private get; set; }

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
@@ -43,33 +43,18 @@ namespace XenAdmin.Wizards.NewVMWizard
             richTextBox1.Text = Messages.NEWVMWIZARD_FINISHPAGE;
         }
 
-        public override string Text
-        {
-            get { return Messages.NEWVMWIZARD_FINISHPAGE_NAME; }
-        }
+        public override string Text => Messages.NEWVMWIZARD_FINISHPAGE_NAME;
 
-        public override string PageTitle
-        {
-            get { return Messages.NEWVMWIZARD_FINISHPAGE_TITLE; }
-        }
+        public override string PageTitle => Messages.NEWVMWIZARD_FINISHPAGE_TITLE;
 
-        public override string HelpID
-        {
-            get { return "Finish"; }
-        }
+        public override string HelpID => "Finish";
 
         public override string NextText(bool isLastPage)
         {
             return Messages.NEWVMWIZARD_FINISHPAGE_CREATE;
         }
 
-        public bool StartImmediately
-        {
-            get
-            {
-                return AutoStartCheckBox.Checked;
-            }
-        }
+        public bool StartImmediately => AutoStartCheckBox.Checked;
 
         private bool _canStartImmediately = true;
 

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
@@ -40,7 +40,6 @@ namespace XenAdmin.Wizards.NewVMWizard
         public Page_Finish()
         {
             InitializeComponent();
-            richTextBox1.Text = Messages.NEWVMWIZARD_FINISHPAGE;
         }
 
         public override string Text => Messages.NEWVMWIZARD_FINISHPAGE_NAME;

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.resx
@@ -112,49 +112,22 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="richTextBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="richTextBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
-  </data>
-  <data name="richTextBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>508, 86</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="richTextBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="richTextBox1.Text" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;richTextBox1.Name" xml:space="preserve">
-    <value>richTextBox1</value>
-  </data>
-  <data name="&gt;&gt;richTextBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;richTextBox1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;richTextBox1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="AutoStartCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="AutoStartCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="AutoStartCheckBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 288</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="AutoStartCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 10, 3, 3</value>
   </data>
   <data name="AutoStartCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>172, 17</value>
@@ -169,18 +142,15 @@
     <value>AutoStartCheckBox</value>
   </data>
   <data name="&gt;&gt;AutoStartCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoStartCheckBox.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;AutoStartCheckBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="SummaryGridView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <metadata name="PropertyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="PropertyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="PropertyColumn.HeaderText" xml:space="preserve">
@@ -189,17 +159,20 @@
   <data name="PropertyColumn.Width" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ValueColumn.HeaderText" xml:space="preserve">
     <value>Value</value>
   </data>
+  <data name="SummaryGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="SummaryGridView.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 97</value>
+    <value>3, 44</value>
   </data>
   <data name="SummaryGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>508, 142</value>
+    <value>509, 231</value>
   </data>
   <data name="SummaryGridView.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -208,15 +181,81 @@
     <value>SummaryGridView</value>
   </data>
   <data name="&gt;&gt;SummaryGridView.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;SummaryGridView.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;SummaryGridView.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 15</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>509, 26</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="label1.Text" xml:space="preserve">
+    <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>515, 308</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AutoStartCheckBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="SummaryGridView" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -229,18 +268,18 @@
     <value>PropertyColumn</value>
   </data>
   <data name="&gt;&gt;PropertyColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ValueColumn.Name" xml:space="preserve">
     <value>ValueColumn</value>
   </data>
   <data name="&gt;&gt;ValueColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>Page_Finish</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -1372,11 +1372,11 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="SettingsPanels\BootDevice.cs" />
-    <Compile Include="SettingsPanels\CPUMemoryEditPage.cs">
+    <Compile Include="SettingsPanels\CpuMemoryEditPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="SettingsPanels\CPUMemoryEditPage.Designer.cs">
-      <DependentUpon>CPUMemoryEditPage.cs</DependentUpon>
+    <Compile Include="SettingsPanels\CpuMemoryEditPage.Designer.cs">
+      <DependentUpon>CpuMemoryEditPage.cs</DependentUpon>
     </Compile>
     <Compile Include="SettingsPanels\GeneralEditPage.cs">
       <SubType>UserControl</SubType>
@@ -2621,8 +2621,8 @@
       <DependentUpon>VMHAEditPage.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsPanels\CPUMemoryEditPage.resx">
-      <DependentUpon>CPUMemoryEditPage.cs</DependentUpon>
+    <EmbeddedResource Include="SettingsPanels\CpuMemoryEditPage.resx">
+      <DependentUpon>CpuMemoryEditPage.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="SettingsPanels\GeneralEditPage.resx">
@@ -5603,12 +5603,12 @@
     <EmbeddedResource Include="SettingsPanels\BootOptionsEditPage.zh-CN.resx">
       <DependentUpon>BootOptionsEditPage.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsPanels\CPUMemoryEditPage.ja.resx">
-      <DependentUpon>CPUMemoryEditPage.cs</DependentUpon>
+    <EmbeddedResource Include="SettingsPanels\CpuMemoryEditPage.ja.resx">
+      <DependentUpon>CpuMemoryEditPage.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsPanels\CPUMemoryEditPage.zh-CN.resx">
-      <DependentUpon>CPUMemoryEditPage.cs</DependentUpon>
+    <EmbeddedResource Include="SettingsPanels\CpuMemoryEditPage.zh-CN.resx">
+      <DependentUpon>CpuMemoryEditPage.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="SettingsPanels\CustomFieldsDisplayPage.ja.resx">

--- a/XenModel/Actions/OvfActions/Import.cs
+++ b/XenModel/Actions/OvfActions/Import.cs
@@ -492,18 +492,21 @@ namespace XenAdmin.Actions.OvfActions
                 //The default memory unit is MB (2^20), however, the RASD may contain a different
                 //one with format byte*memoryBase^memoryPower (byte being a literal string)
 
-                double memoryPower = 20.0;
                 double memoryBase = 2.0;
-               
+                double memoryPower = 20.0;
+
                 foreach (RASD_Type rasd in rasds)
                 {
                     if (rasd.AllocationUnits.Value.ToLower().StartsWith("byte"))
                     {
                         string[] a1 = rasd.AllocationUnits.Value.Split('*', '^');
+
                         if (a1.Length == 3)
                         {
-                            memoryBase = Convert.ToDouble(a1[1].Trim());
-                            memoryPower = Convert.ToDouble(a1[2].Trim());
+                            if (!double.TryParse(a1[1].Trim(), out memoryBase))
+                                memoryBase = 2.0;
+                            if (!double.TryParse(a1[2].Trim(), out memoryPower))
+                                memoryPower = 20.0;
                         }
                     }
 

--- a/XenModel/Actions/OvfActions/Import.cs
+++ b/XenModel/Actions/OvfActions/Import.cs
@@ -490,20 +490,20 @@ namespace XenAdmin.Actions.OvfActions
             if (rasds != null && rasds.Length > 0)
             {
                 //The default memory unit is MB (2^20), however, the RASD may contain a different
-                //one with format Bytes*memoryBase^memoryPower (Bytes being a literal string)
+                //one with format byte*memoryBase^memoryPower (byte being a literal string)
 
                 double memoryPower = 20.0;
                 double memoryBase = 2.0;
                
                 foreach (RASD_Type rasd in rasds)
                 {
-                    if (rasd.AllocationUnits.Value.ToLower().StartsWith("bytes"))
+                    if (rasd.AllocationUnits.Value.ToLower().StartsWith("byte"))
                     {
                         string[] a1 = rasd.AllocationUnits.Value.Split('*', '^');
                         if (a1.Length == 3)
                         {
-                            memoryBase = Convert.ToDouble(a1[1]);
-                            memoryPower = Convert.ToDouble(a1[2]);
+                            memoryBase = Convert.ToDouble(a1[1].Trim());
+                            memoryPower = Convert.ToDouble(a1[2].Trim());
                         }
                     }
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26981,10 +26981,7 @@ namespace XenAdmin {
         
         /// <summary>
         ///   Looks up a localized string similar to The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool.
-        ///
-        ///Server &apos;{0}&apos; has {1} physical CPUs.
-        ///
-        ///Performance of this VM will be greatly reduced if it is started with this many vCPUs..
+        ///You will not be able to start the VM with this configuration..
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -39287,6 +39287,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The amount of physical memory allocated to this VM is greater than the total memory of its home server..
+        /// </summary>
+        public static string VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_HOST {
+            get {
+                return ResourceManager.GetString("VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The amount of physical memory allocated to this VM is greater than the total memory of any server in the pool..
+        /// </summary>
+        public static string VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_POOL {
+            get {
+                return ResourceManager.GetString("VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_POOL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Maximum number of &amp;vCPUs:.
         /// </summary>
         public static string VM_CPUMEMPAGE_MAX_VCPUS_LABEL {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -10608,15 +10608,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Home Server:.
-        /// </summary>
-        public static string CPM_SUMMARY_KEY_HOME_SERVER {
-            get {
-                return ResourceManager.GetString("CPM_SUMMARY_KEY_HOME_SERVER", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Template:.
         /// </summary>
         public static string CPM_SUMMARY_KEY_MIGRATE_TEMPLATE {
@@ -10667,15 +10658,6 @@ namespace XenAdmin {
         public static string CPM_SUMMARY_NETWORK_NOT_FOUND {
             get {
                 return ResourceManager.GetString("CPM_SUMMARY_NETWORK_NOT_FOUND", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unset.
-        /// </summary>
-        public static string CPM_SUMMARY_UNSET {
-            get {
-                return ResourceManager.GetString("CPM_SUMMARY_UNSET", resourceCulture);
             }
         }
         
@@ -17427,6 +17409,15 @@ namespace XenAdmin {
         public static string FINISH_PAGE_STORAGE_FOR_VM {
             get {
                 return ResourceManager.GetString("FINISH_PAGE_STORAGE_FOR_VM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Home server:.
+        /// </summary>
+        public static string FINISH_PAGE_TARGET_FOR_VM {
+            get {
+                return ResourceManager.GetString("FINISH_PAGE_TARGET_FOR_VM", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20923,7 +20923,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. This VM cannot be started on the selected pool..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. You will not be able to start the appliance on the selected pool..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST {
             get {
@@ -20932,7 +20932,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. This VM cannot be started on the selected pool..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -21004,6 +21004,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server..
+        /// </summary>
+        public static string IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST {
+            get {
+                return ResourceManager.GetString("IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool..
+        /// </summary>
+        public static string IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL {
+            get {
+                return ResourceManager.GetString("IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Map the virtual network interfaces in the VMs you are importing to networks in the destination pool or standalone server..
         /// </summary>
         public static string IMPORT_WIZARD_NETWORKING_INTRO {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -39334,7 +39334,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The VM&apos;s home server does not have enough physical CPUs to start the VM. The VM will start on another server.
+        ///   Looks up a localized string similar to The VM&apos;s home server does not have enough physical CPUs to start the VM. The VM will start on another server..
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING {
             get {
@@ -39343,7 +39343,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to It is recommended to allocate at least {0} vCPUs for this VM.
+        ///   Looks up a localized string similar to It is recommended to allocate at least {0} vCPUs for this VM..
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_MIN_WARNING {
             get {
@@ -39352,7 +39352,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There are no servers with enough physical CPUs to start the VM.
+        ///   Looks up a localized string similar to There are no servers with enough physical CPUs to start the VM..
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_WARNING {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -39316,6 +39316,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The host for this VM is does not have enough physical CPUs to start the VM. The VM will start on another host.
+        /// </summary>
+        public static string VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING {
+            get {
+                return ResourceManager.GetString("VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to It is recommended to allocate at least {0} vCPUs for this VM.
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_MIN_WARNING {
@@ -39325,7 +39334,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to More vCPUs than physical CPUs may lead to reduced VM performance.
+        ///   Looks up a localized string similar to There are no hosts with enough physical CPUs to start the VM.
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_WARNING {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26981,11 +26981,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool ({0}). You will not be able to start the VM..
+        ///   Looks up a localized string similar to You have specified {0} vCPUs, but none of the pool servers have more than {1} physical CPUs. You will not be able to start the VM..
         /// </summary>
-        public static string NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN {
+        public static string NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_POOL {
             get {
-                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN", resourceCulture);
+                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_POOL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You have specified {0} vCPUs, but the server you have selected only has {1} physical CPUs. You will not be able to start the VM..
+        /// </summary>
+        public static string NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST {
+            get {
+                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26918,11 +26918,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool.
-        ///
-        ///Server &apos;{0}&apos; has {1} of physical memory in total.
-        ///
-        ///You will not be able to start this VM without increasing the amount of physical memory on one of the servers in the pool..
+        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0})..
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1 {
             get {
@@ -26931,11 +26927,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool.
-        ///
-        ///Server &apos;{0}&apos; has {1} of physical memory available.
-        ///
-        ///You will not be able to start this VM without freeing some space on one of the servers..
+        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0})..
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2 {
             get {
@@ -26989,8 +26981,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool.
-        ///You will not be able to start the VM with this configuration..
+        ///   Looks up a localized string similar to The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool ({0}). You will not be able to start the VM..
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20833,6 +20833,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The appliance contains {0} VM(s) with more than {1} vCPUs. Only trusted VMs are supported with this configuration..
+        /// </summary>
+        public static string IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING {
+            get {
+                return ResourceManager.GetString("IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import VM from....
         /// </summary>
         public static string IMPORT_VM_FROM {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20932,7 +20932,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. You will not be able to start the appliance on the selected pool..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST {
             get {
@@ -26985,15 +26985,6 @@ namespace XenAdmin {
         public static string NEWVMWIZARD_CPUMEMPAGE_VCPUS {
             get {
                 return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_VCPUS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability..
-        /// </summary>
-        public static string NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN {
-            get {
-                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN", resourceCulture);
             }
         }
         
@@ -38650,6 +38641,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability..
+        /// </summary>
+        public static string VCPUS_UNTRUSTED_VM_WARNING {
+            get {
+                return ResourceManager.GetString("VCPUS_UNTRUSTED_VM_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to VDI.
         /// </summary>
         public static string VDI {
@@ -39334,7 +39334,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The host for this VM is does not have enough physical CPUs to start the VM. The VM will start on another host.
+        ///   Looks up a localized string similar to The VM&apos;s home server does not have enough physical CPUs to start the VM. The VM will start on another server.
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING {
             get {
@@ -39352,16 +39352,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability..
-        /// </summary>
-        public static string VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING {
-            get {
-                return ResourceManager.GetString("VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to There are no hosts with enough physical CPUs to start the VM.
+        ///   Looks up a localized string similar to There are no servers with enough physical CPUs to start the VM.
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_WARNING {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26989,6 +26989,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs..
+        /// </summary>
+        public static string NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN {
+            get {
+                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool.
         ///You will not be able to start the VM with this configuration..
         /// </summary>

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -38630,17 +38630,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The number of VCPUs is greater than the number of physical CPUs on the host server. This will significantly reduce VM performance.
-        ///
-        ///To optimize VM performance, you should reduce the number of VCPUs to less than or equal to the number of physical CPUs..
-        /// </summary>
-        public static string VCPUS_MORE_THAN_PCPUS {
-            get {
-                return ResourceManager.GetString("VCPUS_MORE_THAN_PCPUS", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability..
         /// </summary>
         public static string VCPUS_UNTRUSTED_VM_WARNING {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20833,7 +20833,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The appliance contains {0} VM(s) with more than {1} vCPUs. Only trusted VMs are supported with this configuration..
+        ///   Looks up a localized string similar to The appliance contains {0} VM(s) with more than {1} vCPUs. Where a VM may be running actively hostile privileged code {2} recommends that the vCPU limit is set to {1} to prevent impact on system availability..
         /// </summary>
         public static string IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING {
             get {
@@ -26989,7 +26989,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs..
+        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability..
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN {
             get {
@@ -39352,7 +39352,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs..
+        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability..
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -39352,6 +39352,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs..
+        /// </summary>
+        public static string VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING {
+            get {
+                return ResourceManager.GetString("VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no hosts with enough physical CPUs to start the VM.
         /// </summary>
         public static string VM_CPUMEMPAGE_VCPU_WARNING {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20905,7 +20905,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST {
             get {
@@ -20914,7 +20914,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL {
             get {
@@ -20977,7 +20977,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} of memory, while the available memory on the server is {1}. You will not be able to start the VM on the selected server..
         /// </summary>
         public static string IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST {
             get {
@@ -20986,7 +20986,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} of memory, while the maximum available memory on the pool is {1}. You will not be able to start the VM on the selected pool..
         /// </summary>
         public static string IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL {
             get {
@@ -26936,7 +26936,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify the number of virtual CPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. .
+        ///   Looks up a localized string similar to Specify the number of vCPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. .
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_RUBRIC {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26972,17 +26972,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.
-        ///
-        ///Review these settings, then click Previous if you need to change anything. Otherwise, click Create Now to create the new VM. It may take several minutes to create the new VM..
-        /// </summary>
-        public static string NEWVMWIZARD_FINISHPAGE {
-            get {
-                return ResourceManager.GetString("NEWVMWIZARD_FINISHPAGE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &amp;Create Now.
         /// </summary>
         public static string NEWVMWIZARD_FINISHPAGE_CREATE {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -11109,24 +11109,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CPU and Memory.
-        /// </summary>
-        public static string CPU_AND_MEMORY {
-            get {
-                return ResourceManager.GetString("CPU_AND_MEMORY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} vCPU(s) &amp; {1} MB RAM.
-        /// </summary>
-        public static string CPU_AND_MEMORY_SUB {
-            get {
-                return ResourceManager.GetString("CPU_AND_MEMORY_SUB", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} vCPU(s).
         /// </summary>
         public static string CPU_SUB {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26909,20 +26909,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0})..
+        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0})..
         /// </summary>
-        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1 {
+        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_FREE {
             get {
-                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1", resourceCulture);
+                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_FREE", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0})..
+        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0})..
         /// </summary>
-        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2 {
+        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_TOTAL {
             get {
-                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2", resourceCulture);
+                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_TOTAL", resourceCulture);
             }
         }
         
@@ -26981,7 +26981,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have specified {0} vCPUs, but the server you have selected only has {1} physical CPUs. You will not be able to start the VM..
+        ///   Looks up a localized string similar to You have specified {0} vCPUs, but the server has only {1} physical CPUs. You will not be able to start the VM..
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -17431,24 +17431,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Target:.
-        /// </summary>
-        public static string FINISH_PAGE_TARGET {
-            get {
-                return ResourceManager.GetString("FINISH_PAGE_TARGET", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} target:.
-        /// </summary>
-        public static string FINISH_PAGE_TARGET_FOR_VM {
-            get {
-                return ResourceManager.GetString("FINISH_PAGE_TARGET_FOR_VM", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Finish.
         /// </summary>
         public static string FINISH_PAGE_TEXT {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20923,6 +20923,24 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. This VM cannot be started on the selected pool..
+        /// </summary>
+        public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST {
+            get {
+                return ResourceManager.GetString("IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. This VM cannot be started on the selected pool..
+        /// </summary>
+        public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL {
+            get {
+                return ResourceManager.GetString("IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &amp;Import to:.
         /// </summary>
         public static string IMPORT_WIZARD_DESTINATION_DESTINATION {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9395,11 +9395,6 @@ When you configure an NFS storage repository, you simply provide the host name o
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST" xml:space="preserve">
     <value>You have specified {0} vCPUs, but the server has only {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
-  <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
-    <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.
-
-Review these settings, then click Previous if you need to change anything. Otherwise, click Create Now to create the new VM. It may take several minutes to create the new VM.</value>
-  </data>
   <data name="NEWVMWIZARD_FINISHPAGE_CREATE" xml:space="preserve">
     <value>&amp;Create Now</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3800,9 +3800,6 @@ This action cannot be undone. Are you sure you want to continue?</value>
   <data name="CPM_SUMMARY_KEY_DESTINATION" xml:space="preserve">
     <value>Destination:</value>
   </data>
-  <data name="CPM_SUMMARY_KEY_HOME_SERVER" xml:space="preserve">
-    <value>Home Server:</value>
-  </data>
   <data name="CPM_SUMMARY_KEY_MIGRATE_TEMPLATE" xml:space="preserve">
     <value>Template:</value>
   </data>
@@ -3820,9 +3817,6 @@ This action cannot be undone. Are you sure you want to continue?</value>
   </data>
   <data name="CPM_SUMMARY_NETWORK_NOT_FOUND" xml:space="preserve">
     <value>Network not found</value>
-  </data>
-  <data name="CPM_SUMMARY_UNSET" xml:space="preserve">
-    <value>Unset</value>
   </data>
   <data name="CPM_WIZARD_ALL_ON_SAME_SR_RADIO" xml:space="preserve">
     <value>Pl&amp;ace all virtual disks on the same SR:</value>
@@ -6104,6 +6098,9 @@ Would you like to eject these ISOs before continuing?</value>
   </data>
   <data name="FINISH_PAGE_STORAGE_FOR_VM" xml:space="preserve">
     <value>{0} storage:</value>
+  </data>
+  <data name="FINISH_PAGE_TARGET_FOR_VM" xml:space="preserve">
+    <value>Home server:</value>
   </data>
   <data name="FINISH_PAGE_TEXT" xml:space="preserve">
     <value>Finish</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -7299,6 +7299,12 @@ This might result in failure to migrate VMs to this server during the RPU or to 
   </data>
   <data name="IMPORT_WIZARD_ALL_ON_SAME_SR_RADIO" xml:space="preserve">
     <value>Place &amp;all imported virtual disks on this target SR:</value>
+  </data>
+  <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST" xml:space="preserve">
+    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. This VM cannot be started on the selected pool.</value>
+  </data>
+  <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
+    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. This VM cannot be started on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -6105,12 +6105,6 @@ Would you like to eject these ISOs before continuing?</value>
   <data name="FINISH_PAGE_STORAGE_FOR_VM" xml:space="preserve">
     <value>{0} storage:</value>
   </data>
-  <data name="FINISH_PAGE_TARGET" xml:space="preserve">
-    <value>Target:</value>
-  </data>
-  <data name="FINISH_PAGE_TARGET_FOR_VM" xml:space="preserve">
-    <value>{0} target:</value>
-  </data>
   <data name="FINISH_PAGE_TEXT" xml:space="preserve">
     <value>Finish</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13593,6 +13593,9 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
   <data name="VM_CPUMEMPAGE_VCPU_MIN_WARNING" xml:space="preserve">
     <value>It is recommended to allocate at least {0} vCPUs for this VM</value>
   </data>
+  <data name="VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING" xml:space="preserve">
+    <value>You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs.</value>
+  </data>
   <data name="VM_CPUMEMPAGE_VCPU_WARNING" xml:space="preserve">
     <value>There are no hosts with enough physical CPUs to start the VM</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7309,6 +7309,12 @@ This might result in failure to migrate VMs to this server during the RPU or to 
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
     <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
   </data>
+  <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
+    <value>The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool.</value>
+  </data>
+  <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
+    <value>The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server.</value>
+  </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9378,18 +9378,10 @@ When you configure an NFS storage repository, you simply provide the host name o
     <value>(min = {0}, max = {1})</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1" xml:space="preserve">
-    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool.
-
-Server '{0}' has {1} of physical memory in total.
-
-You will not be able to start this VM without increasing the amount of physical memory on one of the servers in the pool.</value>
+    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0}).</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2" xml:space="preserve">
-    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool.
-
-Server '{0}' has {1} of physical memory available.
-
-You will not be able to start this VM without freeing some space on one of the servers.</value>
+    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0}).</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_NAME" xml:space="preserve">
     <value>CPU &amp;&amp; Memory</value>
@@ -9410,8 +9402,7 @@ You will not be able to start this VM without freeing some space on one of the s
     <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN" xml:space="preserve">
-    <value>The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool.
-You will not be able to start the VM with this configuration.</value>
+    <value>The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool ({0}). You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
     <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7295,10 +7295,10 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Place &amp;all imported virtual disks on this target SR:</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server.</value>
+    <value>The imported appliance requires a minimum of {0} vCPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
+    <value>The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>
@@ -7319,10 +7319,10 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Failed to uncompress file {0}. Please see the logs for more information.</value>
   </data>
   <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server.</value>
+    <value>The imported appliance requires a minimum of {0} of memory, while the available memory on the server is {1}. You will not be able to start the VM on the selected server.</value>
   </data>
   <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool.</value>
+    <value>The imported appliance requires a minimum of {0} of memory, while the maximum available memory on the pool is {1}. You will not be able to start the VM on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_NETWORKING_INTRO" xml:space="preserve">
     <value>Map the virtual network interfaces in the VMs you are importing to networks in the destination pool or standalone server.</value>
@@ -9384,7 +9384,7 @@ When you configure an NFS storage repository, you simply provide the host name o
     <value>CPU &amp;&amp; Memory</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_RUBRIC" xml:space="preserve">
-    <value>Specify the number of virtual CPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. </value>
+    <value>Specify the number of vCPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. </value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_TITLE" xml:space="preserve">
     <value>Allocate processor and memory resources</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7270,6 +7270,9 @@ This might result in failure to migrate VMs to this server during the RPU or to 
   <data name="IMPORT_VM_CONFIGURE_STORAGE" xml:space="preserve">
     <value>Configure storage for the new VM</value>
   </data>
+  <data name="IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING" xml:space="preserve">
+    <value>The appliance contains {0} VM(s) with more than {1} vCPUs. Only trusted VMs are supported with this configuration.</value>
+  </data>
   <data name="IMPORT_VM_FROM" xml:space="preserve">
     <value>Import VM from...</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9401,8 +9401,11 @@ When you configure an NFS storage repository, you simply provide the host name o
   <data name="VCPUS_UNTRUSTED_VM_WARNING" xml:space="preserve">
     <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
   </data>
-  <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN" xml:space="preserve">
-    <value>The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool ({0}). You will not be able to start the VM.</value>
+  <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST" xml:space="preserve">
+    <value>You have specified {0} vCPUs, but the server you have selected only has {1} physical CPUs. You will not be able to start the VM.</value>
+  </data>
+  <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_POOL" xml:space="preserve">
+    <value>You have specified {0} vCPUs, but none of the pool servers have more than {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
     <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9406,6 +9406,9 @@ You will not be able to start this VM without freeing some space on one of the s
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUS" xml:space="preserve">
     <value>vCPUs</value>
   </data>
+  <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN" xml:space="preserve">
+    <value>You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs.</value>
+  </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN" xml:space="preserve">
     <value>The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool.
 You will not be able to start the VM with this configuration.</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3971,12 +3971,6 @@ For optimal performance and reliability during VM migration, ensure that the net
   <data name="CPU" xml:space="preserve">
     <value>CPU</value>
   </data>
-  <data name="CPU_AND_MEMORY" xml:space="preserve">
-    <value>CPU and Memory</value>
-  </data>
-  <data name="CPU_AND_MEMORY_SUB" xml:space="preserve">
-    <value>{0} vCPU(s) &amp; {1} MB RAM</value>
-  </data>
   <data name="CPU_SUB" xml:space="preserve">
     <value>{0} vCPU(s)</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -7309,12 +7309,6 @@ This might result in failure to migrate VMs to this server during the RPU or to 
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
     <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
   </data>
-  <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool.</value>
-  </data>
-  <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server.</value>
-  </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>
   </data>
@@ -7332,6 +7326,12 @@ This might result in failure to migrate VMs to this server during the RPU or to 
   </data>
   <data name="IMPORT_WIZARD_FAILED_UNCOMPRESS" xml:space="preserve">
     <value>Failed to uncompress file {0}. Please see the logs for more information.</value>
+  </data>
+  <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
+    <value>The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server.</value>
+  </data>
+  <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
+    <value>The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_NETWORKING_INTRO" xml:space="preserve">
     <value>Map the virtual network interfaces in the VMs you are importing to networks in the destination pool or standalone server.</value>
@@ -9404,14 +9404,11 @@ When you configure an NFS storage repository, you simply provide the host name o
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUS" xml:space="preserve">
     <value>vCPUs</value>
   </data>
-  <data name="VCPUS_UNTRUSTED_VM_WARNING" xml:space="preserve">
-    <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
+  <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_POOL" xml:space="preserve">
+    <value>You have specified {0} vCPUs, but none of the pool servers have more than {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST" xml:space="preserve">
     <value>You have specified {0} vCPUs, but the server you have selected only has {1} physical CPUs. You will not be able to start the VM.</value>
-  </data>
-  <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_POOL" xml:space="preserve">
-    <value>You have specified {0} vCPUs, but none of the pool servers have more than {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
     <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.
@@ -13354,14 +13351,11 @@ To start a {0} trial, click the button below.</value>
   <data name="VCPU_ONLY_WHEN_HALTED" xml:space="preserve">
     <value>The vCPUs can only be changed when the VM is shut down.</value>
   </data>
+  <data name="VCPUS_UNTRUSTED_VM_WARNING" xml:space="preserve">
+    <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
+  </data>
   <data name="VDI" xml:space="preserve">
     <value>VDI</value>
-  </data>
-  <data name="VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
-    <value>The amount of physical memory allocated to this VM is greater than the total memory of its home server.</value>
-  </data>
-  <data name="VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
-    <value>The amount of physical memory allocated to this VM is greater than the total memory of any server in the pool.</value>
   </data>
   <data name="VDI_COPIED" xml:space="preserve">
     <value>Copied disk '{0}' from SR '{1}' to SR '{2}'</value>
@@ -13575,6 +13569,12 @@ To start a {0} trial, click the button below.</value>
   </data>
   <data name="VM_CPUMEMPAGE_INITIAL_VCPUS_LABEL" xml:space="preserve">
     <value>Initial number of v&amp;CPUs:</value>
+  </data>
+  <data name="VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
+    <value>The amount of physical memory allocated to this VM is greater than the total memory of its home server.</value>
+  </data>
+  <data name="VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
+    <value>The amount of physical memory allocated to this VM is greater than the total memory of any server in the pool.</value>
   </data>
   <data name="VM_CPUMEMPAGE_MAX_VCPUS_LABEL" xml:space="preserve">
     <value>Maximum number of &amp;vCPUs:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13348,11 +13348,6 @@ To start a {0} trial, click the button below.</value>
   <data name="VCPU_ONLY_WHEN_HALTED" xml:space="preserve">
     <value>The vCPUs can only be changed when the VM is shut down.</value>
   </data>
-  <data name="VCPUS_MORE_THAN_PCPUS" xml:space="preserve">
-    <value>The number of VCPUs is greater than the number of physical CPUs on the host server. This will significantly reduce VM performance.
-
-To optimize VM performance, you should reduce the number of VCPUs to less than or equal to the number of physical CPUs.</value>
-  </data>
   <data name="VDI" xml:space="preserve">
     <value>VDI</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7271,7 +7271,7 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Configure storage for the new VM</value>
   </data>
   <data name="IMPORT_VM_CPUS_COUNT_UNTRUSTED_WARNING" xml:space="preserve">
-    <value>The appliance contains {0} VM(s) with more than {1} vCPUs. Only trusted VMs are supported with this configuration.</value>
+    <value>The appliance contains {0} VM(s) with more than {1} vCPUs. Where a VM may be running actively hostile privileged code {2} recommends that the vCPU limit is set to {1} to prevent impact on system availability.</value>
   </data>
   <data name="IMPORT_VM_FROM" xml:space="preserve">
     <value>Import VM from...</value>
@@ -9407,7 +9407,7 @@ You will not be able to start this VM without freeing some space on one of the s
     <value>vCPUs</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN" xml:space="preserve">
-    <value>You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs.</value>
+    <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN" xml:space="preserve">
     <value>The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool.
@@ -13594,7 +13594,7 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>It is recommended to allocate at least {0} vCPUs for this VM</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING" xml:space="preserve">
-    <value>You have selected more than {0} vCPUs for the new VM. This configuration is only supported for trusted VMs.</value>
+    <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_WARNING" xml:space="preserve">
     <value>There are no hosts with enough physical CPUs to start the VM</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13582,13 +13582,13 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>If the initial number of vCPUs is set lower than the maximum number, more vCPUs can be added to the virtual machine while it is running. </value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING" xml:space="preserve">
-    <value>The VM's home server does not have enough physical CPUs to start the VM. The VM will start on another server</value>
+    <value>The VM's home server does not have enough physical CPUs to start the VM. The VM will start on another server.</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_MIN_WARNING" xml:space="preserve">
-    <value>It is recommended to allocate at least {0} vCPUs for this VM</value>
+    <value>It is recommended to allocate at least {0} vCPUs for this VM.</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_WARNING" xml:space="preserve">
-    <value>There are no servers with enough physical CPUs to start the VM</value>
+    <value>There are no servers with enough physical CPUs to start the VM.</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPUS_LABEL" xml:space="preserve">
     <value>&amp;Number of vCPUs:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9374,11 +9374,11 @@ When you configure an NFS storage repository, you simply provide the host name o
   <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYINFO" xml:space="preserve">
     <value>(min = {0}, max = {1})</value>
   </data>
-  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1" xml:space="preserve">
-    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0}).</value>
-  </data>
-  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2" xml:space="preserve">
+  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_FREE" xml:space="preserve">
     <value>The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0}).</value>
+  </data>
+  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_TOTAL" xml:space="preserve">
+    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0}).</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_NAME" xml:space="preserve">
     <value>CPU &amp;&amp; Memory</value>
@@ -9399,7 +9399,7 @@ When you configure an NFS storage repository, you simply provide the host name o
     <value>You have specified {0} vCPUs, but none of the pool servers have more than {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST" xml:space="preserve">
-    <value>You have specified {0} vCPUs, but the server you have selected only has {1} physical CPUs. You will not be able to start the VM.</value>
+    <value>You have specified {0} vCPUs, but the server has only {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
     <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13351,6 +13351,12 @@ To start a {0} trial, click the button below.</value>
   <data name="VDI" xml:space="preserve">
     <value>VDI</value>
   </data>
+  <data name="VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
+    <value>The amount of physical memory allocated to this VM is greater than the total memory of its home server.</value>
+  </data>
+  <data name="VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
+    <value>The amount of physical memory allocated to this VM is greater than the total memory of any server in the pool.</value>
+  </data>
   <data name="VDI_COPIED" xml:space="preserve">
     <value>Copied disk '{0}' from SR '{1}' to SR '{2}'</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7301,10 +7301,10 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Place &amp;all imported virtual disks on this target SR:</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. This VM cannot be started on the selected pool.</value>
+    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. You will not be able to start the appliance on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. This VM cannot be started on the selected pool.</value>
+    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7304,7 +7304,7 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Place &amp;all imported virtual disks on this target SR:</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected host is {1}. You will not be able to start the appliance on the selected pool.</value>
+    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
     <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
@@ -9406,7 +9406,7 @@ You will not be able to start this VM without freeing some space on one of the s
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUS" xml:space="preserve">
     <value>vCPUs</value>
   </data>
-  <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUS_TRUSTED_VM_WARN" xml:space="preserve">
+  <data name="VCPUS_UNTRUSTED_VM_WARNING" xml:space="preserve">
     <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN" xml:space="preserve">
@@ -13588,16 +13588,13 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
     <value>If the initial number of vCPUs is set lower than the maximum number, more vCPUs can be added to the virtual machine while it is running. </value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING" xml:space="preserve">
-    <value>The host for this VM is does not have enough physical CPUs to start the VM. The VM will start on another host</value>
+    <value>The VM's home server does not have enough physical CPUs to start the VM. The VM will start on another server</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_MIN_WARNING" xml:space="preserve">
     <value>It is recommended to allocate at least {0} vCPUs for this VM</value>
   </data>
-  <data name="VM_CPUMEMPAGE_VCPU_TRUSTED_WARNING" xml:space="preserve">
-    <value>You have selected more than {0} vCPUs for the new VM. Where a VM may be running actively hostile privileged code {1} recommends that the vCPU limit is set to {0} to prevent impact on system availability.</value>
-  </data>
   <data name="VM_CPUMEMPAGE_VCPU_WARNING" xml:space="preserve">
-    <value>There are no hosts with enough physical CPUs to start the VM</value>
+    <value>There are no servers with enough physical CPUs to start the VM</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPUS_LABEL" xml:space="preserve">
     <value>&amp;Number of vCPUs:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -13581,11 +13581,14 @@ To optimize VM performance, you should reduce the number of VCPUs to less than o
   <data name="VM_CPUMEMPAGE_RUBRIC_HOTPLUG" xml:space="preserve">
     <value>If the initial number of vCPUs is set lower than the maximum number, more vCPUs can be added to the virtual machine while it is running. </value>
   </data>
+  <data name="VM_CPUMEMPAGE_VCPU_HOME_HOST_WARNING" xml:space="preserve">
+    <value>The host for this VM is does not have enough physical CPUs to start the VM. The VM will start on another host</value>
+  </data>
   <data name="VM_CPUMEMPAGE_VCPU_MIN_WARNING" xml:space="preserve">
     <value>It is recommended to allocate at least {0} vCPUs for this VM</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPU_WARNING" xml:space="preserve">
-    <value>More vCPUs than physical CPUs may lead to reduced VM performance</value>
+    <value>There are no hosts with enough physical CPUs to start the VM</value>
   </data>
   <data name="VM_CPUMEMPAGE_VCPUS_LABEL" xml:space="preserve">
     <value>&amp;Number of vCPUs:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9405,10 +9405,7 @@ You will not be able to start this VM without freeing some space on one of the s
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN" xml:space="preserve">
     <value>The number of vCPUs given to the new VM is greater than the number of physical CPUs on any server in the pool.
-
-Server '{0}' has {1} physical CPUs.
-
-Performance of this VM will be greatly reduced if it is started with this many vCPUs.</value>
+You will not be able to start the VM with this configuration.</value>
   </data>
   <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
     <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -479,16 +479,6 @@ namespace XenAPI
             other_config = SetDictionaryKey(other_config, "auto_poweron", value.ToString().ToLower());
         }
 
-        public bool GetIgnoreExcessiveVcpus()
-        {
-            return BoolKey(other_config, "ignore_excessive_vcpus");
-        }
-
-        public void SetIgnoreExcessiveVcpus(bool value)
-        {
-            other_config = SetDictionaryKey(other_config, "ignore_excessive_vcpus", value.ToString().ToLower());
-        }
-
         public string IsOnSharedStorage()
         {
             foreach (XenRef<VBD> vbdRef in VBDs)

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -59,6 +59,8 @@ namespace XenAPI
         public const long DEFAULT_MEM_MIN_IMG_IMPORT = 256 * Util.BINARY_MEGA;
         public const int DEFAULT_CORES_PER_SOCKET = 1;
         public const long MAX_SOCKETS = 16;  // current hard limit in Xen: CA-198276
+        // CP-41825: > 32 vCPUs is only supported for trusted VMs
+        public const long MAX_VCPUS_FOR_NON_TRUSTED_VMS = 32; 
 
         private XmlDocument xdRecommendations = null;
         public const int MAX_ALLOWED_VTPMS = 1;

--- a/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
+++ b/XenModel/XenAPI/FriendlyErrorNames.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAPI {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class FriendlyErrorNames {

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -169,6 +169,11 @@
     <Compile Include="Actions\StatusReport\ZipStatusReportAction.cs" />
     <Compile Include="Alerts\Types\Alert.cs" />
     <Compile Include="BrandManager.cs" />
+    <Compile Include="Messages.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Messages.resx</DependentUpon>
+    </Compile>
     <Compile Include="SshConsole.cs" />
     <Compile Include="FriendlyNames.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -201,11 +206,6 @@
     <Compile Include="FriendlyNameManager.cs" />
     <Compile Include="InvokeHelper.cs" />
     <Compile Include="Mappings\VmMapping.cs" />
-    <Compile Include="Messages.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Messages.resx</DependentUpon>
-    </Compile>
     <Compile Include="Network\Cache.cs" />
     <Compile Include="Network\ConnectTask.cs" />
     <Compile Include="Network\Heartbeat.cs" />


### PR DESCRIPTION
I have decided to open a PR for all three tickets since they all change warning texts around vCPU selections. Please also check my proposal for showing warnings on `CPUMemoryEditPage`, since now there's a large warning that is a bit of an eye sore.
____________________
**Review one commit at a time**, there's a bit of tidying up, which has been contained within separate commits to help you grasp the changes more quickly. Also note that at one point I renamed `Page_CpuMem` to `PageCpuMem` by mistake, there's a commit further down that reverts it, rebasing and squashing them would have been a bit of a mess so I just left them separate.
________________________
**About CA-375532**, this PR also prevents them from starting appliances or new VMs if we know they cannot be started at all.

Technically, some VMs of an appliance could start with this configuration. This is because the `VM_appliance.start` operation doesn't start all VMs at once. Because of that, the VMs with `vCPUs<pCPUs` could start, and the failure could happen later. If an appliance has a large amount of VMs, the failure could happen after a long while, and users will find themselves with a partially started appliance. 

Since we know during the import that some (or all) VMs will fail, I decided it'd be best to prevent it. Users can still import with the warning, and then start the vApp at the end. 

___________

**For CP-41825**, there are no plans to add the value to some property in the backend, so we have to hard code it.

Also, I wanted to ask if we think it'd be nice to change the way we show warnings in `CPUMemoryEditPage`. We could use a warning section as opposed to red labels near controls:

![image](https://user-images.githubusercontent.com/32554698/227160720-57dd7ac7-69ae-48f6-b37a-aa16123ea114.png)
