### PR TITLE
CA-381017: Pass `OriginalString` when fetching EUA

### DIFF
--- a/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
+++ b/XenAdmin/Diagnostics/Checks/UpgradeRequiresEUA.cs
@@ -78,7 +78,7 @@ namespace XenAdmin.Diagnostics.Checks
         private void FetchHostEua(Host host)
         {
             string eua = null;
-            if (Helpers.YangtzeOrGreater(host) && !Helpers.TryLoadHostEua(host, _targetUri, out eua))
+            if (Helpers.YangtzeOrGreater(host) && !Helpers.TryLoadHostEua(host, _targetUri?.OriginalString, out eua))
             {
                 Log.Warn($"Could not fetch EUA file for {host.Name()}");
                 lock (_hostsFailedToFetchEua)

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1576,7 +1576,7 @@ namespace XenAdmin.Core
             return queryString;
         }
 
-        public static bool TryLoadHostEua(Host host, Uri targetUri, out string eua)
+        public static bool TryLoadHostEua(Host host, string targetUri, out string eua)
         {
             eua = null;
             if (host == null || targetUri == null)
@@ -1585,7 +1585,7 @@ namespace XenAdmin.Core
             }
             var args = new Dictionary<string, string>
             {
-                { "url", targetUri.ToString()}
+                { "url", targetUri }
             };
 
             try


### PR DESCRIPTION
The `Uri` constructor removes `:` after the IP/Host name for NFS storage