### PR TITLE
Disallow connection to havana servers.

### DIFF
--- a/XenAdmin/Dialogs/AssignLicenseDialog.cs
+++ b/XenAdmin/Dialogs/AssignLicenseDialog.cs
@@ -124,7 +124,7 @@ namespace XenAdmin.Dialogs
                 enterprisePerUserRadioButton.Text = string.Format(Messages.LICENSE_EDITION_ENTERPRISE_PERUSER_LEGACY, BrandManager.ProductBrand);
                 desktopPlusRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP_PLUS_LEGACY;
                 desktopRadioButton.Text = Messages.LICENSE_EDITION_DESKTOP_LEGACY;
-                desktopCloudRadioButton.Visible = xos.TrueForAll(x => Helpers.JuraOrGreater(x.Connection) || Helpers.HavanaOrGreater(x.Connection));
+                desktopCloudRadioButton.Visible = xos.TrueForAll(x => Helpers.JuraOrGreater(x.Connection));
                 desktopCloudRadioButton.Text = string.Format(Messages.LICENSE_EDITION_DESKTOP_CLOUD_LEGACY,
                     BrandManager.CompanyNameLegacy);
                 standardPerSocketRadioButton.Text = string.Format(Messages.LICENSE_EDITION_STANDARD_PERSOCKET_LEGACY,

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -915,7 +915,7 @@ namespace XenAdmin
             var supporters = connection.Cache.Hosts.Where(h => h.opaque_ref != coordinator.opaque_ref);
             foreach (var supporter in supporters)
             {
-                if (Helpers.HavanaOrGreater(supporter))
+                if (Helpers.NaplesOrGreater(supporter))
                     continue;
 
                 connection.EndConnect();
@@ -978,10 +978,9 @@ namespace XenAdmin
                     return;
                 }
 
-                // Allow connection only to Havana and Naples or greater versions
+                // Allow connection only to Naples or greater versions
 
-                if (!Helpers.HavanaOrGreater(coordinator) ||
-                    Helpers.FalconOrGreater(coordinator) && !Helpers.NaplesOrGreater(coordinator))
+                if (!Helpers.NaplesOrGreater(coordinator))
                 {
                     connection.EndConnect();
 

--- a/XenModel/Utils/Helpers.Versions.cs
+++ b/XenModel/Utils/Helpers.Versions.cs
@@ -190,28 +190,6 @@ namespace XenAdmin.Core
         }
 
         /// <summary>
-        /// Havana platform version is 2.1.1 (same as Ely and Honolulu), so use product version here
-        /// </summary>
-        /// <param name="host">May be null, in which case true is returned.</param>
-        public static bool HavanaOrGreater(IXenConnection conn)
-        {
-            return conn == null || HavanaOrGreater(GetCoordinator(conn));
-        }
-
-        /// <summary>
-        /// Havana platform version is 2.1.1 (same as Ely and Honolulu), so use product version here
-        /// </summary>
-        /// <param name="host">May be null, in which case true is returned.</param>
-        public static bool HavanaOrGreater(Host host)
-        {
-            if (host == null)
-                return true;
-
-            return ElyOrGreater(host) &&
-                   ProductVersionCompare(HostProductVersion(host), BrandManager.ProductVersion712Short) >= 0;
-        }
-
-        /// <summary>
         /// Falcon platform version is 2.3.0
         /// </summary>
         /// <param name="conn">May be null, in which case true is returned.</param>


### PR DESCRIPTION
This PR is mostly for reasons of consistency as the connection will fail before we get to the place where we check versions (the version check comes after a successful connection).

So now there is an amount of code that can be cleaned up (everything applying to servers earlier than Naples), but it is not of high priority to do it now, it can be done at a later time.