### PR TITLE
Miscellaneous fixes to vCPUs warnings

### DIFF
--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -58,6 +58,7 @@ namespace XenAdmin.Wizards.GenericPages
         private string _preferredHomeRef;
         private IXenObject _selectedTargetPool;
         private IXenObject _selectedTarget;
+        private List<IXenObject> _allSelectedTargets = new List<IXenObject>();
 
         #region Nested classes
 
@@ -134,12 +135,15 @@ namespace XenAdmin.Wizards.GenericPages
             get => _selectedTarget;
             set
             {
-                var oldTarget = _selectedTarget;
                 _selectedTarget = value;
-
-                if (oldTarget?.opaque_ref != SelectedTarget?.opaque_ref)
-                    OnSelectedTargetChanged();
+                OnSelectedTargetChanged();
             }
+        }
+
+        public List<IXenObject> AllSelectedTargets
+        {
+            get => _allSelectedTargets;
+            set => _allSelectedTargets = value;
         }
 
         /// <summary>
@@ -608,6 +612,7 @@ namespace XenAdmin.Wizards.GenericPages
             // when selecting a new destination pool, reset the target host selection
             if (SelectedTargetPool != null && !SelectedTargetPool.Equals(m_comboBoxConnection.SelectedItem))
             {
+                AllSelectedTargets.Clear();
                 SelectedTarget = null;
             }
 
@@ -674,16 +679,26 @@ namespace XenAdmin.Wizards.GenericPages
 
         private void m_dataGridView_CellValueChanged(object sender, DataGridViewCellEventArgs e)
         {
-            if (e.RowIndex < 0 || e.ColumnIndex < 0)
+            AllSelectedTargets.Clear();
+            IXenObject newTarget = null;
+            for(var rowIndex = 0; rowIndex < m_dataGridView.RowCount; rowIndex++)
             {
-                return;
+                for (var columnIndex = 0; columnIndex < m_dataGridView.ColumnCount; columnIndex++)
+                {
+                    var cell = m_dataGridView.Rows[rowIndex].Cells[columnIndex];
+                    if (cell.Value is IEnableableXenObjectComboBoxItem value)
+                    {
+                        if (rowIndex == e.RowIndex && columnIndex == e.ColumnIndex)
+                        {
+                            newTarget = value.Item;
+                        }
+                        if(value.Item != null)
+                            AllSelectedTargets.Add(value.Item);
+                    }
+                }
             }
 
-            var cell = m_dataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex];
-            if (cell.Value is IEnableableXenObjectComboBoxItem value)
-            {
-                SelectedTarget = value.Item;
-            }
+            SelectedTarget = newTarget;
         }
 
         #endregion

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -58,7 +58,6 @@ namespace XenAdmin.Wizards.GenericPages
         private string _preferredHomeRef;
         private IXenObject _selectedTargetPool;
         private IXenObject _selectedTarget;
-        private List<IXenObject> _allSelectedTargets = new List<IXenObject>();
 
         #region Nested classes
 
@@ -140,11 +139,7 @@ namespace XenAdmin.Wizards.GenericPages
             }
         }
 
-        public List<IXenObject> AllSelectedTargets
-        {
-            get => _allSelectedTargets;
-            set => _allSelectedTargets = value;
-        }
+        public List<IXenObject> AllSelectedTargets { get; } = new List<IXenObject>();
 
         /// <summary>
         /// Text containing instructions for use - at the top of the page

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -106,6 +106,7 @@ namespace XenAdmin.Wizards.ImportWizard
                 if (vsColl == null)
                     return;
 
+                _ovfVCpusCount.Clear();
                 foreach (var vsType in vsColl.Content)
                 {
                     var vhs = OVF.FindVirtualHardwareSectionByAffinity(SelectedOvfEnvelope, vsType.id, "xen");
@@ -113,7 +114,6 @@ namespace XenAdmin.Wizards.ImportWizard
                     if (data == null)
                         continue;
 
-                    _ovfVCpusCount.Clear();
                     foreach (var rasdType in vhs.Item)
                     {
                         // Processor

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -107,6 +107,7 @@ namespace XenAdmin.Wizards.ImportWizard
                     return;
 
                 _ovfVCpusCount.Clear();
+                _ovfMaxVCpusCount = 0;
                 foreach (var vsType in vsColl.Content)
                 {
                     var vhs = OVF.FindVirtualHardwareSectionByAffinity(SelectedOvfEnvelope, vsType.id, "xen");

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -212,10 +212,10 @@ namespace XenAdmin.Wizards.ImportWizard
 
             ApplianceCanBeStarted = true;
 
-            if (!CheckDestinationHasEnoughPhysicalCpus(out var physicalCpusWarningMessage))
+            if (!CheckDestinationHasEnoughPhysicalCpus(out var physicalCpusWarningMessage, out var applianceCanBeStarted))
             {
                 warnings.Add(physicalCpusWarningMessage);
-                ApplianceCanBeStarted = false;
+                ApplianceCanBeStarted = applianceCanBeStarted;
             }
 
             if (!CheckDestinationHasEnoughMemory(out var memoryWarningMessage))
@@ -290,26 +290,50 @@ namespace XenAdmin.Wizards.ImportWizard
         /// </summary>
         public bool ApplianceCanBeStarted { get; private set; } = true;
 
-        private bool CheckDestinationHasEnoughPhysicalCpus(out string warningMessage)
+        private bool CheckDestinationHasEnoughPhysicalCpus(out string warningMessage, out bool applianceCanBeStarted)
         {
             warningMessage = string.Empty;
+            applianceCanBeStarted = false;
+            
+            // check if the current host selection
+            // can accomodate the VMs in the appliance
+            if (AllSelectedTargets.Count > 0)
+            {
+                var physicalCpus = AllSelectedTargets.Select(GetPhysicalCpus).ToList();
+                var minPhysicalCpus = physicalCpus.Min();
+                var maxPhysicalCpus = physicalCpus.Max();
+               
+                if (maxPhysicalCpus < _ovfMaxVCpusCount)
+                {
+                    // there are no hosts that can accomodate the VM with the largest amount of vCPUs
+                    warningMessage = string.Format(Messages.IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST_ALL, _ovfMaxVCpusCount, maxPhysicalCpus);
+                    return false;
+                }
 
-            var selectedTarget = SelectedTarget ?? SelectedTargetPool;
-            var physicalCpusCount = GetPhysicalCpus(selectedTarget);
+                applianceCanBeStarted = true;
+                if (minPhysicalCpus < _ovfMaxVCpusCount)
+                {
+                    // there is a host that cannot accomodate the VM with the largest amount of vCPUs
+                    // we ask the user to make sure that the mapping they are picking is correct
+                    warningMessage = string.Format(Messages.IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST, _ovfMaxVCpusCount, minPhysicalCpus);
+                    return false;
+                }
+            }
 
-            if (physicalCpusCount < 0 || physicalCpusCount >= _ovfMaxVCpusCount)
+            // there is no host selection, check the pool
+            var poolPhysicalCpus = GetPhysicalCpus(SelectedTargetPool);
+
+            if (poolPhysicalCpus < 0 || poolPhysicalCpus >= _ovfMaxVCpusCount)
+            {
+                applianceCanBeStarted = true;
                 return true;
-
-            if (selectedTarget is Pool)
-                warningMessage = string.Format(Messages.IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL, _ovfMaxVCpusCount, physicalCpusCount);
-            else if (selectedTarget is Host)
-                warningMessage = string.Format(Messages.IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST, _ovfMaxVCpusCount, physicalCpusCount);
-            else
-                return true;
-
+            }
+            
+            warningMessage = string.Format(Messages.IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL, _ovfMaxVCpusCount, poolPhysicalCpus);
             return false;
         }
 
+       
         private bool CheckDestinationHasEnoughMemory(out string warningMessage)
         {
             warningMessage = string.Empty;

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20856,7 +20856,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to At least one VM in the imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
+        ///   Looks up a localized string similar to At least one VM in the imported appliance requires a minimum of {0} vCPUs, but not all servers have sufficient physical CPUs. You will not be able to start a VM if you place its disks in the local storage of a server with insufficient physical CPUs..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20838,7 +20838,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs on at least one VM, but there are servers with insufficient physical CPUs ({1}). Ensure that the VMs are mapped correctly or you will not be able to start the appliance on the selected server..
+        ///   Looks up a localized string similar to At least one VM in the imported appliance requires a minimum of {0} vCPUs, but there are servers with insufficient physical CPUs ({1}). Ensure that the VMs are mapped correctly or you will not be able to start the appliance on the selected server..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST {
             get {
@@ -20847,7 +20847,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the selected servers is {1}. You will not be able to start all the VMs in the appliance with the current selection..
+        ///   Looks up a localized string similar to At least one VM in the imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the selected servers is {1}. You will not be able to start all the VMs in the appliance with the current selection..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST_ALL {
             get {
@@ -20856,7 +20856,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
+        ///   Looks up a localized string similar to At least one VM in the imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20838,11 +20838,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs on at least one VM, but there are servers with insufficient physical CPUs ({1}). Ensure that the VMs are mapped correctly or you will not be able to start the appliance on the selected server..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST {
             get {
                 return ResourceManager.GetString("IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the selected servers is {1}. You will not be able to start all the VMs in the appliance with the current selection..
+        /// </summary>
+        public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST_ALL {
+            get {
+                return ResourceManager.GetString("IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST_ALL", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7270,13 +7270,13 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Place &amp;all imported virtual disks on this target SR:</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} vCPUs on at least one VM, but there are servers with insufficient physical CPUs ({1}). Ensure that the VMs are mapped correctly or you will not be able to start the appliance on the selected server.</value>
+    <value>At least one VM in the imported appliance requires a minimum of {0} vCPUs, but there are servers with insufficient physical CPUs ({1}). Ensure that the VMs are mapped correctly or you will not be able to start the appliance on the selected server.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST_ALL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the selected servers is {1}. You will not be able to start all the VMs in the appliance with the current selection.</value>
+    <value>At least one VM in the imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the selected servers is {1}. You will not be able to start all the VMs in the appliance with the current selection.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
+    <value>At least one VM in the imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7276,7 +7276,7 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>At least one VM in the imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the selected servers is {1}. You will not be able to start all the VMs in the appliance with the current selection.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
-    <value>At least one VM in the imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
+    <value>At least one VM in the imported appliance requires a minimum of {0} vCPUs, but not all servers have sufficient physical CPUs. You will not be able to start a VM if you place its disks in the local storage of a server with insufficient physical CPUs.</value>
   </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7270,7 +7270,10 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Place &amp;all imported virtual disks on this target SR:</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} vCPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server.</value>
+    <value>The imported appliance requires a minimum of {0} vCPUs on at least one VM, but there are servers with insufficient physical CPUs ({1}). Ensure that the VMs are mapped correctly or you will not be able to start the appliance on the selected server.</value>
+  </data>
+  <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST_ALL" xml:space="preserve">
+    <value>The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the selected servers is {1}. You will not be able to start all the VMs in the appliance with the current selection.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
     <value>The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>


### PR DESCRIPTION
Found these while writing test scenarios for the changes.

- The `_ovfVCpusCount` was being cleared at every iteration and only one CPU count remained at the end of it. Caused the > 32 vCPUs to not appear on multi-VM imports with mixed vCPU counts
- Ensure the warning is correctly calculated when moving back and fourth within pages
- Ensure warning takes into account every host selected in the selection page. Previously it was only taking into account the `SelectedTarget`, which is the last item that was selected. As part of this, I also added a new message and modified an existing one.