### PR TITLE
CP-42286: Add friendly name for `pool_total_session_count`

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/DataSet.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataSet.cs
@@ -99,6 +99,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                 case "hits/s":
                 case "misses/s":
                 case "err/s":
+                case "sessions/s":
                     CustomYRange = new DataRange(1, 0, 1, Unit.CountsPerSecond, RangeScaleMode.Auto);
                     break;
                 case "s/s":

--- a/XenModel/FriendlyNames.Designer.cs
+++ b/XenModel/FriendlyNames.Designer.cs
@@ -2086,6 +2086,15 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Session creation rate.
+        /// </summary>
+        public static string Label_performance_pool_session_creation_rate {
+            get {
+                return ResourceManager.GetString("Label-performance.pool_session_creation_rate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Number of tasks.
         /// </summary>
         public static string Label_performance_pool_task_count {

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -792,6 +792,9 @@
   <data name="Label-performance.pool_session_count" xml:space="preserve">
     <value>Number of sessions</value>
   </data>
+  <data name="Label-performance.pool_session_creation_rate" xml:space="preserve">
+    <value>Session creation rate</value>
+  </data>
   <data name="Label-performance.pool_task_count" xml:space="preserve">
     <value>Number of tasks</value>
   </data>


### PR DESCRIPTION
The description has also been updated with this new definition:
https://github.com/xapi-project/xen-api/pull/4942

