### PR TITLE
CA-376480, CA-374325, & CA-378489: Prevent two instances from starting after running installer; Add desktop shortcut option; Remove existing shortcuts

### DIFF
--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -149,7 +149,7 @@
                 <Component Id="ProgramFilesShortcut" Guid="63b44222-b5e8-4ab1-8f68-baed79abbf36">
                     <Condition>INSTALLSHORTCUT</Condition>
                     <Shortcut Id="ApplicationDesktopShortcut" Name="$(var.BrandConsole)" Target="[INSTALLDIR]$(var.BrandConsoleNoSpace).exe" WorkingDirectory="INSTALLDIR"/>
-                    <RemoveFolder Id="DesktopFolder" On="uninstall"/>
+                    <RemoveFolder Id="DesktopFolder" On="both"/>
                     <RegistryValue Root="HKCU" Key="Software\$(var.BrandProduct)\$(var.BrandConsoleNoSpace)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
                 </Component>
             </Directory>
@@ -170,7 +170,7 @@
         <DirectoryRef Id="ApplicationProgramsFolder">
             <Component Id="ApplicationShortcut" Guid="$(var.AppShortcutGuid)">
                 <Shortcut Id="startmenuXenCenter" ShortName="$(var.BrandConsoleShort)" Name="$(var.BrandConsole)" Target="[INSTALLDIR]$(var.BrandConsoleNoSpace).exe" WorkingDirectory="INSTALLDIR" Icon="XenCenterICO" />
-                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
+                <RemoveFolder Id="ApplicationProgramsFolder" On="both" />
                 <RegistryValue Root="HKCU" Key="Software\$(var.BrandProduct)\$(var.BrandConsoleNoSpace)" Name="installed" Type="integer" Value="1" KeyPath="yes" />
             </Component>
         </DirectoryRef>

--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -200,7 +200,7 @@
             <RegistrySearch Id="InstallRegistry" Type="raw" Root="HKLM" Key="Software\$(var.BrandProduct)\$(var.BrandConsoleNoSpace)" Name="InstallDir" />
         </Property>
         <Property Id="REINSTALLMODE" Value="amus" />
-        <Property Id="INSTALLSHORTCUT" />
+        <Property Id="INSTALLSHORTCUT" Value="1"/>
         <CustomAction Id="ClearAllUsers" Property="ALLUSERS" Value="" />
         <CustomAction Id="SetAllUsers" Property="ALLUSERS" Value="1" />
         <InstallExecuteSequence>

--- a/WixInstaller/XenCenter.wxs
+++ b/WixInstaller/XenCenter.wxs
@@ -238,7 +238,7 @@
             <Publish Dialog="ExitDialog" 
                 Control="Finish" 
                 Event="DoAction" 
-                Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT (WixUI_InstallMode="Remove")
+                Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT (WixUI_InstallMode="Remove") AND XS_WixUIRMPressedOk="0"
             </Publish>
         </UI>
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.XenCenter_Launch) $(var.BrandConsole)" />

--- a/WixInstaller/wix_src.patch
+++ b/WixInstaller/wix_src.patch
@@ -111,7 +111,7 @@ diff -ru wixlib/CustomizeDlg.wxs wixlib/CustomizeDlg.wxs
                      <Publish Event="SelectionBrowse" Value="BrowseDlg">1</Publish>
                      <Condition Action="hide">Installed</Condition>
                      <Condition Action="disable">Installed</Condition>
-@@ -28,27 +28,35 @@
+@@ -28,27 +28,34 @@
                      <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
                  </Control>
                  <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.CustomizeDlgBannerBitmap)" />
@@ -132,24 +132,23 @@ diff -ru wixlib/CustomizeDlg.wxs wixlib/CustomizeDlg.wxs
                      <Subscribe Event="SelectionSize" Attribute="Text" />
                  </Control>
 -                <Control Id="Location" Type="Text" X="90" Y="210" Width="200" Height="20" Text="!(loc.CustomizeDlgLocation)">
-+                <Control Id="Location" Type="Text" X="90" Y="175" Width="200" Height="20" Text="!(loc.CustomizeDlgLocation)">
++                <Control Id="Location" Type="Text" X="70" Y="175" Width="220" Height="20" Text="!(loc.CustomizeDlgLocation)">
                      <Subscribe Event="SelectionPath" Attribute="Text" />
                      <Subscribe Event="SelectionPathOn" Attribute="Visible" />
                      <Condition Action="hide">Installed</Condition>
                  </Control>
 -                <Control Id="LocationLabel" Type="Text" X="25" Y="210" Width="65" Height="10" Text="!(loc.CustomizeDlgLocationLabel)">
-+                <Control Id="LocationLabel" Type="Text" X="20" Y="175" Width="65" Height="10" Text="!(loc.CustomizeDlgLocationLabel)">
++                <Control Id="LocationLabel" Type="Text" X="20" Y="175" Width="50" Height="10" Text="!(loc.CustomizeDlgLocationLabel)">
                      <Subscribe Event="SelectionPathOn" Attribute="Visible" />
                      <Condition Action="hide">Installed</Condition>
                  </Control>
-+                <Control Id="UsersLabel" Type="Text" X="20" Y="195" Width="50" Height="10" Text="!(loc.InstallDirDlgUsersLabel)" />
-+                <Control Id="UsersRadioButtonGroupControl" Type="RadioButtonGroup" X="70" Y="195" Width="290" Height="15" Property="Install_All">
++                <Control Id="UsersLabel" Type="Text" X="20" Y="210" Width="50" Height="20" Text="!(loc.InstallDirDlgUsersLabel)" />
++                <Control Id="UsersRadioButtonGroupControl" Type="RadioButtonGroup" X="70" Y="205" Width="290" Height="20" Property="Install_All">
 +                    <RadioButtonGroup Property="Install_All">
-+                        <RadioButton Value="1" X="20" Y="0" Width="100" Height="15" Text="!(loc.InstallDirDlgUsersAllRadioButton)" />
-+                        <RadioButton Value="0" X="125" Y="0" Width="100" Height="15" Text="!(loc.InstallDirDlgUsersOneRadioButton)" />
++                        <RadioButton Value="1" X="0" Y="1" Width="60" Height="20" Text="!(loc.InstallDirDlgUsersAllRadioButton)" />
++                        <RadioButton Value="0" X="60" Y="1" Width="120" Height="20" Text="!(loc.InstallDirDlgUsersOneRadioButton)" />
 +                    </RadioButtonGroup>
 +                </Control>
-+                <Control Id="InstallShortcutCheckbox" Type="CheckBox" X="20" Y="215" Width="290" Height="15" Property="INSTALLSHORTCUT" CheckBoxValue="1" Text="!(loc.InstallDirDlgShortCut)" />
              </Dialog>
          </UI>
      </Fragment>
@@ -998,14 +997,14 @@ diff -ru wixlib/WixUI_zh-CN.wxl wixlib/WixUI_zh-CN.wxl
 diff -ru wixlib/ExitDialog.wxl wixlib/ExitDialog.wxl
 --- wixlib/ExitDialog.wxs	2019-09-15 07:13:54.000000000 +0100
 +++ wixlib/ExitDialog.wxs	2022-06-09 15:28:09.123686200 +0100
-@@ -18,5 +18,5 @@
+@@ -18,4 +18,5 @@
                  </Control>
 -                <Control Id="OptionalCheckBox" Type="CheckBox" X="135" Y="190" Width="220" Height="40" Hidden="yes" Property="WIXUI_EXITDIALOGOPTIONALCHECKBOX" CheckBoxValue="1" Text="[WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT]">
 -                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT Installed</Condition>
-+                <Control Id="OptionalCheckBox" Type="CheckBox" X="135" Y="190" Width="220" Height="40" Hidden="yes" Property="WIXUI_EXITDIALOGOPTIONALCHECKBOX" CheckBoxValue="1"  Text="[WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT]">
++                <Control Id="InstallShortcutCheckbox" Type="CheckBox" X="135" Y="185" Width="290" Height="10" Property="INSTALLSHORTCUT" CheckBoxValue="1" Text="!(loc.InstallDirDlgShortCut)" />
++                <Control Id="OptionalCheckBox" Type="CheckBox" X="135" Y="200" Width="220" Height="10" Hidden="yes" Property="WIXUI_EXITDIALOGOPTIONALCHECKBOX" CheckBoxValue="1" Text="[WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT]">
 +                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT (WixUI_InstallMode="Remove") AND XS_WixUIRMPressedOk="0"</Condition>
                  </Control>
-             </Dialog>
 diff --git wixlib/MsiRMFilesInUse.wxs wixlib/MsiRMFilesInUse.wxs
 --- wixlib/MsiRMFilesInUse.wxs
 +++ wixlib/MsiRMFilesInUse.wxs

--- a/WixInstaller/wix_src.patch
+++ b/WixInstaller/wix_src.patch
@@ -111,7 +111,7 @@ diff -ru wixlib/CustomizeDlg.wxs wixlib/CustomizeDlg.wxs
                      <Publish Event="SelectionBrowse" Value="BrowseDlg">1</Publish>
                      <Condition Action="hide">Installed</Condition>
                      <Condition Action="disable">Installed</Condition>
-@@ -28,27 +28,34 @@
+@@ -28,27 +28,35 @@
                      <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
                  </Control>
                  <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.CustomizeDlgBannerBitmap)" />
@@ -142,13 +142,14 @@ diff -ru wixlib/CustomizeDlg.wxs wixlib/CustomizeDlg.wxs
                      <Subscribe Event="SelectionPathOn" Attribute="Visible" />
                      <Condition Action="hide">Installed</Condition>
                  </Control>
-+                <Control Id="UsersLabel" Type="Text" X="20" Y="197" Width="290" Height="15" Text="!(loc.InstallDirDlgUsersLabel)" />
-+                <Control Id="UsersRadioButtonGroupControl" Type="RadioButtonGroup" X="15" Y="208" Width="290" Height="20" Property="Install_All">
++                <Control Id="UsersLabel" Type="Text" X="20" Y="195" Width="50" Height="10" Text="!(loc.InstallDirDlgUsersLabel)" />
++                <Control Id="UsersRadioButtonGroupControl" Type="RadioButtonGroup" X="70" Y="195" Width="290" Height="15" Property="Install_All">
 +                    <RadioButtonGroup Property="Install_All">
-+                        <RadioButton Value="1" X="20" Y="0" Width="100" Height="20" Text="!(loc.InstallDirDlgUsersAllRadioButton)" />
-+                        <RadioButton Value="0" X="125" Y="0" Width="100" Height="20" Text="!(loc.InstallDirDlgUsersOneRadioButton)" />
++                        <RadioButton Value="1" X="20" Y="0" Width="100" Height="15" Text="!(loc.InstallDirDlgUsersAllRadioButton)" />
++                        <RadioButton Value="0" X="125" Y="0" Width="100" Height="15" Text="!(loc.InstallDirDlgUsersOneRadioButton)" />
 +                    </RadioButtonGroup>
 +                </Control>
++                <Control Id="InstallShortcutCheckbox" Type="CheckBox" X="20" Y="215" Width="290" Height="15" Property="INSTALLSHORTCUT" CheckBoxValue="1" Text="!(loc.InstallDirDlgShortCut)" />
              </Dialog>
          </UI>
      </Fragment>
@@ -210,7 +211,7 @@ diff -ru wixlib/InstallDirDlg.wxs wixlib/InstallDirDlg.wxs
                  <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallDirDlgTitle)" />
                  <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
                  <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
-@@ -21,6 +22,14 @@
+@@ -21,6 +22,13 @@
                  <Control Id="FolderLabel" Type="Text" X="20" Y="60" Width="290" Height="30" NoPrefix="yes" Text="!(loc.InstallDirDlgFolderLabel)" />
                  <Control Id="Folder" Type="PathEdit" X="20" Y="100" Width="320" Height="18" Property="WIXUI_INSTALLDIR" Indirect="yes" />
                  <Control Id="ChangeFolder" Type="PushButton" X="20" Y="120" Width="56" Height="17" Text="!(loc.InstallDirDlgChange)" />
@@ -221,7 +222,6 @@ diff -ru wixlib/InstallDirDlg.wxs wixlib/InstallDirDlg.wxs
 +                        <RadioButton Value="0" X="20" Y="20" Width="260" Height="20" Text="!(loc.InstallDirDlgUsersOneRadioButton)" />
 +                    </RadioButtonGroup>
 +                </Control>
-+                <Control Id="InstallShortcutCheckbox" Type="CheckBox" X="20" Y="210" Width="200" Height="20" Property="INSTALLSHORTCUT" CheckBoxValue="1" Text="!(loc.InstallDirDlgShortCut)" />
              </Dialog>
          </UI>
      </Fragment>

--- a/WixInstaller/wix_src.patch
+++ b/WixInstaller/wix_src.patch
@@ -1005,12 +1005,29 @@ diff -ru wixlib/ExitDialog.wxl wixlib/ExitDialog.wxl
 -                <Control Id="OptionalText" Type="Text" X="135" Y="110" Width="220" Height="80" Transparent="yes" NoPrefix="yes" Hidden="yes" Text="[WIXUI_EXITDIALOGOPTIONALTEXT]">
 -                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALTEXT AND NOT Installed</Condition>
 +                    <Control Id="OptionalText" Type="Text" X="135" Y="110" Width="220" Height="80" Transparent="yes" NoPrefix="yes" Hidden="yes" Text="[WIXUI_EXITDIALOGOPTIONALTEXT]">
-+                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALTEXT AND NOT (WixUI_InstallMode="Remove")</Condition>
++                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALTEXT AND NOT (WixUI_InstallMode="Remove") AND XS_WixUIRMPressedOk="0"</Condition>
                  </Control>
 -                <Control Id="OptionalCheckBox" Type="CheckBox" X="135" Y="190" Width="220" Height="40" Hidden="yes" Property="WIXUI_EXITDIALOGOPTIONALCHECKBOX" CheckBoxValue="1" Text="[WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT]">
 -                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT Installed</Condition>
 +                <Control Id="OptionalCheckBox" Type="CheckBox" X="135" Y="190" Width="220" Height="40" Hidden="yes" Property="WIXUI_EXITDIALOGOPTIONALCHECKBOX" CheckBoxValue="1"  Text="[WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT]">
-+                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT (WixUI_InstallMode="Remove")</Condition>
++                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT (WixUI_InstallMode="Remove") AND XS_WixUIRMPressedOk="0"</Condition>
                  </Control>
              </Dialog>
  
+diff --git wixlib/MsiRMFilesInUse.wxs wixlib/MsiRMFilesInUse.wxs
+--- wixlib/MsiRMFilesInUse.wxs
++++ wixlib/MsiRMFilesInUse.wxs
+@@ -6,10 +6,13 @@
+     <Fragment>
+         <UI>
+             <Property Id="WixUIRMOption" Value="UseRM" />
++            <!-- XS_WixUIRMPressedOk is a custom property. This can be checked to ensure that users did not proceed after using this dialog.-->
++            <Property Id="XS_WixUIRMPressedOk" Value="0" />
+             <Dialog Id="MsiRMFilesInUse" Width="370" Height="270" Title="!(loc.MsiRMFilesInUse_Title)" KeepModeless="yes">
+                 <Control Id="OK" Type="PushButton" X="240" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUIOK)">
+                     <Publish Event="EndDialog" Value="Return">1</Publish>
+                     <Publish Event="RMShutdownAndRestart" Value="0">WixUIRMOption~="UseRM"</Publish>
++                    <Publish Property="XS_WixUIRMPressedOk" Value="1">1</Publish>
+                 </Control>
+                 <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                     <Publish Event="EndDialog" Value="Exit">1</Publish>

--- a/WixInstaller/wix_src.patch
+++ b/WixInstaller/wix_src.patch
@@ -998,14 +998,7 @@ diff -ru wixlib/WixUI_zh-CN.wxl wixlib/WixUI_zh-CN.wxl
 diff -ru wixlib/ExitDialog.wxl wixlib/ExitDialog.wxl
 --- wixlib/ExitDialog.wxs	2019-09-15 07:13:54.000000000 +0100
 +++ wixlib/ExitDialog.wxs	2022-06-09 15:28:09.123686200 +0100
-@@ -13,11 +13,11 @@
-                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
-                 <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="40" Transparent="yes" NoPrefix="yes" Text="!(loc.ExitDialogDescription)" />
-                 <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.ExitDialogTitle)" />
--                <Control Id="OptionalText" Type="Text" X="135" Y="110" Width="220" Height="80" Transparent="yes" NoPrefix="yes" Hidden="yes" Text="[WIXUI_EXITDIALOGOPTIONALTEXT]">
--                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALTEXT AND NOT Installed</Condition>
-+                    <Control Id="OptionalText" Type="Text" X="135" Y="110" Width="220" Height="80" Transparent="yes" NoPrefix="yes" Hidden="yes" Text="[WIXUI_EXITDIALOGOPTIONALTEXT]">
-+                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALTEXT AND NOT (WixUI_InstallMode="Remove") AND XS_WixUIRMPressedOk="0"</Condition>
+@@ -18,5 +18,5 @@
                  </Control>
 -                <Control Id="OptionalCheckBox" Type="CheckBox" X="135" Y="190" Width="220" Height="40" Hidden="yes" Property="WIXUI_EXITDIALOGOPTIONALCHECKBOX" CheckBoxValue="1" Text="[WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT]">
 -                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT Installed</Condition>
@@ -1013,7 +1006,6 @@ diff -ru wixlib/ExitDialog.wxl wixlib/ExitDialog.wxl
 +                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT (WixUI_InstallMode="Remove") AND XS_WixUIRMPressedOk="0"</Condition>
                  </Control>
              </Dialog>
- 
 diff --git wixlib/MsiRMFilesInUse.wxs wixlib/MsiRMFilesInUse.wxs
 --- wixlib/MsiRMFilesInUse.wxs
 +++ wixlib/MsiRMFilesInUse.wxs


### PR DESCRIPTION
When an instance of XenCenter is already running, the installer shows the `MsiRMFilesInUse` fragment. Pressing OK within that fragment with the `WixUIRMOption` property set to `UseRM` means that the `RMShutdownAndRestart` event kicks in at the end of the installation.

This happens at the same time as the existing "Launch XenCenter" event (if the matching checkbox is checked), causing in the executable being started twice at about the same time. My guess is that the pipe system is not initialised at that point, and that's how we get two applications.

To avoid this, this commit adds a new custom property: `XS_WixUIRMPressedOk`. This is set to `1` when the user clicks OK on the `WixUIRMOption`. It allows us to know whether or not that dialog was shown at all, as checking `WixUIRMOption` is not possible (it's already set to `UseRM` by default). By checking the value of this property we prevent the "Launch XenCenter" option to be shown if `MsiRMFilesInUse` was shown to the user (and they clicked OK). This applies both in case of a repair and an upgrade from a previous version.