### PR TITLE
CA-375805: Fixed various issues when an unprivileged user tries to add a disk to a VM:

### DIFF
--- a/XenAdmin/Dialogs/AttachDiskDialog.cs
+++ b/XenAdmin/Dialogs/AttachDiskDialog.cs
@@ -242,7 +242,7 @@ namespace XenAdmin.Dialogs
                 vbd.unpluggable = true;
 
                 // Try to hot plug the VBD.
-                var action = new VbdSaveAndPlugAction(TheVM, vbd, TheVDI.Name(), null, false);
+                var action = new VbdCreateAndPlugAction(TheVM, vbd, TheVDI.Name(), false);
                 action.ShowUserInstruction += Action_ShowUserInstruction;
                 action.RunAsync();
             });

--- a/XenModel/Actions/VM/CreateCdDriveAction.cs
+++ b/XenModel/Actions/VM/CreateCdDriveAction.cs
@@ -49,42 +49,42 @@ namespace XenAdmin.Actions
 
             #region RBAC Dependencies
             ApiMethodsToRoleCheck.Add("vm.assert_agile");
-            ApiMethodsToRoleCheck.AddRange(XenAPI.Role.CommonSessionApiList);
+            ApiMethodsToRoleCheck.AddRange(Role.CommonSessionApiList);
             #endregion
         }
 
         protected override void Run()
         {
             VBD cdrom = VM.FindVMCDROM();
+
             if (cdrom == null)
             {
                 Description = Messages.NEW_DVD_DRIVE_CREATING;
-                // could not find a cd, try and make one
 
                 if (VM.VBDs.Count >= VM.MaxVBDsAllowed())
                 {
                     throw new Exception(Messages.CDDRIVE_MAX_ALLOWED_VBDS);
                 }
 
-                List<String> allowedDevices = new List<String>(XenAPI.VM.get_allowed_VBD_devices(Session, VM.opaque_ref));
+                var allowedDevices = new List<string>(VM.get_allowed_VBD_devices(Session, VM.opaque_ref));
 
                 if (allowedDevices == null || allowedDevices.Count == 0)
                 {
                     throw new Exception(Messages.CDDRIVE_MAX_ALLOWED_VBDS);
                 }
 
-                XenAPI.VBD cdDrive = new XenAPI.VBD
+                VBD cdDrive = new VBD
                 {
-                    VM = new XenAPI.XenRef<XenAPI.VM>(VM.opaque_ref),
+                    VM = new XenRef<VM>(VM.opaque_ref),
                     bootable = false,
                     device = "",
                     userdevice = allowedDevices.Contains("3") ? "3" : allowedDevices[0],
                     empty = true,
-                    type = XenAPI.vbd_type.CD,
-                    mode = XenAPI.vbd_mode.RO
+                    type = vbd_type.CD,
+                    mode = vbd_mode.RO
                 };
 
-                var cdCreate = new VbdSaveAndPlugAction(VM, cdDrive, Messages.DVD_DRIVE, Session, true);
+                var cdCreate = new VbdCreateAndPlugAction(VM, cdDrive, Messages.DVD_DRIVE, true);
                 cdCreate.ShowUserInstruction += msg => ShowUserInstruction?.Invoke(msg);
                 cdCreate.RunSync(Session);
                 Description = Messages.NEW_DVD_DRIVE_DONE;

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -138,7 +138,7 @@
     <Compile Include="Actions\USB\DeleteVUSBAction.cs" />
     <Compile Include="Actions\USB\SetUsbPassthroughAction.cs" />
     <Compile Include="Actions\VBD\VbdEditAction.cs" />
-    <Compile Include="Actions\VBD\VbdSaveAndPlugAction.cs" />
+    <Compile Include="Actions\VBD\VbdCreateAndPlugAction.cs" />
     <Compile Include="Actions\DR\VdiOpenDatabaseAction.cs" />
     <Compile Include="Actions\VDI\CreateDiskAction.cs" />
     <Compile Include="Actions\VDI\MigrateVirtualDiskAction.cs" />


### PR DESCRIPTION
- Adding a disk on local SR to an HA protected VM was crashing.
- The user could not plug the disk to the VM even after providing credentials on the role elevation dialog.
- The user had to enter credentials for each of the sub-actions involved in adding a disk.