### PR TITLE
Stop using reflection for the creation of context menu builders; and some smaller corrections.

### DIFF
--- a/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
+++ b/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
@@ -90,27 +90,6 @@ namespace XenAdmin.Commands
         }
 
         /// <summary>
-        /// Shows the context menu for the specified xen object at the current mouse location.
-        /// </summary>
-        /// <param name="xenObject">The xen object for which the context menu is required.</param>
-        public void Show(IXenObject xenObject)
-        {
-            Show(xenObject, Form.MousePosition);
-        }
-
-        /// <summary>
-        /// Shows the context menu for the specified xen object at the specified location.
-        /// </summary>
-        /// <param name="xenObject">The xen object for which the context menu is required.</param>
-        /// <param name="point">The location of the context menu.</param>
-        public void Show(IXenObject xenObject, Point point)
-        {
-            ContextMenuStrip menu = new ContextMenuStrip();
-            menu.Items.AddRange(Build(xenObject));
-            menu.Show(point);
-        }
-
-        /// <summary>
         /// Builds the context menu for the specified XenObject.
         /// </summary>
         /// <param name="xenObject">The xen object for which the context menu items are required.</param>

--- a/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
+++ b/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
@@ -30,17 +30,15 @@
 
 using System;
 using System.Collections.Generic;
-using XenAPI;
-using System.Windows.Forms;
-using XenAdmin.Model;
-using XenAdmin.Core;
-using System.Reflection;
-using System.Diagnostics;
 using System.Collections.ObjectModel;
-using System.Drawing;
+using System.Diagnostics;
 using System.Linq;
+using System.Windows.Forms;
+using XenAdmin.Core;
 using XenAdmin.Dialogs;
+using XenAdmin.Model;
 using XenAdmin.Plugins;
+using XenAPI;
 
 
 namespace XenAdmin.Commands
@@ -56,22 +54,41 @@ namespace XenAdmin.Commands
 
         static ContextMenuBuilder()
         {
-            List<Builder> list = new List<Builder>();
-
-            foreach (Type type in Assembly.GetCallingAssembly().GetTypes())
+            var list = new List<Builder>
             {
-                if (typeof(Builder).IsAssignableFrom(type) && !type.IsAbstract)
-                {
-                    try
-                    {
-                        list.Add((Builder)Activator.CreateInstance(type));
-                    }
-                    catch (MissingMethodException)
-                    {
+                new MixedPoolsAndStandaloneHosts(),
+                new MultiplePools(),
+                new MultipleDifferentXenObjectTypes(),
+                new MultipleSRs(),
+                new SingleVDI(),
+                new MultipleVDI(),
+                new SingleNetwork(),
+                new DisconnectedHosts(),
+                new MixedVMsAndTemplates(),
+                new MultipleAliveHosts(),
+                new SingleAliveHostInPool(),
+                new SingleAliveStandaloneHost(),
+                new MultipleHostsSomeDeadSomeAlive(),
+                new DeadHosts(),
+                new SinglePool(),
+                new SingleSnapshot(),
+                new SingleTemplate(),
+                new SingleVmAppliance(),
+                new MultipleVmAppliance(),
+                new SingleVM(),
+                new SingleSR(),
+                new SingleFolder(),
+                new MultipleTemplates(),
+                new MultipleSnapshots(),
+                new MultipleVMsInPool(),
+                new MultipleVMsOverMultiplePools(),
+                new MultipleFolders(),
+                new SingleTag(),
+                new MultipleTags(),
+                new SingleDockerContainer(),
+                new MultipleDockerContainers()
+            };
 
-                    }
-                }
-            }
             Builders = new ReadOnlyCollection<Builder>(list);
         }
 
@@ -82,11 +99,8 @@ namespace XenAdmin.Commands
         /// <param name="mainWindow">The main window command interface. This can be found on mainwindow.</param>
         public ContextMenuBuilder(PluginManager pluginManager, IMainWindow mainWindow)
         {
-            Util.ThrowIfParameterNull(pluginManager, "pluginManager");
-            Util.ThrowIfParameterNull(pluginManager, "mainWindow");
-
-            _pluginManager = pluginManager;
-            _mainWindow = mainWindow;
+            _pluginManager = pluginManager ?? throw new ArgumentNullException(nameof(pluginManager));
+            _mainWindow = mainWindow ?? throw new ArgumentNullException(nameof(mainWindow));
         }
 
         /// <summary>
@@ -106,7 +120,7 @@ namespace XenAdmin.Commands
         /// <returns>The context menu items.</returns>
         public ToolStripItem[] Build(SelectedItem selection)
         {
-            return Build(new SelectedItem[] { selection });
+            return Build(new[] { selection });
         }
 
         /// <summary>
@@ -116,12 +130,10 @@ namespace XenAdmin.Commands
         /// <returns>The context menu items.</returns>
         public ToolStripItem[] Build(IEnumerable<SelectedItem> selection)
         {
-            Util.ThrowIfParameterNull(selection, "selection");
+            var selectionList = new SelectedItemCollection(selection ?? throw new ArgumentNullException(nameof(selection)));
 
             foreach (Builder builder in Builders)
             {
-                SelectedItemCollection selectionList = new SelectedItemCollection(selection);
-
                 if (builder.IsValid(selectionList))
                 {
                     ContextMenuItemCollection items = new ContextMenuItemCollection(_mainWindow, _pluginManager);
@@ -134,7 +146,7 @@ namespace XenAdmin.Commands
                 }
             }
 
-            return new ToolStripItem[0];
+            return Array.Empty<ToolStripItem>();
         }
 
         [Conditional("DEBUG")]
@@ -163,13 +175,13 @@ namespace XenAdmin.Commands
                            string.Join("\n", usedKeys.Select(kvp => $"{kvp.Key} => {string.Join(", ", kvp.Value)}")));
         }
 
+        #region Nested Classes
+
         private abstract class Builder
         {
             public abstract void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items);
             public abstract bool IsValid(SelectedItemCollection selection);
         }
-
-        #region MixedPoolsAndStandaloneHosts class
 
         private class MixedPoolsAndStandaloneHosts : Builder
         {
@@ -210,10 +222,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultiplePools class
-
         private class MultiplePools : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -241,10 +249,6 @@ namespace XenAdmin.Commands
                 return false;
             }
         }
-
-        #endregion
-
-        #region MultipleDifferentTypes
 
         private class MultipleDifferentXenObjectTypes : Builder
         {
@@ -288,10 +292,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleSRs
-
         private class MultipleSRs : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -308,10 +308,6 @@ namespace XenAdmin.Commands
                 return selection.Count > 1 && selection.AllItemsAre<SR>();
             }
         }
-
-        #endregion
-
-        #region SingleVDI
 
         private class SingleVDI : Builder
         {
@@ -331,10 +327,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleVDI
-
         private class MultipleVDI : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -351,10 +343,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region SingleNetwork
-
         private class SingleNetwork : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -370,10 +358,6 @@ namespace XenAdmin.Commands
                 // HIMN should not be editable
             }
         }
-
-        #endregion
-
-        #region DisconnectedHosts
 
         private class DisconnectedHosts : Builder
         {
@@ -416,10 +400,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MixedVMsSnapshotsTemplates class
-
         private class MixedVMsAndTemplates : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -461,10 +441,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleAliveHosts class
-
         private class MultipleAliveHosts : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -500,16 +476,10 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region SingleAliveHostInPool class
-
         private class SingleAliveHostInPool : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
             {
-                Host host = (Host)selection[0].XenObject;
-
                 items.AddIfEnabled(new NewVMCommand(mainWindow, selection));
                 items.AddIfEnabled(new NewSRCommand(mainWindow, selection));
 				items.AddIfEnabled(new ImportCommand(mainWindow, selection));
@@ -557,16 +527,10 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region SingleAliveStandaloneHost class
-
         private class SingleAliveStandaloneHost : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
             {
-                Host host = (Host)selection[0].XenObject;
-
                 items.AddIfEnabled(new NewVMCommand(mainWindow, selection));
                 items.AddIfEnabled(new NewSRCommand(mainWindow, selection));
 				items.AddIfEnabled(new ImportCommand(mainWindow, selection));
@@ -613,10 +577,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleHostsSomeDeadSomeAlive class
-
         private class MultipleHostsSomeDeadSomeAlive : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -648,10 +608,6 @@ namespace XenAdmin.Commands
                 return foundAlive && foundDead;
             }
         }
-
-        #endregion
-
-        #region DeadHosts class
 
         private class DeadHosts : Builder
         {
@@ -686,10 +642,6 @@ namespace XenAdmin.Commands
                 return false;
             }
         }
-
-        #endregion
-
-        #region SinglePool class
 
         private class SinglePool : Builder
         {
@@ -743,10 +695,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region SingleSnapshot class
-
         private class SingleSnapshot : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -771,10 +719,6 @@ namespace XenAdmin.Commands
                 return false;
             }
         }
-
-        #endregion
-
-        #region SingleTemplate class
 
         private class SingleTemplate : Builder
         {
@@ -811,10 +755,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-		#region SingleVmAppliance class
-
 		private class SingleVmAppliance : Builder
 		{
 			public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -838,10 +778,6 @@ namespace XenAdmin.Commands
 			}
 		}
 
-		#endregion
-
-        #region Multiple VMAppliance class
-
         private class MultipleVmAppliance : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -855,10 +791,6 @@ namespace XenAdmin.Commands
                 return selection.AllItemsAre<VM_appliance>();
             }
         }
-
-        #endregion
-
-        #region SingleVM class
 
         private class SingleVM : Builder
         {
@@ -918,10 +850,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region SingleSR class
-
         private class SingleSR : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -947,10 +875,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region SingleFolder class
-
         private class SingleFolder : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -967,10 +891,6 @@ namespace XenAdmin.Commands
                 return selection.ContainsOneItemOfType<Folder>();
             }
         }
-
-        #endregion
-
-        #region MultipleVMs class
 
         private abstract class MultipleVMs : Builder
         {
@@ -993,10 +913,6 @@ namespace XenAdmin.Commands
                 return false;
             }
         }
-
-        #endregion
-
-        #region MultipleTemplates class
 
         private class MultipleTemplates : Builder
         {
@@ -1027,10 +943,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleSnapshots class
-
         private class MultipleSnapshots : Builder
         {
             public override bool IsValid(SelectedItemCollection selection)
@@ -1058,10 +970,6 @@ namespace XenAdmin.Commands
                 items.AddIfEnabled(new DeleteSnapshotCommand(mainWindow, selection));
             }
         }
-
-        #endregion
-
-        #region MultipleVMsInPool class
 
         private class MultipleVMsInPool : MultipleVMs
         {
@@ -1120,11 +1028,6 @@ namespace XenAdmin.Commands
             }
         }
 
-
-        #endregion
-
-        #region MultipleVMsOverMultiplePools class
-
         private class MultipleVMsOverMultiplePools : MultipleVMs
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -1155,10 +1058,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleFolders class
-
         private class MultipleFolders : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -1173,10 +1072,6 @@ namespace XenAdmin.Commands
                 return selection.AllItemsAre<Folder>() && selection.Count > 1;
             }
         }
-
-        #endregion
-
-        #region SingleTag class
 
         private class SingleTag : Builder
         {
@@ -1197,10 +1092,6 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleTags class
-
         private class MultipleTags : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
@@ -1219,16 +1110,10 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region SingleDockerContainer class
-
         private class SingleDockerContainer : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
             {
-                DockerContainer vm = (DockerContainer)selection[0].XenObject;
-
                 items.AddIfEnabled(new StartDockerContainerCommand(mainWindow, selection));
                 items.AddIfEnabled(new StopDockerContainerCommand(mainWindow, selection));
                 items.AddIfEnabled(new PauseDockerContainerCommand(mainWindow, selection));
@@ -1248,11 +1133,7 @@ namespace XenAdmin.Commands
             }
         }
 
-        #endregion
-
-        #region MultipleDockerContainers class
-
-        private abstract class MultipleDockerContainers : Builder
+        private class MultipleDockerContainers : Builder
         {
             public override void Build(IMainWindow mainWindow, SelectedItemCollection selection, ContextMenuItemCollection items)
             {

--- a/XenModel/Utils/Util.cs
+++ b/XenModel/Utils/Util.cs
@@ -29,8 +29,6 @@
  */
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Xml;
 
@@ -493,46 +491,6 @@ namespace XenAdmin
         }
 
         /// <summary>
-        /// Loads the specified non-generic IEnumerable into a generic List&lt;T&gt;.
-        /// </summary>
-        /// <typeparam name="T">The type to convert each element to</typeparam>
-        /// <param name="input">The input non-generic IEnumerable.</param>
-        /// <returns>Generic List&lt;T&gt;</returns>
-        public static List<T> PopulateList<T>(IEnumerable input)
-        {
-            ThrowIfParameterNull(input, "input");
-            List<T> output = new List<T>();
-            foreach (T t in input)
-            {
-                output.Add(t);
-            }
-            return output;
-        }
-
-        /// <summary>
-        /// Gets a List that represents the specified IEnumerable. If the input isn't a List then one gets created by passing the input into
-        /// List's constructor. If the input is already a List then it is returned directly.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="input">The input.</param>
-        /// <returns>A list for the specified enumerable</returns>
-        public static List<T> GetList<T>(IEnumerable<T> input)
-        {
-            if (input == null)
-            {
-                return null;
-            }
-
-            var list = input as List<T>;
-
-            if (list != null)
-            {
-                return list;
-            }
-            return new List<T>(input);
-        }
-
-        /// <summary>
         /// Matches 1-65535 inclusive.
         /// </summary>
         /// <param name="s">The string to be parsed</param>
@@ -546,39 +504,5 @@ namespace XenAdmin
 
             return 0 < port && port <= 65535;
         }
-
-        public static string GetXmlNodeInnerText(XmlNode node, string xPath)
-        {
-            ThrowIfParameterNull(node, "node");
-            ThrowIfStringParameterNullOrEmpty(xPath, "xPath");
-
-            XmlNodeList nodes = node.SelectNodes(xPath);
-
-            if (nodes == null || nodes.Count == 0)
-            {
-                throw new InvalidOperationException("Node not found: " + xPath);
-            }
-
-            return nodes[0].InnerText;
-        }
-
-        /// <summary>
-        /// Get the first node with name 'value' and returns its innerText. Used for getting results of CGSL async actions.
-        /// </summary>
-        /// <param name="xml">The XML.</param>
-        /// <returns>The contents of the first node with name 'value'.</returns>
-        public static string GetContentsOfValueNode(string xml)
-        {
-            ThrowIfStringParameterNullOrEmpty(xml, "xml");
-
-            var doc = new XmlDocument();
-            doc.LoadXml(xml);
-
-            // If we've got this from an async task result, then it will be wrapped
-            // in a <value> element.
-            var nodes = doc.GetElementsByTagName("value");
-            return nodes.Count > 0 ? nodes[0].InnerText : null;
-        }
-
     }
 }


### PR DESCRIPTION
Reflection is used quite a lot in the application, but it is a sloppy practice which should be avoided unless absolutely necessary. It generates code smells in static analysers because some of the code appears unused. Most importantly though, it is error prone, which is not obvious before runtime because the compiler cannot catch the issues. In this particular case the MultipleDockerContainers was erroneoulsy marked as abstract, hence a specialised context menu was not constructed for it (we did not notice because the containers feature has been deprecated, but the risk remained).