### PR TITLE
CA-380218: It was not possible to create VMs with VDIs smaller than the max disk…

### DIFF
--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -499,9 +499,8 @@ namespace XenAPI
             var sm = GetSM();
 
             var vdiSizeUnlimited = sm != null && Array.IndexOf(sm.capabilities, "LARGE_VDI") != -1;
-            var vdiSize = vdis.Sum(vdi => vdi.virtual_size);
 
-            if (!vdiSizeUnlimited && vdiSize > DISK_MAX_SIZE)
+            if (!vdiSizeUnlimited && vdis.Any(vdi => vdi.virtual_size > DISK_MAX_SIZE))
             {
                 cannotFitReason = string.Format(Messages.SR_DISKSIZE_EXCEEDS_DISK_MAX_SIZE,
                     Util.DiskSizeString(DISK_MAX_SIZE, 0));
@@ -516,6 +515,7 @@ namespace XenAPI
 
             var isThinlyProvisioned = sm != null && Array.IndexOf(sm.capabilities, "THIN_PROVISIONING") != -1;
             var vdiPhysicalUtilization = vdis.Sum(vdi => vdi.physical_utilisation);
+            var vdiSize = vdis.Sum(vdi => vdi.virtual_size);
             var sizeToConsider = isThinlyProvisioned ? vdiPhysicalUtilization : vdiSize;
 
             if (sizeToConsider > physical_size)


### PR DESCRIPTION
… size when the summed size exceeded the latter limit. The limitation of 2TB for non-GFS2 SRs is on the size of individual VDIs, not the total.