### PR TITLE
CA-379640, CA-356178, CA-370866: Do not reset remote consoles if they're still attempting connection to a VM

### DIFF
--- a/XenAdmin/ConsoleView/RdpClient.cs
+++ b/XenAdmin/ConsoleView/RdpClient.cs
@@ -97,6 +97,11 @@ namespace XenAdmin.ConsoleView
             rdpControl.Resize += resizeHandler;
         }
 
+        private bool _connecting;
+        private bool _authWarningVisible;
+
+        public bool IsAttemptingConnection => _connecting || _authWarningVisible; 
+
         private void RDPConfigure(Size currentConsoleSize)
         {
             rdpControl.BeginInit();
@@ -104,7 +109,7 @@ namespace XenAdmin.ConsoleView
             rdpControl.Dock = DockStyle.None;
             rdpControl.Anchor = AnchorStyles.None;
             rdpControl.Size = currentConsoleSize;
-            RDPAddOnDisconnected();
+            AddRDPEventHandlers();
             rdpControl.Enter += RdpEnter;
             rdpControl.Leave += rdpClient_Leave;
             rdpControl.GotFocus += rdpClient_GotFocus;
@@ -123,15 +128,28 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        private void RDPAddOnDisconnected()
+        private void AddRDPEventHandlers()
         {
             if (rdpControl == null)
                 return;
 
-            if (rdpClient9 == null)
-                rdpClient6.OnDisconnected += rdpClient_OnDisconnected;
-            else
-                rdpClient9.OnDisconnected += rdpClient_OnDisconnected;
+            var rdpClient = (IRdpClient)rdpClient9 ?? rdpClient6;
+            if (rdpClient == null)
+            {
+                return;
+            }
+
+            rdpClient.OnDisconnected += (_, e) =>
+            {
+                Program.AssertOnEventThread();
+                OnDisconnected?.Invoke(this, EventArgs.Empty);
+            };
+            rdpClient.OnConnected += (_1, _2) => _connecting = false;
+            rdpClient.OnConnecting += (_1, _2) => _connecting = true;
+            rdpClient.OnDisconnected += (_1, _2) => _connecting = _authWarningVisible = false;
+            rdpClient.OnAuthenticationWarningDisplayed += (_1, _2) => _authWarningVisible = true;
+            rdpClient.OnAuthenticationWarningDismissed += (_1, _2) => _authWarningVisible = false;
+
         }
 
         private void RDPSetSettings()
@@ -166,21 +184,38 @@ namespace XenAdmin.ConsoleView
             if (rdpControl == null)
                 return;
 
-            if (rdpClient9 == null)
+            var rdpClientName = rdpClient9 == null ? "RDPClient6" : "RDPClient9";
+            var rdpClient = (IRdpClient) rdpClient9 ?? rdpClient6;
+
+            Log.Debug($"Connecting {rdpClientName} using server '{rdpIP}', width '{w}' and height '{h}'");
+
+            if (rdpClient == null)
             {
-                Log.Debug($"Connecting RDPClient6 using server '{rdpIP}', width '{w}' and height '{h}'");
-                rdpClient6.Server = rdpIP;
-                rdpClient6.DesktopWidth = w;
-                rdpClient6.DesktopHeight = h;
-                rdpClient6.Connect();
+                Log.Warn("RDPConnect called with an uninitialized RDP client. Aborting connection attempt.");
+                return;
             }
-            else
+
+            rdpClient.Server = rdpIP;
+            rdpClient.DesktopWidth = w;
+            rdpClient.DesktopHeight = h;
+            try
             {
-                Log.Debug($"Connecting RDPClient9 using server '{rdpIP}', width '{w}' and height '{h}'");
-                rdpClient9.Server = rdpIP;
-                rdpClient9.DesktopWidth = w;
-                rdpClient9.DesktopHeight = h;
-                rdpClient9.Connect();
+                rdpClient.Connect();
+            }
+            catch (COMException comException)
+            {
+                // The Connect method returns E_FAIL if it is called while the control is already connected or in the connecting state.
+                // see https://learn.microsoft.com/en-us/windows/win32/termserv/imstscax-connect#remarks for more information.
+                // The HRESULT value is taken from https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/705fb797-2175-4a90-b5a3-3918024b10b8
+                var eFailHResultValue = Convert.ToInt32("0x80004005", 16);
+                if (comException.ErrorCode == eFailHResultValue)
+                {
+                    Log.Warn("Attempted connection while RDP client was connected or connected already.");
+                }
+                else
+                {
+                    throw;
+                }
             }
         }
 
@@ -221,15 +256,6 @@ namespace XenAdmin.ConsoleView
         private int DesktopWidth
         {
             get { return rdpControl == null ? 0 : (rdpClient9 == null ? rdpClient6.DesktopWidth : rdpClient9.DesktopWidth); }
-        }
-
-        void rdpClient_OnDisconnected(object sender, AxMSTSCLib.IMsTscAxEvents_OnDisconnectedEvent e)
-        {
-            Program.AssertOnEventThread();
-
-            if (OnDisconnected != null)
-                OnDisconnected(this, null);
-
         }
 
         //refresh to draw focus border in correct position after display is updated

--- a/XenAdmin/ConsoleView/RdpClient.cs
+++ b/XenAdmin/ConsoleView/RdpClient.cs
@@ -144,11 +144,11 @@ namespace XenAdmin.ConsoleView
                 Program.AssertOnEventThread();
                 OnDisconnected?.Invoke(this, EventArgs.Empty);
             };
-            rdpClient.OnConnected += (_1, _2) => _connecting = false;
-            rdpClient.OnConnecting += (_1, _2) => _connecting = true;
-            rdpClient.OnDisconnected += (_1, _2) => _connecting = _authWarningVisible = false;
-            rdpClient.OnAuthenticationWarningDisplayed += (_1, _2) => _authWarningVisible = true;
-            rdpClient.OnAuthenticationWarningDismissed += (_1, _2) => _authWarningVisible = false;
+            rdpClient.OnConnected += (_, e) => _connecting = false;
+            rdpClient.OnConnecting += (_, e) => _connecting = true;
+            rdpClient.OnDisconnected += (_, e) => _connecting = _authWarningVisible = false;
+            rdpClient.OnAuthenticationWarningDisplayed += (_, e) => _authWarningVisible = true;
+            rdpClient.OnAuthenticationWarningDismissed += (_, e) => _authWarningVisible = false;
 
         }
 
@@ -179,7 +179,7 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        public void RDPConnect(string rdpIP, int w, int h)
+        public void RDPConnect(string rdpIP, int width, int height)
         {
             if (rdpControl == null)
                 return;
@@ -187,7 +187,7 @@ namespace XenAdmin.ConsoleView
             var rdpClientName = rdpClient9 == null ? "RDPClient6" : "RDPClient9";
             var rdpClient = (IRdpClient) rdpClient9 ?? rdpClient6;
 
-            Log.Debug($"Connecting {rdpClientName} using server '{rdpIP}', width '{w}' and height '{h}'");
+            Log.Debug($"Connecting {rdpClientName} using server '{rdpIP}', width '{width}' and height '{height}'");
 
             if (rdpClient == null)
             {
@@ -196,8 +196,8 @@ namespace XenAdmin.ConsoleView
             }
 
             rdpClient.Server = rdpIP;
-            rdpClient.DesktopWidth = w;
-            rdpClient.DesktopHeight = h;
+            rdpClient.DesktopWidth = width;
+            rdpClient.DesktopHeight = height;
             try
             {
                 rdpClient.Connect();

--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -1324,7 +1324,7 @@ namespace XenAdmin.ConsoleView
             if (!RDPControlEnabled)
                 toggleConsoleButton.Enabled = false;
 
-            vncScreen.ImediatelyPollForConsole();
+            vncScreen.ImmediatelyPollForConsole();
         }
 
         internal void SwitchIfRequired()

--- a/XenAdmin/ConsoleView/VNCTabView.cs
+++ b/XenAdmin/ConsoleView/VNCTabView.cs
@@ -1227,7 +1227,7 @@ namespace XenAdmin.ConsoleView
         private void TryToConnectRDP(object x)
         {
             bool hasToReconnect = vncScreen.RdpIp == null;
-            vncScreen.RdpIp = vncScreen.PollPort(XSVNCScreen.RDP_PORT, true);
+            vncScreen.RdpIp = vncScreen.PollPort(XSVNCScreen.RDPPort, true);
             Program.Invoke(this, (MethodInvoker)(() =>
             {
                 if (hasToReconnect)
@@ -1324,7 +1324,7 @@ namespace XenAdmin.ConsoleView
             if (!RDPControlEnabled)
                 toggleConsoleButton.Enabled = false;
 
-            vncScreen.imediatelyPollForConsole();
+            vncScreen.ImediatelyPollForConsole();
         }
 
         internal void SwitchIfRequired()

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -155,7 +155,7 @@ namespace XenAdmin.ConsoleView
             ElevatedPassword = elevatedPassword;
 
 #pragma warning disable 0219
-            IntPtr _ = Handle;
+            var _ = Handle;
 #pragma warning restore 0219
 
             initSubControl();
@@ -164,7 +164,7 @@ namespace XenAdmin.ConsoleView
             if (source == null)
                 return;
             Properties.Settings.Default.PropertyChanged += Default_PropertyChanged;
-            VM_guest_metrics guestMetrics = Source.Connection.Resolve<VM_guest_metrics>(Source.guest_metrics);
+            var guestMetrics = Source.Connection.Resolve<VM_guest_metrics>(Source.guest_metrics);
             if (guestMetrics == null)
                 return;
 
@@ -186,7 +186,7 @@ namespace XenAdmin.ConsoleView
 
             Source.PropertyChanged -= new PropertyChangedEventHandler(VM_PropertyChanged);
 
-            VM_guest_metrics guestMetrics = Source.Connection.Resolve<VM_guest_metrics>(Source.guest_metrics);
+            var guestMetrics = Source.Connection.Resolve<VM_guest_metrics>(Source.guest_metrics);
             if (guestMetrics == null)
                 return;
 
@@ -201,7 +201,7 @@ namespace XenAdmin.ConsoleView
 
             if (e.PropertyName == "networks")
             {
-                Dictionary<string, string> newNetworks = (sender as VM_guest_metrics).networks;
+                var newNetworks = (sender as VM_guest_metrics).networks;
                 if (!equateDictionary<string, string>(newNetworks, cachedNetworks))
                 {
                     Log.InfoFormat("Detected IP address change in vm {0}, repolling for VNC/RDP...", Source.Name());
@@ -218,7 +218,7 @@ namespace XenAdmin.ConsoleView
             if (d1.Count != d2.Count)
                 return false;
 
-            foreach (T key in d1.Keys)
+            foreach (var key in d1.Keys)
             {
                 if (!d2.ContainsKey(key) || !d2[key].Equals(d1[key]))
                     return false;
@@ -511,10 +511,10 @@ namespace XenAdmin.ConsoleView
             if (string.IsNullOrEmpty(RdpIp) && !UseVNC && RemoteConsole != null)
                 return;
 
-            bool wasFocused = false;
+            var wasFocused = false;
             Controls.Clear();
             //console size with some offset to accomodate focus rectangle
-            Size currentConsoleSize = new Size(Size.Width - CONSOLE_SIZE_OFFSET, Size.Height - CONSOLE_SIZE_OFFSET);
+            var currentConsoleSize = new Size(Size.Width - CONSOLE_SIZE_OFFSET, Size.Height - CONSOLE_SIZE_OFFSET);
 
             lock (_rdpConnectionLock)
             {
@@ -640,7 +640,7 @@ namespace XenAdmin.ConsoleView
                     scaling = false;
                     initSubControl();
                     // Check if we have really switched. If not, change useVNC back (CA-102755)
-                    bool switched = true;
+                    var switched = true;
                     if (useVNC) // we wanted VNC
                     {
                         if (vncClient == null && rdpClient != null) // it is actually RDP
@@ -721,10 +721,10 @@ namespace XenAdmin.ConsoleView
                 if (Source == null)
                     return null;
 
-                if (Source.IsControlDomainZero(out Host host))
+                if (Source.IsControlDomainZero(out var host))
                     return string.Format(Messages.CONSOLE_HOST, host.Name());
 
-                if (Source.IsSrDriverDomain(out SR sr))
+                if (Source.IsSrDriverDomain(out var sr))
                     return string.Format(Messages.CONSOLE_SR_DRIVER_DOMAIN, sr.Name());
 
                 return Source.Name();
@@ -768,7 +768,7 @@ namespace XenAdmin.ConsoleView
 
         private void VM_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            VM vm = (VM)sender;
+            var vm = (VM)sender;
 
             if (vm.uuid != Source.uuid)
                 return;
@@ -865,8 +865,8 @@ namespace XenAdmin.ConsoleView
             {
                 consoles = Source.Connection.ResolveAll(hostedConsoles);
             }
-            bool good_console = false;
-            foreach (Console console in consoles)
+            var good_console = false;
+            foreach (var console in consoles)
             {
                 if (console.opaque_ref == old_console.opaque_ref &&
                     console.location == old_console.location)
@@ -889,10 +889,10 @@ namespace XenAdmin.ConsoleView
 
             Program.AssertOffEventThread();
 
-            KeyValuePair<VNCGraphicsClient, Exception> kvp = (KeyValuePair<VNCGraphicsClient, Exception>)o;
+            var kvp = (KeyValuePair<VNCGraphicsClient, Exception>)o;
 
-            VNCGraphicsClient v = kvp.Key;
-            Exception error = kvp.Value;
+            var v = kvp.Key;
+            var error = kvp.Value;
 
             try
             {
@@ -904,7 +904,7 @@ namespace XenAdmin.ConsoleView
                         consoles = sourceVM.Connection.ResolveAll(hostedConsoles);
                     }
 
-                    foreach (Console console in consoles)
+                    foreach (var console in consoles)
                     {
                         if (vncClient != v)
                         {
@@ -921,11 +921,11 @@ namespace XenAdmin.ConsoleView
                             }
                             catch (Exception exn)
                             {
-                                Failure failure = exn as Failure;
-                                bool isHostGoneMessage = failure != null
-                                    && failure.ErrorDescription.Count == 2
-                                    && failure.ErrorDescription[0] == Failure.INTERNAL_ERROR
-                                    && failure.ErrorDescription[1] == string.Format(Messages.HOST_GONE, BrandManager.BrandConsole);
+                                var failure = exn as Failure;
+                                var isHostGoneMessage = failure != null
+                                                        && failure.ErrorDescription.Count == 2
+                                                        && failure.ErrorDescription[0] == Failure.INTERNAL_ERROR
+                                                        && failure.ErrorDescription[1] == string.Format(Messages.HOST_GONE, BrandManager.BrandConsole);
 
                                 if (isHostGoneMessage)
                                 {
@@ -958,7 +958,7 @@ namespace XenAdmin.ConsoleView
                     vncPassword = Settings.GetVNCPassword(sourceVM.uuid);
                     if (vncPassword == null)
                     {
-                        bool lifecycleOperationInProgress = sourceVM.current_operations.Values.Any(VM.is_lifecycle_operation);
+                        var lifecycleOperationInProgress = sourceVM.current_operations.Values.Any(VM.is_lifecycle_operation);
                         if (haveTriedLoginWithoutPassword && !lifecycleOperationInProgress)
                         {
                             Program.Invoke(this, delegate
@@ -1014,7 +1014,7 @@ namespace XenAdmin.ConsoleView
             Program.AssertOnEventThread();
 
             // Prompt for password
-            VNCPasswordDialog f = new VNCPasswordDialog(error, sourceVM);
+            var f = new VNCPasswordDialog(error, sourceVM);
             try
             {
                 if (f.ShowDialog(this) == DialogResult.OK)
@@ -1056,7 +1056,7 @@ namespace XenAdmin.ConsoleView
 
         private Stream connectGuest(string ip_address, int port, IXenConnection connection)
         {
-            string uriString = string.Format("http://{0}:{1}/", ip_address, port);
+            var uriString = string.Format("http://{0}:{1}/", ip_address, port);
             Log.DebugFormat("Trying to connect to: {0}", uriString);          
             return HTTP.ConnectStream(new Uri(uriString), XenAdminConfigManager.Provider.GetProxyFromSettings(connection), true, 0);           
         }
@@ -1065,13 +1065,13 @@ namespace XenAdmin.ConsoleView
         {
             Program.AssertOffEventThread();
 
-            Host host = console.Connection.Resolve(Source.resident_on);
+            var host = console.Connection.Resolve(Source.resident_on);
             if (host == null)
             {
                 throw new Failure(Failure.INTERNAL_ERROR, string.Format(Messages.HOST_GONE, BrandManager.BrandConsole));
             }
 
-            Uri uri = new Uri(console.location);
+            var uri = new Uri(console.location);
             string sesssionRef;
 
             lock (activeSessionLock)
@@ -1082,7 +1082,7 @@ namespace XenAdmin.ConsoleView
                 sesssionRef = activeSession.opaque_ref;
             }
 
-            Stream stream = HTTPHelper.CONNECT(uri, console.Connection, sesssionRef, false);
+            var stream = HTTPHelper.CONNECT(uri, console.Connection, sesssionRef, false);
 
             InvokeConnection(v, stream, console);
         }
@@ -1140,7 +1140,7 @@ namespace XenAdmin.ConsoleView
 
             Program.Invoke(this, delegate()
             {
-                VNCGraphicsClient v = (VNCGraphicsClient)sender;
+                var v = (VNCGraphicsClient)sender;
 
                 if (exn is VNCAuthenticationException || exn is CryptographicException)
                 {
@@ -1170,7 +1170,7 @@ namespace XenAdmin.ConsoleView
 
         private void SleepAndRetryConnection(object o)
         {
-            VNCGraphicsClient v = (VNCGraphicsClient)o;
+            var v = (VNCGraphicsClient)o;
 
             Program.AssertOffEventThread();
 
@@ -1184,7 +1184,7 @@ namespace XenAdmin.ConsoleView
             base.OnPaint(e);
             if (errorMessage != null)
             {
-                SizeF size = e.Graphics.MeasureString(errorMessage, Font);
+                var size = e.Graphics.MeasureString(errorMessage, Font);
                 e.Graphics.DrawString(errorMessage, Font, Brushes.Black,
                     ((Width - size.Width) / 2), ((Height - size.Height) / 2));
             }
@@ -1192,9 +1192,9 @@ namespace XenAdmin.ConsoleView
             // draw focus rectangle
             if (DisplayFocusRectangle && ContainsFocus && RemoteConsole != null)
             {
-                Rectangle focusRect = Rectangle.Inflate(RemoteConsole.ConsoleBounds, VNCGraphicsClient.BORDER_PADDING / 2,
+                var focusRect = Rectangle.Inflate(RemoteConsole.ConsoleBounds, VNCGraphicsClient.BORDER_PADDING / 2,
                                                     VNCGraphicsClient.BORDER_PADDING / 2);
-                using (Pen pen = new Pen(focusColor, VNCGraphicsClient.BORDER_WIDTH))
+                using (var pen = new Pen(focusColor, VNCGraphicsClient.BORDER_WIDTH))
                 {
                     if (Focused)
                         pen.DashStyle = DashStyle.Dash;
@@ -1323,9 +1323,9 @@ namespace XenAdmin.ConsoleView
             const int WM_KEYDOWN = 0x100;
             const int WM_SYSKEYDOWN = 0x104;
 
-            bool down = ((msg.Msg == WM_KEYDOWN) || (msg.Msg == WM_SYSKEYDOWN));
+            var down = ((msg.Msg == WM_KEYDOWN) || (msg.Msg == WM_SYSKEYDOWN));
 
-            Keys key = keyData;
+            var key = keyData;
 
             if ((key & Keys.Control) == Keys.Control)
                 key = key & ~Keys.Control;
@@ -1337,7 +1337,7 @@ namespace XenAdmin.ConsoleView
                 key = key & ~Keys.Shift;
 
             // use TranslateKeyMessage to identify if Left or Right modifier keys have been pressed/released
-            Keys extKey = ConsoleKeyHandler.TranslateKeyMessage(msg);
+            var extKey = ConsoleKeyHandler.TranslateKeyMessage(msg);
 
             return Keysym(down, key, extKey);
         }
@@ -1362,7 +1362,7 @@ namespace XenAdmin.ConsoleView
             // we need to do this here, because we cannot otherwise distinguish between Left and Right modifier keys on KeyUp
             if (!pressed)
             {
-                List<Keys> extendedKeys = ConsoleKeyHandler.GetExtendedKeys(key);
+                var extendedKeys = ConsoleKeyHandler.GetExtendedKeys(key);
                 foreach (var k in extendedKeys)
                 {
                     pressedKeys.Remove(k);

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -116,14 +116,14 @@ namespace XenAdmin.ConsoleView
         public event Action<bool> GpuStatusChanged;
         public event Action<string> ConnectionNameChanged;
 
-        public bool RdpVersionWarningNeeded { get { return rdpClient != null && rdpClient.needsRdpVersionWarning; }}
+        public bool RdpVersionWarningNeeded => rdpClient != null && rdpClient.needsRdpVersionWarning;
 
         internal readonly VNCTabView parentVNCTabView;
 
         [DefaultValue(false)]
         public bool UserWantsToSwitchProtocol { get; set; }
 
-        private bool hasRDP { get { return Source != null && Source.HasRDP(); } }
+        private bool hasRDP => Source != null && Source.HasRDP();
 
         /// <summary>
         /// Whether we have tried to login without providing a password (covers the case where the user
@@ -248,13 +248,7 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        public Size DesktopSize
-        {
-            get
-            {
-                return RemoteConsole != null ? RemoteConsole.DesktopSize : Size.Empty;
-            }
-        }
+        public Size DesktopSize => RemoteConsole != null ? RemoteConsole.DesktopSize : Size.Empty;
 
         /// <summary>
         /// Nothrow guarantee.
@@ -494,7 +488,7 @@ namespace XenAdmin.ConsoleView
 
         public IRemoteConsole RemoteConsole
         {
-            get { return vncClient != null ? (IRemoteConsole)vncClient : rdpClient; }
+            get => vncClient != null ? (IRemoteConsole)vncClient : rdpClient;
             set 
             {
                 if (vncClient != null) 
@@ -637,10 +631,7 @@ namespace XenAdmin.ConsoleView
 
         internal bool UseVNC
         {
-            get
-            {
-                return useVNC;
-            }
+            get => useVNC;
             set
             {
                 if (value != useVNC)
@@ -675,10 +666,7 @@ namespace XenAdmin.ConsoleView
         /// </summary>
         public bool UseSource
         {
-            get
-            {
-                return useSource;
-            }
+            get => useSource;
             set
             {
                 if (value != useSource)
@@ -692,10 +680,7 @@ namespace XenAdmin.ConsoleView
 
         private VM Source
         {
-            get
-            {
-                return sourceVM;
-            }
+            get => sourceVM;
             set
             {
                 if (connectionPoller != null)
@@ -1223,7 +1208,7 @@ namespace XenAdmin.ConsoleView
         private bool displayFocusRectangle = true;
         public bool DisplayFocusRectangle
         {
-            get { return displayFocusRectangle; }
+            get => displayFocusRectangle;
             set
             {
                 displayFocusRectangle = value;

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -66,7 +66,7 @@ namespace XenAdmin.ConsoleView
 
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        private int ConnectionRetries = 0;
+        private int ConnectionRetries;
 
         private volatile bool useVNC = true;
 
@@ -78,17 +78,17 @@ namespace XenAdmin.ConsoleView
         /// May only be written on the event thread.  May be read off the event thread, to check whether
         /// the VNC source has been switched during connection.
         /// </summary>
-        private volatile VNCGraphicsClient vncClient = null;
+        private volatile VNCGraphicsClient vncClient;
 
         private RdpClient rdpClient;
 
-        private Timer connectionPoller = null;
+        private Timer connectionPoller;
 
-        private VM sourceVM = null;
-        private bool sourceIsPV = false;
+        private VM sourceVM;
+        private bool sourceIsPV;
 
         private readonly Object hostedConsolesLock = new Object();
-        private List<XenRef<Console>> hostedConsoles = null;
+        private List<XenRef<Console>> hostedConsoles;
 
         /// <summary>
         /// This is assigned when the hosted connection connects up.  It's used by PollPort to check for
@@ -96,7 +96,7 @@ namespace XenAdmin.ConsoleView
         /// poll for the in-guest VNC using the same session.  activeSession must be accessed only under
         /// the activeSessionLock.
         /// </summary>
-        private Session activeSession = null;
+        private Session activeSession;
         private readonly Object activeSessionLock = new Object();
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace XenAdmin.ConsoleView
         /// pendingVNCConnectionLock.  Work under this lock must be non-blocking, because it's used on
         /// Dispose.
         /// </summary>
-        private Stream pendingVNCConnection = null;
+        private Stream pendingVNCConnection;
         private readonly Object pendingVNCConnectionLock = new Object();
 
         internal EventHandler ResizeHandler;
@@ -130,15 +130,15 @@ namespace XenAdmin.ConsoleView
         /// has configured VNC not to require a login password). If no password is saved, passwordless
         /// login is tried once.
         /// </summary>
-        private bool haveTriedLoginWithoutPassword = false;
-        private bool ignoreNextError = false;
+        private bool haveTriedLoginWithoutPassword;
+        private bool ignoreNextError;
 
         private Dictionary<string, string> cachedNetworks;
 
         /// <summary>
         /// The last known VNC password for this VM.
         /// </summary>
-        private char[] vncPassword = null;
+        private char[] vncPassword;
 
         internal ConsoleKeyHandler KeyHandler;
 
@@ -897,7 +897,7 @@ namespace XenAdmin.ConsoleView
         /// CA-11201: GUI logs are being massively spammed. Prevent "INTERNAL_ERROR Host has disappeared"
         /// appearing more than once.
         /// </summary>
-        private bool _suppressHostGoneMessage = false;
+        private bool _suppressHostGoneMessage;
         private void Connect(object o)
         {
             if (Program.RunInAutomatedTestMode)
@@ -1145,7 +1145,7 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        private String errorMessage = null;
+        private String errorMessage;
 
         private void ErrorHandler(object sender, Exception exn)
         {
@@ -1332,7 +1332,7 @@ namespace XenAdmin.ConsoleView
         }
 
         private Set<Keys> pressedKeys = new Set<Keys>();
-        private bool modifierKeyPressedAlone = false;
+        private bool modifierKeyPressedAlone;
         
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -819,7 +819,7 @@ namespace XenAdmin.ConsoleView
                 ConnectionNameChanged(ConnectionName);
         }
 
-        internal void ImediatelyPollForConsole()
+        internal void ImmediatelyPollForConsole()
         {
             _connectionPoller?.Change(0, RDP_POLL_INTERVAL);
         }
@@ -832,14 +832,14 @@ namespace XenAdmin.ConsoleView
             {
                 _hostedConsoles = Source.consoles;
             }
-            if (UseVNC && _vncClient != null && ConnectionSuperceded())
+            if (UseVNC && _vncClient != null && ConnectionSuperseded())
             {
                 InitSubControl();
             }
         }
 
         /// <summary>
-        /// A connection is superceded if it's connected to a console that's no longer being
+        /// A connection is superseded if it's connected to a console that's no longer being
         /// advertised by the server and there's a replacement that _is_ being advertised, or
         /// if its not connected at all.
         /// 
@@ -847,12 +847,12 @@ namespace XenAdmin.ConsoleView
         /// For this reason, we need to close down ourselves when we see that the console has
         /// been replaced by a newer one (i.e. after a reboot).
         /// </summary>
-        private bool ConnectionSuperceded()
+        private bool ConnectionSuperseded()
         {
-            return !_vncClient.Connected || ConsoleSuperceded((Console)_vncClient.Console);
+            return !_vncClient.Connected || ConsoleSuperseded((Console)_vncClient.Console);
         }
 
-        private bool ConsoleSuperceded(Console oldConsole)
+        private bool ConsoleSuperseded(Console oldConsole)
         {
             if (oldConsole == null)
                 return true;
@@ -1049,9 +1049,9 @@ namespace XenAdmin.ConsoleView
             });
         }
 
-        private Stream ConnectGuest(string ipAddress, int port, IXenConnection connection)
+        private static Stream ConnectGuest(string ipAddress, int port, IXenConnection connection)
         {
-            var uriString = string.Format("http://{0}:{1}/", ipAddress, port);
+            var uriString = $"http://{ipAddress}:{port}/";
             Log.DebugFormat("Trying to connect to: {0}", uriString);          
             return HTTP.ConnectStream(new Uri(uriString), XenAdminConfigManager.Provider.GetProxyFromSettings(connection), true, 0);           
         }
@@ -1155,7 +1155,7 @@ namespace XenAdmin.ConsoleView
             });
         }
 
-        private void SleepAndRetryConnection_(VNCGraphicsClient v)
+        private void SleepAndRetryConnection_(IDisposable v)
         {
             ThreadPool.QueueUserWorkItem(SleepAndRetryConnection, v);
         }
@@ -1229,7 +1229,6 @@ namespace XenAdmin.ConsoleView
             base.OnGotFocus(e);
 
             RefreshScreen();
-
         }
 
         protected override void OnLostFocus(EventArgs e)
@@ -1325,15 +1324,15 @@ namespace XenAdmin.ConsoleView
             // use TranslateKeyMessage to identify if Left or Right modifier keys have been pressed/released
             var extKey = ConsoleKeyHandler.TranslateKeyMessage(msg);
 
-            return Keysym(down, key, extKey);
+            return KeySym(down, key, extKey);
         }
 
         protected override void OnKeyUp(KeyEventArgs e)
         {
-            e.Handled = Keysym(false, e.KeyCode, e.KeyCode);
+            e.Handled = KeySym(false, e.KeyCode, e.KeyCode);
         }
 
-        private bool Keysym(bool pressed, Keys key, Keys extendedKey)
+        private bool KeySym(bool pressed, Keys key, Keys extendedKey)
         {
             if (!pressed && _pressedKeys.Count == 0) // we received key-up, but not key-down - ignore
                 return true;

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -146,7 +146,6 @@ namespace XenAdmin.ConsoleView
         internal string ElevatedPassword;
 
         internal XSVNCScreen(VM source, EventHandler resizeHandler, VNCTabView parent, string elevatedUsername, string elevatedPassword)
-            : base()
         {
             ResizeHandler = resizeHandler;
             parentVNCTabView = parent;

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -97,6 +97,7 @@ namespace XenAdmin.ConsoleView
         /// the activeSessionLock.
         /// </summary>
         private Session _activeSession;
+
         private readonly object _activeSessionLock = new object();
 
         /// <summary>
@@ -107,6 +108,7 @@ namespace XenAdmin.ConsoleView
         /// Dispose.
         /// </summary>
         private Stream _pendingVNCConnection;
+
         private readonly object _pendingVNCConnectionLock = new object();
 
         internal EventHandler ResizeHandler;
@@ -120,8 +122,7 @@ namespace XenAdmin.ConsoleView
 
         internal readonly VNCTabView ParentVNCTabView;
 
-        [DefaultValue(false)]
-        public bool UserWantsToSwitchProtocol { get; set; }
+        [DefaultValue(false)] public bool UserWantsToSwitchProtocol { get; set; }
 
         private bool HasRDP => Source != null && Source.HasRDP();
 
@@ -131,6 +132,7 @@ namespace XenAdmin.ConsoleView
         /// login is tried once.
         /// </summary>
         private bool _haveTriedLoginWithoutPassword;
+
         private bool _ignoreNextError;
 
         private Dictionary<string, string> _cachedNetworks;
@@ -145,7 +147,8 @@ namespace XenAdmin.ConsoleView
         internal string ElevatedUsername;
         internal string ElevatedPassword;
 
-        internal XSVNCScreen(VM source, EventHandler resizeHandler, VNCTabView parent, string elevatedUsername, string elevatedPassword)
+        internal XSVNCScreen(VM source, EventHandler resizeHandler, VNCTabView parent, string elevatedUsername,
+            string elevatedPassword)
         {
             ResizeHandler = resizeHandler;
             ParentVNCTabView = parent;
@@ -191,7 +194,6 @@ namespace XenAdmin.ConsoleView
                 return;
 
             guestMetrics.PropertyChanged -= guestMetrics_PropertyChanged;
-
         }
 
         private void guestMetrics_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -213,7 +215,8 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        private static bool EquateDictionary<T, TS>(Dictionary<T, TS> d1, Dictionary<T, TS> d2) where TS : IEquatable<TS>
+        private static bool EquateDictionary<T, TS>(Dictionary<T, TS> d1, Dictionary<T, TS> d2)
+            where TS : IEquatable<TS>
         {
             if (d1.Count != d2.Count)
                 return false;
@@ -308,7 +311,7 @@ namespace XenAdmin.ConsoleView
             VncIp = null;
             var openIp = PollPort(VNC_PORT, true);
 
-            if (openIp == null) 
+            if (openIp == null)
                 return;
             VncIp = openIp;
 
@@ -371,12 +374,13 @@ namespace XenAdmin.ConsoleView
                         }
                     }
                 }
+
                 ipAddresses = ipAddresses.Distinct().ToList();
 
                 ipAddresses.AddRange(ipv6Addresses); // make sure IPv4 addresses are scanned first (CA-102755)
                 // add IP addresses for networks without PIFs
                 ipAddresses.AddRange(ipAddressesForNetworksWithoutPifs);
-                ipAddresses.AddRange(ipv6AddressesForNetworksWithoutPifs); 
+                ipAddresses.AddRange(ipv6AddressesForNetworksWithoutPifs);
 
 
                 foreach (var ipAddress in ipAddresses)
@@ -394,6 +398,7 @@ namespace XenAdmin.ConsoleView
                         {
                             s.Close();
                         }
+
                         return ipAddress;
                     }
                     catch (Exception exn)
@@ -437,6 +442,7 @@ namespace XenAdmin.ConsoleView
             {
                 Log.Warn("Exception while polling VM for port " + port + ".", e);
             }
+
             return null;
         }
 
@@ -454,6 +460,7 @@ namespace XenAdmin.ConsoleView
                 oldPending = _pendingVNCConnection;
                 _pendingVNCConnection = s;
             }
+
             if (oldPending != null)
             {
                 try
@@ -468,6 +475,7 @@ namespace XenAdmin.ConsoleView
         }
 
         private bool _scaling;
+
         public bool Scaling
         {
             get
@@ -488,11 +496,11 @@ namespace XenAdmin.ConsoleView
         public IRemoteConsole RemoteConsole
         {
             get => _vncClient != null ? (IRemoteConsole)_vncClient : _rdpClient;
-            set 
+            set
             {
-                if (_vncClient != null) 
-                    _vncClient = (VNCGraphicsClient) value ;
-                else if (_rdpClient != null) 
+                if (_vncClient != null)
+                    _vncClient = (VNCGraphicsClient)value;
+                else if (_rdpClient != null)
                     _rdpClient = (RdpClient)value;
             }
         }
@@ -527,15 +535,17 @@ namespace XenAdmin.ConsoleView
                     {
                         preventResetConsole = true;
                     }
-                    if(!preventResetConsole)
+
+                    if (!preventResetConsole)
                     {
                         RemoteConsole.DisconnectAndDispose();
                         RemoteConsole = null;
                     }
+
                     _vncPassword = null;
                 }
             }
-            
+
 
             // Reset
             _haveTriedLoginWithoutPassword = false;
@@ -591,7 +601,7 @@ namespace XenAdmin.ConsoleView
         internal bool MustConnectRemoteDesktop()
         {
             return (UseVNC || string.IsNullOrEmpty(RdpIp)) &&
-                Source.HasGPUPassthrough() && Source.power_state == vm_power_state.Running;
+                   Source.HasGPUPassthrough() && Source.power_state == vm_power_state.Running;
         }
 
         private void SetKeyboardAndMouseCapture(bool value)
@@ -619,15 +629,12 @@ namespace XenAdmin.ConsoleView
                     Program.Invoke(this, OnDetectRDP);
                 AutoSwitchRDPLater = false;
             }
+
             if (ParentVNCTabView.IsRDPControlEnabled())
                 ParentVNCTabView.EnableToggleVNCButton();
         }
 
-        internal bool AutoSwitchRDPLater
-        {
-            get;
-            set; 
-        }
+        internal bool AutoSwitchRDPLater { get; set; }
 
         internal bool UseVNC
         {
@@ -652,15 +659,17 @@ namespace XenAdmin.ConsoleView
                         if (_rdpClient == null && _vncClient != null) // it is actually VNC
                             switched = false;
                     }
-                    if (!switched) 
+
+                    if (!switched)
                     {
                         _useVNC = !_useVNC;
-                    } 
+                    }
                 }
             }
         }
 
         private volatile bool _useSource = true;
+
         /// <summary>
         /// Indicates whether to use the source or the detected vncIP
         /// </summary>
@@ -702,7 +711,7 @@ namespace XenAdmin.ConsoleView
                     value.PropertyChanged += VM_PropertyChanged;
 
                     _sourceIsPv = !value.IsHVM();
-                    
+
                     StartPolling();
 
                     lock (_hostedConsolesLock)
@@ -752,7 +761,7 @@ namespace XenAdmin.ConsoleView
                 ParentVNCTabView.DisableToggleVNCButton();
             }
 
-            if (ParentVNCTabView.IsRDPControlEnabled()) 
+            if (ParentVNCTabView.IsRDPControlEnabled())
                 return;
 
             if (InDefaultConsole())
@@ -760,11 +769,13 @@ namespace XenAdmin.ConsoleView
                 ParentVNCTabView.DisableToggleVNCButton();
             }
 
-            if (Source == null || Source.IsControlDomainZero(out _)) 
+            if (Source == null || Source.IsControlDomainZero(out _))
                 return;
 
             //Start the polling again
-            _connectionPoller = !Source.IsHVM() ? new Timer(PollVNCPort, null, RETRY_SLEEP_TIME, RDP_POLL_INTERVAL) : new Timer(PollRDPPort, null, RETRY_SLEEP_TIME, RDP_POLL_INTERVAL);
+            _connectionPoller = !Source.IsHVM()
+                ? new Timer(PollVNCPort, null, RETRY_SLEEP_TIME, RDP_POLL_INTERVAL)
+                : new Timer(PollRDPPort, null, RETRY_SLEEP_TIME, RDP_POLL_INTERVAL);
         }
 
         private void VM_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -796,7 +807,7 @@ namespace XenAdmin.ConsoleView
                 _connectionPoller?.Change(RETRY_SLEEP_TIME, RDP_POLL_INTERVAL);
             }
             else if (e.PropertyName == "power_state" &&
-                (vm.power_state == vm_power_state.Halted || vm.power_state == vm_power_state.Suspended))
+                     (vm.power_state == vm_power_state.Halted || vm.power_state == vm_power_state.Suspended))
             {
                 ParentVNCTabView.VMPowerOff();
                 _connectionPoller?.Change(Timeout.Infinite, Timeout.Infinite);
@@ -809,10 +820,7 @@ namespace XenAdmin.ConsoleView
 
             if (e.PropertyName == "power_state" || e.PropertyName == "VGPUs")
             {
-                Program.Invoke(this, () =>
-                {
-                    GpuStatusChanged?.Invoke(MustConnectRemoteDesktop());
-                });
+                Program.Invoke(this, () => { GpuStatusChanged?.Invoke(MustConnectRemoteDesktop()); });
             }
 
             if (e.PropertyName == "name_label" && ConnectionNameChanged != null)
@@ -832,6 +840,7 @@ namespace XenAdmin.ConsoleView
             {
                 _hostedConsoles = Source.consoles;
             }
+
             if (UseVNC && _vncClient != null && ConnectionSuperseded())
             {
                 InitSubControl();
@@ -862,6 +871,7 @@ namespace XenAdmin.ConsoleView
             {
                 consoles = Source.Connection.ResolveAll(_hostedConsoles);
             }
+
             var goodConsole = false;
             foreach (var console in consoles)
             {
@@ -871,6 +881,7 @@ namespace XenAdmin.ConsoleView
                 else if (console.protocol == console_protocol.rfb)
                     goodConsole = true;
             }
+
             return goodConsole;
         }
 
@@ -879,6 +890,7 @@ namespace XenAdmin.ConsoleView
         /// appearing more than once.
         /// </summary>
         private bool _suppressHostGoneMessage;
+
         private void Connect(object o)
         {
             if (Program.RunInAutomatedTestMode)
@@ -922,7 +934,8 @@ namespace XenAdmin.ConsoleView
                                 var isHostGoneMessage = failure != null
                                                         && failure.ErrorDescription.Count == 2
                                                         && failure.ErrorDescription[0] == Failure.INTERNAL_ERROR
-                                                        && failure.ErrorDescription[1] == string.Format(Messages.HOST_GONE, BrandManager.BrandConsole);
+                                                        && failure.ErrorDescription[1] ==
+                                                        string.Format(Messages.HOST_GONE, BrandManager.BrandConsole);
 
                                 if (isHostGoneMessage)
                                 {
@@ -952,16 +965,15 @@ namespace XenAdmin.ConsoleView
                         OnVncConnectionAttemptCancelled();
                         return;
                     }
+
                     _vncPassword = Settings.GetVNCPassword(_sourceVm.uuid);
                     if (_vncPassword == null)
                     {
-                        var lifecycleOperationInProgress = _sourceVm.current_operations.Values.Any(VM.is_lifecycle_operation);
+                        var lifecycleOperationInProgress =
+                            _sourceVm.current_operations.Values.Any(VM.is_lifecycle_operation);
                         if (_haveTriedLoginWithoutPassword && !lifecycleOperationInProgress)
                         {
-                            Program.Invoke(this, delegate
-                            {
-                                PromptForPassword(_ignoreNextError ? null : error);
-                            });
+                            Program.Invoke(this, delegate { PromptForPassword(_ignoreNextError ? null : error); });
                             _ignoreNextError = false;
                             if (_vncPassword == null)
                             {
@@ -986,17 +998,19 @@ namespace XenAdmin.ConsoleView
                         Log.DebugFormat("Using pending VNC connection");
                         _pendingVNCConnection = null;
                     }
+
                     if (s == null)
                     {
                         Log.DebugFormat("Connecting to vncIP={0}, port={1}", VncIp, VNC_PORT);
                         s = ConnectGuest(VncIp, VNC_PORT, _sourceVm.Connection);
                         Log.DebugFormat("Connected to vncIP={0}, port={1}", VncIp, VNC_PORT);
                     }
+
                     InvokeConnection(v, s, null);
 
                     // store the empty vnc password after a successful passwordless login
                     if (_haveTriedLoginWithoutPassword && _vncPassword.Length == 0)
-                        Program.Invoke(this, () => Settings.SetVNCPassword(_sourceVm.uuid, _vncPassword)); 
+                        Program.Invoke(this, () => Settings.SetVNCPassword(_sourceVm.uuid, _vncPassword));
                 }
             }
             catch (Exception exn)
@@ -1052,8 +1066,9 @@ namespace XenAdmin.ConsoleView
         private static Stream ConnectGuest(string ipAddress, int port, IXenConnection connection)
         {
             var uriString = $"http://{ipAddress}:{port}/";
-            Log.DebugFormat("Trying to connect to: {0}", uriString);          
-            return HTTP.ConnectStream(new Uri(uriString), XenAdminConfigManager.Provider.GetProxyFromSettings(connection), true, 0);           
+            Log.DebugFormat("Trying to connect to: {0}", uriString);
+            return HTTP.ConnectStream(new Uri(uriString),
+                XenAdminConfigManager.Provider.GetProxyFromSettings(connection), true, 0);
         }
 
         private void ConnectHostedConsole(VNCGraphicsClient v, Console console)
@@ -1072,8 +1087,9 @@ namespace XenAdmin.ConsoleView
             lock (_activeSessionLock)
             {
                 // use the elevated credentials, if provided, for connecting to the console (CA-91132)
-                _activeSession = (string.IsNullOrEmpty(ElevatedUsername) || string.IsNullOrEmpty(ElevatedPassword)) ?
-                    console.Connection.DuplicateSession() : console.Connection.ElevatedSession(ElevatedUsername, ElevatedPassword);
+                _activeSession = (string.IsNullOrEmpty(ElevatedUsername) || string.IsNullOrEmpty(ElevatedPassword))
+                    ? console.Connection.DuplicateSession()
+                    : console.Connection.ElevatedSession(ElevatedUsername, ElevatedPassword);
                 sessionRef = _activeSession.opaque_ref;
             }
 
@@ -1185,7 +1201,7 @@ namespace XenAdmin.ConsoleView
             if (DisplayFocusRectangle && ContainsFocus && RemoteConsole != null)
             {
                 var focusRect = Rectangle.Inflate(RemoteConsole.ConsoleBounds, VNCGraphicsClient.BORDER_PADDING / 2,
-                                                    VNCGraphicsClient.BORDER_PADDING / 2);
+                    VNCGraphicsClient.BORDER_PADDING / 2);
                 using (var pen = new Pen(_focusColor, VNCGraphicsClient.BORDER_WIDTH))
                 {
                     if (Focused)
@@ -1197,6 +1213,7 @@ namespace XenAdmin.ConsoleView
 
         // Save this for when we init a new vncClient.
         private bool _displayFocusRectangle = true;
+
         public bool DisplayFocusRectangle
         {
             get => _displayFocusRectangle;
@@ -1246,7 +1263,7 @@ namespace XenAdmin.ConsoleView
 
         protected override void OnEnter(EventArgs e)
         {
-            Program.AssertOnEventThread(); 
+            Program.AssertOnEventThread();
             base.OnEnter(e);
 
             CaptureKeyboardAndMouse();
@@ -1270,8 +1287,9 @@ namespace XenAdmin.ConsoleView
             {
                 SetKeyboardAndMouseCapture(false);
             }
+
             ActiveControl = null;
-            
+
             EnableMenuShortcuts();
         }
 
@@ -1284,6 +1302,7 @@ namespace XenAdmin.ConsoleView
                 {
                     SetKeyboardAndMouseCapture(true);
                 }
+
                 Unpause();
             }
 
@@ -1302,7 +1321,7 @@ namespace XenAdmin.ConsoleView
 
         private Set<Keys> _pressedKeys = new Set<Keys>();
         private bool _modifierKeyPressedAlone;
-        
+
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
             const int WM_KEYDOWN = 0x100;
@@ -1337,7 +1356,8 @@ namespace XenAdmin.ConsoleView
             if (!pressed && _pressedKeys.Count == 0) // we received key-up, but not key-down - ignore
                 return true;
 
-            if (KeyHandler.handleExtras(pressed, _pressedKeys, KeyHandler.ExtraKeys, extendedKey, KeyHandler.ModifierKeys, ref _modifierKeyPressedAlone))
+            if (KeyHandler.handleExtras(pressed, _pressedKeys, KeyHandler.ExtraKeys, extendedKey,
+                    KeyHandler.ModifierKeys, ref _modifierKeyPressedAlone))
             {
                 Focus();
                 return true;
@@ -1355,12 +1375,13 @@ namespace XenAdmin.ConsoleView
             }
 
             if (key == Keys.Tab || (key == (Keys.Tab | Keys.Shift)))
-                return false;           
+                return false;
 
             return false;
         }
 
         private Size _oldSize;
+
         public void UpdateRDPResolution(bool fullscreen = false)
         {
             if (_rdpClient == null || _oldSize.Equals(Size))
@@ -1368,9 +1389,10 @@ namespace XenAdmin.ConsoleView
 
             //no offsets in fullscreen mode because there is no need to accomodate focus border 
             if (fullscreen)
-                _rdpClient.UpdateDisplay(Size.Width, Size.Height, new Point(0,0));
+                _rdpClient.UpdateDisplay(Size.Width, Size.Height, new Point(0, 0));
             else
-                _rdpClient.UpdateDisplay(Size.Width - CONSOLE_SIZE_OFFSET, Size.Height - CONSOLE_SIZE_OFFSET, new Point(3,3));
+                _rdpClient.UpdateDisplay(Size.Width - CONSOLE_SIZE_OFFSET, Size.Height - CONSOLE_SIZE_OFFSET,
+                    new Point(3, 3));
             _oldSize = new Size(Size.Width, Size.Height);
             Refresh();
         }

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -772,6 +772,8 @@ namespace XenAdmin.ConsoleView
             if (Source == null || Source.IsControlDomainZero(out _))
                 return;
 
+            _connectionPoller?.Dispose();
+
             //Start the polling again
             _connectionPoller = !Source.IsHVM()
                 ? new Timer(PollVNCPort, null, RETRY_SLEEP_TIME, RDP_POLL_INTERVAL)

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -585,8 +585,7 @@ namespace XenAdmin.ConsoleView
                     RemoteConsole.Activate();
             }
 
-            if (GpuStatusChanged != null)
-                GpuStatusChanged(MustConnectRemoteDesktop());
+            GpuStatusChanged?.Invoke(MustConnectRemoteDesktop());
         }
 
         internal bool MustConnectRemoteDesktop()
@@ -605,8 +604,10 @@ namespace XenAdmin.ConsoleView
         {
             if (_vncClient != null)
                 ThreadPool.QueueUserWorkItem(Connect, new KeyValuePair<VNCGraphicsClient, Exception>(_vncClient, null));
-            else if (_rdpClient != null)
-                _rdpClient.Connect(RdpIp);
+            else
+            {
+                _rdpClient?.Connect(RdpIp);
+            }
         }
 
         void ConnectionSuccess(object sender, EventArgs e)
@@ -792,15 +793,13 @@ namespace XenAdmin.ConsoleView
             {
                 ParentVNCTabView.VMPowerOn();
                 ConnectNewHostedConsole();
-                if (_connectionPoller != null)
-                    _connectionPoller.Change(RETRY_SLEEP_TIME, RDP_POLL_INTERVAL);
+                _connectionPoller?.Change(RETRY_SLEEP_TIME, RDP_POLL_INTERVAL);
             }
             else if (e.PropertyName == "power_state" &&
                 (vm.power_state == vm_power_state.Halted || vm.power_state == vm_power_state.Suspended))
             {
                 ParentVNCTabView.VMPowerOff();
-                if (_connectionPoller != null)
-                    _connectionPoller.Change(Timeout.Infinite, Timeout.Infinite);
+                _connectionPoller?.Change(Timeout.Infinite, Timeout.Infinite);
             }
             else if (e.PropertyName == "domid")
             {
@@ -812,8 +811,7 @@ namespace XenAdmin.ConsoleView
             {
                 Program.Invoke(this, () =>
                 {
-                    if (GpuStatusChanged != null)
-                        GpuStatusChanged(MustConnectRemoteDesktop());
+                    GpuStatusChanged?.Invoke(MustConnectRemoteDesktop());
                 });
             }
 
@@ -823,8 +821,7 @@ namespace XenAdmin.ConsoleView
 
         internal void ImediatelyPollForConsole()
         {
-            if (_connectionPoller != null)
-                _connectionPoller.Change(0, RDP_POLL_INTERVAL);
+            _connectionPoller?.Change(0, RDP_POLL_INTERVAL);
         }
 
         private void ConnectNewHostedConsole()
@@ -1039,8 +1036,7 @@ namespace XenAdmin.ConsoleView
             Program.Invoke(this, delegate
             {
                 Log.Debug("User cancelled during VNC authentication");
-                if (UserCancelledAuth != null)
-                    UserCancelledAuth(this, null);
+                UserCancelledAuth?.Invoke(this, null);
             });
         }
 
@@ -1049,8 +1045,7 @@ namespace XenAdmin.ConsoleView
             Program.Invoke(this, delegate
             {
                 Log.Debug("Cancelled VNC connection attempt");
-                if (VncConnectionAttemptCancelled != null)
-                    VncConnectionAttemptCancelled(this, null);
+                VncConnectionAttemptCancelled?.Invoke(this, null);
             });
         }
 
@@ -1123,10 +1118,7 @@ namespace XenAdmin.ConsoleView
         {
             Program.AssertOnEventThread();
 
-            if (RemoteConsole != null)
-            {
-                RemoteConsole.SendCAD();
-            }
+            RemoteConsole?.SendCAD();
         }
 
         private string _errorMessage;
@@ -1220,19 +1212,13 @@ namespace XenAdmin.ConsoleView
 
         internal Image Snapshot()
         {
-            if (RemoteConsole != null)
-                return RemoteConsole.Snapshot();
-
-            return null;
+            return RemoteConsole?.Snapshot();
         }
 
         internal void RefreshScreen()
         {
             Program.AssertOnEventThread();
-            if (RemoteConsole?.ConsoleControl != null)
-            {
-                RemoteConsole.ConsoleControl.Refresh();
-            }
+            RemoteConsole?.ConsoleControl?.Refresh();
             Invalidate();
             Update();
         }

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -64,7 +64,7 @@ namespace XenAdmin.ConsoleView
         private const int VNC_PORT = 5900;
         private const int CONSOLE_SIZE_OFFSET = 6;
 
-        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
 
         private int ConnectionRetries;
 
@@ -568,7 +568,7 @@ namespace XenAdmin.ConsoleView
                 }
             }
 
-            if (RemoteConsole != null && RemoteConsole.ConsoleControl != null)
+            if (RemoteConsole?.ConsoleControl != null)
             {
                 RemoteConsole.KeyHandler = KeyHandler;
                 RemoteConsole.SendScanCodes = !sourceIsPV;
@@ -597,7 +597,7 @@ namespace XenAdmin.ConsoleView
 
         private void SetKeyboardAndMouseCapture(bool value)
         {
-            if (RemoteConsole != null && RemoteConsole.ConsoleControl != null)
+            if (RemoteConsole?.ConsoleControl != null)
                 RemoteConsole.ConsoleControl.TabStop = value;
         }
 
@@ -1229,7 +1229,7 @@ namespace XenAdmin.ConsoleView
         internal void RefreshScreen()
         {
             Program.AssertOnEventThread();
-            if (RemoteConsole != null && RemoteConsole.ConsoleControl != null)
+            if (RemoteConsole?.ConsoleControl != null)
             {
                 RemoteConsole.ConsoleControl.Refresh();
             }

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -247,7 +247,7 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        public Size DesktopSize => RemoteConsole != null ? RemoteConsole.DesktopSize : Size.Empty;
+        public Size DesktopSize => RemoteConsole?.DesktopSize ?? Size.Empty;
 
         /// <summary>
         /// Nothrow guarantee.

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -614,10 +614,8 @@ namespace XenAdmin.ConsoleView
         {
             if (_vncClient != null)
                 ThreadPool.QueueUserWorkItem(Connect, new KeyValuePair<VNCGraphicsClient, Exception>(_vncClient, null));
-            else
-            {
-                _rdpClient?.Connect(RdpIp);
-            }
+            else if (_rdpClient != null)
+                _rdpClient.Connect(RdpIp);
         }
 
         private void ConnectionSuccess(object sender, EventArgs e)

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -170,7 +170,7 @@ namespace XenAdmin.ConsoleView
 
             cachedNetworks = guestMetrics.networks;
 
-            guestMetrics.PropertyChanged += new PropertyChangedEventHandler(guestMetrics_PropertyChanged);
+            guestMetrics.PropertyChanged += guestMetrics_PropertyChanged;
         }
 
         void Default_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -184,13 +184,13 @@ namespace XenAdmin.ConsoleView
             if (Source == null)
                 return;
 
-            Source.PropertyChanged -= new PropertyChangedEventHandler(VM_PropertyChanged);
+            Source.PropertyChanged -= VM_PropertyChanged;
 
             var guestMetrics = Source.Connection.Resolve<VM_guest_metrics>(Source.guest_metrics);
             if (guestMetrics == null)
                 return;
 
-            guestMetrics.PropertyChanged -= new PropertyChangedEventHandler(guestMetrics_PropertyChanged);
+            guestMetrics.PropertyChanged -= guestMetrics_PropertyChanged;
 
         }
 
@@ -564,7 +564,7 @@ namespace XenAdmin.ConsoleView
                     AutoScrollMinSize = oldSize;
                     rdpClient = new RdpClient(this, currentConsoleSize, ResizeHandler);
 
-                    rdpClient.OnDisconnected += new EventHandler(parentVNCTabView.RdpDisconnectedHandler);
+                    rdpClient.OnDisconnected += parentVNCTabView.RdpDisconnectedHandler;
                 }
             }
 
@@ -604,7 +604,7 @@ namespace XenAdmin.ConsoleView
         private void ConnectToRemoteConsole()
         {
             if (vncClient != null)
-                ThreadPool.QueueUserWorkItem(new WaitCallback(Connect), new KeyValuePair<VNCGraphicsClient, Exception>(vncClient, null));
+                ThreadPool.QueueUserWorkItem(Connect, new KeyValuePair<VNCGraphicsClient, Exception>(vncClient, null));
             else if (rdpClient != null)
                 rdpClient.Connect(RdpIp);
         }
@@ -690,7 +690,7 @@ namespace XenAdmin.ConsoleView
 
                 if (sourceVM != null)
                 {
-                    sourceVM.PropertyChanged -= new PropertyChangedEventHandler(VM_PropertyChanged);
+                    sourceVM.PropertyChanged -= VM_PropertyChanged;
                     sourceVM = null;
                 }
 
@@ -698,7 +698,7 @@ namespace XenAdmin.ConsoleView
 
                 if (value != null)
                 {
-                    value.PropertyChanged += new PropertyChangedEventHandler(VM_PropertyChanged);
+                    value.PropertyChanged += VM_PropertyChanged;
 
                     sourceIsPV = !value.IsHVM();
                     
@@ -1115,7 +1115,7 @@ namespace XenAdmin.ConsoleView
         {
             if (vncClient == v && !v.Terminated && Source.power_state == vm_power_state.Running)
             {
-                ThreadPool.QueueUserWorkItem(new WaitCallback(Connect), new KeyValuePair<VNCGraphicsClient, Exception>(v, exn));
+                ThreadPool.QueueUserWorkItem(Connect, new KeyValuePair<VNCGraphicsClient, Exception>(v, exn));
             }
         }
 
@@ -1165,7 +1165,7 @@ namespace XenAdmin.ConsoleView
 
         private void SleepAndRetryConnection_(VNCGraphicsClient v)
         {
-            ThreadPool.QueueUserWorkItem(new WaitCallback(SleepAndRetryConnection), v);
+            ThreadPool.QueueUserWorkItem(SleepAndRetryConnection, v);
         }
 
         private void SleepAndRetryConnection(object o)

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -70,7 +70,7 @@ namespace XenAdmin.ConsoleView
 
         private volatile bool _useVNC = true;
 
-        private bool _autoCaptureKeyboardAndMouse = true;
+        private readonly bool _autoCaptureKeyboardAndMouse = true;
 
         private readonly Color _focusColor = SystemColors.MenuHighlight;
 
@@ -173,7 +173,7 @@ namespace XenAdmin.ConsoleView
             guestMetrics.PropertyChanged += guestMetrics_PropertyChanged;
         }
 
-        void Default_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Default_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "EnableRDPPolling")
                 Program.Invoke(this, StartPolling);
@@ -194,7 +194,7 @@ namespace XenAdmin.ConsoleView
 
         }
 
-        void guestMetrics_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void guestMetrics_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (Source == null)
                 return;
@@ -610,7 +610,7 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        void ConnectionSuccess(object sender, EventArgs e)
+        private void ConnectionSuccess(object sender, EventArgs e)
         {
             _connectionRetries = 0;
             if (AutoSwitchRDPLater)

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -558,8 +558,8 @@ namespace XenAdmin.ConsoleView
             {
                 if (rdpClient == null)
                 {
-                    if (ParentForm is FullScreenForm)
-                        currentConsoleSize = ((FullScreenForm)ParentForm).GetContentSize();
+                    if (ParentForm is FullScreenForm form)
+                        currentConsoleSize = form.GetContentSize();
                     AutoScroll = true;
                     AutoScrollMinSize = oldSize;
                     rdpClient = new RdpClient(this, currentConsoleSize, ResizeHandler);

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -164,7 +164,7 @@ namespace XenAdmin.ConsoleView
             if (source == null)
                 return;
             Properties.Settings.Default.PropertyChanged += Default_PropertyChanged;
-            var guestMetrics = Source.Connection.Resolve<VM_guest_metrics>(Source.guest_metrics);
+            var guestMetrics = Source.Connection.Resolve(Source.guest_metrics);
             if (guestMetrics == null)
                 return;
 
@@ -186,7 +186,7 @@ namespace XenAdmin.ConsoleView
 
             Source.PropertyChanged -= VM_PropertyChanged;
 
-            var guestMetrics = Source.Connection.Resolve<VM_guest_metrics>(Source.guest_metrics);
+            var guestMetrics = Source.Connection.Resolve(Source.guest_metrics);
             if (guestMetrics == null)
                 return;
 
@@ -202,7 +202,7 @@ namespace XenAdmin.ConsoleView
             if (e.PropertyName == "networks")
             {
                 var newNetworks = (sender as VM_guest_metrics).networks;
-                if (!equateDictionary<string, string>(newNetworks, cachedNetworks))
+                if (!equateDictionary(newNetworks, cachedNetworks))
                 {
                     Log.InfoFormat("Detected IP address change in vm {0}, repolling for VNC/RDP...", Source.Name());
 
@@ -1352,7 +1352,7 @@ namespace XenAdmin.ConsoleView
             if (!pressed && pressedKeys.Count == 0) // we received key-up, but not key-down - ignore
                 return true;
 
-            if (KeyHandler.handleExtras<Keys>(pressed, pressedKeys, KeyHandler.ExtraKeys, extendedKey, KeyHandler.ModifierKeys, ref modifierKeyPressedAlone))
+            if (KeyHandler.handleExtras(pressed, pressedKeys, KeyHandler.ExtraKeys, extendedKey, KeyHandler.ModifierKeys, ref modifierKeyPressedAlone))
             {
                 Focus();
                 return true;

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -976,7 +976,7 @@ namespace XenAdmin.ConsoleView
                         else
                         {
                             Log.Debug("Attempting passwordless VNC login");
-                            vncPassword = new char[0];
+                            vncPassword = Array.Empty<char>();
                             ignoreNextError = true;
                             haveTriedLoginWithoutPassword = true;
                         }
@@ -1072,17 +1072,17 @@ namespace XenAdmin.ConsoleView
             }
 
             var uri = new Uri(console.location);
-            string sesssionRef;
+            string sessionRef;
 
             lock (activeSessionLock)
             {
                 // use the elevated credentials, if provided, for connecting to the console (CA-91132)
                 activeSession = (string.IsNullOrEmpty(ElevatedUsername) || string.IsNullOrEmpty(ElevatedPassword)) ?
                     console.Connection.DuplicateSession() : console.Connection.ElevatedSession(ElevatedUsername, ElevatedPassword);
-                sesssionRef = activeSession.opaque_ref;
+                sessionRef = activeSession.opaque_ref;
             }
 
-            var stream = HTTPHelper.CONNECT(uri, console.Connection, sesssionRef, false);
+            var stream = HTTPHelper.CONNECT(uri, console.Connection, sessionRef, false);
 
             InvokeConnection(v, stream, console);
         }

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -148,10 +148,10 @@ namespace XenAdmin.ConsoleView
         internal XSVNCScreen(VM source, EventHandler resizeHandler, VNCTabView parent, string elevatedUsername, string elevatedPassword)
             : base()
         {
-            this.ResizeHandler = resizeHandler;
-            this.parentVNCTabView = parent;
-            this.Source = source;
-            this.KeyHandler = parentVNCTabView.KeyHandler;
+            ResizeHandler = resizeHandler;
+            parentVNCTabView = parent;
+            Source = source;
+            KeyHandler = parentVNCTabView.KeyHandler;
             ElevatedUsername = elevatedUsername;
             ElevatedPassword = elevatedPassword;
 
@@ -519,9 +519,9 @@ namespace XenAdmin.ConsoleView
                 return;
 
             bool wasFocused = false;
-            this.Controls.Clear();
+            Controls.Clear();
             //console size with some offset to accomodate focus rectangle
-            Size currentConsoleSize = new Size(this.Size.Width - CONSOLE_SIZE_OFFSET, this.Size.Height - CONSOLE_SIZE_OFFSET);
+            Size currentConsoleSize = new Size(Size.Width - CONSOLE_SIZE_OFFSET, Size.Height - CONSOLE_SIZE_OFFSET);
 
             lock (_rdpConnectionLock)
             {
@@ -539,7 +539,7 @@ namespace XenAdmin.ConsoleView
                         RemoteConsole.DisconnectAndDispose();
                         RemoteConsole = null;
                     }
-                    this.vncPassword = null;
+                    vncPassword = null;
                 }
             }
             
@@ -549,8 +549,8 @@ namespace XenAdmin.ConsoleView
 
             if (UseVNC || String.IsNullOrEmpty(RdpIp))
             {
-                this.AutoScroll = false;
-                this.AutoScrollMinSize = new Size(0, 0);
+                AutoScroll = false;
+                AutoScrollMinSize = new Size(0, 0);
 
                 vncClient = new VNCGraphicsClient(this);
 
@@ -565,10 +565,10 @@ namespace XenAdmin.ConsoleView
             {
                 if (rdpClient == null)
                 {
-                    if (this.ParentForm is FullScreenForm)
+                    if (ParentForm is FullScreenForm)
                         currentConsoleSize = ((FullScreenForm)ParentForm).GetContentSize();
-                    this.AutoScroll = true;
-                    this.AutoScrollMinSize = oldSize;
+                    AutoScroll = true;
+                    AutoScrollMinSize = oldSize;
                     rdpClient = new RdpClient(this, currentConsoleSize, ResizeHandler);
 
                     rdpClient.OnDisconnected += new EventHandler(parentVNCTabView.RdpDisconnectedHandler);
@@ -577,10 +577,10 @@ namespace XenAdmin.ConsoleView
 
             if (RemoteConsole != null && RemoteConsole.ConsoleControl != null)
             {
-                RemoteConsole.KeyHandler = this.KeyHandler;
-                RemoteConsole.SendScanCodes = !this.sourceIsPV;
+                RemoteConsole.KeyHandler = KeyHandler;
+                RemoteConsole.SendScanCodes = !sourceIsPV;
                 RemoteConsole.Scaling = Scaling;
-                RemoteConsole.DisplayBorder = this.displayFocusRectangle;
+                RemoteConsole.DisplayBorder = displayFocusRectangle;
                 SetKeyboardAndMouseCapture(autoCaptureKeyboardAndMouse);
                 if (wasPaused)
                     RemoteConsole.Pause();
@@ -694,7 +694,7 @@ namespace XenAdmin.ConsoleView
         {
             get
             {
-                return this.sourceVM;
+                return sourceVM;
             }
             set
             {
@@ -971,8 +971,8 @@ namespace XenAdmin.ConsoleView
                         OnVncConnectionAttemptCancelled();
                         return;
                     }
-                    this.vncPassword = Settings.GetVNCPassword(sourceVM.uuid);
-                    if (this.vncPassword == null)
+                    vncPassword = Settings.GetVNCPassword(sourceVM.uuid);
+                    if (vncPassword == null)
                     {
                         bool lifecycleOperationInProgress = sourceVM.current_operations.Values.Any(VM.is_lifecycle_operation);
                         if (haveTriedLoginWithoutPassword && !lifecycleOperationInProgress)
@@ -982,7 +982,7 @@ namespace XenAdmin.ConsoleView
                                 promptForPassword(ignoreNextError ? null : error);
                             });
                             ignoreNextError = false;
-                            if (this.vncPassword == null)
+                            if (vncPassword == null)
                             {
                                 Log.Debug("User cancelled VNC password prompt: aborting connection attempt");
                                 OnUserCancelledAuth();
@@ -992,7 +992,7 @@ namespace XenAdmin.ConsoleView
                         else
                         {
                             Log.Debug("Attempting passwordless VNC login");
-                            this.vncPassword = new char[0];
+                            vncPassword = new char[0];
                             ignoreNextError = true;
                             haveTriedLoginWithoutPassword = true;
                         }
@@ -1007,15 +1007,15 @@ namespace XenAdmin.ConsoleView
                     }
                     if (s == null)
                     {
-                        Log.DebugFormat("Connecting to vncIP={0}, port={1}", this.VncIp, VNC_PORT);
-                        s = connectGuest(this.VncIp, VNC_PORT, sourceVM.Connection);
-                        Log.DebugFormat("Connected to vncIP={0}, port={1}", this.VncIp, VNC_PORT);
+                        Log.DebugFormat("Connecting to vncIP={0}, port={1}", VncIp, VNC_PORT);
+                        s = connectGuest(VncIp, VNC_PORT, sourceVM.Connection);
+                        Log.DebugFormat("Connected to vncIP={0}, port={1}", VncIp, VNC_PORT);
                     }
                     InvokeConnection(v, s, null);
 
                     // store the empty vnc password after a successful passwordless login
-                    if (haveTriedLoginWithoutPassword && this.vncPassword.Length == 0)
-                        Program.Invoke(this, () => Settings.SetVNCPassword(sourceVM.uuid, this.vncPassword)); 
+                    if (haveTriedLoginWithoutPassword && vncPassword.Length == 0)
+                        Program.Invoke(this, () => Settings.SetVNCPassword(sourceVM.uuid, vncPassword)); 
                 }
             }
             catch (Exception exn)
@@ -1036,8 +1036,8 @@ namespace XenAdmin.ConsoleView
                 if (f.ShowDialog(this) == DialogResult.OK)
                 {
                     // Store password for next time
-                    this.vncPassword = f.Password;
-                    Settings.SetVNCPassword(sourceVM.uuid, this.vncPassword);
+                    vncPassword = f.Password;
+                    Settings.SetVNCPassword(sourceVM.uuid, vncPassword);
                 }
                 else
                 {
@@ -1118,11 +1118,11 @@ namespace XenAdmin.ConsoleView
                 }
                 else
                 {
-                    v.SendScanCodes = UseSource && !this.sourceIsPV;
+                    v.SendScanCodes = UseSource && !sourceIsPV;
                     v.SourceVM = sourceVM;
                     v.Console = console;
                     v.UseQemuExtKeyEncoding = sourceVM != null && Helpers.InvernessOrGreater(sourceVM.Connection);
-                    v.Connect(stream, this.vncPassword);
+                    v.Connect(stream, vncPassword);
                 }
             });
         }
@@ -1151,7 +1151,7 @@ namespace XenAdmin.ConsoleView
         {
             Program.AssertOffEventThread();
 
-            if (this.Disposing || this.IsDisposed)
+            if (Disposing || IsDisposed)
                 return;
 
             Program.Invoke(this, delegate()
@@ -1174,7 +1174,7 @@ namespace XenAdmin.ConsoleView
                 else
                 {
                     Log.Warn(exn, exn);
-                    this.errorMessage = exn.Message;
+                    errorMessage = exn.Message;
                 }
             });
         }
@@ -1198,21 +1198,21 @@ namespace XenAdmin.ConsoleView
         protected override void OnPaint(PaintEventArgs e)
         {
             base.OnPaint(e);
-            if (this.errorMessage != null)
+            if (errorMessage != null)
             {
-                SizeF size = e.Graphics.MeasureString(this.errorMessage, this.Font);
-                e.Graphics.DrawString(this.errorMessage, this.Font, Brushes.Black,
-                    ((this.Width - size.Width) / 2), ((this.Height - size.Height) / 2));
+                SizeF size = e.Graphics.MeasureString(errorMessage, Font);
+                e.Graphics.DrawString(errorMessage, Font, Brushes.Black,
+                    ((Width - size.Width) / 2), ((Height - size.Height) / 2));
             }
 
             // draw focus rectangle
-            if (DisplayFocusRectangle && this.ContainsFocus && RemoteConsole != null)
+            if (DisplayFocusRectangle && ContainsFocus && RemoteConsole != null)
             {
                 Rectangle focusRect = Rectangle.Inflate(RemoteConsole.ConsoleBounds, VNCGraphicsClient.BORDER_PADDING / 2,
                                                     VNCGraphicsClient.BORDER_PADDING / 2);
                 using (Pen pen = new Pen(focusColor, VNCGraphicsClient.BORDER_WIDTH))
                 {
-                    if (this.Focused)
+                    if (Focused)
                         pen.DashStyle = DashStyle.Dash;
                     e.Graphics.DrawRectangle(pen, focusRect);
                 }
@@ -1267,7 +1267,7 @@ namespace XenAdmin.ConsoleView
             Program.AssertOnEventThread();
             base.OnLostFocus(e);
 
-            this.pressedKeys = new Set<Keys>();
+            pressedKeys = new Set<Keys>();
 
             // reset tab stop
             SetKeyboardAndMouseCapture(autoCaptureKeyboardAndMouse);
@@ -1370,7 +1370,7 @@ namespace XenAdmin.ConsoleView
 
             if (KeyHandler.handleExtras<Keys>(pressed, pressedKeys, KeyHandler.ExtraKeys, extendedKey, KeyHandler.ModifierKeys, ref modifierKeyPressedAlone))
             {
-                this.Focus();
+                Focus();
                 return true;
             }
 
@@ -1394,15 +1394,15 @@ namespace XenAdmin.ConsoleView
         private Size oldSize;
         public void UpdateRDPResolution(bool fullscreen = false)
         {
-            if (rdpClient == null || oldSize.Equals(this.Size))
+            if (rdpClient == null || oldSize.Equals(Size))
                 return;
 
             //no offsets in fullscreen mode because there is no need to accomodate focus border 
             if (fullscreen)
-                rdpClient.UpdateDisplay(this.Size.Width, this.Size.Height, new Point(0,0));
+                rdpClient.UpdateDisplay(Size.Width, Size.Height, new Point(0,0));
             else
-                rdpClient.UpdateDisplay(this.Size.Width - CONSOLE_SIZE_OFFSET, this.Size.Height - CONSOLE_SIZE_OFFSET, new Point(3,3));
-            oldSize = new Size(this.Size.Width, this.Size.Height);
+                rdpClient.UpdateDisplay(Size.Width - CONSOLE_SIZE_OFFSET, Size.Height - CONSOLE_SIZE_OFFSET, new Point(3,3));
+            oldSize = new Size(Size.Width, Size.Height);
             Refresh();
         }
     }

--- a/XenAdmin/ConsoleView/XSVNCScreen.cs
+++ b/XenAdmin/ConsoleView/XSVNCScreen.cs
@@ -87,7 +87,7 @@ namespace XenAdmin.ConsoleView
         private VM sourceVM;
         private bool sourceIsPV;
 
-        private readonly Object hostedConsolesLock = new Object();
+        private readonly object hostedConsolesLock = new object();
         private List<XenRef<Console>> hostedConsoles;
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace XenAdmin.ConsoleView
         /// the activeSessionLock.
         /// </summary>
         private Session activeSession;
-        private readonly Object activeSessionLock = new Object();
+        private readonly object activeSessionLock = new object();
 
         /// <summary>
         /// Xvnc will block us if we're too quick with the disconnect and reconnect that we do
@@ -107,7 +107,7 @@ namespace XenAdmin.ConsoleView
         /// Dispose.
         /// </summary>
         private Stream pendingVNCConnection;
-        private readonly Object pendingVNCConnectionLock = new Object();
+        private readonly object pendingVNCConnectionLock = new object();
 
         internal EventHandler ResizeHandler;
 
@@ -515,7 +515,7 @@ namespace XenAdmin.ConsoleView
             Program.AssertOnEventThread();
 
             //When switch to RDP from VNC, if RDP IP is empty, do not try to switch.
-            if (String.IsNullOrEmpty(RdpIp) && !UseVNC && RemoteConsole != null)
+            if (string.IsNullOrEmpty(RdpIp) && !UseVNC && RemoteConsole != null)
                 return;
 
             bool wasFocused = false;
@@ -547,7 +547,7 @@ namespace XenAdmin.ConsoleView
             // Reset
             haveTriedLoginWithoutPassword = false;
 
-            if (UseVNC || String.IsNullOrEmpty(RdpIp))
+            if (UseVNC || string.IsNullOrEmpty(RdpIp))
             {
                 AutoScroll = false;
                 AutoScrollMinSize = new Size(0, 0);
@@ -1072,7 +1072,7 @@ namespace XenAdmin.ConsoleView
 
         private Stream connectGuest(string ip_address, int port, IXenConnection connection)
         {
-            string uriString = String.Format("http://{0}:{1}/", ip_address, port);
+            string uriString = string.Format("http://{0}:{1}/", ip_address, port);
             Log.DebugFormat("Trying to connect to: {0}", uriString);          
             return HTTP.ConnectStream(new Uri(uriString), XenAdminConfigManager.Provider.GetProxyFromSettings(connection), true, 0);           
         }
@@ -1145,7 +1145,7 @@ namespace XenAdmin.ConsoleView
             }
         }
 
-        private String errorMessage;
+        private string errorMessage;
 
         private void ErrorHandler(object sender, Exception exn)
         {

--- a/XenAdmin/RDP/IRdpClient.cs
+++ b/XenAdmin/RDP/IRdpClient.cs
@@ -28,16 +28,26 @@
  * SUCH DAMAGE.
  */
 
+using AxMSTSCLib;
+using System;
+
 namespace XenAdmin.RDP
 {
-    public class MsRdpClient6 : AxMSTSCLib.AxMsRdpClient6, IRdpClient
+    /// <summary>
+    /// Interface used to address common fields of RPDClients without
+    /// changing AXMSTSCLib.cs
+    /// </summary>
+    internal interface IRdpClient
     {
-        protected override void WndProc(ref System.Windows.Forms.Message m)
-        {
-            //Fix for the missing focus issue on the rdp client component
-            if (m.Msg == 0x0021) //WM_MOUSEACTIVATE ref:http://msdn.microsoft.com/en-us/library/ms645612(VS.85).aspx
-                this.Select();
-            base.WndProc(ref m);
-        }
+        int DesktopWidth { get; set; }
+        string Server { get; set; }
+        int DesktopHeight { get; set; }
+        void Connect();
+
+        event EventHandler OnConnected;
+        event EventHandler OnConnecting;
+        event IMsTscAxEvents_OnDisconnectedEventHandler OnDisconnected;
+        event EventHandler OnAuthenticationWarningDisplayed;
+        event EventHandler OnAuthenticationWarningDismissed;
     }
 }

--- a/XenAdmin/RDP/MsRdpClient9.cs
+++ b/XenAdmin/RDP/MsRdpClient9.cs
@@ -30,13 +30,8 @@
 
 namespace XenAdmin.RDP
 {
-    public class MsRdpClient9 : AxMSTSCLib.AxMsRdpClient9
+    public class MsRdpClient9 : AxMSTSCLib.AxMsRdpClient9, IRdpClient
     {
-        public MsRdpClient9()
-            : base()
-        {
-        }
-
         protected override void WndProc(ref System.Windows.Forms.Message m)
         {
             //Fix for the missing focus issue on the rdp client component

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -417,6 +417,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="RDP\IRdpClient.cs" />
     <Compile Include="SettingsPanels\ClusteringEditPage.cs">
       <SubType>UserControl</SubType>
     </Compile>


### PR DESCRIPTION
I split into commits so it's easier to review them, since the PR contains a lot of tidying up for `XSVNCScreen`.


If you want to reproduce the issue this is fixing, just add multiple calls to `ThreadPool.QueueUserWorkItem(TryToConnectRDP);` in `VNCTabView.cs:1178`:

```csharp
                    if (vncScreen.RdpIp == null)
                        toggleConsoleButton.Enabled = false;
                    ThreadPool.QueueUserWorkItem(TryToConnectRDP);
                    ThreadPool.QueueUserWorkItem(TryToConnectRDP);
                    ThreadPool.QueueUserWorkItem(TryToConnectRDP);
                    ThreadPool.QueueUserWorkItem(TryToConnectRDP);
                    ThreadPool.QueueUserWorkItem(TryToConnectRDP);
```

The changes in 2f8dde440622a70da699906e60f64398bf427cd8 prevent `AccessViolationException`s being called, as they're hit when two instances of `AxMSTSCLib.AxMsRdpClient9` call `Connect` on the same IP + Port combination, which results in the same memory being accessed in unmanaged code.


Also as part of this PR:
- [Add IRdpClient to abstract some common functionality of RDP clients](https://github.com/xenserver/xenadmin/commit/7067629b29e194d3842887c472b3bfee3e704c5f)

    The reason this wasn't added to the `AxMsRdpClientX` classes is that I thought it best to not touch `AxMSTSCLib` classes as they are likely generated.

- [Catch HRESULT E_FAIL exceptions for IRDPClient.Connect calls](https://github.com/xenserver/xenadmin/commit/9ea0a53447d4a4bcd5fb1db7890467cfe52ec31d)

   The `Connect` method returns `E_FAIL` if it is called while the control is already connected or in the connecting state. This can be hit when a lot of connections are being opened at the same time, and it's there as a failsafe.

   Also adds `IsAttemptingConnection` as a new field

- [Dispose of timer when creating new port polling Timer](https://github.com/xenserver/xenadmin/pull/3169/commits/60a5580d207d7b1df4fdf1b57ad5715f66b0317b)
  
  While testing I found that there were a couple of ways whereby multiple `Timer`s could be running indefinitely (unless `XSVNCScreen.cs` was disposed of). This happened because we were not disposing of the `Timer` in `StartPolling`.

