### PR TITLE
CA-379402: Fix EUA check & add hotfix check to `HostMemoryPostUpgradeCheck`

### DIFF
--- a/XenAdmin/Diagnostics/Checks/HostMemoryPostUpgradeCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/HostMemoryPostUpgradeCheck.cs
@@ -31,6 +31,7 @@
 using System;
 using System.Collections.Generic;
 using XenAdmin.Core;
+using XenAdmin.Diagnostics.Hotfixing;
 using XenAdmin.Diagnostics.Problems;
 using XenAdmin.Diagnostics.Problems.HostProblem;
 using XenAPI;
@@ -53,6 +54,10 @@ namespace XenAdmin.Diagnostics.Checks
 
         protected override Problem RunHostCheck()
         {
+            var hotfix = HotfixFactory.Hotfix(Host);
+            if (hotfix != null && hotfix.ShouldBeAppliedTo(Host))
+                return new HostDoesNotHaveHotfixWarning(this, Host);
+
             if (TryGetDom0MemoryPostUpgrade(out var dom0MemoryPostUpgrade))
             {
                 var currentDom0Memory = Host.dom0_memory();

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -170,6 +170,12 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
             //Checks used in automatic mode only, for hosts that will be upgraded
             if (!ManualUpgrade)
             {
+                var prepareToUpgradeChecks = (from Host host in hostsToUpgrade
+                    select new PrepareToUpgradeCheck(host, InstallMethodConfig) as Check).ToList();
+
+                if (prepareToUpgradeChecks.Count > 0)
+                    groups.Add(new CheckGroup(Messages.CHECKING_PREPARE_TO_UPGRADE, prepareToUpgradeChecks));
+
                 // EUA check
                 var euaCheck = GetPermanentCheck("EUA",
                 new UpgradeRequiresEua(this, hostsToUpgrade, InstallMethodConfig));
@@ -186,12 +192,6 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
 
                 if (safeToUpgradeChecks.Count > 0)
                     groups.Add(new CheckGroup(Messages.CHECKING_SAFE_TO_UPGRADE, safeToUpgradeChecks));
-
-                var prepareToUpgradeChecks = (from Host host in hostsToUpgrade
-                    select new PrepareToUpgradeCheck(host, InstallMethodConfig) as Check).ToList();
-
-                if (prepareToUpgradeChecks.Count > 0)
-                    groups.Add(new CheckGroup(Messages.CHECKING_PREPARE_TO_UPGRADE, prepareToUpgradeChecks));
             }
 
             //vSwitch controller check - for each pool

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizardPrecheckPage.cs
@@ -173,8 +173,11 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
                 // EUA check
                 var euaCheck = GetPermanentCheck("EUA",
                 new UpgradeRequiresEua(this, hostsToUpgrade, InstallMethodConfig));
-                var euaChecks = new List<Check> { euaCheck };
-                groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
+                if (euaCheck.CanRun())
+                {
+                    var euaChecks = new List<Check> { euaCheck };
+                    groups.Add(new CheckGroup(Messages.ACCEPT_EUA_CHECK_GROUP_NAME, euaChecks));
+                }
 
                 var safeToUpgradeChecks = (from Host host in hostsToUpgrade
                     let check = new SafeToUpgradeCheck(host, InstallMethodConfig)


### PR DESCRIPTION
- b834a7e842b3042caa716c92c33b491027bc7769 ensures we do not run EUA check for upgrades for pre-82X
- 0dfcc3852abdba193ce0bb5dcf304b2931eb5f6c adds a missing hotfix presence check for `HostMemoryPostUpgradeCheck`