### PR TITLE
Do not pre-pend key to `InternalStageAuthToken` query parameters

### DIFF
--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
   </ItemGroup>


### PR DESCRIPTION
Use of `InternalStageAuthToken=foo` is not needed anymore. Furthermore, we can now provide any token format.