### PR TITLE
CA-376887: Fix threading management for `ArchiveMaintainer`

### DIFF
--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -533,6 +533,24 @@ namespace XenAdmin.Controls.CustomDataGraph
             }
         }
 
+
+        public static ArchiveInterval NextArchiveDown(ArchiveInterval current)
+        {
+            switch (current)
+            {
+                case ArchiveInterval.FiveSecond:
+                    return ArchiveInterval.None;
+                case ArchiveInterval.OneMinute:
+                    return ArchiveInterval.FiveSecond;
+                case ArchiveInterval.OneHour:
+                    return ArchiveInterval.OneMinute;
+                case ArchiveInterval.OneDay:
+                    return ArchiveInterval.OneHour;
+                default:
+                    return ArchiveInterval.None;
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -586,21 +604,5 @@ namespace XenAdmin.Controls.CustomDataGraph
 
         #endregion
 
-        public static ArchiveInterval NextArchiveDown(ArchiveInterval current)
-        {
-            switch (current)
-            {
-                case ArchiveInterval.FiveSecond:
-                    return ArchiveInterval.None;
-                case ArchiveInterval.OneMinute:
-                    return ArchiveInterval.FiveSecond;
-                case ArchiveInterval.OneHour:
-                    return ArchiveInterval.OneMinute;
-                case ArchiveInterval.OneDay:
-                    return ArchiveInterval.OneHour;
-                default:
-                    return ArchiveInterval.None;
-            }
-        }
     }
 }

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -67,11 +67,6 @@ namespace XenAdmin.Controls.CustomDataGraph
         private const int HOURS_IN_ONE_WEEK = 168;
         private const int DAYS_IN_ONE_YEAR = 366;
 
-        private static readonly TimeSpan FiveSeconds = TimeSpan.FromSeconds(5);
-        private static readonly TimeSpan OneMinute = TimeSpan.FromMinutes(1);
-        private static readonly TimeSpan OneHour = TimeSpan.FromHours(1);
-        private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
-
         private const int SLEEP_TIME = 5000;
 
         private static readonly log4net.ILog Log =
@@ -126,7 +121,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
             while (!_cancellationTokenSource.Token.IsCancellationRequested)
             {
-                if (serverWas - LastFiveSecondCollection > FiveSeconds)
+                if (serverWas - LastFiveSecondCollection > TimeSpan.FromSeconds(5))
                 {
                     Get(ArchiveInterval.FiveSecond, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
@@ -137,7 +132,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                     Archives[ArchiveInterval.FiveSecond].Load(_setsAdded);
                 }
 
-                if (serverWas - LastOneMinuteCollection > OneMinute)
+                if (serverWas - LastOneMinuteCollection > TimeSpan.FromMinutes(1))
                 {
                     Get(ArchiveInterval.OneMinute, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
@@ -148,7 +143,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                     Archives[ArchiveInterval.OneMinute].Load(_setsAdded);
                 }
 
-                if (serverWas - LastOneHourCollection > OneHour)
+                if (serverWas - LastOneHourCollection > TimeSpan.FromHours(1))
                 {
                     Get(ArchiveInterval.OneHour, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
@@ -159,7 +154,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                     Archives[ArchiveInterval.OneHour].Load(_setsAdded);
                 }
 
-                if (serverWas - LastOneDayCollection > OneDay)
+                if (serverWas - LastOneDayCollection > TimeSpan.FromDays(1))
                 {
                     Get(ArchiveInterval.OneDay, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -489,11 +489,6 @@ namespace XenAdmin.Controls.CustomDataGraph
 
         public void Stop()
         {
-            _cancellationTokenSource.Cancel();
-        }
-
-        public void Pause()
-        {
            _cancellationTokenSource.Cancel();
         }
 

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -127,9 +127,9 @@ namespace XenAdmin.Controls.CustomDataGraph
             {
                 Program.AssertOnEventThread();
 
-                string oldref = _xenObject == null ? "" : _xenObject.opaque_ref;
+                var oldref = _xenObject == null ? "" : _xenObject.opaque_ref;
                 _xenObject = value;
-                string newref = _xenObject == null ? "" : _xenObject.opaque_ref;
+                var newref = _xenObject == null ? "" : _xenObject.opaque_ref;
                 FirstTime = FirstTime || newref != oldref;
             }
         }
@@ -167,9 +167,9 @@ namespace XenAdmin.Controls.CustomDataGraph
         {
             while (_runThread)
             {
-                IXenObject xenObject = XenObject;
+                var xenObject = XenObject;
 
-                DateTime serverWas = ServerNow; // get time before updating so we don't miss any 5 second updates if getting the past data
+                var serverWas = ServerNow; // get time before updating so we don't miss any 5 second updates if getting the past data
 
                 if (FirstTime)
                 {
@@ -187,7 +187,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
                     _dataSources.Clear();
 
-                    foreach (DataArchive a in Archives.Values)
+                    foreach (var a in Archives.Values)
                         a.ClearSets();
 
                     LoadingInitialData = true;
@@ -267,9 +267,9 @@ namespace XenAdmin.Controls.CustomDataGraph
                 if (uri == null)
                     return;
 
-                using (Stream httpstream = HTTPHelper.GET(uri, xenObject.Connection, true))
+                using (var httpstream = HTTPHelper.GET(uri, xenObject.Connection, true))
                 {
-                    using (XmlReader reader = XmlReader.Create(httpstream))
+                    using (var reader = XmlReader.Create(httpstream))
                     {
                         _setsAdded = new List<DataSet>();
                         while (reader.Read())
@@ -336,7 +336,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
         private static Uri BuildUri(Host host, string path, string query)
         {
-            UriBuilder builder = new UriBuilder
+            var builder = new UriBuilder
             {
                 Scheme = host.Connection.UriScheme,
                 Host = host.address,
@@ -431,11 +431,11 @@ namespace XenAdmin.Controls.CustomDataGraph
                         return;
                     }
 
-                    ArchiveInterval i = GetArchiveIntervalFromFiveSecs(_currentInterval);
+                    var i = GetArchiveIntervalFromFiveSecs(_currentInterval);
                     if (i != ArchiveInterval.None)
                         Archives[i].CopyLoad(_setsAdded, _dataSources);
 
-                    foreach (DataSet set in _setsAdded)
+                    foreach (var set in _setsAdded)
                         set.Points.Clear();
                     _bailOut = false;
                 }
@@ -446,25 +446,25 @@ namespace XenAdmin.Controls.CustomDataGraph
 
             if (_lastNode == "name")
             {
-                string str = reader.ReadContentAsString();
+                var str = reader.ReadContentAsString();
                 _setsAdded.Add(new DataSet(xmo, false, str, _dataSources));
             }
             else if (_lastNode == "step")
             {
-                string str = reader.ReadContentAsString();
+                var str = reader.ReadContentAsString();
                 _stepSize = long.Parse(str, CultureInfo.InvariantCulture);
             }
             else if (_lastNode == "lastupdate")
             {
-                string str = reader.ReadContentAsString();
+                var str = reader.ReadContentAsString();
                 _endTime = long.Parse(str, CultureInfo.InvariantCulture);
             }
             else if (_lastNode == "pdp_per_row")
             {
-                string str = reader.ReadContentAsString();
+                var str = reader.ReadContentAsString();
                 _currentInterval = long.Parse(str, CultureInfo.InvariantCulture);
 
-                long modInterval = _endTime % (_stepSize * _currentInterval);
+                var modInterval = _endTime % (_stepSize * _currentInterval);
                 long stepCount = _currentInterval == 1 ? FIVE_SECONDS_IN_TEN_MINUTES // 120 * 5 seconds in 10 minutes
                                : _currentInterval == 12 ? MINUTES_IN_TWO_HOURS   // 120 minutes in 2 hours
                                : _currentInterval == 720 ? HOURS_IN_ONE_WEEK     // 168 hours in a week
@@ -474,7 +474,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             }
             else if (_lastNode == "cf")
             {
-                string str = reader.ReadContentAsString();
+                var str = reader.ReadContentAsString();
                 if (str != "AVERAGE")
                     _bailOut = true;
             }
@@ -483,8 +483,8 @@ namespace XenAdmin.Controls.CustomDataGraph
                 if (_bailOut || _setsAdded.Count <= _valueCount)
                     return;
 
-                DataSet set = _setsAdded[_valueCount];
-                string str = reader.ReadContentAsString();
+                var set = _setsAdded[_valueCount];
+                var str = reader.ReadContentAsString();
                 set.AddPoint(str, _currentTime, _setsAdded, _dataSources);
                 _valueCount++;
             }
@@ -503,21 +503,21 @@ namespace XenAdmin.Controls.CustomDataGraph
             if (reader.NodeType != XmlNodeType.Text) return;
             if (_lastNode == "entry")
             {
-                string str = reader.ReadContentAsString();
+                var str = reader.ReadContentAsString();
                 DataSet set = null;
 
-                if (DataSet.ParseId(str, out string objType, out string objUuid, out string dataSourceName))
+                if (DataSet.ParseId(str, out var objType, out var objUuid, out var dataSourceName))
                 {
                     if (objType == "host")
                     {
-                        Host host = xo.Connection.Cache.Hosts.FirstOrDefault(h => h.uuid == objUuid);
+                        var host = xo.Connection.Cache.Hosts.FirstOrDefault(h => h.uuid == objUuid);
                         if (host != null)
                             set = new DataSet(host, (xo as Host)?.uuid != objUuid, dataSourceName, _dataSources);
                     }
 
                     if (objType == "vm")
                     {
-                        VM vm = xo.Connection.Cache.VMs.FirstOrDefault(v => v.uuid == objUuid);
+                        var vm = xo.Connection.Cache.VMs.FirstOrDefault(v => v.uuid == objUuid);
                         if (vm != null)
                             set = new DataSet(vm, (xo as VM)?.uuid != objUuid, dataSourceName, _dataSources);
                     }
@@ -530,14 +530,14 @@ namespace XenAdmin.Controls.CustomDataGraph
             }
             else if (_lastNode == "t")
             {
-                string str = reader.ReadContentAsString();
+                var str = reader.ReadContentAsString();
                 _currentTime = new DateTime((Convert.ToInt64(str) * TimeSpan.TicksPerSecond) + Util.TicksBefore1970).ToLocalTime().Ticks;
             }
             else if (_lastNode == "v")
             {
                 if (_setsAdded.Count <= _valueCount) return;
-                DataSet set = _setsAdded[_valueCount];
-                string str = reader.ReadContentAsString();
+                var set = _setsAdded[_valueCount];
+                var str = reader.ReadContentAsString();
                 set.AddPoint(str, _currentTime, _setsAdded, _dataSources);
                 _valueCount++;
             }

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -52,41 +52,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
     public class ArchiveMaintainer
     {
-        private const long TICKS_IN_ONE_SECOND = 10000000;
-        private const long TICKS_IN_FIVE_SECONDS = 50000000;
-        private const long TICKS_IN_ONE_MINUTE = 600000000;
-        internal const long TICKS_IN_TEN_MINUTES = 6000000000;
-        private const long TICKS_IN_ONE_HOUR = 36000000000;
-        internal const long TICKS_IN_TWO_HOURS = 72000000000;
-        private const long TICKS_IN_ONE_DAY = 864000000000;
-        internal const long TICKS_IN_SEVEN_DAYS = 6048000000000;
-        internal const long TICKS_IN_ONE_YEAR = 316224000000000;
-
-        private const int FIVE_SECONDS_IN_TEN_MINUTES = 120;
-        private const int MINUTES_IN_TWO_HOURS = 120;
-        private const int HOURS_IN_ONE_WEEK = 168;
-        private const int DAYS_IN_ONE_YEAR = 366;
-
-        private const int SLEEP_TIME = 5000;
-
-        private static readonly log4net.ILog Log =
-            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
-
-        internal event Action ArchivesUpdated;
-
-        internal readonly Dictionary<ArchiveInterval, DataArchive> Archives = new Dictionary<ArchiveInterval, DataArchive>();
-
-        private CancellationTokenSource _cancellationTokenSource;
-        private List<DataSet> _setsAdded;
-        private List<Data_source> _dataSources = new List<Data_source>();
-
-        private long _endTime;
-        private bool _bailOut;
-        private long _currentInterval;
-        private long _stepSize;
-        private long _currentTime;
-        private int _valueCount;
-        private string _lastNode = string.Empty;
+        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
 
         public IXenObject XenObject { get; }
 
@@ -95,13 +61,41 @@ namespace XenAdmin.Controls.CustomDataGraph
         public DateTime LastOneHourCollection = DateTime.MinValue;
         public DateTime LastOneDayCollection = DateTime.MinValue;
 
+        public DateTime GraphNow => DateTime.Now - (ClientServerOffset + TimeSpan.FromSeconds(15));
+        public TimeSpan ClientServerOffset => XenObject?.Connection.ServerTimeOffset ?? TimeSpan.Zero;
         public bool LoadingInitialData;
 
+        internal const long TICKS_IN_ONE_SECOND = 10000000;
+        internal const long TICKS_IN_FIVE_SECONDS = 50000000;
+        internal const long TICKS_IN_ONE_MINUTE = 600000000;
+        internal const long TICKS_IN_TEN_MINUTES = 6000000000;
+        internal const long TICKS_IN_ONE_HOUR = 36000000000;
+        internal const long TICKS_IN_TWO_HOURS = 72000000000;
+        internal const long TICKS_IN_ONE_DAY = 864000000000;
+        internal const long TICKS_IN_SEVEN_DAYS = 6048000000000;
+        internal const long TICKS_IN_ONE_YEAR = 316224000000000;
+
+        internal const int FIVE_SECONDS_IN_TEN_MINUTES = 120;
+        internal const int MINUTES_IN_TWO_HOURS = 120;
+        internal const int HOURS_IN_ONE_WEEK = 168;
+        internal const int DAYS_IN_ONE_YEAR = 366;
+
+        internal event Action ArchivesUpdated;
+        internal readonly Dictionary<ArchiveInterval, DataArchive> Archives = new Dictionary<ArchiveInterval, DataArchive>();
+
+        private const int SLEEP_TIME = 5000;
+
+        private CancellationTokenSource _cancellationTokenSource;
+        private List<DataSet> _setsAdded;
+        private List<Data_source> _dataSources = new List<Data_source>();
         private DateTime ServerNow => DateTime.UtcNow.Subtract(ClientServerOffset);
-
-        public DateTime GraphNow => DateTime.Now - (ClientServerOffset + TimeSpan.FromSeconds(15));
-
-        public TimeSpan ClientServerOffset => XenObject?.Connection.ServerTimeOffset ?? TimeSpan.Zero;
+        private long _endTime;
+        private bool _bailOut;
+        private long _currentInterval;
+        private long _stepSize;
+        private long _currentTime;
+        private int _valueCount;
+        private string _lastNode = string.Empty;
 
         public ArchiveMaintainer(IXenObject xenObject)
         {

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -77,45 +77,18 @@ namespace XenAdmin.Controls.CustomDataGraph
         private static readonly log4net.ILog Log =
             log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        /// <summary>
-        /// Fired (on a background thread) when new performance data are received from the server
-        /// </summary>
         internal event Action ArchivesUpdated;
 
         internal readonly Dictionary<ArchiveInterval, DataArchive> Archives =
             new Dictionary<ArchiveInterval, DataArchive>();
 
-        /// <summary>
-        /// for pausing the retrieval of updates
-        /// call Monitor.PulseAll(UpdateMonitor) on resume
-        /// </summary>
         private readonly object _updateMonitor = new object();
-
-        /// <summary>
-        /// for waiting between updates
-        /// the Monitor has a timeout too so we either wait for 'SleepTime' or a pulseall on WaitUpdates
-        /// </summary>
         private readonly object _waitUpdates = new object();
-
         private Thread _updaterThread;
-
-        /// <summary>
-        ///  if true UpdaterThread will keep looping
-        /// </summary>
         private bool _runThread;
-
-        /// <summary>
-        /// Whether the thread is started or not
-        /// </summary>
         private bool _threadRunning;
-
-        /// <summary>
-        /// collection for holding updates whil
-        /// </summary>
         private List<DataSet> _setsAdded;
-
         private List<Data_source> _dataSources = new List<Data_source>();
-
         private IXenObject _xenObject;
 
         private long _endTime;
@@ -299,6 +272,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         }
 
         #region Uri generators
+
         private Uri UpdateUri(ArchiveInterval interval, IXenObject xo)
         {
             var sessionRef = xo?.Connection?.Session?.opaque_ref;
@@ -357,10 +331,10 @@ namespace XenAdmin.Controls.CustomDataGraph
             };
             return builder.Uri;
         }
+
         #endregion
 
         #region Data fetcher methods
-
 
         private void RRD_Full_InspectCurrentNode(XmlReader reader, IXenObject xmo)
         {
@@ -501,11 +475,10 @@ namespace XenAdmin.Controls.CustomDataGraph
             }
         }
 
-
         #endregion
 
         #region Actions
-        
+
         public void Start()
         {
             if (_threadRunning)
@@ -522,7 +495,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                     Monitor.PulseAll(_waitUpdates);
             }
         }
-        
+
         public void Stop()
         {
             _threadRunning = false;
@@ -533,7 +506,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             lock (_updateMonitor)
                 Monitor.PulseAll(_updateMonitor);
         }
-        
+
         public void Pause()
         {
             _threadRunning = false; // stop updating
@@ -544,7 +517,6 @@ namespace XenAdmin.Controls.CustomDataGraph
         #endregion
 
         #region Public static methods
-
 
         public static long ToTicks(ArchiveInterval interval)
         {
@@ -560,7 +532,6 @@ namespace XenAdmin.Controls.CustomDataGraph
                     return TICKS_IN_ONE_DAY;
             }
         }
-
 
         #endregion
 
@@ -596,8 +567,24 @@ namespace XenAdmin.Controls.CustomDataGraph
             return 0;
         }
 
-        #endregion
+        private static ArchiveInterval GetArchiveIntervalFromFiveSecs(long v)
+        {
+            switch (v)
+            {
+                case 1:
+                    return ArchiveInterval.FiveSecond;
+                case 12:
+                    return ArchiveInterval.OneMinute;
+                case 720:
+                    return ArchiveInterval.OneHour;
+                case 17280:
+                    return ArchiveInterval.OneDay;
+                default:
+                    return ArchiveInterval.None;
+            }
+        }
 
+        #endregion
 
         public static ArchiveInterval NextArchiveDown(ArchiveInterval current)
         {

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -79,8 +79,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
         internal event Action ArchivesUpdated;
 
-        internal readonly Dictionary<ArchiveInterval, DataArchive> Archives =
-            new Dictionary<ArchiveInterval, DataArchive>();
+        internal readonly Dictionary<ArchiveInterval, DataArchive> Archives = new Dictionary<ArchiveInterval, DataArchive>();
 
         private CancellationTokenSource _cancellationTokenSource;
         private List<DataSet> _setsAdded;
@@ -101,7 +100,6 @@ namespace XenAdmin.Controls.CustomDataGraph
         public DateTime LastOneHourCollection = DateTime.MinValue;
         public DateTime LastOneDayCollection = DateTime.MinValue;
 
-        public bool FirstTime = true;
         public bool LoadingInitialData;
 
         private DateTime ServerNow => DateTime.UtcNow.Subtract(ClientServerOffset);

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -543,6 +543,8 @@ namespace XenAdmin.Controls.CustomDataGraph
             }
         }
 
+        #region Actions
+
         /// <summary>
         /// run this to start or resume getting updates
         /// </summary>
@@ -586,6 +588,9 @@ namespace XenAdmin.Controls.CustomDataGraph
             lock (_waitUpdates) // clear the first Monitor.Wait so we pause the thread instantly.
                 Monitor.PulseAll(_waitUpdates);
         }
+
+        #endregion
+
 
         public static ArchiveInterval NextArchiveDown(ArchiveInterval current)
         {

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -31,7 +31,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -55,7 +54,6 @@ namespace XenAdmin.Controls.CustomDataGraph
     {
         private const long TICKS_IN_ONE_SECOND = 10000000;
         private const long TICKS_IN_FIVE_SECONDS = 50000000;
-        internal const long TICKS_IN_TEN_SECONDS = 100000000;
         private const long TICKS_IN_ONE_MINUTE = 600000000;
         internal const long TICKS_IN_TEN_MINUTES = 6000000000;
         private const long TICKS_IN_ONE_HOUR = 36000000000;

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -75,7 +75,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         private const int SLEEP_TIME = 5000;
 
         private static readonly log4net.ILog Log =
-            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
 
         internal event Action ArchivesUpdated;
 
@@ -84,7 +84,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
         private readonly object _updateMonitor = new object();
         private readonly object _waitUpdates = new object();
-        private Thread _updaterThread;
+        private readonly Thread _updaterThread;
         private bool _runThread;
         private bool _threadRunning;
         private List<DataSet> _setsAdded;

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -52,7 +52,8 @@ namespace XenAdmin.Controls.CustomDataGraph
 
     public class ArchiveMaintainer
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
+        private static readonly log4net.ILog Log =
+            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
 
         public IXenObject XenObject { get; }
 
@@ -81,7 +82,9 @@ namespace XenAdmin.Controls.CustomDataGraph
         internal const int DAYS_IN_ONE_YEAR = 366;
 
         internal event Action ArchivesUpdated;
-        internal readonly Dictionary<ArchiveInterval, DataArchive> Archives = new Dictionary<ArchiveInterval, DataArchive>();
+
+        internal readonly Dictionary<ArchiveInterval, DataArchive> Archives =
+            new Dictionary<ArchiveInterval, DataArchive>();
 
         private const int SLEEP_TIME = 5000;
 
@@ -117,44 +120,52 @@ namespace XenAdmin.Controls.CustomDataGraph
             {
                 if (serverWas - LastFiveSecondCollection > TimeSpan.FromSeconds(5))
                 {
-                    Get(ArchiveInterval.FiveSecond, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
+                    Get(ArchiveInterval.FiveSecond, UpdateUri, RRD_Update_InspectCurrentNode, XenObject,
+                        _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
                     {
                         break;
                     }
+
                     LastFiveSecondCollection = serverWas;
                     Archives[ArchiveInterval.FiveSecond].Load(_setsAdded);
                 }
 
                 if (serverWas - LastOneMinuteCollection > TimeSpan.FromMinutes(1))
                 {
-                    Get(ArchiveInterval.OneMinute, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
+                    Get(ArchiveInterval.OneMinute, UpdateUri, RRD_Update_InspectCurrentNode, XenObject,
+                        _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
                     {
                         break;
                     }
+
                     LastOneMinuteCollection = serverWas;
                     Archives[ArchiveInterval.OneMinute].Load(_setsAdded);
                 }
 
                 if (serverWas - LastOneHourCollection > TimeSpan.FromHours(1))
                 {
-                    Get(ArchiveInterval.OneHour, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
+                    Get(ArchiveInterval.OneHour, UpdateUri, RRD_Update_InspectCurrentNode, XenObject,
+                        _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
                     {
                         break;
                     }
+
                     LastOneHourCollection = serverWas;
                     Archives[ArchiveInterval.OneHour].Load(_setsAdded);
                 }
 
                 if (serverWas - LastOneDayCollection > TimeSpan.FromDays(1))
                 {
-                    Get(ArchiveInterval.OneDay, UpdateUri, RRD_Update_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
+                    Get(ArchiveInterval.OneDay, UpdateUri, RRD_Update_InspectCurrentNode, XenObject,
+                        _cancellationTokenSource.Token);
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
                     {
                         break;
                     }
+
                     LastOneDayCollection = serverWas;
                     Archives[ArchiveInterval.OneDay].Load(_setsAdded);
                 }
@@ -163,6 +174,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                 {
                     break;
                 }
+
                 ArchivesUpdated?.Invoke();
                 Thread.Sleep(SLEEP_TIME);
             }
@@ -191,6 +203,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             {
                 return;
             }
+
             LoadingInitialData = true;
             ArchivesUpdated?.Invoke();
 
@@ -205,11 +218,14 @@ namespace XenAdmin.Controls.CustomDataGraph
                         _dataSources = VM.get_data_sources(vm.Connection.Session, vm.opaque_ref);
                         break;
                 }
+
                 if (_cancellationTokenSource.Token.IsCancellationRequested)
                 {
                     return;
                 }
-                Get(ArchiveInterval.None, RrdsUri, RRD_Full_InspectCurrentNode, XenObject, _cancellationTokenSource.Token);
+
+                Get(ArchiveInterval.None, RrdsUri, RRD_Full_InspectCurrentNode, XenObject,
+                    _cancellationTokenSource.Token);
             }
             catch (Exception e)
             {
@@ -221,6 +237,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             {
                 return;
             }
+
             ArchivesUpdated?.Invoke();
             LoadingInitialData = false;
 
@@ -253,7 +270,9 @@ namespace XenAdmin.Controls.CustomDataGraph
             }
             catch (Exception e)
             {
-                Log.Warn($"Get updates for {(xenObject is Host ? "Host" : "VM")}: {(xenObject != null ? xenObject.opaque_ref : Helper.NullOpaqueRef)} Failed.", e);
+                Log.Warn(
+                    $"Get updates for {(xenObject is Host ? "Host" : "VM")}: {(xenObject != null ? xenObject.opaque_ref : Helper.NullOpaqueRef)} Failed.",
+                    e);
             }
         }
 
@@ -281,7 +300,8 @@ namespace XenAdmin.Controls.CustomDataGraph
                         $"session_id={escapedRef}&start={startTime}&cf=AVERAGE&interval={duration}&vm_uuid={vm.uuid}");
                 }
                 default:
-                    const string issue = "ArchiveMaintainer.UpdateUri was given an invalid XenObject. Only Hosts and VMs are supported.";
+                    const string issue =
+                        "ArchiveMaintainer.UpdateUri was given an invalid XenObject. Only Hosts and VMs are supported.";
                     Log.Warn(issue);
                     Debug.Assert(false, issue);
                     return null;
@@ -306,7 +326,8 @@ namespace XenAdmin.Controls.CustomDataGraph
                     return BuildUri(vmHost, "vm_rrds", $"session_id={escapedRef}&uuid={vm.uuid}");
                 }
                 default:
-                    const string issue = "ArchiveMaintainer.UpdateUri was given an invalid XenObject. Only Hosts and VMs are supported.";
+                    const string issue =
+                        "ArchiveMaintainer.UpdateUri was given an invalid XenObject. Only Hosts and VMs are supported.";
                     Log.Warn(issue);
                     Debug.Assert(false, issue);
                     return null;
@@ -398,10 +419,13 @@ namespace XenAdmin.Controls.CustomDataGraph
                     _currentInterval = long.Parse(str, CultureInfo.InvariantCulture);
 
                     var modInterval = _endTime % (_stepSize * _currentInterval);
-                    long stepCount = _currentInterval == 1 ? FIVE_SECONDS_IN_TEN_MINUTES // 120 * 5 seconds in 10 minutes
-                        : _currentInterval == 12 ? MINUTES_IN_TWO_HOURS // 120 minutes in 2 hours
-                        : _currentInterval == 720 ? HOURS_IN_ONE_WEEK // 168 hours in a week
-                        : DAYS_IN_ONE_YEAR; // 366 days in a year
+                    long stepCount = _currentInterval == 1
+                        ? FIVE_SECONDS_IN_TEN_MINUTES // 120 * 5 seconds in 10 minutes
+                        : _currentInterval == 12
+                            ? MINUTES_IN_TWO_HOURS // 120 minutes in 2 hours
+                            : _currentInterval == 720
+                                ? HOURS_IN_ONE_WEEK // 168 hours in a week
+                                : DAYS_IN_ONE_YEAR; // 366 days in a year
 
                     _currentTime =
                         new DateTime((((_endTime - modInterval) - (_stepSize * _currentInterval * stepCount)) *
@@ -495,7 +519,7 @@ namespace XenAdmin.Controls.CustomDataGraph
 
         public void Stop()
         {
-           _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Cancel();
         }
 
         #endregion
@@ -586,6 +610,5 @@ namespace XenAdmin.Controls.CustomDataGraph
         }
 
         #endregion
-
     }
 }

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -121,7 +121,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             XenObject = xenObject;
         }
 
-        private void Update(object _)
+        private void StartUpdateLoop(object _)
         {
             var serverWas = ServerNow;
             InitialLoad(serverWas);
@@ -484,7 +484,7 @@ namespace XenAdmin.Controls.CustomDataGraph
         public void Start()
         {
             _cancellationTokenSource = new CancellationTokenSource();
-            ThreadPool.QueueUserWorkItem(Update);
+            ThreadPool.QueueUserWorkItem(StartUpdateLoop);
         }
 
         public void Stop()

--- a/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
+++ b/XenAdmin/Controls/CustomDataGraph/ArchiveMaintainer.cs
@@ -127,10 +127,10 @@ namespace XenAdmin.Controls.CustomDataGraph
             {
                 Program.AssertOnEventThread();
 
-                var oldref = _xenObject == null ? "" : _xenObject.opaque_ref;
+                var oldReference = _xenObject == null ? "" : _xenObject.opaque_ref;
                 _xenObject = value;
-                var newref = _xenObject == null ? "" : _xenObject.opaque_ref;
-                FirstTime = FirstTime || newref != oldref;
+                var newReference = _xenObject == null ? "" : _xenObject.opaque_ref;
+                FirstTime = FirstTime || newReference != oldReference;
             }
         }
 
@@ -267,9 +267,9 @@ namespace XenAdmin.Controls.CustomDataGraph
                 if (uri == null)
                     return;
 
-                using (var httpstream = HTTPHelper.GET(uri, xenObject.Connection, true))
+                using (var stream = HTTPHelper.GET(uri, xenObject.Connection, true))
                 {
-                    using (var reader = XmlReader.Create(httpstream))
+                    using (var reader = XmlReader.Create(stream))
                     {
                         _setsAdded = new List<DataSet>();
                         while (reader.Read())

--- a/XenAdmin/Controls/CustomDataGraph/DataPlotNav.cs
+++ b/XenAdmin/Controls/CustomDataGraph/DataPlotNav.cs
@@ -220,22 +220,22 @@ namespace XenAdmin.Controls.CustomDataGraph
             ArchiveInterval interval = GetCurrentLeftArchiveInterval();
 
             if (interval == ArchiveInterval.FiveSecond)
-                return TimeSpan.FromTicks(ArchiveMaintainer.TicksInTenMinutes);
+                return TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_TEN_MINUTES);
             if (interval == ArchiveInterval.OneMinute)
-                return TimeSpan.FromTicks(ArchiveMaintainer.TicksInTwoHours);
+                return TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_TWO_HOURS);
             if (interval == ArchiveInterval.OneHour)
-                return TimeSpan.FromTicks(ArchiveMaintainer.TicksInSevenDays);
-            return TimeSpan.FromTicks(ArchiveMaintainer.TicksInOneYear);
+                return TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_SEVEN_DAYS);
+            return TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_ONE_YEAR);
         }
 
         public ArchiveInterval GetCurrentLeftArchiveInterval()
         {
             //TimeSpan t = ArchiveMaintainer != null ? ArchiveMaintainer.ClientServerOffset : TimeSpan.Zero;
-            if (GraphOffset.Ticks + GraphWidth.Ticks < ArchiveMaintainer.TicksInTenMinutes)
+            if (GraphOffset.Ticks + GraphWidth.Ticks < ArchiveMaintainer.TICKS_IN_TEN_MINUTES)
                 return ArchiveInterval.FiveSecond;
-            if (GraphOffset.Ticks + GraphWidth.Ticks < ArchiveMaintainer.TicksInTwoHours)
+            if (GraphOffset.Ticks + GraphWidth.Ticks < ArchiveMaintainer.TICKS_IN_TWO_HOURS)
                 return ArchiveInterval.OneMinute;
-            if (GraphOffset.Ticks + GraphWidth.Ticks < ArchiveMaintainer.TicksInSevenDays)
+            if (GraphOffset.Ticks + GraphWidth.Ticks < ArchiveMaintainer.TICKS_IN_SEVEN_DAYS)
                 return ArchiveInterval.OneHour;
             return ArchiveInterval.OneDay;
         }
@@ -243,11 +243,11 @@ namespace XenAdmin.Controls.CustomDataGraph
         public ArchiveInterval GetCurrentWidthArchiveInterval()
         {
             //TimeSpan t = ArchiveMaintainer != null ? ArchiveMaintainer.ClientServerOffset : TimeSpan.Zero;
-            if (GraphWidth.Ticks < ArchiveMaintainer.TicksInTenMinutes)
+            if (GraphWidth.Ticks < ArchiveMaintainer.TICKS_IN_TEN_MINUTES)
                 return ArchiveInterval.FiveSecond;
-            if (GraphWidth.Ticks < ArchiveMaintainer.TicksInTwoHours)
+            if (GraphWidth.Ticks < ArchiveMaintainer.TICKS_IN_TWO_HOURS)
                 return ArchiveInterval.OneMinute;
-            if (GraphWidth.Ticks < ArchiveMaintainer.TicksInSevenDays)
+            if (GraphWidth.Ticks < ArchiveMaintainer.TICKS_IN_SEVEN_DAYS)
                 return ArchiveInterval.OneHour;
             return ArchiveInterval.OneDay;
         }
@@ -391,11 +391,11 @@ namespace XenAdmin.Controls.CustomDataGraph
             {
                 TimeSpan width = Animating ? AnimateCurrentWidth : ScrollViewWidth;
                 TimeSpan offset = Animating ? AnimateCurrentOffset : ScrollViewOffset;
-                if (offset.Ticks + width.Ticks <= ArchiveMaintainer.TicksInTenMinutes)
+                if (offset.Ticks + width.Ticks <= ArchiveMaintainer.TICKS_IN_TEN_MINUTES)
                     return ArchiveInterval.FiveSecond;
-                else if (offset.Ticks + width.Ticks <= ArchiveMaintainer.TicksInTwoHours)
+                else if (offset.Ticks + width.Ticks <= ArchiveMaintainer.TICKS_IN_TWO_HOURS)
                     return ArchiveInterval.OneMinute;
-                else if (offset.Ticks + width.Ticks <= ArchiveMaintainer.TicksInSevenDays)
+                else if (offset.Ticks + width.Ticks <= ArchiveMaintainer.TICKS_IN_SEVEN_DAYS)
                     return ArchiveInterval.OneHour;
                 else
                     return ArchiveInterval.OneDay;
@@ -407,11 +407,11 @@ namespace XenAdmin.Controls.CustomDataGraph
             get
             {
                 TimeSpan width = Animating ? AnimateCurrentWidth : ScrollViewWidth;
-                if (width.Ticks <= ArchiveMaintainer.TicksInTenMinutes)
+                if (width.Ticks <= ArchiveMaintainer.TICKS_IN_TEN_MINUTES)
                     return ArchiveInterval.FiveSecond;
-                else if (width.Ticks <= ArchiveMaintainer.TicksInTwoHours)
+                else if (width.Ticks <= ArchiveMaintainer.TICKS_IN_TWO_HOURS)
                     return ArchiveInterval.OneMinute;
-                else if (width.Ticks <= ArchiveMaintainer.TicksInSevenDays)
+                else if (width.Ticks <= ArchiveMaintainer.TICKS_IN_SEVEN_DAYS)
                     return ArchiveInterval.OneHour;
                 else
                     return ArchiveInterval.OneDay;
@@ -567,7 +567,7 @@ namespace XenAdmin.Controls.CustomDataGraph
             set { _scrollViewOffset = value; }
         }
 
-        private TimeSpan _scrollViewWidth = TimeSpan.FromTicks(ArchiveMaintainer.TicksInTwoHours);
+        private TimeSpan _scrollViewWidth = TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_TWO_HOURS);
 
         public TimeSpan ScrollViewWidth
         {
@@ -647,12 +647,12 @@ namespace XenAdmin.Controls.CustomDataGraph
         {
             while (true)
             {
-                if (GraphWidth.Ticks < ScrollViewWidth.Ticks * 0.1 && ScrollViewWidth.Ticks / 7 > ArchiveMaintainer.TicksInTenMinutes)
+                if (GraphWidth.Ticks < ScrollViewWidth.Ticks * 0.1 && ScrollViewWidth.Ticks / 7 > ArchiveMaintainer.TICKS_IN_TEN_MINUTES)
                 {
                     AnimateCurrentWidth = ScrollViewWidth;
                     Animating = true;
 
-                    if (ScrollViewWidth.Ticks / 7 > ArchiveMaintainer.TicksInTenMinutes)
+                    if (ScrollViewWidth.Ticks / 7 > ArchiveMaintainer.TICKS_IN_TEN_MINUTES)
                     {
                         ScrollViewWidth = TimeSpan.FromTicks(ScrollViewWidth.Ticks / 7);
                     }
@@ -661,10 +661,10 @@ namespace XenAdmin.Controls.CustomDataGraph
                 {
                     AnimateCurrentWidth = ScrollViewWidth;
                     Animating = true;
-                    ScrollViewWidth = TimeSpan.FromTicks(ArchiveMaintainer.TicksInTenMinutes);
+                    ScrollViewWidth = TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_TEN_MINUTES);
                     break;
                 }
-                else if (GraphWidth.Ticks > ScrollViewWidth.Ticks * 0.7 && ScrollViewWidth.Ticks * 7 < ArchiveMaintainer.TicksInOneYear)
+                else if (GraphWidth.Ticks > ScrollViewWidth.Ticks * 0.7 && ScrollViewWidth.Ticks * 7 < ArchiveMaintainer.TICKS_IN_ONE_YEAR)
                 {
                     AnimateCurrentWidth = ScrollViewWidth;
                     Animating = true;
@@ -674,7 +674,7 @@ namespace XenAdmin.Controls.CustomDataGraph
                 {
                     AnimateCurrentWidth = ScrollViewWidth;
                     Animating = true;
-                    ScrollViewWidth = TimeSpan.FromTicks(ArchiveMaintainer.TicksInOneYear);
+                    ScrollViewWidth = TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_ONE_YEAR);
                     break;
                 }
                 else
@@ -898,11 +898,11 @@ namespace XenAdmin.Controls.CustomDataGraph
                     return;
                 GraphOffset = TimeSpan.Zero;
             }
-            else if (GraphOffset.Ticks + GraphWidth.Ticks - delta > ArchiveMaintainer.TicksInOneYear)
+            else if (GraphOffset.Ticks + GraphWidth.Ticks - delta > ArchiveMaintainer.TICKS_IN_ONE_YEAR)
             {
-                if (GraphOffset.Ticks == ArchiveMaintainer.TicksInOneYear - GraphWidth.Ticks)
+                if (GraphOffset.Ticks == ArchiveMaintainer.TICKS_IN_ONE_YEAR - GraphWidth.Ticks)
                     return;
-                GraphOffset = TimeSpan.FromTicks(ArchiveMaintainer.TicksInOneYear - GraphWidth.Ticks);
+                GraphOffset = TimeSpan.FromTicks(ArchiveMaintainer.TICKS_IN_ONE_YEAR - GraphWidth.Ticks);
             }
             else
             {

--- a/XenAdmin/TabPages/PerformancePage.cs
+++ b/XenAdmin/TabPages/PerformancePage.cs
@@ -70,7 +70,7 @@ namespace XenAdmin.TabPages
             base.Text = Messages.PERFORMANCE_TAB_TITLE;
             UpdateMoveButtons();
         }
-
+         
         public override string HelpID => "TabPagePerformance";
 
         /// <summary> 
@@ -81,16 +81,16 @@ namespace XenAdmin.TabPages
         {
             if (_disposed)
                 return;
-            
-            ArchiveMaintainer.Stop();
+
+            _archiveMaintainers.ForEach(a =>
+            {
+                a.Stop();
+                a.ArchivesUpdated -= ArchiveMaintainer_ArchivesUpdated;
+            });
 
             if (disposing)
             {
-                ArchiveMaintainer.ArchivesUpdated -= ArchiveMaintainer_ArchivesUpdated;
-
-                if (components != null)
-                    components.Dispose();
-
+                components?.Dispose();
                 _disposed = true;
             }
             base.Dispose(disposing);
@@ -185,7 +185,7 @@ namespace XenAdmin.TabPages
                     _archiveMaintainers.Where(a => !a.XenObject.Equals(value)).ToList().ForEach(a =>
                     {
                         a.ArchivesUpdated -= ArchiveMaintainer_ArchivesUpdated;
-                        a.Pause();
+                        a.Stop();
                     });
                     var existingArchive = _archiveMaintainers.FirstOrDefault(a => a.XenObject.Equals(value));
                     if (existingArchive == null)
@@ -335,7 +335,10 @@ namespace XenAdmin.TabPages
             DeregEvents();
 
             if (ArchiveMaintainer != null)
-                ArchiveMaintainer.Pause();
+            {
+                ArchiveMaintainer.ArchivesUpdated -= ArchiveMaintainer_ArchivesUpdated;
+                ArchiveMaintainer.Stop();
+            }
         }
 
         private void ArchiveMaintainer_ArchivesUpdated()


### PR DESCRIPTION
I have split this PR in many commits because it contains a lot of tidying up. I highly suggest you read through the PR one commit at a time.

The underlying issue that is being addressed here is that `ArchiveMaintainer` wasn't stricly tied to its XenObject before. While fetching operations were running the XenObject could change. A similar issue happened with other private fields such as `FirstTime`. The latter was the cause for one the issues described in the original ticket description.

This refactor removes the manual handling of the `Thread` and instead uses `CancellationToken`s to manage ongoing requests. The new `ArchiveMaintainer` is related to **one** `XenObject`. If a user navigates away from the `XenObject`'s Performance tab the operation will spawn a new thread while the old one is cancelled. The new thread operates under a separate `ArchiveMaintainer` and has its own state. If the user goes back to the original `XenObject`, its `ArchiveMaintainer` spawns a new thread. If the previous one was still cancelling, that will still happen in the background. Before the changes, there was only one `Thread` and one `ArchiveMaintainer`.

Furthermore, the use of `CancellationToken` has been injected all the way into the `while (reader.Read())` of the data fetching requests. This avoids useless hanging of threads that are waiting on large data to dowload even though we don't need it anymore.

`PerformancePage` is now the handler of all the `ArchiveMaintainer`s, and it is also responsible for telling the UI controls which `ArchiveMaintainer` is the one they should be using.