### PR TITLE
CA-378482: Fix cancellation and multi-thread support to `ConversionWizard` `BackgroundWorker`s

### DIFF
--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.resx
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMNetworkPage.resx
@@ -148,7 +148,7 @@
     <value>m_labelIntro</value>
   </data>
   <data name="&gt;&gt;m_labelIntro.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.Common.AutoHeightLabel, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.Common.AutoHeightLabel, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_labelIntro.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -364,7 +364,7 @@
     <value>4</value>
   </data>
   <data name="m_checkBoxMac.Text" xml:space="preserve">
-    <value>&amp;Preserve virtual MAC addresses</value>
+    <value>Preserve virtual &amp;MAC addresses</value>
   </data>
   <data name="&gt;&gt;m_checkBoxMac.Name" xml:space="preserve">
     <value>m_checkBoxMac</value>
@@ -442,6 +442,6 @@
     <value>SelectMultipleVMNetworkPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
- `DoWorkEventArgs.Cancel` was never actually set to `true`, so `RunWorkerCompletedEventArgs.Cancelled` was always false. This adds correct implementation of cancellation mechanisms for `BackgroundWorker`s
- Ensure no UI changes are made if a `BackgroundWorker` completes after a page has been disposed (by for instance closing the wizard)
- Moving back and fourth between pages sometimes caused issues because `BackroundWorker.RunWorkerAsync` calls were made before the previous run finished. This "enqueues" another run if one hasn't completed
- Update accessibility letter in `SelectMultipleNetworkPage` from `P` to `M` since it clashed with the `Previous` button

I have used the same pattern for every page. One could argue that we need a `XenTabPage` subclass with multithread support to load things on load but that was just a bigger refactor that was going to take ages to review and we have bigger fish to fry at the moment I'm afraid