### PR TITLE
CP-41573 & CP-41923: Add EUA check to RPU Wizard and bump `RPU005` to 5.0

### DIFF
--- a/XenAdmin/Diagnostics/Checks/Check.cs
+++ b/XenAdmin/Diagnostics/Checks/Check.cs
@@ -60,7 +60,7 @@ namespace XenAdmin.Diagnostics.Checks
         }
 
         public abstract string Description { get; }
-        public abstract IXenObject XenObject { get; }
+        public abstract IList<IXenObject> XenObjects { get; }
 
         public virtual string SuccessfulCheckDescription =>
             string.IsNullOrEmpty(Description)
@@ -73,7 +73,6 @@ namespace XenAdmin.Diagnostics.Checks
         }
     }
 
-
     public abstract class PoolCheck : Check
     {
         protected PoolCheck(Pool pool)
@@ -83,7 +82,7 @@ namespace XenAdmin.Diagnostics.Checks
 
         protected Pool Pool { get; }
 
-        public sealed override IXenObject XenObject => Pool;
+        public sealed override IList<IXenObject> XenObjects => new IXenObject[] { Pool };
 
         public override string SuccessfulCheckDescription =>
             string.IsNullOrEmpty(Description)
@@ -102,7 +101,7 @@ namespace XenAdmin.Diagnostics.Checks
 
         protected Host Host { get; }
 
-        public sealed override IXenObject XenObject => Host;
+        public sealed override IList<IXenObject> XenObjects => new IXenObject[] { Host };
 
         public override string SuccessfulCheckDescription =>
             string.IsNullOrEmpty(Description)

--- a/XenAdmin/Diagnostics/Checks/ClientVersionCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/ClientVersionCheck.cs
@@ -28,6 +28,7 @@
  * SUCH DAMAGE.
  */
 
+using System.Collections.Generic;
 using XenAdmin.Diagnostics.Problems;
 using XenAdmin.Core;
 using XenAPI;
@@ -36,7 +37,7 @@ namespace XenAdmin.Diagnostics.Checks
 {
     public class ClientVersionCheck : Check
     {
-        private XenServerVersion _newServerVersion;
+        private readonly XenServerVersion _newServerVersion;
 
         public ClientVersionCheck(XenServerVersion newServerVersion)
         {
@@ -56,6 +57,6 @@ namespace XenAdmin.Diagnostics.Checks
 
         public override string Description => string.Format(Messages.XENCENTER_VERSION_CHECK_DESCRIPTION, BrandManager.BrandConsole);
 
-        public override IXenObject XenObject => null;
+        public override IList<IXenObject> XenObjects => null;
     }
 }

--- a/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
+++ b/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
@@ -75,6 +75,7 @@ namespace XenAdmin.Diagnostics.Checks
             string eua = null;
             if (Helpers.Post82X(host) && !Helpers.TryLoadHostEua(host, _targetUri, out eua))
             {
+                Log.Warn($"Could not fetch EUA file for {host.Name()}");
                 lock (_hostsFailedToFetchEua)
                 {
                     _hostsFailedToFetchEua.Add(host);

--- a/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
+++ b/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
@@ -31,6 +31,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms;
 using XenAdmin.Core;
 using XenAPI;
 using XenAdmin.Diagnostics.Problems;
@@ -43,13 +44,16 @@ namespace XenAdmin.Diagnostics.Checks
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
 
         private readonly Uri _targetUri;
+        private readonly Control _control;
         private readonly HashSet<string> _euas;
         private readonly HashSet<IXenObject> _hostsFailedToFetchEua;
-        public UpgradeRequiresEua(List<Host> hosts, IReadOnlyDictionary<string, string> installMethodConfig)
+        public UpgradeRequiresEua(Control control, List<Host> hosts, IReadOnlyDictionary<string, string> installMethodConfig)
             : base(hosts)
         {
             if (installMethodConfig == null || !installMethodConfig.TryGetValue("url", out var uriText))
                 return;
+
+            _control = control;
 
             try
             {
@@ -95,7 +99,7 @@ namespace XenAdmin.Diagnostics.Checks
             }
             lock (_euas)
             {
-                return new EuaNotAcceptedProblem( this, _euas.ToList());
+                return new EuaNotAcceptedProblem( _control, this, _euas.ToList());
             }
         }
 

--- a/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
+++ b/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
@@ -40,14 +40,26 @@ namespace XenAdmin.Diagnostics.Checks
 {
     internal class UpgradeRequiresEua : UpgradeCheck
     {
+        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
+
         private readonly Uri _targetUri;
-        public UpgradeRequiresEua(List<Host> hosts, Uri targetUri)
+        public UpgradeRequiresEua(List<Host> hosts, IReadOnlyDictionary<string, string> installMethodConfig)
             : base(hosts)
         {
-            _targetUri = targetUri;
+            if (installMethodConfig == null || !installMethodConfig.TryGetValue("url", out var uriText))
+                return;
+
+            try
+            {
+                _targetUri = new Uri(uriText);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex);
+            }
         }
 
-        public override bool CanRun() => Hosts.Any(Helpers.Post82X);
+        public override bool CanRun() => _targetUri != null && Hosts.Any(Helpers.Post82X);
 
         protected override Problem RunCheck()
         {

--- a/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
+++ b/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
@@ -70,12 +70,12 @@ namespace XenAdmin.Diagnostics.Checks
             _hostsFailedToFetchEua = new HashSet<IXenObject>();
         }
 
-        public override bool CanRun() => _targetUri != null && Hosts.Any(Helpers.Post82X);
+        public override bool CanRun() => _targetUri != null && Hosts.Any(Helpers.YangtzeOrGreater);
 
         private void FetchHostEua(Host host)
         {
             string eua = null;
-            if (Helpers.Post82X(host) && !Helpers.TryLoadHostEua(host, _targetUri, out eua))
+            if (Helpers.YangtzeOrGreater(host) && !Helpers.TryLoadHostEua(host, _targetUri, out eua))
             {
                 Log.Warn($"Could not fetch EUA file for {host.Name()}");
                 lock (_hostsFailedToFetchEua)

--- a/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
+++ b/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
@@ -1,0 +1,75 @@
+﻿/* Copyright (c) Cloud Software Group, Inc. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using XenAdmin.Core;
+using XenAPI;
+using XenAdmin.Diagnostics.Problems;
+using XenAdmin.Diagnostics.Problems.UtilityProblem;
+
+namespace XenAdmin.Diagnostics.Checks
+{
+    internal class UpgradeRequiresEua : UpgradeCheck
+    {
+        private readonly Uri _targetUri;
+        public UpgradeRequiresEua(List<Host> hosts, Uri targetUri)
+            : base(hosts)
+        {
+            _targetUri = targetUri;
+        }
+
+        public override bool CanRun() => Hosts.Any(Helpers.Post82X);
+
+        protected override Problem RunCheck()
+        {
+            return new EuaNotAcceptedProblem( this, Hosts.Where(Helpers.Post82X).ToList(), _targetUri);
+        }
+
+        public override string Description => Messages.ACCEPT_EUA_CHECK_DESCRIPTION;
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is UpgradeRequiresEua item))
+            {
+                return false;
+            }
+
+
+            return _targetUri.Equals(item._targetUri) && base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return _targetUri.GetHashCode() ^ base.GetHashCode();
+        }
+    }
+}

--- a/XenAdmin/Diagnostics/Hotfixing/HotfixFactory.cs
+++ b/XenAdmin/Diagnostics/Hotfixing/HotfixFactory.cs
@@ -41,10 +41,10 @@ namespace XenAdmin.Diagnostics.Hotfixing
             Stockholm
         }
 
-        private static readonly Hotfix stockholmHotfix = new SingleHotfix
+        private static readonly Hotfix StockholmHotfix = new SingleHotfix
         {
             Filename = "RPU005",
-            UUID = "f9f63a51-509f-46fc-8c99-820fcac2228c"
+            UUID = "38a7eeeb-31ec-4de3-934f-13929ad3e339"
         };
 
         public static Hotfix Hotfix(Host host)
@@ -57,7 +57,7 @@ namespace XenAdmin.Diagnostics.Hotfixing
         public static Hotfix Hotfix(HotfixableServerVersion version)
         {
             if (version == HotfixableServerVersion.Stockholm)
-                return stockholmHotfix;
+                return StockholmHotfix;
 
             throw new ArgumentException("A version was provided for which there is no hotfix filename");
         }

--- a/XenAdmin/Diagnostics/Problems/Problem.cs
+++ b/XenAdmin/Diagnostics/Problems/Problem.cs
@@ -104,7 +104,7 @@ namespace XenAdmin.Diagnostics.Problems
                 result = string.Compare(Title, other.Title, StringComparison.InvariantCulture);
 
             if (result == 0 && Check?.XenObjects != null && other.Check?.XenObjects != null)
-                result = Check.XenObjects.Count.CompareTo(other.Check.XenObjects.Count);
+                result = Check.XenObjects.SequenceEqual(other.Check.XenObjects) ? 0 : Check.XenObjects.Count.CompareTo(other.Check.XenObjects.Count);
 
             return result;
         }

--- a/XenAdmin/Diagnostics/Problems/Problem.cs
+++ b/XenAdmin/Diagnostics/Problems/Problem.cs
@@ -98,13 +98,13 @@ namespace XenAdmin.Diagnostics.Problems
             if (other == null)
                 return 1;
 
-            var result = string.Compare(Description, other.Description);
+            var result = string.Compare(Description, other.Description, StringComparison.InvariantCulture);
 
             if (result == 0)
-                result = string.Compare(Title, other.Title);
+                result = string.Compare(Title, other.Title, StringComparison.InvariantCulture);
 
-            if (result == 0 && Check != null && Check.XenObject != null && other.Check != null)
-                result = Check.XenObject.CompareTo(other.Check.XenObject);
+            if (result == 0 && Check?.XenObjects != null && other.Check?.XenObjects != null)
+                result = Check.XenObjects.Count.CompareTo(other.Check.XenObjects.Count);
 
             return result;
         }

--- a/XenAdmin/Diagnostics/Problems/UtilityProblem/EUANotAcceptedProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/UtilityProblem/EUANotAcceptedProblem.cs
@@ -57,8 +57,10 @@ namespace XenAdmin.Diagnostics.Problems.UtilityProblem
             {
                 _check.Completed = d.ShowDialog(_control) == DialogResult.Yes;
             }
-            cancelled = true;
-            return null;
+            cancelled = false;
+
+            // we use a dummy action to force the Pre-Check page to reload once the dialog is closed
+            return new DelegatedAsyncAction(null, string.Empty, string.Empty, string.Empty, _ => {},true);
         }
 
         public override string HelpMessage => Messages.ACCEPT_EUA_PROBLEM_HELP_MESSAGE;

--- a/XenAdmin/Diagnostics/Problems/UtilityProblem/EUANotAcceptedProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/UtilityProblem/EUANotAcceptedProblem.cs
@@ -1,0 +1,85 @@
+﻿/* Copyright (c) Cloud Software Group, Inc. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using XenAdmin.Actions;
+using XenAdmin.Diagnostics.Checks;
+using XenAdmin.Dialogs;
+using XenAPI;
+
+namespace XenAdmin.Diagnostics.Problems.UtilityProblem
+{
+    internal class EuaNotAcceptedProblem : Problem
+    {
+        private readonly List<Host> _hosts;
+        private readonly Check _check;
+        private readonly Uri _targetUri;
+        public EuaNotAcceptedProblem(Check check, List<Host> hosts, Uri targetUri)
+            : base(check)
+        {
+            _check = check;
+            _hosts = hosts;
+            _targetUri = targetUri;
+        }
+
+        public override string Description => Messages.ACCEPT_EUA_PROBLEM_DESCRIPTION;
+
+        protected override AsyncAction CreateAction(out bool cancelled)
+        {
+            using (var d = new AcceptEuaDialog(_hosts,  _targetUri))
+            {
+                _check.Completed = d.ShowDialog(Program.MainWindow) == DialogResult.Yes;
+            }
+            cancelled = true;
+            return null;
+        }
+
+        public override string HelpMessage => Messages.ACCEPT_EUA_PROBLEM_HELP_MESSAGE;
+
+        public sealed override string Title => string.Empty;
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is EuaNotAcceptedProblem item))
+            {
+                return false;
+            }
+
+            return _targetUri.Equals(item._targetUri) && base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return _targetUri.GetHashCode() ^ base.GetHashCode();
+        }
+    }
+}

--- a/XenAdmin/Diagnostics/Problems/UtilityProblem/EUANotAcceptedProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/UtilityProblem/EUANotAcceptedProblem.cs
@@ -40,9 +40,11 @@ namespace XenAdmin.Diagnostics.Problems.UtilityProblem
     {
         private readonly List<string> _euas;
         private readonly Check _check;
-        public EuaNotAcceptedProblem(Check check, List<string> euas)
+        private readonly Control _control;
+        public EuaNotAcceptedProblem(Control control, Check check, List<string> euas)
             : base(check)
         {
+            _control = control;
             _check = check;
             _euas = euas;
         }
@@ -53,7 +55,7 @@ namespace XenAdmin.Diagnostics.Problems.UtilityProblem
         {
             using (var d = new AcceptEuaDialog(_euas))
             {
-                _check.Completed = d.ShowDialog(Program.MainWindow) == DialogResult.Yes;
+                _check.Completed = d.ShowDialog(_control) == DialogResult.Yes;
             }
             cancelled = true;
             return null;

--- a/XenAdmin/Diagnostics/Problems/UtilityProblem/EuaNotFoundProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/UtilityProblem/EuaNotFoundProblem.cs
@@ -40,11 +40,9 @@ namespace XenAdmin.Diagnostics.Problems.UtilityProblem
     internal class EuaNotFoundProblem : Problem
     {
         private readonly List<IXenObject> _hosts;
-        private readonly Check _check;
         public EuaNotFoundProblem(Check check, List<IXenObject> hosts)
             : base(check)
         {
-            _check = check;
             _hosts = hosts;
         }
 

--- a/XenAdmin/Diagnostics/Problems/UtilityProblem/EuaNotFoundProblem.cs
+++ b/XenAdmin/Diagnostics/Problems/UtilityProblem/EuaNotFoundProblem.cs
@@ -58,7 +58,7 @@ namespace XenAdmin.Diagnostics.Problems.UtilityProblem
         {
             Program.Invoke(Program.MainWindow, () =>
             {
-                using (var dlg = new InformationDialog(Messages.EUA_NOT_FOUND_PROBLEM_MORE_INFO))
+                using (var dlg = new InformationDialog(Messages.PROBLEM_PREPARE_TO_UPGRADE))
                     dlg.ShowDialog();
             });
 

--- a/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
@@ -39,13 +39,11 @@ namespace XenAdmin.Dialogs
             this.buttonsFlowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.declineButton = new System.Windows.Forms.Button();
             this.acceptButton = new System.Windows.Forms.Button();
-            this.spinnerIcon = new XenAdmin.Controls.SpinnerIcon();
             this.tableLayoutPanel.SuspendLayout();
             this.warningTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.warningPictureBox)).BeginInit();
             this.euaPanel.SuspendLayout();
             this.buttonsFlowLayoutPanel.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.spinnerIcon)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel
@@ -86,7 +84,6 @@ namespace XenAdmin.Dialogs
             // 
             // euaPanel
             // 
-            this.euaPanel.Controls.Add(this.spinnerIcon);
             this.euaPanel.Controls.Add(this.euaTextBox);
             resources.ApplyResources(this.euaPanel, "euaPanel");
             this.euaPanel.Name = "euaPanel";
@@ -120,13 +117,6 @@ namespace XenAdmin.Dialogs
             this.acceptButton.Name = "acceptButton";
             this.acceptButton.UseVisualStyleBackColor = true;
             // 
-            // spinnerIcon
-            // 
-            this.spinnerIcon.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.spinnerIcon, "spinnerIcon");
-            this.spinnerIcon.Name = "spinnerIcon";
-            this.spinnerIcon.TabStop = false;
-            // 
             // AcceptEuaDialog
             // 
             resources.ApplyResources(this, "$this");
@@ -142,7 +132,6 @@ namespace XenAdmin.Dialogs
             this.euaPanel.ResumeLayout(false);
             this.buttonsFlowLayoutPanel.ResumeLayout(false);
             this.buttonsFlowLayoutPanel.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.spinnerIcon)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -156,7 +145,6 @@ namespace XenAdmin.Dialogs
         private System.Windows.Forms.PictureBox warningPictureBox;
         private System.Windows.Forms.Label warningLabel;
         private System.Windows.Forms.Panel euaPanel;
-        private Controls.SpinnerIcon spinnerIcon;
         private System.Windows.Forms.RichTextBox euaTextBox;
         private System.Windows.Forms.FlowLayoutPanel buttonsFlowLayoutPanel;
         private System.Windows.Forms.Button declineButton;

--- a/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
@@ -125,8 +125,10 @@ namespace XenAdmin.Dialogs
             this.BackColor = System.Drawing.SystemColors.Control;
             this.CancelButton = this.declineButton;
             this.Controls.Add(this.tableLayoutPanel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.HelpButton = false;
             this.Name = "AcceptEuaDialog";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.tableLayoutPanel.ResumeLayout(false);
             this.tableLayoutPanel.PerformLayout();
             this.warningTableLayoutPanel.ResumeLayout(false);

--- a/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
@@ -1,0 +1,165 @@
+namespace XenAdmin.Dialogs
+{
+    partial class AcceptEuaDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AcceptEuaDialog));
+            this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.infoLabel = new System.Windows.Forms.Label();
+            this.warningTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.warningPictureBox = new System.Windows.Forms.PictureBox();
+            this.warningLabel = new System.Windows.Forms.Label();
+            this.euaPanel = new System.Windows.Forms.Panel();
+            this.euaTextBox = new System.Windows.Forms.RichTextBox();
+            this.buttonsFlowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.declineButton = new System.Windows.Forms.Button();
+            this.acceptButton = new System.Windows.Forms.Button();
+            this.spinnerIcon = new XenAdmin.Controls.SpinnerIcon();
+            this.tableLayoutPanel.SuspendLayout();
+            this.warningTableLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.warningPictureBox)).BeginInit();
+            this.euaPanel.SuspendLayout();
+            this.buttonsFlowLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.spinnerIcon)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel
+            // 
+            resources.ApplyResources(this.tableLayoutPanel, "tableLayoutPanel");
+            this.tableLayoutPanel.BackColor = System.Drawing.SystemColors.Control;
+            this.tableLayoutPanel.Controls.Add(this.infoLabel, 0, 0);
+            this.tableLayoutPanel.Controls.Add(this.warningTableLayoutPanel, 0, 2);
+            this.tableLayoutPanel.Controls.Add(this.euaPanel, 0, 1);
+            this.tableLayoutPanel.Controls.Add(this.buttonsFlowLayoutPanel, 0, 3);
+            this.tableLayoutPanel.Name = "tableLayoutPanel";
+            // 
+            // infoLabel
+            // 
+            resources.ApplyResources(this.infoLabel, "infoLabel");
+            this.infoLabel.BackColor = System.Drawing.Color.Transparent;
+            this.tableLayoutPanel.SetColumnSpan(this.infoLabel, 2);
+            this.infoLabel.Name = "infoLabel";
+            // 
+            // warningTableLayoutPanel
+            // 
+            resources.ApplyResources(this.warningTableLayoutPanel, "warningTableLayoutPanel");
+            this.warningTableLayoutPanel.Controls.Add(this.warningPictureBox, 0, 0);
+            this.warningTableLayoutPanel.Controls.Add(this.warningLabel, 1, 0);
+            this.warningTableLayoutPanel.Name = "warningTableLayoutPanel";
+            // 
+            // warningPictureBox
+            // 
+            resources.ApplyResources(this.warningPictureBox, "warningPictureBox");
+            this.warningPictureBox.Image = global::XenAdmin.Properties.Resources._000_WarningAlert_h32bit_32;
+            this.warningPictureBox.Name = "warningPictureBox";
+            this.warningPictureBox.TabStop = false;
+            // 
+            // warningLabel
+            // 
+            resources.ApplyResources(this.warningLabel, "warningLabel");
+            this.warningLabel.Name = "warningLabel";
+            // 
+            // euaPanel
+            // 
+            this.euaPanel.Controls.Add(this.spinnerIcon);
+            this.euaPanel.Controls.Add(this.euaTextBox);
+            resources.ApplyResources(this.euaPanel, "euaPanel");
+            this.euaPanel.Name = "euaPanel";
+            // 
+            // euaTextBox
+            // 
+            this.euaTextBox.BackColor = System.Drawing.SystemColors.Window;
+            this.euaTextBox.Cursor = System.Windows.Forms.Cursors.Default;
+            resources.ApplyResources(this.euaTextBox, "euaTextBox");
+            this.euaTextBox.Name = "euaTextBox";
+            this.euaTextBox.ReadOnly = true;
+            // 
+            // buttonsFlowLayoutPanel
+            // 
+            this.buttonsFlowLayoutPanel.Controls.Add(this.declineButton);
+            this.buttonsFlowLayoutPanel.Controls.Add(this.acceptButton);
+            resources.ApplyResources(this.buttonsFlowLayoutPanel, "buttonsFlowLayoutPanel");
+            this.buttonsFlowLayoutPanel.Name = "buttonsFlowLayoutPanel";
+            // 
+            // declineButton
+            // 
+            resources.ApplyResources(this.declineButton, "declineButton");
+            this.declineButton.DialogResult = System.Windows.Forms.DialogResult.No;
+            this.declineButton.Name = "declineButton";
+            this.declineButton.UseVisualStyleBackColor = true;
+            // 
+            // acceptButton
+            // 
+            resources.ApplyResources(this.acceptButton, "acceptButton");
+            this.acceptButton.DialogResult = System.Windows.Forms.DialogResult.Yes;
+            this.acceptButton.Name = "acceptButton";
+            this.acceptButton.UseVisualStyleBackColor = true;
+            // 
+            // spinnerIcon
+            // 
+            this.spinnerIcon.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            resources.ApplyResources(this.spinnerIcon, "spinnerIcon");
+            this.spinnerIcon.Name = "spinnerIcon";
+            this.spinnerIcon.TabStop = false;
+            // 
+            // AcceptEuaDialog
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.BackColor = System.Drawing.Color.White;
+            this.Controls.Add(this.tableLayoutPanel);
+            this.HelpButton = false;
+            this.Name = "AcceptEuaDialog";
+            this.tableLayoutPanel.ResumeLayout(false);
+            this.tableLayoutPanel.PerformLayout();
+            this.warningTableLayoutPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.warningPictureBox)).EndInit();
+            this.euaPanel.ResumeLayout(false);
+            this.buttonsFlowLayoutPanel.ResumeLayout(false);
+            this.buttonsFlowLayoutPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.spinnerIcon)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel;
+        private System.Windows.Forms.Label infoLabel;
+        private System.Windows.Forms.TableLayoutPanel warningTableLayoutPanel;
+        private System.Windows.Forms.PictureBox warningPictureBox;
+        private System.Windows.Forms.Label warningLabel;
+        private System.Windows.Forms.Panel euaPanel;
+        private Controls.SpinnerIcon spinnerIcon;
+        private System.Windows.Forms.RichTextBox euaTextBox;
+        private System.Windows.Forms.FlowLayoutPanel buttonsFlowLayoutPanel;
+        private System.Windows.Forms.Button declineButton;
+        private System.Windows.Forms.Button acceptButton;
+    }
+}

--- a/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
@@ -119,9 +119,11 @@ namespace XenAdmin.Dialogs
             // 
             // AcceptEuaDialog
             // 
+            this.AcceptButton = this.declineButton;
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.Control;
+            this.CancelButton = this.declineButton;
             this.Controls.Add(this.tableLayoutPanel);
             this.HelpButton = false;
             this.Name = "AcceptEuaDialog";

--- a/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.Designer.cs
@@ -121,7 +121,7 @@ namespace XenAdmin.Dialogs
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.BackColor = System.Drawing.Color.White;
+            this.BackColor = System.Drawing.SystemColors.Control;
             this.Controls.Add(this.tableLayoutPanel);
             this.HelpButton = false;
             this.Name = "AcceptEuaDialog";

--- a/XenAdmin/Dialogs/AcceptEuaDialog.cs
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.cs
@@ -42,6 +42,7 @@ namespace XenAdmin.Dialogs
         public AcceptEuaDialog(List<string> euas)
         {
             InitializeComponent();
+            
             _euas = euas;
             _warnings = new HashSet<string>();
             warningTableLayoutPanel.Visible = false;

--- a/XenAdmin/Dialogs/AcceptEuaDialog.cs
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.cs
@@ -1,0 +1,126 @@
+﻿/* Copyright (c) Cloud Software Group, Inc. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using XenAdmin.Core;
+using XenAPI;
+
+
+namespace XenAdmin.Dialogs
+{
+    public partial class AcceptEuaDialog : XenDialogBase
+    {
+        private readonly List<Host> _hosts;
+        private readonly Uri _targetUri;
+        private readonly HashSet<string> _euas;
+        private readonly HashSet<string> _errors;
+        private readonly HashSet<string> _warnings;
+
+
+        public AcceptEuaDialog(List<Host> hosts, Uri targetUri)
+        {
+            InitializeComponent();
+            _hosts = hosts;
+            _targetUri = targetUri;
+            _euas = new HashSet<string>();
+            _errors = new HashSet<string>();
+            _warnings = new HashSet<string>();
+
+            SetLoading(true);
+            warningTableLayoutPanel.Visible = false;
+
+            ThreadPool.QueueUserWorkItem(LoadEuas, null);
+        }
+
+        private void LoadEuas(object _)
+        {
+           _hosts.AsParallel().ForAll(FetchHostEua);
+
+            Program.BeginInvoke(this, () =>
+            {
+                if (_euas.Count > 1)
+                {
+                    _warnings.Add(Messages.ACCEPT_EUA_MORE_THAN_ONE_FOUND);
+                }
+
+                if (_warnings.Count > 0 || _errors.Count > 0)
+                {
+                    warningTableLayoutPanel.Visible = true;
+                    warningLabel.Text = string.Join(Environment.NewLine, _errors.Concat(_warnings));
+                }
+                else
+                {
+                    warningTableLayoutPanel.Visible = false;
+                }
+
+                euaTextBox.Text = string.Join($"{Environment.NewLine}___________________________{Environment.NewLine}", _euas);
+                SetLoading(false);
+            });
+        }
+
+        private void FetchHostEua(Host host)
+        {
+            if (!Helpers.TryLoadHostEua(host, _targetUri, out var eua) && Helpers.Post82X(host))
+            {
+                _errors.Add(string.Format(Messages.ACCEPT_EUA_CANNOT_FETCH, BrandManager.BrandConsole));
+                return;
+            }
+
+            lock (_euas)
+            {
+                _euas.Add(eua);
+            }
+        }
+        private void SetLoading(bool loading)
+        {
+            if (loading)
+            {
+                spinnerIcon.StartSpinning();
+            }
+            else
+            {
+                spinnerIcon.StopSpinning();
+            }
+
+            lock (_euas)
+            {
+                acceptButton.Enabled = euaTextBox.Visible = !loading && _euas.Count > 0 && _errors.Count == 0;
+            }
+        }
+
+        private void button_click(object sender, EventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/XenAdmin/Dialogs/AcceptEuaDialog.ja.resx
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.ja.resx
@@ -1,0 +1,483 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element msdata:IsDataSet="true" name="root">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="OkButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <data name="OkButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="OkButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="OkButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>336, 207</value>
+  </data>
+  <data name="OkButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 12, 12</value>
+  </data>
+  <data name="OkButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="OkButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="OkButton.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="&gt;&gt;OkButton.Name" xml:space="preserve">
+    <value>OkButton</value>
+  </data>
+  <data name="&gt;&gt;OkButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OkButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;OkButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 138</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>15, 3, 12, 6</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LicenseDetailsTextBox.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Both</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>396, 60</value>
+  </data>
+  <data name="LicenseDetailsTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.Name" xml:space="preserve">
+    <value>LicenseDetailsTextBox</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="linkLabel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="linkLabel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="linkLabel1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="linkLabel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 77</value>
+  </data>
+  <data name="linkLabel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 11, 14, 0</value>
+  </data>
+  <data name="linkLabel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 15</value>
+  </data>
+  <data name="linkLabel1.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="linkLabel1.Text" xml:space="preserve">
+    <value>著作権情報を表示</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Name" xml:space="preserve">
+    <value>linkLabel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 52</value>
+  </data>
+  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 3, 14, 5</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 15</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>著作権</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="licenseDetailsLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="licenseDetailsLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="licenseDetailsLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="licenseDetailsLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 115</value>
+  </data>
+  <data name="licenseDetailsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 23, 14, 5</value>
+  </data>
+  <data name="licenseDetailsLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 15</value>
+  </data>
+  <data name="licenseDetailsLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="licenseDetailsLabel.Text" xml:space="preserve">
+    <value>{0} のライセンス適用先:</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.Name" xml:space="preserve">
+    <value>licenseDetailsLabel</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="VersionLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="VersionLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="VersionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="VersionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 23</value>
+  </data>
+  <data name="VersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 23, 14, 5</value>
+  </data>
+  <data name="VersionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>45, 15</value>
+  </data>
+  <data name="VersionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="VersionLabel.Text" xml:space="preserve">
+    <value>バージョン</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.Name" xml:space="preserve">
+    <value>VersionLabel</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="showAgainCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showAgainCheckBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="showAgainCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="showAgainCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 210</value>
+  </data>
+  <data name="showAgainCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>12, 6, 3, 3</value>
+  </data>
+  <data name="showAgainCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 19</value>
+  </data>
+  <data name="showAgainCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="showAgainCheckBox.Text" xml:space="preserve">
+    <value>{0} を開くときにこのダイアログ ボックスを開く(&amp;S)</value>
+  </data>
+  <data name="showAgainCheckBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.Name" xml:space="preserve">
+    <value>showAgainCheckBox</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 79</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 242</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="LicenseDetailsTextBox" Row="5" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="OkButton" Row="6" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="linkLabel1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="label2" Row="1" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="licenseDetailsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="VersionLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="showAgainCheckBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100,AutoSize,20" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,20,AutoSize,0" />&lt;/TableLayoutSettings></value>
+  </data>
+  <data name="pictureBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pictureBox1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 79</value>
+  </data>
+  <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>423, 321</value>
+  </data>
+  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>{0} のバージョン情報</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>AboutDialog</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/XenAdmin/Dialogs/AcceptEuaDialog.resx
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.resx
@@ -273,39 +273,6 @@
   <data name="warningTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="warningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,40,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="spinnerIcon.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="spinnerIcon.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 9pt</value>
-  </data>
-  <data name="spinnerIcon.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="spinnerIcon.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="spinnerIcon.Size" type="System.Drawing.Size, System.Drawing">
-    <value>600, 359</value>
-  </data>
-  <data name="spinnerIcon.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
-  </data>
-  <data name="spinnerIcon.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;spinnerIcon.Name" xml:space="preserve">
-    <value>spinnerIcon</value>
-  </data>
-  <data name="&gt;&gt;spinnerIcon.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.SpinnerIcon, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;spinnerIcon.Parent" xml:space="preserve">
-    <value>euaPanel</value>
-  </data>
-  <data name="&gt;&gt;spinnerIcon.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="euaTextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -334,7 +301,7 @@
     <value>euaPanel</value>
   </data>
   <data name="&gt;&gt;euaTextBox.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="euaPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -940,9 +907,6 @@
         AAAAAAAAAAAAAPAPAADgBwAAwAMAAIABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAB
         AADAAwAA4AcAAPAPAAA=
 </value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>

--- a/XenAdmin/Dialogs/AcceptEuaDialog.resx
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.resx
@@ -148,7 +148,7 @@
     <value>3, 3, 3, 3</value>
   </data>
   <data name="infoLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>600, 24</value>
+    <value>580, 24</value>
   </data>
   <data name="infoLabel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -220,7 +220,7 @@
     <value>3, 3, 3, 3</value>
   </data>
   <data name="warningLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>554, 38</value>
+    <value>534, 38</value>
   </data>
   <data name="warningLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -244,13 +244,13 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="warningTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 401</value>
+    <value>6, 381</value>
   </data>
   <data name="warningTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="warningTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>600, 44</value>
+    <value>580, 44</value>
   </data>
   <data name="warningTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -283,7 +283,7 @@
     <value>0, 0</value>
   </data>
   <data name="euaTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>600, 359</value>
+    <value>580, 339</value>
   </data>
   <data name="euaTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -313,7 +313,7 @@
     <value>6, 36</value>
   </data>
   <data name="euaPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>600, 359</value>
+    <value>580, 339</value>
   </data>
   <data name="euaPanel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -340,7 +340,7 @@
     <value>NoControl</value>
   </data>
   <data name="declineButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>483, 3</value>
+    <value>463, 3</value>
   </data>
   <data name="declineButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>114, 25</value>
@@ -373,7 +373,7 @@
     <value>NoControl</value>
   </data>
   <data name="acceptButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>289, 3</value>
+    <value>269, 3</value>
   </data>
   <data name="acceptButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>188, 25</value>
@@ -406,10 +406,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonsFlowLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 451</value>
+    <value>6, 431</value>
   </data>
   <data name="buttonsFlowLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>600, 34</value>
+    <value>580, 34</value>
   </data>
   <data name="buttonsFlowLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -433,7 +433,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="tableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>10, 10</value>
   </data>
   <data name="tableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -445,10 +445,10 @@
     <value>4</value>
   </data>
   <data name="tableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>612, 491</value>
+    <value>592, 471</value>
   </data>
   <data name="tableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel.Name" xml:space="preserve">
     <value>tableLayoutPanel</value>
@@ -463,7 +463,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="infoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="warningTableLayoutPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="euaPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonsFlowLayoutPanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="Absolute,30,Percent,100,AutoSize,0,Absolute,40" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="infoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="warningTableLayoutPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="euaPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonsFlowLayoutPanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="Absolute,30,Percent,100,AutoSize,0,Absolute,40" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -907,6 +907,9 @@
         AAAAAAAAAAAAAPAPAADgBwAAwAMAAIABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAB
         AADAAwAA4AcAAPAPAAA=
 </value>
+  </data>
+  <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 10, 10, 10</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>

--- a/XenAdmin/Dialogs/AcceptEuaDialog.resx
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.resx
@@ -1,0 +1,959 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="tableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="tableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="infoLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="infoLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="infoLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="infoLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="infoLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 6</value>
+  </data>
+  <data name="infoLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="infoLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>600, 24</value>
+  </data>
+  <data name="infoLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="infoLabel.Text" xml:space="preserve">
+    <value>Please read and accept the End User Agreement (EUA) in order to proceed.</value>
+  </data>
+  <data name="&gt;&gt;infoLabel.Name" xml:space="preserve">
+    <value>infoLabel</value>
+  </data>
+  <data name="&gt;&gt;infoLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;infoLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;infoLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="warningTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="warningPictureBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="warningPictureBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="warningPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="warningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="warningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 38</value>
+  </data>
+  <data name="warningPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
+  </data>
+  <data name="warningPictureBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;warningPictureBox.Name" xml:space="preserve">
+    <value>warningPictureBox</value>
+  </data>
+  <data name="&gt;&gt;warningPictureBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningPictureBox.Parent" xml:space="preserve">
+    <value>warningTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;warningPictureBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="warningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="warningLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="warningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="warningLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>43, 3</value>
+  </data>
+  <data name="warningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="warningLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>554, 38</value>
+  </data>
+  <data name="warningLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.Name" xml:space="preserve">
+    <value>warningLabel</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.Parent" xml:space="preserve">
+    <value>warningTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;warningLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="warningTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="warningTableLayoutPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="warningTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 401</value>
+  </data>
+  <data name="warningTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="warningTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>600, 44</value>
+  </data>
+  <data name="warningTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="warningTableLayoutPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;warningTableLayoutPanel.Name" xml:space="preserve">
+    <value>warningTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;warningTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;warningTableLayoutPanel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;warningTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="warningTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="warningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,40,AutoSize,0" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="spinnerIcon.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="spinnerIcon.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="spinnerIcon.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="spinnerIcon.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="spinnerIcon.Size" type="System.Drawing.Size, System.Drawing">
+    <value>600, 359</value>
+  </data>
+  <data name="spinnerIcon.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>CenterImage</value>
+  </data>
+  <data name="spinnerIcon.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;spinnerIcon.Name" xml:space="preserve">
+    <value>spinnerIcon</value>
+  </data>
+  <data name="&gt;&gt;spinnerIcon.Type" xml:space="preserve">
+    <value>XenAdmin.Controls.SpinnerIcon, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;spinnerIcon.Parent" xml:space="preserve">
+    <value>euaPanel</value>
+  </data>
+  <data name="&gt;&gt;spinnerIcon.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="euaTextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="euaTextBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="euaTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="euaTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>600, 359</value>
+  </data>
+  <data name="euaTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="euaTextBox.Text" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;euaTextBox.Name" xml:space="preserve">
+    <value>euaTextBox</value>
+  </data>
+  <data name="&gt;&gt;euaTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;euaTextBox.Parent" xml:space="preserve">
+    <value>euaPanel</value>
+  </data>
+  <data name="&gt;&gt;euaTextBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="euaPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="euaPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="euaPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 36</value>
+  </data>
+  <data name="euaPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>600, 359</value>
+  </data>
+  <data name="euaPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;euaPanel.Name" xml:space="preserve">
+    <value>euaPanel</value>
+  </data>
+  <data name="&gt;&gt;euaPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;euaPanel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;euaPanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="declineButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="declineButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="declineButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="declineButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>483, 3</value>
+  </data>
+  <data name="declineButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 25</value>
+  </data>
+  <data name="declineButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="declineButton.Text" xml:space="preserve">
+    <value>I &amp;decline</value>
+  </data>
+  <data name="&gt;&gt;declineButton.Name" xml:space="preserve">
+    <value>declineButton</value>
+  </data>
+  <data name="&gt;&gt;declineButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;declineButton.Parent" xml:space="preserve">
+    <value>buttonsFlowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;declineButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="acceptButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="acceptButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="acceptButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="acceptButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>289, 3</value>
+  </data>
+  <data name="acceptButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>188, 25</value>
+  </data>
+  <data name="acceptButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="acceptButton.Text" xml:space="preserve">
+    <value>I have read and &amp;accept the terms</value>
+  </data>
+  <data name="&gt;&gt;acceptButton.Name" xml:space="preserve">
+    <value>acceptButton</value>
+  </data>
+  <data name="&gt;&gt;acceptButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;acceptButton.Parent" xml:space="preserve">
+    <value>buttonsFlowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;acceptButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonsFlowLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="buttonsFlowLayoutPanel.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
+    <value>RightToLeft</value>
+  </data>
+  <data name="buttonsFlowLayoutPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="buttonsFlowLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 451</value>
+  </data>
+  <data name="buttonsFlowLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>600, 34</value>
+  </data>
+  <data name="buttonsFlowLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;buttonsFlowLayoutPanel.Name" xml:space="preserve">
+    <value>buttonsFlowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;buttonsFlowLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonsFlowLayoutPanel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;buttonsFlowLayoutPanel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="tableLayoutPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>612, 491</value>
+  </data>
+  <data name="tableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.Name" xml:space="preserve">
+    <value>tableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="infoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="warningTableLayoutPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="euaPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonsFlowLayoutPanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="Absolute,30,Percent,100,AutoSize,0,Absolute,40" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>612, 491</value>
+  </data>
+  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAkAMDAQAAEABABoBgAAlgAAACAgEAABAAQA6AIAAP4GAAAQEBAAAQAEACgBAADmCQAAMDAAAAEA
+        CACoDgAADgsAACAgAAABAAgAqAgAALYZAAAQEAAAAQAIAGgFAABeIgAAMDAAAAEAIACoJQAAxicAACAg
+        AAABACAAqBAAAG5NAAAQEAAAAQAgAGgEAAAWXgAAKAAAADAAAABgAAAAAQAEAAAAAACABAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAIAAAIAAAACAgACAAAAAgACAAICAAACAgIAAwMDAAAAA/wAA/wAAAP//AP8A
+        AAD/AP8A//8AAP///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB3d3AAAAAAAAAAAA
+        AAAAAAAAAAAAAHd3eIiId3dwAAAAAAAAAAAAAAAAAAAHd4iIhEREiIiHdwAAAAAAAAAAAAAAAAB4iERE
+        TMzMRERIiHAAAAAAAAAAAAAAAAeERMzMzMzMzMzERIcAAAAAAAAAAAAAB3hEzMzMzMzMzMzMxEh3AAAA
+        AAAAAAAAeIRMzMzMzMzMzMzMzMSIcAAAAAAAAAAHhEzMzMzMzMzMzMzMzMxEhwAAAAAAAAB4RMzMzMzM
+        zMzMzMzMzMzESHAAAAAAAAeETMzMzMzMzMzMzMzMzMzMRIcAAAAAAAeEzMzMzMzMzMzMzMzMzMzMxIcA
+        AAAAAHhMzMzMzMzMzMzMzMzMzMzMzEhwAAAAB4RMzMzMzMzMzMzMzMzMzMzMzESHAAAAB4TMzMzMzMzM
+        zMzMzMzMzMzMzMSHAAAAeEzP/////4zMzMzMj////4zMzMxIcAAAeEzM//////jMzMzP////+MzMzMxI
+        cAAHhMzMz/////+MzMzP////+MzMzMzEhwAHhMzMzP/////4zMz/////jMzMzMzEhwAHhMzMzMz/////
+        jM/////4zMzMzMzEhwAHhMzMzMzP////+I////+MzMzMzMzEhwAHhMzMzMzM//////////+MzMzMzMzE
+        hwB4TMzMzMzMz/////////jMzMzMzMzMSHB4TMzMzMzMzM///////4zMzMzMzMzMSHB4TMzMzMzMzMyP
+        /////4zMzMzMzMzMSHB4TMzMzMzMzMyP//////jMzMzMzMzMSHB4TMzMzMzMzMyP//////+MzMzMzMzM
+        SHAHhMzMzMzMzMj////////4jMzMzMzEhwAHhMzMzMzMzI//////////+MzMzMzEhwAHhMzMzMzMyP//
+        ///P/////4zMzMzEhwAHhMzMzMzMj/////zM//////iMzMzEhwAHhMzMzMzMj/////zMz//////4zMzE
+        hwAAeEzMzMzI/////8zMzM//////jMxIcAAAeEzMzMyP/////MzMzMz/////+MxIcAAAB4TMzMzMzMzM
+        zMzMzMzMzMzMzMSHAAAAB4RMzMzMzMzMzMzMzMzMzMzMzESHAAAAAHhMzMzMzMzMzMzMzMzMzMzMzEhw
+        AAAAAAeEzMzMzMzMzMzMzMzMzMzMxIcAAAAAAAeETMzMzMzMzMzMzMzMzMzMRIcAAAAAAAB4RMzMzMzM
+        zMzMzMzMzMzESHAAAAAAAAAHhEzMzMzMzMzMzMzMzMxEhwAAAAAAAAAAeIRMzMzMzMzMzMzMzMSIcAAA
+        AAAAAAAAB3hEzMzMzMzMzMzMxEh3AAAAAAAAAAAAAAeERMzMzMzMzMzERIcAAAAAAAAAAAAAAAB4iERE
+        TMzMRERIiHAAAAAAAAAAAAAAAAAHd4iIhEREiIiHdwAAAAAAAAAAAAAAAAAAAHd3eIiId3dwAAAAAAAA
+        AAAAAAAAAAAAAAAAB3d3AAAAAAAAAAAAAAD///////8AAP//+D///wAA//8AAf//AAD/+AAAP/8AAP/w
+        AAAf/wAA/+AAAA//AAD/gAAAA/8AAP8AAAAB/wAA/gAAAAD/AAD8AAAAAH8AAPgAAAAAPwAA+AAAAAA/
+        AADwAAAAAB8AAOAAAAAADwAA4AAAAAAPAADAAAAAAAcAAMAAAAAABwAAgAAAAAADAACAAAAAAAMAAIAA
+        AAAAAwAAgAAAAAADAACAAAAAAAMAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAB
+        AACAAAAAAAMAAIAAAAAAAwAAgAAAAAADAACAAAAAAAMAAIAAAAAAAwAAwAAAAAAHAADAAAAAAAcAAOAA
+        AAAADwAA4AAAAAAPAADwAAAAAB8AAPgAAAAAPwAA+AAAAAA/AAD8AAAAAH8AAP4AAAAA/wAA/wAAAAH/
+        AAD/gAAAA/8AAP/gAAAP/wAA//AAAB//AAD/+AAAP/8AAP//AAH//wAA///4P///AAAoAAAAIAAAAEAA
+        AAABAAQAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAgAAAAICAAIAAAACAAIAAgIAAAICA
+        gADAwMAAAAD/AAD/AAAA//8A/wAAAP8A/wD//wAA////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHd3cA
+        AAAAAAAAAAAAAAd3eIiId3cAAAAAAAAAAAB4iIRERIiIcAAAAAAAAAB3hERMzMxERIdwAAAAAAAHiEzM
+        zMzMzMxIhwAAAAAAeETMzMzMzMzMxEhwAAAAB4TMzMzMzMzMzMzEhwAAAAeEzMzMzMzMzMzMxIcAAAB4
+        TMzMzMzMzMzMzMxIcAAHhM///4zMzMj//4zMxIcAB4TM////jMzP///MzMSHAAeEzM////jM////zMzE
+        hwAHhMzM////iP//jMzMxIcAeEzMzMz//////8zMzMxIcHhMzMzMz/////jMzMzMSHB4TMzMzMyP///4
+        zMzMzEhweEzMzMzMj////4zMzMxIcHhMzMzMyP/////4zMzMSHAHhMzMzI///8///4zMxIcAB4TMzMj/
+        //zM////jMSHAAeEzMzP///8zM////jEhwAHhMzMj///zMzM////hIcAAHhMzMzMzMzMzMzMzEhwAAAH
+        hMzMzMzMzMzMzMSHAAAAB4TMzMzMzMzMzMzEhwAAAAB4RMzMzMzMzMzESHAAAAAAB4hMzMzMzMzMSIcA
+        AAAAAAB3hERMzMxERIdwAAAAAAAAAHiIhEREiIhwAAAAAAAAAAAHd3iIiHd3AAAAAAAAAAAAAAAHd3cA
+        AAAAAAAA///////4P///gAP//wAB//wAAH/4AAA/8AAAH+AAAA/gAAAPwAAAB4AAAAOAAAADgAAAA4AA
+        AAMAAAABAAAAAQAAAAEAAAABAAAAAYAAAAOAAAADgAAAA4AAAAPAAAAH4AAAD+AAAA/wAAAf+AAAP/wA
+        AH//AAH//4AD///4P/8oAAAAEAAAACAAAAABAAQAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        gAAAgAAAAICAAIAAAACAAIAAgIAAAICAgADAwMAAAAD/AAD/AAAA//8A/wAAAP8A/wD//wAA////AAAA
+        B3d3cAAAAAd0RERHcAAAdEzMzMRHAAdMzMzMzMRwB0zMzMzMxHB0z/jMj/zMR3TM//j//MxHdMzP///M
+        zEd0zMz/+MzMR3TMyP///MxHdMzP/M//jEcHTMzMzMzEcAdMzMzMzMRwAHRMzMzERwAAB3REREdwAAAA
+        B3d3cAAA+B8AAOAHAADAAwAAgAEAAIABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAAgAEAAMAD
+        AADgBwAA+B8AACgAAAAwAAAAYAAAAAEACAAAAAAAAAkAAAAAAAAAAAAAAAEAAAABAAAAAAAAZgAAAG0Y
+        EgBmMzMAZmZmAH9/fwCKHAAAjyEFAI8lCgCUIwEAmycAAJwrBgCVKg0AjikRAJMuFQCOMR4AmzESAJg2
+        HgCmLQAAqS8AAKwxAACxNAAAuDkBAJU9KgCvQRMAmkc2AMFDBADKUgoA4lIAANJjEgDbdxoAx200AIlP
+        RgCiVUMAuG9HAKpnWgCZZmYAtH50AOOPJgDrqjMAkYqIAJmZmQChoaEApqamAKmpqQCurq4Aubm5AL6+
+        vgDMmZkA1bi1AMDAwADGxsYAycnJAM3NzQDQ0NAA1NTUANnZ2QDe3t4A4+PjAObm5gDp6ekA7OzsAPHx
+        8QD19fUA+fn5AP7+/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///8AAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQUFBQUFBQUFBQAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQUFKCgoKSkpKSgoKAUFBQAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAABQUFBCklIh8fHRwcHR8fIiUpBAUFBQAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAFBCwoIh4eJicnJycnJycnJh4dIigsBAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQUEKCIeJicn
+        JycnJycnJycnJycnJh4iKAQFBQAAAAAAAAAAAAAAAAAAAAAAAAAFBCkiHiYnJycnJycnJycnJycnJycn
+        JycmHiIpBAUAAAAAAAAAAAAAAAAAAAAAAAUEKB8mJycnJycnJycnJycnJycnJycnJycnJx4fKAQFAAAA
+        AAAAAAAAAAAAAAAABQQoHiYnJycmJiYmJiYmJiYmJiYmJiYmJiYnJyYmHSgEBQAAAAAAAAAAAAAAAAAF
+        BCgdJiYmJiYmJiYmJiYeHh4eHh4mJiYmJiYmJiYmJh0oBAUAAAAAAAAAAAAAAAUEKB0eJiYmJh4eHh4e
+        Hh4eHh4eHh4eHh4eHh4eJiYmJh4dKAQFAAAAAAAAAAAAAAUpHx4eHh4eHh4eHR0dHR0dHR0dHR0dHR0d
+        HR4eHh4eHh4eHykFAAAAAAAAAAAABSgiHR4eHh0dHR0dHRsbGxsbGxsbGxsbGxsbHR0dHR0dHh4eHSIo
+        BQAAAAAAAAAFBCgbHR0dHR0bGxsbGxsbGxsaGhoaGhobGxsbGxsbGxsdHR0dHRsoBAUAAAAAAAAFKCIb
+        HTo6PDo8Ojw6OisaGhoaGhoaGhoyPDw8PDw8PDkbGxsbHRsiKAUAAAAAAAAFKBobGxtAQEBAQEBAQEAv
+        GhoaGhoaGitAQEBAQEBAQBoaGhsbGxsaKAUAAAAAAAUEIhoaGhoaP0BAQEBAQEBAORYWFhYWFjxAQEBA
+        QEBAGhoaGhoaGhoaIigFAAAAAAUpGBoaGhYWFj9AQEBAQEBAQDwrFhYWNEBAQEBAQEA/FhYWFhYWGhoa
+        GCkFAAAAAAUlFhYWFhYWFhYWQEBAQEBAQEBALBYrQEBAQEBAQD8WFhYWFhYWFhYWFiUFAAAABQQjFRUV
+        FRUVFRUVFUBAQEBAQEBAQDc/QEBAQEBAQBUVFRUVFRUVFRUVFSMoBQAABSghFRUVFRUVFRUVFRU/QEBA
+        QEBAQEBAQEBAQEBAFRUVFRUVFRUVFRUVFSEoBQAABSghFBQUFBQUFBQUFBQUFEBAQEBAQEBAQEBAQEA/
+        FBQUFBQUFBQUFBQUFCEoBQAABSkYExMTExMTExMTExMTExNAQEBAQEBAQEBAQDkTExMTExMTExMTExMT
+        ExgpBQAABSkSEhISEhISEhISEhISEhISPEBAQEBAQEBAQCwSEhISEhISEhISEhISEhIpBQAABSkSEhIS
+        EhISEhISEhISEhISLEBAQEBAQEBAQEAvEhISEhISEhISEhISEhIpBQAABSkQCgoKCgoKCgoKCgoKCgoK
+        PEBAQEBAQEBAQEBANwoKCgoKCgoKCgoKChApBQAABSgZCgoSEhISEgoKCgoKCgo3QEBAQEBAQEBAQEBA
+        QDwrCgoKChISEhIKChkoBQAABSgZCgoLCwsLCgoKCgoKCi9AQEBAQEBAQEBAQEBAQEBALAoKCgoLCwsK
+        ChkoBQAABSgkCQkQCwsLCQkKCgoJK0BAQEBAQEA/CT9AQEBAQEBAQDQKCQkLCwsJCSQoBQAAAAUoCQkQ
+        EBAMCQkJCQkrP0BAQEBAQEAJCQkJQEBAQEBAQEA8KwkMEBAJCSgFAAAAAAUpDgkRERAQDA4KCQk8QEBA
+        QEBAQAkJCQkJCUBAQEBAQEBAPysQEBAJDikFAAAAAAUoIAYRFxERDg4ODDlAQEBAQEBAPwcJCQgHCQlA
+        QEBAQEBAQEAyEREGICgFAAAAAAAFKAYRGRkXEREOMkBAQEBAQEA/BgkHBwYHBwcIP0BAQEBAQEBAOREG
+        KAUAAAAAAAAFKCAOISEZFxcREQ4ODQ0NCQgICQ0HCAkNCAgNDQ0ODhERFxcZIQ0gKAUAAAAAAAAFBCgG
+        GSMhIRkXFxERDw4ODQ0NDQ0NDQ0NDQ0ODg8RERcXGSEhGQYoBAUAAAAAAAAABSggDyMjIyEhGRcXFxEP
+        Dw8PDw8PDw8PDw8PERcXFxkhISMjDyAoBQAAAAAAAAAAAAUpFyElJSMjIyEZGRkXFxcXFxcXFxcXFxcX
+        GRkZISEjIyUZFykFAAAAAAAAAAAAAAUEKA8jJSUlJSMjISEhGRkZGRkZGRkZGRkhISEjIyUlJSMPKAQF
+        AAAAAAAAAAAAAAAFBCgXIzAlJSUlJSMjIyMhISEhISEhISMjIyUlJSUlIxcoBAUAAAAAAAAAAAAAAAAA
+        BQQoFyMwMDAwJSUlJSUlJSUlJSUlJSUlJSUwMDAjFygEBQAAAAAAAAAAAAAAAAAAAAUEKCAjMDAwMDAw
+        MDAwMDAlMDAwMDAwMDAwMCMgKAQFAAAAAAAAAAAAAAAAAAAAAAAFBCkgGSUxMTExMTAwMDAwMDAwMDEx
+        MTElFyApBAUAAAAAAAAAAAAAAAAAAAAAAAAABQUoKCAZJTExMTExMTExMTExMTEwJRkgKCgFBQAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAFBCgoIA8gJDAwMTU1MTAwJCAPICgoBAUAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAABQUFKCkoIAMDAgEBAgMDICgpKAUFBQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQUF
+        KCgoKSkpKSgoKAUFBQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQUFBQUFBQUFBQAA
+        AAAAAAAAAAAAAAAAAAAAAAAA////////AAD///////8AAP//wA///wAA//4AAf//AAD/8AAAP/8AAP/g
+        AAAf/wAA/4AAAAf/AAD/AAAAA/8AAP4AAAAB/wAA/AAAAAD/AAD4AAAAAH8AAPAAAAAAPwAA8AAAAAA/
+        AADgAAAAAB8AAMAAAAAADwAAwAAAAAAPAADAAAAAAA8AAIAAAAAABwAAgAAAAAAHAACAAAAAAAcAAAAA
+        AAAAAwAAAAAAAAADAAAAAAAAAAMAAAAAAAAAAwAAAAAAAAADAAAAAAAAAAMAAAAAAAAAAwAAAAAAAAAD
+        AAAAAAAAAAMAAAAAAAAAAwAAgAAAAAAHAACAAAAAAAcAAIAAAAAABwAAwAAAAAAPAADAAAAAAA8AAMAA
+        AAAADwAA4AAAAAAfAADwAAAAAD8AAPAAAAAAPwAA+AAAAAB/AAD8AAAAAP8AAP4AAAAB/wAA/wAAAAP/
+        AAD/gAAAB/8AAP/gAAAf/wAA//AAAD//AAD//gAB//8AAP//wA///wAAKAAAACAAAABAAAAAAQAIAAAA
+        AAAABAAAAAAAAAAAAAAAAQAAAAEAAAAAAACUHQQAlSkSAJU2HgCfOB0AvDQFALY3DQC5NgkAtzkPAKo6
+        FgCoNxgAtTsTAI4+LQDBOAQAyTwEAL5CEwC3RB8AokAkAKdOLwC2RyQAuE0sALFTLACvUjsAulc5AM5B
+        BQDSRwcA0kgIANZQCgDdUA8A21sPAMpKEgDEVB4A1VUTAN1READbWxAA0FUdAOxMAQDgUQ8A51sLAOla
+        CgDeYxIA4GkTAOpqEgDkdhgA63oYAMpfKwC8XUAAu21bAIxvZgDCb1cAw3RfAMR3YgDEe2gA6IAcAOeD
+        IADohiAA7JAkAOybKwDKgG0Ax4FwAM2NfgCQkJAAq6urAK+vrwCwsLAAtra2AL6+vgDRlIQA0piJANSe
+        kADWoZQA2KWZAMDAwADExMQA09PTANTU1ADZ2dkA3NzcAOHh4QDl5eUA6enpAO7u7gDx8fEA9fX1APn5
+        +QD+/v4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAP///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPT09PT09AAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAA9PTAtJSQkJS0wPT0AAAAAAAAAAAAAAAAAAAAAAAA9MCEnKiw3ODg3LConHDA9AAAA
+        AAAAAAAAAAAAAAAAPSMmNzk5OTk5OTk5OTk3JyM9AAAAAAAAAAAAAAAAAD0hNjg4ODg4ODk4ODg4ODg4
+        NSE9AAAAAAAAAAAAAAA9JTU2NjY2NjY2NjY2NjY2Njc2NRw9AAAAAAAAAAAAPSArKysrKysrKysrKysr
+        KysrKysrKyA9AAAAAAAAAD0fKCgpKCkpKSkoKSkpKSkpKSkpKCkoKB89AAAAAAAAMBwdUVFRUVFPIh0d
+        HR0iQVJSUlJRHR0dHDAAAAAAAD0eGxsbVFRUVFRUPhsbGxtUVFRUVBsbGxsbHj0AAAAAPRkaGhoaVFRU
+        VFRUSBoaT1RUVFRSGRoaGhoZPQAAAAAwGBgYGBgYVFRUVFRUTUhUVFRUUhgYGBgYGBgwAAAAPRUODg4O
+        Dg4ODlRUVFRUVFRUVFQODg4ODg4ODhU9AAA9Dw4ODg4ODg4ODlRUVFRUVFRUDg4ODg4ODg4ODz0AAD0O
+        BQUNBQUNBQUNBU1UVFRUVFINBQUNBQUNBQUOPQAAPQUFDQUFDQUFDQUFTVRUVFRUVFQ+DQUFDQUFDQU9
+        AAA9CwUFBQUFBQUHBUhUVFRUVFRUVFRIBQUFBQUHCz0AAD0SBwcHBwcHBwc+VFRUVFQHVFRUVFRPBwcH
+        BwcSPQAAADAIBgYLBwYGQVRUVFRUBgYGVFRUVFRSPgYGBjAAAAAAPQsLCwsLCwtSVFRUVFILCwsLVFRU
+        VFRUQQsLPQAAAAA9CRAQEBAQT1JUVFRUEBAQEBAQVFRUVFRUSwk9AAAAAAAwExQUFBQUFBQUFBQUFBQU
+        FBQUFBQUFBQTMAAAAAAAAD0RFy4uLi4uLi4uLi4uLi4uLi4uLi4uFxE9AAAAAAAAAD0RMTExMTExMTEx
+        MTExMTExMTExMTERPQAAAAAAAAAAAD0JMjo6Ojo6Ojo6Ojo6Ojo6OjozCj0AAAAAAAAAAAAAAD0EMkND
+        Q0NDQ0NDQ0NDQ0NDNAQ9AAAAAAAAAAAAAAAAAD0DETo8Q0VGR0ZGRkQ8OxEDPQAAAAAAAAAAAAAAAAAA
+        AD0wAhEWLzs8PDsvFhECMD0AAAAAAAAAAAAAAAAAAAAAAAA9PTAMAgEBAgwwPT0AAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAD09PT09PQAAAAAAAAAAAAAAAAAA////////////8D///4AH//4AAf/8AAD/+AAAf/AA
+        AD/gAAAfwAAAD8AAAA+AAAAHgAAAB4AAAAcAAAADAAAAAwAAAAMAAAADAAAAAwAAAAOAAAAHgAAAB4AA
+        AAfAAAAPwAAAD+AAAB/wAAA/+AAAf/wAAP/+AAH//4AH///wP/8oAAAAEAAAACAAAAABAAgAAAAAAAAB
+        AAAAAAAAAAAAAAABAAAAAQAAAAAAAJMqDwClPRMAojkcAK5CHwCzRxcAvlAcAL1ZGwC6SyIAsk8yAMhW
+        IADNWyIAylcoAMpYLwDNXTgA1GchANRyIgDbcSMA4XwmAMJhRADOaEgA0WVCANNyUwDqiykAurq6AL+/
+        vwDT09MA19fXAOnp6QDt7e0A8/PzAPb29gD5+fkA/v7+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAA////AAAAAAAAAQEBAQEBAAAAAAAAAAABAQcQFxcQBwEBAAAAAAABAhIX
+        FxcXFxcSAgEAAAABAhISEhISEhISEhICAQAAAQ8RERERERERERERDwEAAQUPHx8aDw8ZHx8PDw8FAQEG
+        DwsgIB0ZHyAfCw8LBgEBCgsLCyAgICAfCwsLCwoBAQoLCwsLHSAgGwsLCwsKAQEIDAwMGSAgICAdDAwM
+        CAEBBA0NDSAgDQ0gICAZDQQBAAENDg4ODg4ODg4ODg0BAAABAxUVFRUVFRUVFRUDAQAAAAEDFBYWFhYW
+        FhQDAQAAAAAAAQEJExYWEwkBAQAAAAAAAAAAAQEBAQEBAAAAAAD4HwAA4AcAAMADAACAAQAAgAEAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAIABAACAAQAAwAMAAOAHAAD4HwAAKAAAADAAAABgAAAAAQAgAAAA
+        AACAJQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAQEBAAkBAQARAQEAHQEBADEBAQBVAQEAdQEBAI0BAQCdAQEAsQEBAL0BA
+        QC9AQEAsQEBAJ0BAQCNAQEAdQEBAFUBAQAxAQEAHQEBABEBAQAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAJAQEAFQEBADEBAQBdAQEAkQEBAMUBAQENAQEBXQEBAYkBA
+        QGZAQEByQEBAeUBAQHlAQEByQEBAZkBAQGJAQEBXQEBAQ0BAQDFAQEAkQEBAF0BAQAxAQEAFQEBAAgAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEACQEBABEBAQAxAQEAZQEBALEBAQEhAQEBiTk5Ol1pa
+        WsddXV3XXV1d2mNjY/FlZWX8ZWVl/GNjY/JcXFzdXV1d21lZWc5NTU2nQEBAhkBAQHpAQEBiQEBASEBA
+        QCxAQEAZQEBADEBAQARAQEACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQANAQEAJQEBAFkBAQClAQEBKVFRUn11d
+        XdVlZWX8cXFx/YKCgv6JiYn+iYmJ/pSUlP+ampr/mpqa/5SUlP+JiYn+iYmJ/oKCgv5xcXH9ZWVl/Vxc
+        XN5RUVG4QEBAh0BAQHJAQEBKQEBAKUBAQBZAQEAJQEBAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEABQEBABEBAQA5AQEAgQEBAQFRU
+        VJtjY2PvcXFx/YKCgv6UlJT/qop4/7p6Vv/KajP/ymoz/9paEv/iUgD/4lIA/9paEv/KajP/ymoz/7p6
+        Vv+qinj/lJSU/4KCgv5xcXH9YmJi81FRUbtAQECJQEBAa0BAQEBAQEAgQEBADkBAQARAQEABAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAJAQEAFQEBAEUBA
+        QCdRUVF7YWFh4HFxcf2Pj4/+opKJ/8BxRf/bahr/5n8b/+mXKP/rpjH/7bA2/+61Of/uuDv/7rg7/+21
+        Of/trzb/66Uw/+mVJ//mfRr/22gZ/8BxRf+ikon/j4+P/nFxcf1fX1/pTExMrkBAQIJAQEBXQEBAJ0BA
+        QBFAQEAFQEBAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAAkBA
+        QAdAQEAVQEBALFxcXLdra2v8iYmJ/qGSif/BdkX/43gX/+iYKf/srDX/7bQ5/+21Of/ttDn/7bM5/+2z
+        OP/tszj/7bM4/+2zOP/tszn/7bQ5/+21Of/tszn/7Ks0/+iVKP/idBX/wXVF/6GSif+JiYn+a2tr/VlZ
+        WdRAQECMQEBAZEBAQCxAQEAVQEBAB0BAQAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AABAQEABQEBABUBAQBVAQEAzX19fzXFxcf2UlJT/vXBF/+ByFf/nlin/66s0/+yvNv/srjb/7K01/+ut
+        Nf/rrDX/66w0/+urNP/rqzT/66s0/+urNP/rrDT/66w1/+utNf/srTX/7K42/+yvNv/rqTP/55Qn/99u
+        E/+9cEX/lJSU/3Fxcf1cXFzfQEBAkkBAQHFAQEAzQEBAFUBAQAVAQEABAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAABAQEAEQEBAEVBQUEJjY2Psd3d3/aGRif/KdTX/44Ug/+mjMP/qqDP/6qYy/+qm
+        Mf/ppDD/6aMw/+miL//poS//6KAu/+ifLv/ony7/6J8u/+ifLv/ooC7/6aEv/+miL//pozD/6aQx/+qm
+        Mf/qpzL/6qgz/+igLv/igR7/yXM1/6GRif93d3f9YmJi80ZGRqBAQEBxQEBALEBAQBFAQEAEAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQANAQEAOQEBAJ2RkZOp9fX39oJGJ/9VsHf/jiyP/550t/+if
+        Lv/nnS3/55ss/+aZK//mlyr/5ZYp/+WUKP/lkyj/5JIn/+SRJ//kkSf/5JEn/+SRJ//kkif/5ZMo/+WU
+        KP/llin/5pgq/+aaK//nmyz/550t/+ifLv/nnCz/4oci/9VqHP+gkYn/fHx8/mJiYvNAQECSQEBAZEBA
+        QCdAQEAOQEBAAwAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAAkBAQAlAQEAgYGBgxHd3d/2gkYn/02sd/+GI
+        Iv/klSn/5JUp/+OSKP/jkCf/4o4l/+KLJP/hiSP/4Ich/+CFIf/ghCD/34If/9+BH//fgR7/34Ee/9+B
+        H//fgh//4IQg/+CFIf/hhyL/4Ykj/+KLJP/ijiX/45An/+STKP/klSn/5JQp/+CFIf/SaBz/oJGJ/3d3
+        d/1cXFzfQEBAjEBAQFdAQEAgQEBACUBAQAIAAAAAAAAAAAAAAAAAAAAAQEBABEBAQBZfX1+ncXFx/aCR
+        if/PZRv/3YAe/+CKJP/giiT/4Igi/9+EIf/egR//3X4d/9x7HP/beBr/23YZ/9p0GP/acxj/2XEX/9lw
+        Fv/ZcBb/2XAW/9lxFv/ZcRf/2nMY/9p0GP/bdhn/23kb/9x8HP/dfh7/3oEf/9+FIf/giCL/4Iok/+CK
+        JP/dfR3/zmMa/6CRif9xcXH9WVlZ1EBAQIJAQEBAQEBAFkBAQAQAAAAAAAAAAAAAAABAQEACQEBADFhY
+        WFdra2v8lJSU/8BrNP/Ycxj/3H8e/9x+Hv/bexz/2nca/9l0Gf/YcRf/124W/9ZrFP/VaBP/1GYS/9Rk
+        Ef/TYxD/02EP/9NgD//TYA//02AP/9NhD//TYQ//02MQ/9RkEf/UZhL/1WgT/9ZrFf/Xbhb/2HEX/9l0
+        Gf/aeBv/23sc/9x+Hv/cfh7/13AX/8BqNP+UlJT/a2tr/UxMTK5AQEBrQEBAKUBAQAxAQEACAAAAAAAA
+        AABAQEAFQEBAGWNjY9KJiYn+tGtF/9FhEP/Xchn/13IY/9ZvF//UaxX/02gU/9JlEv/RYhD/0F8P/89c
+        Df/PWgz/zlgL/85WC//NVQr/zVMJ/81TCf/NUwn/zVMJ/81TCf/NUwn/zVUK/85WC//OWAv/z1oM/89c
+        Df/QXw//0mIR/9JlEv/UaRT/1WwV/9ZvF//Xchn/1nEY/9BfD/+0a0X/iYmJ/l9fX+lAQECJQEBASkBA
+        QBlAQEAFAAAAAEBAQAJAQEAMXFxccHJycvyfkIn/xFEM/6ZVFv+jVBb/olEV/6FPE/+hTBL/oEoR/59I
+        EP+eRg//nkQO/59DDf+/Sgn/yEwG/8hLBv/ISgX/x0kF/8dJBf/HSQX/x0kF/8dJBf/GSQX/q0MJ/5o/
+        DP+aPwz/mkEN/5pBDv+bRA7/nEUP/51HEf+fShH/wFoU/89gEP/QZBL/0WcU/9FlE//KUAj/n5CJ/3Fx
+        cf1RUVG7QEBAckBAQCxAQEAMQEBAAkBAQARAQEAXZGRk5o+Pj/6yakX/yVUN/8GIYv/j4N//5+fn/+fn
+        5//n5+f/5+fn/+fn5//n5+f/5+fn/+Tk5P+Xd2b/rD8I/8JDA//DQgL/w0IC/8NCAv/DQgL/w0IC/8NC
+        Av+wQAj/u66o/+np6f/p6en/6enp/+np6f/p6en/6enp/+np6f/Xxr3/w1UU/8lTC//KVgz/y1oO/8xb
+        D//JVAv/smpF/4+Pj/5iYmLzQEBAh0BAQEhAQEAXQEBABEBAQAddXV1qcnJy/J6Qif/CRgX/xlIL/8ZR
+        Cv/OeUj/9Onj//7+/v/+/f3///////79/f/+/f3//v39///////8+/v/tKSc/5c5DP+8PgL/vz4B/78+
+        Af+/PgH/vz4B/7s+A/+SaFT//Pv7///////+/f3//v39///////+/f3///////fy7//EYzD/wkcF/8NK
+        B//ETAj/xU4J/8ZSCv/GUQr/wUUE/56Qif9xcXH9UVFRuEBAQGJAQEAkQEBAB0BAQAxiYmK2g4OD/axl
+        Rf/ARgb/wUoH/8FIB//ARgb/xVkj/+bNwP/+/f3///////79/f/+/f3//v39///////+/f3//v39/9PN
+        y/+HPh3/tjsC/7s7AP+7OwD/uzsA/449GP/t7Ov//v39///////+/f3//v39///////+/f3//f39/8yA
+        XP+9PwL/vkED/75CBP+/RAX/wEYG/8FIB//BSgf/v0UF/6xlRf+CgoL+XFxc3kBAQHpAQEAxQEBADEBA
+        QBVmZmb6lJSU/7ZGE/+9QwX/vEMF/7xBBP+7PwP/uj4D/7xCCv/XpY3//Pv7////////////////////
+        ///////////////////s6+v/h1hD/6w2A/+4OAD/pTYG/8S5tf//////////////////////////////
+        ///+/v7/1qWQ/7k6Af+5OwH/uTsB/7o8Av+6PgP/uz8D/7xBBP+8QwX/vEMF/7ZGFP+UlJT/ZWVl/UBA
+        QIZAQEBDQEBAFVtbW05ycnL8oIR4/7Y5Av+4PgP/uDwD/7c7Av+3OgL/tjkB/7Y4Af+2OQL/ynxa//Xw
+        7f/+/f3//v39///////+/f3//v39///////+/f3/+Pf3/5yBdf+WMAX/kGhY//39/f/+/f3//v39////
+        ///+/f3//v39//7+/v/exbv/tz8L/7U3AP+1NwD/tjgB/7Y4Af+2OQH/tzoC/7c7Av+4PAP/uD0D/7Y5
+        Av+ghHj/cXFx/U1NTadAQEBXQEBAHWJiYpmDg4P9pW1W/7M2Af+zNwH/szcB/7M2Af+zNgH/sjUA/7I1
+        AP+yNQD/sjQA/71ZL//t29T//v39///////+/f3//v39///////+/f3//v39//39/f/LxMH/8O/u////
+        ///+/f3//v39///////+/f3//v39/+/m4/+4TSD/sjQA/7I0AP+yNAD/sjUA/7I1AP+yNQD/szYB/7M2
+        Af+zNwH/szcB/7M2Af+lbVb/goKC/llZWc5AQEBiQEBAI2NjY7OJiYn+qFUz/7AzAf+wNAH/sDMA/68z
+        AP+vMwD/rzMA/68yAP+vMgD/rzIA/68yAP+zPxD/27Wm//7+/v//////////////////////////////
+        ////////////////////////////////////////+/r5/71mQ/+vMgD/rzIA/68yAP+vMgD/rzIA/68y
+        AP+vMwD/rzMA/68zAP+wMwD/sDQB/7AzAf+oVTP/iYmJ/l1dXdtAQEBmQEBAJ2NjY7WJiYn+plQz/6wx
+        AP+sMQD/rDEA/6wxAP+sMQD/rDEA/6wxAP+sMQD/rDEA/6wxAP+sMQD/rTMD/8uMdP/59/b//v39////
+        ///+/f3//v39///////+/f3//v39///////+/f3//v39///////+/f3/w4ly/6wxAP+sMQD/rDEA/6wx
+        AP+sMQD/rDEA/6wxAP+sMQD/rDEA/6wxAP+sMQD/rDEA/6wxAP+mVDP/iYmJ/lxcXN1AQEByQEBALGVl
+        ZeKUlJT+pzsS/6kvAP+pLwD/qS8A/6kvAP+pLwD/qS8A/6kvAP+pLwD/qS8A/6kvAP+pLwD/qS8A/6kv
+        AP+8ZUP/7ePf//7+/v/+/f3//v39///////+/f3//v39///////+/f3//v39//7+/v/EpJj/qTIE/6kv
+        AP+pLwD/qS8A/6kvAP+pLwD/qS8A/6kvAP+pLwD/qS8A/6kvAP+pLwD/qS8A/6kvAP+nOxL/lJSU/2Nj
+        Y/JAQEB5QEBAL2ZmZvmampr/pi0A/6YtAP+mLQD/pi0A/6YtAP+mLQD/pi0A/6YtAP+mLQD/pi0A/6Yt
+        AP+mLQD/pi0A/6YtAP+mLQD/qkAY/9S7sf/+/v7///////////////////////////////////////7+
+        /v+ScGT/ly0G/6YtAP+mLQD/pi0A/6YtAP+mLQD/pi0A/6YtAP+mLQD/pi0A/6YtAP+mLQD/pi0A/6Yt
+        AP+mLQD/mpqa/2VlZfxAQEB5QEBAL2ZmZvmampr/oysA/6MrAP+jKwD/oysA/6MsAf+jLAH/oysA/6Mr
+        AP+jKwD/oysA/6MrAP+jKwD/oysA/6MrAP+jKwD/oiwC/4FKNv/8+/v//v39///////+/f3//v39////
+        ///+/f3//v39///////7+vr/rJuV/4QqCv+hKwH/oysA/6MrAP+jKwD/oysA/6MrAP+jKwD/oysA/6Ms
+        Af+jKwD/oysA/6MrAP+jKwD/mpqa/2VlZfxAQEByQEBALGVlZeGUlJT+nzYS/6ApAP+gKQD/oSsC/6Er
+        Av+hKwL/oCoB/6AqAf+gKgH/oCkA/6ApAP+gKQD/oCkA/6ApAP+fKQD/fC8V/+Ti4f/+/f3//v39////
+        ///+/f3//v39///////+/f3//v39///////+/f3//v39/9DKyP94NB3/nCkC/6ApAP+gKQD/oCkA/6Aq
+        Af+gKgH/oCoB/6ErAv+gKgH/oCkA/6ApAP+fNhL/lJSU/2NjY/FAQEBmQEBAJ2NjY7GJiYn+nE0z/50n
+        AP+dJwD/nyoE/58qBP+eKgP/nikC/54pAv+dKAH/nSgB/50oAf+dJwD/nScA/50nAP+DKAr/y8TC////
+        ///////////////////////////////////////////////////////////////////s6+v/flRG/5In
+        A/+dKAH/nSgB/50oAf+eKQL/nikC/54qA/+eKgP/nScA/50nAP+cTTP/iYmJ/l1dXdpAQEBiQEBAI2Rk
+        ZK+JiYn+mk0z/5omAP+aJgD/nS0I/50sB/+cKwb/nCkE/5spA/+bKAL/mygC/5onAf+aJwH/micB/4wm
+        Bf+rmpX//v39///////+/f3//v39///////+/f3//v39/+zk4f/+/f3//v39///////+/f3//v39////
+        ///+/f3/+fn5/5uFff+CJgj/migD/5soAv+bKQP/nCkE/5wrBv+cKwb/miYA/5omAP+aTTP/iYmJ/l1d
+        XddAQEBXQEBAHWNjY5ODg4P9mWZW/5ckAP+XJAD/nTAO/5wuDP+bLAn/mioH/5koBf+ZJwT/mCcD/5gm
+        Av+YJgL/kiUD/41vZv/8+/v//v39///////+/f3//v39///////+/f3/2sW+/500E//MpJj//fz8////
+        ///+/f3//v39///////+/f3///////38/P/Cubb/dCwV/5YnBf+ZKAX/mioH/5ssCf+bLQv/lyQA/5ck
+        AP+ZZlb/goKC/lpaWsdAQEBDQEBAFWFhYUBycnL7mYB4/5QiAP+UIgD/nTUW/5sxEf+aLg7/mSwM/5gq
+        Cf+XKAf/liYF/5YlBP+SJgT/eEk7//f39//////////////////////////////////x6uj/n0Aj/5Qi
+        AP+VJQP/u4Bu//v5+f/////////////////////////////////+/v7/5OPi/3VENv+QKgv/mSwM/5ov
+        D/+bMRH/lCIA/5QiAP+ZgHj/cXFx/U5OTpdAQEAxQEBADEBAQAdmZmb5lJSU/pIuEv+RIAD/njkd/504
+        G/+aMhX/mC8R/5csDv+WKgv/lSgJ/5MmCP9zMyH/6ejn///////+/f3//v39///////+/f3//v39//z7
+        +/+uaVb/kSEB/5EhAf+RIQH/kSEB/65iTf/z7Or//v39///////+/f3///////79/f/+/f3///////Tz
+        8/+Ncmv/hi0U/5kyFf+aMxb/kSAA/5IuEv+UlJT/ZWVl/EBAQGJAQEAkQEBAB0BAQARkZGStg4OD/ZNV
+        Rf+OHgD/nTsh/6BBKP+cOR//mTQZ/5cxFf+WLhL/lCoO/3grFv/Uz87/////////////////////////
+        /////////v7+/8Wdkv+PIgT/jyED/48hA/+PIQP/jyED/48hA/+gRy//6NrW//7+/v//////////////
+        ///////////////////8/Pz/tKmm/3o0Iv+XNBr/jh4A/5NVRf+CgoL+XV1d1UBAQEhAQEAXQEBABEBA
+        QAJjY2NacnJy+5iMif+LHAD/mTce/6RMNv+gRS7/nD0l/5k3Hv+XMxr/jjMc/7iqpv/28/L/9vPy//bz
+        8v/28vH/9vLx//by8f/28vH/3svH/5EqEP+NIAX/jSAF/40gBf+NIAX/jiEG/44hBv+OIgf/ljMa/9i+
+        t//7+fn/+/r5//v6+f/7+vn/+/r5//v6+f/7+vn/+/r5/9fU0/96Qzb/ih0B/5iMif9xcXH9VFRUn0BA
+        QCxAQEAMQEBAAgAAAABAQEAFZWVl34+Pj/6QVEX/kSwT/6hYRP+lUz//oUs2/5xBK/+ZOyT/ljkh/5g8
+        Jv+YOyT/lzki/5Y4IP+VNh7/lTUc/5QzG/+TMhn/kCoR/40kCv+NJAr/jCMJ/40kCv+NJAr/jSQK/40l
+        C/+OJgz/jygO/5EtFP+bQSv/nUQu/55GMf+gSjT/ok04/6NQO/+lVED/qFpH/6hdS/+TOCH/kFRF/4+P
+        j/5jY2PvQEBASkBAQBlAQEAFAAAAAAAAAABAQEACY2NjWnJycvuYjIn/hRkA/6BMOf+rYE//p1pI/6RT
+        QP+eSTX/mkEs/5c7Jv+VOCL/lDUf/5IxG/+QLxj/kC0W/48rFP+OKRL/jikS/40oEf+NJxD/jScQ/40n
+        EP+NKBH/jikS/44pEv+PKxT/kC0W/5AvGP+SMRv/lDUf/5U4Iv+YPCf/mkEs/5xFMf+iTzz/plhG/55I
+        NP+FGQD/mIyJ/3Fxcf1UVFSbQEBAKUBAQAxAQEACAAAAAAAAAAAAAAAAQEBABGVlZcWJiYn+jVJF/5I0
+        IP+valv/rmhZ/6tjU/+nXEz/oVFA/5xINv+ZQi//lz4r/5U6J/+TNyP/kjUh/5EyHv+QMR3/jzAb/48v
+        Gv+PLxr/ji4Z/48vGv+PLxr/jzAb/5AxHf+RMh7/kjUh/5M3I/+VOif/lz4r/5lCL/+bRjT/n048/6VY
+        R/+rY1P/rGRV/5EyHv+NUkX/iYmJ/mFhYeBAQEBAQEBAFkBAQAQAAAAAAAAAAAAAAAAAAAAAQEBAAmJi
+        Yj5sbGz6lJSU/ohBM/+eTj7/tnlt/7JzZv+vbF//q2ZY/6deUP+iVEX/nUw8/5pHNv+YQzL/lj8u/5U9
+        LP+UOyn/kzoo/5M5J/+SOCb/kjgm/5I4Jv+TOSf/kzoo/5Q7Kf+VPSz/lj8u/5hDMv+aRzb/nEo6/6BR
+        Qf+lWkv/qmRW/69sX/+yc2b/nUs7/4hBM/+UlJT/a2tr/FFRUXtAQEAgQEBACUBAQAIAAAAAAAAAAAAA
+        AAAAAAAAAAAAAEBAQANkZGSPcnJy+5eLif+IMSL/qWRX/7uFe/+4fnT/tHht/7FyZ/+ubWH/qmVZ/6Rb
+        Tv+gVUf/nE0//5tLPP+ZSDn/mEY3/5hFNv+XRDX/l0Q1/5dENf+YRTb/mEY3/5lIOf+bSzz/nE0//59S
+        RP+jWEv/p2FU/61rX/+xcmf/tHht/7h+dP+mX1L/hzAh/5eLif9xcXH9XFxct0BAQCdAQEAOQEBAAwAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEAEZWVlq3h4ePuWi4n/jDsu/65vZf/BkYn/vYqC/7qF
+        fP+4gHf/tHpx/7F1a/+vcGb/q2pf/6djWP+kXlL/olpO/6BXS/+fVEj/nlNH/59USP+fVUn/oVhM/6Nc
+        UP+mYFX/qWdc/65uZP+xdWv/tHpx/7iAd/+6hXz/vYqC/6xsYf+MOi3/louJ/3d3d/1fX1/NQEBALEBA
+        QBFAQEAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEABQEBABWVlZd99fX38louJ/4s8
+        MP+tcWf/yJ+Z/8Wak//ClY7/v4+I/7yKgv+6hn7/uIJ6/7V/dv+0fHP/snlw/7J4b/+xd27/sXZt/7F3
+        bv+yeG//snlw/7R8c/+1f3b/uIJ6/7qGfv+8ioL/v4+I/8KVjv/FmpP/rG5k/4o7L/+Wi4n/fX19/WNj
+        Y+xAQEAzQEBAFUBAQAVAQEABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAAl9f
+        XyFlZWXfeHh4+5aLif+JS0H/pGJZ/8igmv/MqKP/yqOe/8igmv/FnJb/w5iS/8GUjv/Akoz/vo+J/76P
+        iP+9jof/vY2G/72Oh/++j4j/vo+J/8CSjP/BlI7/w5iS/8Wclv/IoJr/yqOe/8Wclv+iX1b/iEpB/5aL
+        if93d3f9ZGRk6lBQUEJAQEAVQEBAB0BAQAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAEBAQAJAQEAFZWVlq3JycvuUlJT+g0tF/49AN/+zfnj/1bi0/9O1sf/Rsa3/z66q/86r
+        p//MqKT/y6ai/8qkoP/KpKD/yqSg/8qkoP/KpKD/y6ai/8yopP/Oq6f/z66q/9Gxrf/TtLD/snt1/44/
+        Nv+DS0X/lJSU/3Fxcf1gYGDEQEBAJ0BAQBFAQEAFQEBAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEABQEBABGRkZI9sbGz6iYmJ/pWKif+BSkX/j0Q8/695
+        dP/Nq6j/28LA/9rBvv/Yvrv/17y5/9e8uf/Wu7j/1ru4/9a7uP/XvLn/17y5/9i+u//awb7/zKmm/694
+        c/+PQzv/gUpF/5WKif+JiYn+a2tr/F9fX6dAQEAgQEBADkBAQARAQEABAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQANiYmI+ZWVlxXJy
+        cvuPj4/+lYqJ/39JRf98Lif/kkpE/6hvav+7j4v/y6mm/9e9u//fysj/38rI/9e9u//KqKX/u46K/6hv
+        av+SSkT/fC4n/39JRf+Vion/j4+P/nJycvxjY2PSWFhYV0BAQBZAQEAJQEBAAwAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AABAQEACQEBABGNjY1plZWXfcnJy+4ODg/2UlJT+j3p4/4NZVv94ODP/eDgz/20YEv9nBwD/ZwcA/20Y
+        Ev94ODP/eDgz/4NZVv+Penj/lJSU/4ODg/1ycnL8ZGRk5lxcXHBAQEAZQEBADEBAQARAQEACAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAJAQEAFY2NjWmRkZK1mZmb5cnJy+4ODg/2JiYn+iYmJ/pSU
+        lP6ampr/mpqa/5SUlP6JiYn+iYmJ/oODg/1ycnL8ZmZm+mJiYrZdXV1qQEBAF0BAQAxAQEAFQEBAAgAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAAkBAQARAQEAHYWFhQGNj
+        Y5NkZGSvY2NjsWVlZeFmZmb5ZmZm+WVlZeJjY2O1Y2Njs2JiYplbW1tOQEBAFUBAQAxAQEAHQEBABEBA
+        QAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP/8
+        AAA//wAA//AAAA//AAD/wAAAA/8AAP+AAAAB/wAA/gAAAAB/AAD8AAAAAD8AAPgAAAAAHwAA8AAAAAAP
+        AADwAAAAAA8AAOAAAAAABwAAwAAAAAADAADAAAAAAAMAAIAAAAAAAQAAgAAAAAABAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAABAACAAAAAAAEAAMAAAAAAAwAAwAAAAAAD
+        AADgAAAAAAcAAPAAAAAADwAA8AAAAAAPAAD4AAAAAB8AAPwAAAAAPwAA/gAAAAB/AAD/gAAAAf8AAP/A
+        AAAD/wAA//AAAA//AAD//AAAP/8AACgAAAAgAAAAQAAAAAEAIAAAAAAAgBAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAISE
+        hDiEhISNhISEqoSEhOKEhIT/hISE/4SEhOKEhISqhISEjYSEhDgAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAISE
+        hHGEhITim3hn/7JsSv/KYCz/4FIP/+xNAf/sTQH/4FIP/8pgLP+ya0n/m3hn/4SEhOKEhIRxAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAISE
+        hFWEhITimndn/91SEP/pWwr/6msS/+t7Gf/riCH/7JEl/+yRJf/riSL/63wa/+psEv/pXQr/3VEP/5p3
+        Z/+EhITihISEVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AACEhIRxj352/9BWHv/nXAv/644l/+uXKf/snCz/7KAv/+ygLv/soC//7KEv/+ygLv/snS3/7Jws/+uX
+        Kf/rjiX/51wL/9BWHv+PfXX/hISEcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAhISEqph3aP/ZVhP/6YMg/+qTKP/qlCf/6pUp/+qUJ//qlCj/6pQo/+qVKf/qlSn/6pQn/+qT
+        KP/qlCj/65Up/+qTJ//qlSn/6IEd/9lWE/+Yd2j/hISEqgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAISEhHGYdmf/4VQI/+d/Hv/ohiH/6Ici/+iGIf/ohiH/6IYh/+iGIf/ohiH/6IYh/+iH
+        Iv/oiCL/6IYh/+iGIf/oiCL/54Qh/+iGIf/ohiH/5n4d/+FUCP+Ydmf/hISEcQAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAACEhIRVjn52/9VWE//kdxr/5Hkb/+R3Gv/keRv/5Hga/+R3Gv/kdhn/5HYZ/+R3
+        Gf/kdxr/5HcZ/+R4Gv/keBr/5Hga/+R3Gf/keBr/5Hca/+R2Gf/kdxn/5Hga/9VWE/+Ofnb/hISEVQAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAISEhOLCVSD/wFoV/79dFv+/XRb/v10W/8BeFv+/XRX/xl8U/95o
+        E//faRP/4GoU/+BqFP/faBP/32kU/9FkFf+9XBb/vVwW/71cFv+9XBb/vVwW/81jF//faBP/32US/8VV
+        H/+EhITiAAAAAAAAAAAAAAAAAAAAAAAAAACEhIRxlnZo/9pWDf/PimH/7Orp/+/v7//v7+//7+/v/+/v
+        7//j4N7/nlw0/9haEP/bXA//21wP/9tcD//XWxH/sJOB//Dw8P/w8PD/8PDw//Dw8P/p5eL/0Gsu/9tc
+        D//bWw//2lcN/5Z2aP+EhIRxAAAAAAAAAAAAAAAAAAAAAISEhOLKSxL/11IL/9ZSC//ceEP/9eji////
+        ///////////////////5+fn/nnNb/8pPDv/WUQr/1lIL/6BaNf/8/Pz//////////////////v7+/92M
+        Yf/WUgv/11IL/9ZRCv/XUgv/yksS/4SEhOIAAAAAAAAAAAAAAACEhIQ4lHVo/9JIB//SSQj/0kkI/9JJ
+        CP/VWh//7c2+//7+/v/////////////////+/v7/t6CV/7VFEP+1RhH/497b//////////////////7+
+        /v/hrZT/0kgH/9JJCP/SSQj/0kkI/9JJCP/SSAf/lHVo/4SEhDgAAAAAAAAAAISEhI2sXTz/zkIF/85D
+        Bv/OQwb/zkMG/85DBv/PRgr/4aWK//79/f//////////////////////18/L/72onv//////////////
+        ////////6M3B/85HDf/OQgX/zkIF/85DBv/OQwb/zkMG/85DBv+sXTz/hISEjQAAAAAAAAAAhISEqrJU
+        Lf/JPgT/yj4E/8k+BP/JPQT/yT4E/8k+BP/JPgT/1XpU//jx7v//////////////////////////////
+        //////////////Ho5P/MUyL/yj4E/8k+BP/JPgT/yT4E/8o+BP/JPgT/yT4E/7JULf+EhISqAAAAAAAA
+        AACEhITiv0MT/8U7BP/FOwT/xTwE/8U7A//FOwP/xTsE/8U7A//FOwP/y1kq/+3Yz//+/v7/////////
+        ///////////////////9+/v/wmM8/8U7A//FOwP/xTsD/8U7A//FOwP/xTwE/8U7A//FOwT/v0MT/4SE
+        hOIAAAAAAAAAAISEhP/COAP/wjkE/8I4A//COAP/wjgD/8I4A//COAP/wjgD/8I4A//COAP/wT8M/8al
+        mf////////////////////////////Dt6/+USSz/vzgE/8I4A//COAP/wjgD/8I4A//COAP/wjgD/8I4
+        A//COAP/hISE/wAAAAAAAAAAhISE/782Bf+/NgX/vzYF/782Bf+/NgX/vzYF/782Bf+/NgX/vzYF/782
+        Bf+pOA//1czI//////////////////////////////////j4+P+WaVj/tDYI/782Bf+/NgX/vzYF/782
+        Bf+/NgX/wDcG/782Bf+EhIT/AAAAAAAAAACEhITitz0T/7w2B/+8NQb/vTYH/7w1Bv+8NQb/vDUG/7w1
+        Bv+8NQb/szYK/7ehmv///////////////////////v7+//////////////////7+/v+1oJj/ojYQ/7w1
+        Bv+8NQb/vTYH/7w2B/+8Ngf/tz0T/4SEhOIAAAAAAAAAAISEhKqoTzD/ujcJ/7o3Cf+6Nwr/ujcJ/7o3
+        Cf+6Nwn/ujcK/7c3Cv+cdWj//v7+//////////////////Dl4v/Lgmn/+vb0////////////////////
+        ///Z0s//kD4h/7g3Cf+6Nwn/ujcK/7o3Cf+oTzD/hISEqgAAAAAAAAAAhISEjaBWPv+4Og//tzkO/7c5
+        Dv+3OQ7/tzgN/7c4Df+2OA3/jlM///v7+//////////////////8+/v/wmlL/7c4Df/CXz7/8eTg////
+        ///////////////////z8vL/jllH/7E5D/+3OQ7/tzgN/6BWPv+EhISNAAAAAAAAAACEhIQ4jnFn/7Y8
+        E/+3PRT/tz0U/7c9FP+3PRT/tjwT/5FDKf/z8vH//////////////////v7+/9Gah/+3PRT/tz0U/7c9
+        FP+9UCz/6M/G//7+/v/////////////////9/f3/pouC/6Q8GP+2OxP/jnFn/4SEhDgAAAAAAAAAAAAA
+        AACEhITiqzsX/7hFIP+3Qh3/uEUg/7dEH/+zRiP/x52Q/+K+sv/kv7P/5L+z/+O+s//arJ7/uEYi/7dC
+        Hf+3Qh3/t0Id/7dCHf+5SCT/2qqa/+jJwP/oycD/6Mm//+jJv//mx73/upGE/6Q9HP+EhITiAAAAAAAA
+        AAAAAAAAAAAAAISEhHGNcGf/t0km/7lOLP+5Ty3/uk8u/7lOLP+6Ty7/uk8u/7pPLv+6Ty7/uk8u/7pP
+        Lv+6Ty7/uk8u/7pPLv+6Ty7/uk8u/7pPLv+6Ty7/uU8t/7pPLv+6Ty7/uk8u/7pPLv+3SCX/jXBn/4SE
+        hHEAAAAAAAAAAAAAAAAAAAAAAAAAAISEhOKjQSX/u1g6/71cP/++XkH/vVw//75eQf++X0L/vl9C/75f
+        Qv++X0L/vl9C/75fQv++X0L/vl9C/75fQv++X0L/vl9C/75fQv++X0P/vl5B/75eQf+9XUD/u1Y4/6NB
+        Jf+EhITiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhISEVYh6dv+nQCP/w3BY/8JtVf/BbFT/wm5W/8Ju
+        Vv/Cblb/wm5W/8JuVv/Cblb/wm5W/8JuVv/Cblb/wm5W/8JuVv/Cblb/wm5W/8NxWf/Cblb/w3FZ/8Ju
+        Vv+nQCP/iHp2/4SEhFUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhISEcYpvZ/+pOBn/xHVg/8qC
+        b//Kgm//yoFu/8qBbv/KgW7/yoFu/8qBbv/KgW7/yoFu/8qBbv/KgW7/yoFu/8qBbv/KgW7/y4Rx/8qB
+        bv/FeGP/qTgZ/4pvZ/+EhIRxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhISEqopu
+        Z/+gOR7/xHhl/9GWhv/Rlob/0ZaG/9GWhv/Rlob/0ZaG/9GWhv/Rlob/0ZaG/9GWhv/Rlob/0ZaG/9GW
+        hv/RlIT/xXxp/6A5Hv+Kbmf/hISEqgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAhISEcYd5dv+WNx//qD4j/8eCcf/Njn//0pmK/9Sfkf/XpZj/2Kaa/9immv/Xppn/1qKV/9KZ
+        iv/Njn//x4Jx/6g+JP+WNx//h3l2/4SEhHEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAhISEVYSEhOKIbmf/lioS/6Q5If+wVD7/vG9c/8eEdP/Li33/y4x+/8eD
+        c/+8blz/sFM8/6Q5IP+WKxL/iG5n/4SEhOKEhIRVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAISEhHGEhITiiG1o/4xWS/+PPy7/kykT/5Ue
+        BP+VHgT/kykT/48/Lv+MVkv/iG1o/4SEhOKEhIRxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACEhIQ4hISEjYSE
+        hKqEhITihISE/4SEhP+EhITihISEqoSEhI2EhIQ4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAA////////////wA///wAD//wAAP/4AAB/8AAAP+AAAB/AAAAPwAAAD4AA
+        AAeAAAAHAAAAAwAAAAMAAAADAAAAAwAAAAMAAAADAAAAAwAAAAMAAAADAAAAA4AAAAeAAAAHwAAAD8AA
+        AA/gAAAf8AAAP/gAAH/8AAD//wAD///AD/8oAAAAEAAAACAAAAABACAAAAAAAEAEAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAJQrDxyUKw9xlCsPqpQrD+KUKw/ilCsPqpQrD3GUKw8cAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAJQrD3GUKw//vloc/9RzI//qjCr/6owq/9RzI/++Whz/lCsP/5Qr
+        D3EAAAAAAAAAAAAAAAAAAAAAAAAAAJQrD6qnQBT/4X8n/+qKKv/qiir/6ooq/+qKKv/qiir/6ooq/+F/
+        J/+nQBT/lCsPqgAAAAAAAAAAAAAAAJQrD3GmPRT/4n0n/+J9J//ifSf/4n0n/+J9J//ifSf/4n0n/+J9
+        J//ifSf/4n0n/6Y9FP+UKw9xAAAAAJQrDxyTKw//xGMh/8pqIv/KaiL/1W8j/9tyJP/bciT/13Ak/8lp
+        Iv/JaSL/zWsj/9tyJP/UaiL/lCsP/5QrDxyUKw9xtEgY/9macv/08vD/9/f3/86/tv+4YCf/1Wgi/61+
+        YP/39/f/9/f3/9ORZv/VaCL/1Wgi/7RIGP+UKw+NlCsPqr9RHf/QYSL/03xM//bq4///////6uXi/6Rx
+        VP/49vX//////+K3n//QYSL/0GEi/9BhIv+/UR3/lCsPqpQrD+LIVyH/zVwj/81cI//MZDD/686///7+
+        /v///////////+XQxf/LXib/zVwj/81cI//NXCP/yFch/5QrD/+UKw/ixVUk/8pYJf/KWCX/ylgl/8VZ
+        Kf/l3Nj////////////Qv7j/sFMq/8pYJf/KWCX/ylgl/8VVJP+UKw//lCsPqrtMI//KWCn/ylgp/8lY
+        Kf+thnb///////v49//v3tf//////+vm5P+iWz7/ylgp/8pYKf+7TCP/lCsPqpQrD3GvQyD/ylkw/8pZ
+        MP+jZ1L//v7+//7+/v/WmYP/yV43/+jHuv/+/v7//Pv7/6d5af/EVy//r0Mg/5QrD42UKw8clCsP/8ha
+        Nf/LXjn/y4Bn/9CHbv/PhGv/zV45/81eOf/MXjr/z4Vs/9GLc//RinP/vWNF/5QrD/+UKw8cAAAAAJQr
+        D3GjOhz/0WZD/9FmQ//RZkP/0WZD/9FmQ//RZkP/0WZD/9FmQ//RZkP/0WZD/6M6HP+UKw9xAAAAAAAA
+        AAAAAAAAlCsPqqM7Hv/OaUn/03NU/9ZxUf/WcVH/1nFR/9ZxUf/WcVH/zmlJ/6M7Hv+UKw+qAAAAAAAA
+        AAAAAAAAAAAAAAAAAACUKw9xlCsP/7NQM//DYkX/1XVY/9V1WP/DYkX/s1Az/5QrD/+UKw9xAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAJQrDxyUKw9xlCsPqpQrD+KUKw/ilCsPqpQrD3GUKw8cAAAAAAAA
+        AAAAAAAAAAAAAPAPAADgBwAAwAMAAIABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAB
+        AADAAwAA4AcAAPAPAAA=
+</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Read and Accept the End User Agreement</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>AcceptEuaDialog</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>XenAdmin.Dialogs.XenDialogBase, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/XenAdmin/Dialogs/AcceptEuaDialog.resx
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.resx
@@ -244,7 +244,7 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="warningTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 381</value>
+    <value>6, 383</value>
   </data>
   <data name="warningTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
@@ -283,7 +283,7 @@
     <value>0, 0</value>
   </data>
   <data name="euaTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>580, 339</value>
+    <value>580, 341</value>
   </data>
   <data name="euaTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -313,7 +313,7 @@
     <value>6, 36</value>
   </data>
   <data name="euaPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>580, 339</value>
+    <value>580, 341</value>
   </data>
   <data name="euaPanel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -406,10 +406,10 @@
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonsFlowLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 431</value>
+    <value>6, 433</value>
   </data>
   <data name="buttonsFlowLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>580, 34</value>
+    <value>580, 32</value>
   </data>
   <data name="buttonsFlowLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -463,7 +463,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="infoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="warningTableLayoutPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="euaPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonsFlowLayoutPanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="Absolute,30,Percent,100,AutoSize,0,Absolute,40" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="infoLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="warningTableLayoutPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="euaPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonsFlowLayoutPanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="Absolute,30,Percent,100,AutoSize,0,Absolute,38" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/Dialogs/AcceptEuaDialog.resx
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.resx
@@ -121,16 +121,13 @@
   <data name="tableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
   <data name="tableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="infoLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="infoLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -473,9 +470,6 @@
   </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>612, 491</value>

--- a/XenAdmin/Dialogs/AcceptEuaDialog.zh-CN.resx
+++ b/XenAdmin/Dialogs/AcceptEuaDialog.zh-CN.resx
@@ -1,0 +1,483 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element msdata:IsDataSet="true" name="root">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+                <xsd:element minOccurs="0" msdata:Ordinal="2" name="comment" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute msdata:Ordinal="1" name="name" type="xsd:string" use="required"/>
+              <xsd:attribute msdata:Ordinal="3" name="type" type="xsd:string"/>
+              <xsd:attribute msdata:Ordinal="4" name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element minOccurs="0" msdata:Ordinal="1" name="value" type="xsd:string"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="OkButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+  <data name="OkButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="OkButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="OkButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>336, 207</value>
+  </data>
+  <data name="OkButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 12, 12</value>
+  </data>
+  <data name="OkButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+  <data name="OkButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="OkButton.Text" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="&gt;&gt;OkButton.Name" xml:space="preserve">
+    <value>OkButton</value>
+  </data>
+  <data name="&gt;&gt;OkButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OkButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;OkButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 138</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>15, 3, 12, 6</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LicenseDetailsTextBox.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Both</value>
+  </data>
+  <data name="LicenseDetailsTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>396, 60</value>
+  </data>
+  <data name="LicenseDetailsTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.Name" xml:space="preserve">
+    <value>LicenseDetailsTextBox</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;LicenseDetailsTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="linkLabel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="linkLabel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="linkLabel1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="linkLabel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 77</value>
+  </data>
+  <data name="linkLabel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 11, 14, 0</value>
+  </data>
+  <data name="linkLabel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 15</value>
+  </data>
+  <data name="linkLabel1.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="linkLabel1.Text" xml:space="preserve">
+    <value>查看法律声明</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Name" xml:space="preserve">
+    <value>linkLabel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 52</value>
+  </data>
+  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 3, 14, 5</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 15</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>版权所有</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="licenseDetailsLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="licenseDetailsLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="licenseDetailsLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="licenseDetailsLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 115</value>
+  </data>
+  <data name="licenseDetailsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 23, 14, 5</value>
+  </data>
+  <data name="licenseDetailsLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 15</value>
+  </data>
+  <data name="licenseDetailsLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="licenseDetailsLabel.Text" xml:space="preserve">
+    <value>{0} 授权给:</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.Name" xml:space="preserve">
+    <value>licenseDetailsLabel</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;licenseDetailsLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="VersionLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="VersionLabel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="VersionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="VersionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 23</value>
+  </data>
+  <data name="VersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>14, 23, 14, 5</value>
+  </data>
+  <data name="VersionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>45, 15</value>
+  </data>
+  <data name="VersionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="VersionLabel.Text" xml:space="preserve">
+    <value>版本</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.Name" xml:space="preserve">
+    <value>VersionLabel</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;VersionLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="showAgainCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showAgainCheckBox.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="showAgainCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="showAgainCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 210</value>
+  </data>
+  <data name="showAgainCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>12, 6, 3, 3</value>
+  </data>
+  <data name="showAgainCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 19</value>
+  </data>
+  <data name="showAgainCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="showAgainCheckBox.Text" xml:space="preserve">
+    <value>打开 {0} 时显示此对话框(&amp;S)</value>
+  </data>
+  <data name="showAgainCheckBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.Name" xml:space="preserve">
+    <value>showAgainCheckBox</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;showAgainCheckBox.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 79</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 242</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?>&lt;TableLayoutSettings>&lt;Controls>&lt;Control Name="LicenseDetailsTextBox" Row="5" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="OkButton" Row="6" RowSpan="1" Column="1" ColumnSpan="1" />&lt;Control Name="linkLabel1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" />&lt;Control Name="label2" Row="1" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="licenseDetailsLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="VersionLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="2" />&lt;Control Name="showAgainCheckBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" />&lt;/Controls>&lt;Columns Styles="Percent,100,AutoSize,20" />&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,20,AutoSize,0" />&lt;/TableLayoutSettings></value>
+  </data>
+  <data name="pictureBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="pictureBox1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="pictureBox1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 79</value>
+  </data>
+  <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>96, 96</value>
+  </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>423, 321</value>
+  </data>
+  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8pt</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>关于 {0}</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>AboutDialog</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>XenAdmin.Dialogs.XenDialogBase, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -226,8 +226,10 @@ namespace XenAdmin.Wizards.PatchingWizard
                     // this host is no longer live -> remove all previous problems regarding this host
                     Problem curProblem = problem;
                     ProblemsResolvedPreCheck.RemoveAll(p =>
-                        p.Check != null && p.Check.XenObject != null && curProblem.Check != null &&
-                        p.Check.XenObject.Equals(curProblem.Check.XenObject));
+                        p.Check?.XenObjects != null && p.Check.XenObjects.Count > 0 &&
+                        curProblem.Check?.XenObjects != null && curProblem.Check.XenObjects.Count > 0 &&
+                        p.Check.XenObjects.SequenceEqual(curProblem.Check.XenObjects)
+                    );
                 }
 
                 if (ProblemsResolvedPreCheck.Contains(problem))

--- a/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
+++ b/XenAdmin/Wizards/PatchingWizard/PatchingWizard_PrecheckPage.cs
@@ -230,10 +230,10 @@ namespace XenAdmin.Wizards.PatchingWizard
                 if (problem is HostNotLive)
                 {
                     // this host is no longer live -> remove all previous problems regarding this host
-                    Problem curProblem = problem;
+                    var curProblem = problem;
                     ProblemsResolvedPreCheck.RemoveAll(p =>
-                        p.Check?.XenObjects != null && p.Check.XenObjects.Count > 0 &&
-                        curProblem.Check?.XenObjects != null && curProblem.Check.XenObjects.Count > 0 &&
+                        p.Check?.XenObjects != null &&
+                        curProblem.Check?.XenObjects != null &&
                         p.Check.XenObjects.SequenceEqual(curProblem.Check.XenObjects)
                     );
                 }

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -168,7 +168,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 groups.Add(new CheckGroup(Messages.CHECKING_UPGRADE_HOTFIX_STATUS, hotfixChecks));
 
             // EUA check
-            var euaCheck = GetPermanentCheck("EUA", new UpgradeRequiresEua(hostsToUpgrade, InstallMethodConfig));
+            var euaCheck = GetPermanentCheck("EUA", new UpgradeRequiresEua(this, hostsToUpgrade, InstallMethodConfig));
             var euaChecks = new List<Check> { euaCheck };
             groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
 

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -45,8 +45,6 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 {
     public partial class RollingUpgradeWizardPrecheckPage : PatchingWizard_PrecheckPage
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
-
         public RollingUpgradeWizardPrecheckPage()
         {
             InitializeComponent();
@@ -170,24 +168,9 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 groups.Add(new CheckGroup(Messages.CHECKING_UPGRADE_HOTFIX_STATUS, hotfixChecks));
 
             // EUA check
-            if (InstallMethodConfig != null && InstallMethodConfig.TryGetValue("url", out var uriText))
-            {
-                Uri targetUri = null;
-                try
-                {
-                    targetUri = new Uri(uriText);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex);
-                }
-
-                var euaCheck = GetPermanentCheck("EUA", new UpgradeRequiresEua(hostsToUpgrade, targetUri));
-
-                var euaChecks = new List<Check> { euaCheck };
-
-                groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
-            }
+            var euaCheck = GetPermanentCheck("EUA", new UpgradeRequiresEua(hostsToUpgrade, InstallMethodConfig));
+            var euaChecks = new List<Check> { euaCheck };
+            groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
 
             //SafeToUpgrade- and PrepareToUpgrade- checks - in automatic mode only, for hosts that will be upgraded
             if (!ManualUpgrade)

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -169,6 +169,26 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             if (hotfixChecks.Count > 0)
                 groups.Add(new CheckGroup(Messages.CHECKING_UPGRADE_HOTFIX_STATUS, hotfixChecks));
 
+            // EUA check
+            if (InstallMethodConfig != null && InstallMethodConfig.TryGetValue("url", out var uriText))
+            {
+                Uri targetUri = null;
+                try
+                {
+                    targetUri = new Uri(uriText);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex);
+                }
+
+                var euaCheck = GetPermanentCheck("EUA", new UpgradeRequiresEua(hostsToUpgrade, targetUri));
+
+                var euaChecks = new List<Check> { euaCheck };
+
+                groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
+            }
+
             //SafeToUpgrade- and PrepareToUpgrade- checks - in automatic mode only, for hosts that will be upgraded
             if (!ManualUpgrade)
             {
@@ -296,27 +316,6 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
             if (deprecatedSRsChecks.Count > 0)
                 groups.Add(new CheckGroup(Messages.CHECKING_DEPRECATED_SRS, deprecatedSRsChecks));
-
-
-            // EUA check
-            if (InstallMethodConfig != null && InstallMethodConfig.TryGetValue("url", out var uriText))
-            {
-                Uri targetUri = null;
-                try
-                {
-                    targetUri = new Uri(uriText);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex);
-                }
-
-                var euaCheck = GetPermanentCheck("EUA", new UpgradeRequiresEua(hostsToUpgrade, targetUri));
-
-                var euaChecks = new List<Check> { euaCheck };
-
-                groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
-            }
 
             return groups;
         }

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -167,6 +167,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             if (hotfixChecks.Count > 0)
                 groups.Add(new CheckGroup(Messages.CHECKING_UPGRADE_HOTFIX_STATUS, hotfixChecks));
 
+            //Checks used in automatic mode only, for hosts that will be upgraded
             if (!ManualUpgrade)
             {
                 // EUA check
@@ -174,11 +175,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 new UpgradeRequiresEua(this, hostsToUpgrade, InstallMethodConfig));
                 var euaChecks = new List<Check> { euaCheck };
                 groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
-            } 
 
-            //SafeToUpgrade- and PrepareToUpgrade- checks - in automatic mode only, for hosts that will be upgraded
-            if (!ManualUpgrade)
-            {
                 var safeToUpgradeChecks = (from Host host in hostsToUpgrade
                     let check = new SafeToUpgradeCheck(host, InstallMethodConfig)
                     where check.CanRun()

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -167,10 +167,14 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             if (hotfixChecks.Count > 0)
                 groups.Add(new CheckGroup(Messages.CHECKING_UPGRADE_HOTFIX_STATUS, hotfixChecks));
 
-            // EUA check
-            var euaCheck = GetPermanentCheck("EUA", new UpgradeRequiresEua(this, hostsToUpgrade, InstallMethodConfig));
-            var euaChecks = new List<Check> { euaCheck };
-            groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
+            if (!ManualUpgrade)
+            {
+                // EUA check
+                var euaCheck = GetPermanentCheck("EUA",
+                new UpgradeRequiresEua(this, hostsToUpgrade, InstallMethodConfig));
+                var euaChecks = new List<Check> { euaCheck };
+                groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
+            } 
 
             //SafeToUpgrade- and PrepareToUpgrade- checks - in automatic mode only, for hosts that will be upgraded
             if (!ManualUpgrade)

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Diagnostics\Checks\DiskSpaceForBatchUpdatesCheck.cs" />
     <Compile Include="Diagnostics\Checks\HealthCheckServiceCheck.cs" />
     <Compile Include="Diagnostics\Checks\PoolHasDeprecatedSrsCheck.cs" />
+    <Compile Include="Diagnostics\Checks\UpgradeRequiresEua.cs" />
     <Compile Include="Diagnostics\Checks\PowerOniLoCheck.cs" />
     <Compile Include="Diagnostics\Checks\PoolLegacySslCheck.cs" />
     <Compile Include="Diagnostics\Checks\PrepareToUpgradeCheck.cs" />
@@ -271,8 +272,15 @@
     <Compile Include="Diagnostics\Problems\PoolProblem\NotLicensedForAutomatedUpdatesWarning.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\ServerSelectionProblem.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\VSwitchControllerProblem.cs" />
+    <Compile Include="Diagnostics\Problems\UtilityProblem\EuaNotAcceptedProblem.cs" />
     <Compile Include="Diagnostics\Problems\UtilityProblem\CfuNotAvailableProblem.cs" />
     <Compile Include="Diagnostics\Problems\VMProblem\InvalidVCPUConfiguration.cs" />
+    <Compile Include="Dialogs\AcceptEuaDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Dialogs\AcceptEuaDialog.Designer.cs">
+      <DependentUpon>AcceptEuaDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\AddVGPUDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1616,6 +1624,16 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\XenSearch\QueryPanel.zh-CN.resx">
       <DependentUpon>QueryPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\AcceptEuaDialog.ja.resx">
+      <DependentUpon>AcceptEuaDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\AcceptEuaDialog.resx">
+      <DependentUpon>AcceptEuaDialog.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\AcceptEuaDialog.zh-CN.resx">
+      <DependentUpon>AcceptEuaDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\AddVGPUDialog.ja.resx">
       <DependentUpon>AddVGPUDialog.cs</DependentUpon>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -272,6 +272,7 @@
     <Compile Include="Diagnostics\Problems\PoolProblem\NotLicensedForAutomatedUpdatesWarning.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\ServerSelectionProblem.cs" />
     <Compile Include="Diagnostics\Problems\PoolProblem\VSwitchControllerProblem.cs" />
+    <Compile Include="Diagnostics\Problems\UtilityProblem\EuaNotFoundProblem.cs" />
     <Compile Include="Diagnostics\Problems\UtilityProblem\EuaNotAcceptedProblem.cs" />
     <Compile Include="Diagnostics\Problems\UtilityProblem\CfuNotAvailableProblem.cs" />
     <Compile Include="Diagnostics\Problems\VMProblem\InvalidVCPUConfiguration.cs" />

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -16305,15 +16305,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} could not fetch an End User Agreement (EUA), but expected one. Please ensure that the selected source URI is valid and that all the pool coordinators can access its contents..
-        /// </summary>
-        public static string EUA_NOT_FOUND_PROBLEM_MORE_INFO {
-            get {
-                return ResourceManager.GetString("EUA_NOT_FOUND_PROBLEM_MORE_INFO", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to EULA.
         /// </summary>
         public static string EULA {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -61,6 +61,60 @@ namespace XenAdmin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} encountered an issue while trying to fetch the EUA. Ensure that the selected source URI is valid and that all the pool coordinators can access its contents..
+        /// </summary>
+        public static string ACCEPT_EUA_CANNOT_FETCH {
+            get {
+                return ResourceManager.GetString("ACCEPT_EUA_CANNOT_FETCH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Checking for the presence of an EUA.
+        /// </summary>
+        public static string ACCEPT_EUA_CHECK_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("ACCEPT_EUA_CHECK_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Looking for an EUA to be accepted.
+        /// </summary>
+        public static string ACCEPT_EUA_CHECK_GROUP_NAME {
+            get {
+                return ResourceManager.GetString("ACCEPT_EUA_CHECK_GROUP_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More than one EUA was fetched. Please ensure you have read all of them before accepting..
+        /// </summary>
+        public static string ACCEPT_EUA_MORE_THAN_ONE_FOUND {
+            get {
+                return ResourceManager.GetString("ACCEPT_EUA_MORE_THAN_ONE_FOUND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You must accept the End User Agreement (EUA).
+        /// </summary>
+        public static string ACCEPT_EUA_PROBLEM_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("ACCEPT_EUA_PROBLEM_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to See EUA....
+        /// </summary>
+        public static string ACCEPT_EUA_PROBLEM_HELP_MESSAGE {
+            get {
+                return ResourceManager.GetString("ACCEPT_EUA_PROBLEM_HELP_MESSAGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Activating virtual disks....
         /// </summary>
         public static string ACTION_ACTIVATING_MULTIPLE_VDIS_STATUS {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -61,15 +61,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} encountered an issue while trying to fetch the EUA. Ensure that the selected source URI is valid and that all the pool coordinators can access its contents..
-        /// </summary>
-        public static string ACCEPT_EUA_CANNOT_FETCH {
-            get {
-                return ResourceManager.GetString("ACCEPT_EUA_CANNOT_FETCH", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Checking for the presence of an EUA.
         /// </summary>
         public static string ACCEPT_EUA_CHECK_DESCRIPTION {
@@ -16301,6 +16292,24 @@ namespace XenAdmin {
         public static string ERROR_VM_NOT_HALTED {
             get {
                 return ResourceManager.GetString("ERROR_VM_NOT_HALTED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} encountered an issue while trying to fetch the EUA..
+        /// </summary>
+        public static string EUA_NOT_FOUND_PROBLEM_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("EUA_NOT_FOUND_PROBLEM_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} could not fetch an End User Agreement (EUA), but expected one. Please ensure that the selected source URI is valid and that all the pool coordinators can access its contents..
+        /// </summary>
+        public static string EUA_NOT_FOUND_PROBLEM_MORE_INFO {
+            get {
+                return ResourceManager.GetString("EUA_NOT_FOUND_PROBLEM_MORE_INFO", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -5729,9 +5729,6 @@ Would you like to eject these ISOs before continuing?</value>
   <data name="EUA_NOT_FOUND_PROBLEM_DESCRIPTION" xml:space="preserve">
     <value>{0} encountered an issue while trying to fetch the EUA.</value>
   </data>
-  <data name="EUA_NOT_FOUND_PROBLEM_MORE_INFO" xml:space="preserve">
-    <value>{0} could not fetch an End User Agreement (EUA), but expected one. Please ensure that the selected source URI is valid and that all the pool coordinators can access its contents.</value>
-  </data>
   <data name="EULA" xml:space="preserve">
     <value>EULA</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ACCEPT_EUA_CANNOT_FETCH" xml:space="preserve">
-    <value>{0} encountered an issue while trying to fetch the EUA. Ensure that the selected source URI is valid and that all the pool coordinators can access its contents.</value>
-  </data>
   <data name="ACCEPT_EUA_CHECK_DESCRIPTION" xml:space="preserve">
     <value>Checking for the presence of an EUA</value>
   </data>
@@ -5728,6 +5725,12 @@ Would you like to eject these ISOs before continuing?</value>
   </data>
   <data name="ERROR_VM_NOT_HALTED" xml:space="preserve">
     <value>Please shut down or suspend VM '{0}' before exporting.</value>
+  </data>
+  <data name="EUA_NOT_FOUND_PROBLEM_DESCRIPTION" xml:space="preserve">
+    <value>{0} encountered an issue while trying to fetch the EUA.</value>
+  </data>
+  <data name="EUA_NOT_FOUND_PROBLEM_MORE_INFO" xml:space="preserve">
+    <value>{0} could not fetch an End User Agreement (EUA), but expected one. Please ensure that the selected source URI is valid and that all the pool coordinators can access its contents.</value>
   </data>
   <data name="EULA" xml:space="preserve">
     <value>EULA</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -117,6 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ACCEPT_EUA_CANNOT_FETCH" xml:space="preserve">
+    <value>{0} encountered an issue while trying to fetch the EUA. Ensure that the selected source URI is valid and that all the pool coordinators can access its contents.</value>
+  </data>
+  <data name="ACCEPT_EUA_CHECK_DESCRIPTION" xml:space="preserve">
+    <value>Checking for the presence of an EUA</value>
+  </data>
+  <data name="ACCEPT_EUA_CHECK_GROUP_NAME" xml:space="preserve">
+    <value>Looking for an EUA to be accepted</value>
+  </data>
+  <data name="ACCEPT_EUA_MORE_THAN_ONE_FOUND" xml:space="preserve">
+    <value>More than one EUA was fetched. Please ensure you have read all of them before accepting.</value>
+  </data>
+  <data name="ACCEPT_EUA_PROBLEM_DESCRIPTION" xml:space="preserve">
+    <value>You must accept the End User Agreement (EUA)</value>
+  </data>
+  <data name="ACCEPT_EUA_PROBLEM_HELP_MESSAGE" xml:space="preserve">
+    <value>See EUA...</value>
+  </data>
   <data name="ACTION_ACTIVATING_MULTIPLE_VDIS_STATUS" xml:space="preserve">
     <value>Activating virtual disks...</value>
   </data>

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -28,6 +28,7 @@
  * SUCH DAMAGE.
  */
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -1579,6 +1580,34 @@ namespace XenAdmin.Core
             }
 
             return queryString;
+        }
+
+        public static bool TryLoadHostEua(Host host, Uri targetUri, out string eua)
+        {
+            eua = null;
+            if (host == null || targetUri == null)
+            {
+                return false;
+            }
+            var args = new Dictionary<string, string>
+            {
+                { "url", targetUri.ToString()}
+            };
+
+            try
+            {
+                var result = Host.call_plugin(host.Connection.Session, host.opaque_ref, "prepare_host_upgrade.py", "getEUA", args);
+                var jsonPayloadDefinition = new { eua = string.Empty };
+                var parsedPayload = JsonConvert.DeserializeAnonymousType(result, jsonPayloadDefinition);
+
+                eua = parsedPayload.eua;
+            }
+            catch (Exception ex)
+            {
+                log.Error(ex);
+            }
+
+            return eua != null;
         }
     }
 }

--- a/scripts/hotfix-map.json
+++ b/scripts/hotfix-map.json
@@ -1,7 +1,7 @@
 {
   "files": [
     {
-      "pattern": "builds/xs/hotfixes/trunk/RPU005/4.0/RPU005.iso",
+      "pattern": "builds/xs/hotfixes/trunk/RPU005/5.0/RPU005.iso",
       "target": "xenadmin.git/Branding/Hotfixes/RPU005.iso",
       "flat": "true"
     }


### PR DESCRIPTION
We only expect Post82X hosts to have this capability. We will be adding a blocking precheck to ensure that all hosts can fetch the EUA. For testing, just ensure you're using the latest XenServer version. Feel free to ping me for help on how to test this locally. Please read the text below to get an understanding of why there are so many changes to `Check`s.

__________________________________

As part of this PR, I had to introduce the concept of a "permanent" check.

> Why can't we just add a normal check?

`Check` instances are created when the prechecks page is created or when the user hits on _Check again_ or _Resolve all_. This is usually fine because the `Check` objects look for changes in the properties or configuration of its associated `IXenObject`s to see if the `Problem` related to the `Check` has been resolved or not; e.g.: if a VM was running, it is simple to check that the VM is in the correct power state after running the action that resolves the problem.

However, we cannot use this mechanism to check if the user has accepted the EUA or not. We could technically update the pool's `gui-config` property, but XenCenter is not required to change properties of the pool when the user accepts the EUA and changing this property would introduce more issues.

> How does this PR address this issue?

We needed a way to check if the `Problem` had been solved by using the application's memory. To achieve this, some `Check` objects had to be kept across page reloads etc.. These are the _permanent checks_. They are saved in memory and use the new `check.Completed` property to check if their `Problem` has been resolved. They rely on the `Problem` instance to update the `Check`'s status.

To achieve this, `Check` and `Problem` objects related to permanent checks must override `Equals` and `GetHashCode` if they have custom properties (e.g. the `_targetUri` for the EUA `Check` and associated `Problem`). This is because the current logic only checks for changes in the `IXenObject`s related to the `Check`. If one were to not override `Equals`/`GetHashCode`, changes to the `_targetUri` property would not be kept, because XenCenter cannot know that the permanent check needs to be re-generated.



Hopefully we won't need to add many more of these special checks, but just in case I have added docs, so those + the usage in `UpgradeRequiresEua.cs` and `EuaNotAcceptedProblem` should help devs add similar `Check`s.