### PR TITLE
Bumped branding to v4.15. Removed leftover references of branded components.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@
  * SUCH DAMAGE.
  */
 
-def XENADMIN_BRANDING_TAG = 'v4.14'
+def XENADMIN_BRANDING_TAG = 'v4.15'
 
 @Library(['PacmanSharedLibrary', "xencenter-pipeline@v4.7"])
 import com.citrix.pipeline.xencenter.*

--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -184,7 +184,6 @@
             <ComponentRef Id="RegistryEntries" />
             <ComponentRef Id="ApplicationShortcut" />
             <ComponentRef Id="ProgramFilesShortcut" />
-            <ComponentGroupRef Id="BrandedComponents" />
         </Feature>
 
         <UIRef Id="$(var.BrandInstallerUI)" />

--- a/scripts/xenadmin-build.sh
+++ b/scripts/xenadmin-build.sh
@@ -155,11 +155,11 @@ do
   mkdir -p obj${name} out${name}
 
   WixLangId=$(locale_id ${locale} | tr -d [:space:]) RepoRoot=$(cygpath -w ${REPO}) \
-    ${CANDLE} -ext WiXNetFxExtension -ext WixUtilExtension -out obj${name}/ ${BRANDING_BRAND_CONSOLE_NO_SPACE}.wxs branding.wxs
+    ${CANDLE} -ext WiXNetFxExtension -ext WixUtilExtension -out obj${name}/ ${BRANDING_BRAND_CONSOLE_NO_SPACE}.wxs
 
   ${LIGHT} -sval -ext WiXNetFxExtension -ext WixUtilExtension -out out${name}/${name}.msi \
           -loc wixlib/wixui_${locale}.wxl -loc ${locale}.wxl \
-          obj${name}/${BRANDING_BRAND_CONSOLE_NO_SPACE}.wixobj obj${name}/branding.wixobj lib/WixUI_InstallDir.wixlib
+          obj${name}/${BRANDING_BRAND_CONSOLE_NO_SPACE}.wixobj lib/WixUI_InstallDir.wixlib
 
   cp ${WIX}/out${name}/${name}.msi ${WIX}
 done


### PR DESCRIPTION
This fixes the broken build.