### PR TITLE
Prevent `long` overflow when VM has a very large amount of memory

### DIFF
--- a/XenAdmin/Controls/Ballooning/ShinyBar.cs
+++ b/XenAdmin/Controls/Ballooning/ShinyBar.cs
@@ -263,7 +263,7 @@ namespace XenAdmin.Controls.Ballooning
                         Size size = Drawing.MeasureText(g, label, Program.DefaultFont);
                         Rectangle rect = new Rectangle(new Point(pos - size.Width/2, text_top), size);
 
-                        if (LabelShouldBeShown(max, label, x))
+                        if (LabelShouldBeShown(max, x))
                         {
                             Drawing.DrawText(g, label, Program.DefaultFont, rect, Grid, Color.Transparent);
                         }
@@ -282,7 +282,7 @@ namespace XenAdmin.Controls.Ballooning
         /// <param name="label"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        private static bool LabelShouldBeShown(double max, string label, double x)
+        private static bool LabelShouldBeShown(double max, double x)
         {
             return max <= Util.BINARY_GIGA  || (x % (0.5 * Util.BINARY_GIGA)) == 0;
         }

--- a/XenAdmin/Controls/Ballooning/ShinyBar.cs
+++ b/XenAdmin/Controls/Ballooning/ShinyBar.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
@@ -222,12 +223,7 @@ namespace XenAdmin.Controls.Ballooning
 
         protected void DrawGrid(Graphics g, Rectangle barArea, double bytesPerPixel, double max)
         {
-            // prevent max overflows from creating an infinite loop
-            if (max <= 0)
-            {
-                return;
-            }
-
+            Debug.Assert(max > 0, "Memory value should be larger than zero");
             const int min_gap = 40;  // min gap between consecutive labels (which are on alternate ticks)
             const int line_height = 12;
 

--- a/XenAdmin/Controls/Ballooning/ShinyBar.cs
+++ b/XenAdmin/Controls/Ballooning/ShinyBar.cs
@@ -222,6 +222,12 @@ namespace XenAdmin.Controls.Ballooning
 
         protected void DrawGrid(Graphics g, Rectangle barArea, double bytesPerPixel, double max)
         {
+            // prevent max overflows from creating an infinite loop
+            if (max <= 0)
+            {
+                return;
+            }
+
             const int min_gap = 40;  // min gap between consecutive labels (which are on alternate ticks)
             const int line_height = 12;
 
@@ -244,7 +250,7 @@ namespace XenAdmin.Controls.Ballooning
             using (Pen pen = new Pen(Grid))
             {
                 bool withLabel = true;
-                for (long x = 0; x <= max; x += incr)
+                for (double x = 0; x <= max; x += incr)
                 {
                     // Tick
                     int pos = barArea.Left + (int)((double)x / bytesPerPixel);
@@ -276,7 +282,7 @@ namespace XenAdmin.Controls.Ballooning
         /// <param name="label"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        private static bool LabelShouldBeShown(double max, string label, long x)
+        private static bool LabelShouldBeShown(double max, string label, double x)
         {
             return max <= Util.BINARY_GIGA  || (x % (0.5 * Util.BINARY_GIGA)) == 0;
         }

--- a/XenAdmin/Controls/Ballooning/ShinyBar.cs
+++ b/XenAdmin/Controls/Ballooning/ShinyBar.cs
@@ -242,15 +242,15 @@ namespace XenAdmin.Controls.Ballooning
             int text_top = text_bottom - labelSize.Height;
 
             // Calculate a suitable increment
-            long incr = Util.BINARY_MEGA / 2;
-            while((double)incr / bytesPerPixel * 2 < min_gap + longest)
+            var incr = Util.BINARY_MEGA / 2.0;
+            while(incr / bytesPerPixel * 2 < min_gap + longest)
                 incr *= 2;
 
             // Draw the grid
             using (Pen pen = new Pen(Grid))
             {
                 bool withLabel = true;
-                for (double x = 0; x <= max; x += incr)
+                for (var x = 0.0; x <= max; x += incr)
                 {
                     // Tick
                     int pos = barArea.Left + (int)((double)x / bytesPerPixel);
@@ -279,7 +279,6 @@ namespace XenAdmin.Controls.Ballooning
         /// 2. If the maximum is greater than 1 GB, then show only the labels that are a multiple of half a GB.
         /// </summary>
         /// <param name="max"></param>
-        /// <param name="label"></param>
         /// <param name="x"></param>
         /// <returns></returns>
         private static bool LabelShouldBeShown(double max, double x)


### PR DESCRIPTION
Resulted in XenCenter hanging with a significant memory leak.

I know what you're going to ask: "How could this possibly happen, anyway?"

Well it happened to me, so here's a PR to fix it 🤷 

To repro the issue "just" edit an OVF to have 10 exabytes of memory, import it, then open its Memory tab (or the host's)