### PR TITLE
CP-44767, CP-44766 & CP-44765: Refactor usage of VM restrictions and add `reference_label` to OVFs

### DIFF
--- a/XenAdmin/Commands/ActivateVBDCommand.cs
+++ b/XenAdmin/Commands/ActivateVBDCommand.cs
@@ -78,7 +78,7 @@ namespace XenAdmin.Commands
                 return false;
             }
 
-            return !vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED);
+            return !vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.IoDriversInstalled);
         }
 
         private bool CanRun(VBD vbd)
@@ -139,7 +139,7 @@ namespace XenAdmin.Commands
                 return Messages.TOOLTIP_DEACTIVATE_SYSVDI;
 
             if (AreIODriversNeededAndMissing(vm))
-                return vm.HasNewVirtualisationStates()
+                return vm.HasNewVirtualizationStates()
                     ? string.Format(Messages.CANNOT_ACTIVATE_VD_VM_NEEDS_IO_DRIVERS, Helpers.GetName(vm).Ellipsise(50))
                     : string.Format(Messages.CANNOT_ACTIVATE_VD_VM_NEEDS_TOOLS, BrandManager.VmTools, Helpers.GetName(vm).Ellipsise(50));
               

--- a/XenAdmin/Commands/DeactivateVBDCommand.cs
+++ b/XenAdmin/Commands/DeactivateVBDCommand.cs
@@ -79,7 +79,7 @@ namespace XenAdmin.Commands
                 return false;
             }
 
-            return !vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED);
+            return !vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.IoDriversInstalled);
         }
 
         private bool CanRun(VBD vbd)
@@ -140,7 +140,7 @@ namespace XenAdmin.Commands
                 return Messages.TOOLTIP_DEACTIVATE_SYSVDI;
 
             if (AreIODriversNeededAndMissing(vm))
-                return vm.HasNewVirtualisationStates()
+                return vm.HasNewVirtualizationStates()
                     ? string.Format(Messages.CANNOT_DEACTIVATE_VDI_NEEDS_IO_DRIVERS, Helpers.GetName(vm).Ellipsise(50))
                     : string.Format(Messages.CANNOT_DEACTIVATE_VDI_NEEDS_TOOLS, BrandManager.VmTools, Helpers.GetName(vm).Ellipsise(50));
 

--- a/XenAdmin/Commands/InstallToolsCommand.cs
+++ b/XenAdmin/Commands/InstallToolsCommand.cs
@@ -275,10 +275,10 @@ namespace XenAdmin.Commands
             if (vm == null || vm.is_a_template || vm.Locked || vm.power_state != vm_power_state.Running)
                 return false;
 
-            var vStatus = vm.GetVirtualisationStatus(out _);
+            var vStatus = vm.GetVirtualizationStatus(out _);
 
-            if (vStatus.HasFlag(VM.VirtualisationStatus.UNKNOWN) ||
-                vStatus.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED) && vStatus.HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED))
+            if (vStatus.HasFlag(VM.VirtualizationStatus.Unknown) ||
+                vStatus.HasFlag(VM.VirtualizationStatus.IoDriversInstalled) && vStatus.HasFlag(VM.VirtualizationStatus.ManagementInstalled))
                 return false;
 
             var vmHome = vm.Home();

--- a/XenAdmin/Commands/VMLifeCycleCommand.cs
+++ b/XenAdmin/Commands/VMLifeCycleCommand.cs
@@ -162,19 +162,19 @@ namespace XenAdmin.Commands
             if (vm == null)
                 return null;
 
-            var status = vm.GetVirtualisationStatus(out _);
+            var status = vm.GetVirtualizationStatus(out _);
             //trying to guess the reason
-            if (vm.HasNewVirtualisationStates())
+            if (vm.HasNewVirtualizationStates())
             {
-                if (!status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED)) //note: this will also be true when the enum is in Unknown state
+                if (!status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled)) //note: this will also be true when the enum is in Unknown state
                     return Messages.VM_MISSING_IO_DRIVERS;
             }
             else
             {
-                if (status == VM.VirtualisationStatus.NOT_INSTALLED || status.HasFlag(VM.VirtualisationStatus.UNKNOWN))
+                if (status == VM.VirtualizationStatus.NotInstalled || status.HasFlag(VM.VirtualizationStatus.Unknown))
                     return FriendlyErrorNames.VM_MISSING_PV_DRIVERS;
 
-                if (status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
+                if (status.HasFlag(VM.VirtualizationStatus.PvDriversOutOfDate))
                     return FriendlyErrorNames.VM_OLD_PV_DRIVERS;
             }
 

--- a/XenAdmin/Controls/Ballooning/VMMemoryControlsBasic.cs
+++ b/XenAdmin/Controls/Ballooning/VMMemoryControlsBasic.cs
@@ -87,11 +87,11 @@ namespace XenAdmin.Controls.Ballooning
                 {
                     // If all the Virtualisation Statuses are the same, report that reason.
                     // Otherwise give a generic message.
-                    VM.VirtualisationStatus vs0 = vm0.GetVirtualisationStatus(out _);
+                    VM.VirtualizationStatus vs0 = vm0.GetVirtualizationStatus(out _);
                     bool identical = true;
                     foreach (VM vm in vms)
                     {
-                        if (vm.GetVirtualisationStatus(out _) != vs0)
+                        if (vm.GetVirtualizationStatus(out _) != vs0)
                         {
                             identical = false;
                             break;
@@ -99,14 +99,14 @@ namespace XenAdmin.Controls.Ballooning
                     }
                     if (identical)
                     {
-                        var status = vm0.GetVirtualisationStatus(out _);
-                        if (status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+                        var status = vm0.GetVirtualizationStatus(out _);
+                        if (status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
                             labelDMCUnavailable.Text = Messages.DMC_UNAVAILABLE_NOTSUPPORTED_PLURAL;
-                        else if (!status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
-                            labelDMCUnavailable.Text = vm0.HasNewVirtualisationStates()
+                        else if (!status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
+                            labelDMCUnavailable.Text = vm0.HasNewVirtualizationStates()
                                 ? Messages.DMC_UNAVAILABLE_NO_IO_NO_MGMNT_PLURAL
                                 : string.Format(Messages.DMC_UNAVAILABLE_NOTOOLS_PLURAL, BrandManager.VmTools);
-                        else if (status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
+                        else if (status.HasFlag(VM.VirtualizationStatus.PvDriversOutOfDate))
                             labelDMCUnavailable.Text = string.Format(Messages.DMC_UNAVAILABLE_OLDTOOLS_PLURAL, BrandManager.VmTools);
                         else
                             labelDMCUnavailable.Text = Messages.DMC_UNAVAILABLE_VMS;
@@ -123,15 +123,15 @@ namespace XenAdmin.Controls.Ballooning
                 }
                 else
                 {
-                    var status = vm0.GetVirtualisationStatus(out _);
+                    var status = vm0.GetVirtualizationStatus(out _);
 
-                    if (status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+                    if (status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
                             labelDMCUnavailable.Text = Messages.DMC_UNAVAILABLE_NOTSUPPORTED;
-                    else if (!status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
-                        labelDMCUnavailable.Text = vm0.HasNewVirtualisationStates()
+                    else if (!status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
+                        labelDMCUnavailable.Text = vm0.HasNewVirtualizationStates()
                             ? Messages.DMC_UNAVAILABLE_NO_IO_NO_MGMNT
                             : string.Format(Messages.DMC_UNAVAILABLE_NOTOOLS, BrandManager.VmTools);
-                    else if (status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
+                    else if (status.HasFlag(VM.VirtualizationStatus.PvDriversOutOfDate))
                             labelDMCUnavailable.Text = string.Format(Messages.DMC_UNAVAILABLE_OLDTOOLS, BrandManager.VmTools);
                     else
                         labelDMCUnavailable.Text = Messages.DMC_UNAVAILABLE_VM;

--- a/XenAdmin/Controls/Ballooning/VMMemoryControlsNoEdit.cs
+++ b/XenAdmin/Controls/Ballooning/VMMemoryControlsNoEdit.cs
@@ -93,7 +93,7 @@ namespace XenAdmin.Controls.Ballooning
 
             editButton.Visible = vms.All(vm =>
                 vm.power_state == vm_power_state.Halted ||
-                vm.power_state == vm_power_state.Running && !vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.UNKNOWN));
+                vm.power_state == vm_power_state.Running && !vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.Unknown));
 
             vmShinyBar.Populate(vms, false);
 

--- a/XenAdmin/Controls/HaNtolControl.cs
+++ b/XenAdmin/Controls/HaNtolControl.cs
@@ -54,7 +54,7 @@ namespace XenAdmin.Controls
         protected long ntolMax = -1;
         protected long ntol = -1;
         private IXenConnection connection;
-        private Dictionary<VM, VM.HA_Restart_Priority> settings;
+        private Dictionary<VM, VM.HaRestartPriority> settings;
 
         private readonly CollectionChangeEventHandler VM_CollectionChangedWithInvoke;
 
@@ -111,13 +111,13 @@ namespace XenAdmin.Controls
         /// ha_compute_hypothetical_max_host_failures_to_tolerate. May not be null.
         /// </summary>
         [Browsable(false), ReadOnly(true)]
-        public Dictionary<VM, VM.HA_Restart_Priority> Settings
+        public Dictionary<VM, VM.HaRestartPriority> Settings
         {
             get { return settings; }
             set
             {
                 System.Diagnostics.Trace.Assert(value != null);
-                settings = new Dictionary<VM, VM.HA_Restart_Priority>(value);
+                settings = new Dictionary<VM, VM.HaRestartPriority>(value);
                 // Trigger ntol update
                 waitingNtolUpdate.Set();
             }

--- a/XenAdmin/Controls/NetworkingTab/NetworkList.cs
+++ b/XenAdmin/Controls/NetworkingTab/NetworkList.cs
@@ -430,7 +430,7 @@ namespace XenAdmin.Controls.NetworkingTab
                 if (vm.power_state == vm_power_state.Suspended)
                 {
                     RemoveButtonContainer.SetToolTip(Messages.TOOLTIP_REMOVE_NETWORK_SUSPENDED);
-                    EditButtonContainer.SetToolTip(vm.HasNewVirtualisationStates()
+                    EditButtonContainer.SetToolTip(vm.HasNewVirtualizationStates()
                         ? Messages.TOOLTIP_EDIT_NETWORK_IO_DRIVERS
                         : string.Format(Messages.TOOLTIP_EDIT_NETWORK_TOOLS, BrandManager.VmTools));
                     toolTipContainerActivateToggle.SetToolTip(vif.currently_attached 
@@ -438,12 +438,12 @@ namespace XenAdmin.Controls.NetworkingTab
                 }
                 else
                 {
-                    if (vm.power_state == vm_power_state.Running && !vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+                    if (vm.power_state == vm_power_state.Running && !vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
                     {
-                        RemoveButtonContainer.SetToolTip(vm.HasNewVirtualisationStates()
+                        RemoveButtonContainer.SetToolTip(vm.HasNewVirtualizationStates()
                             ? Messages.TOOLTIP_REMOVE_NETWORK_IO_DRIVERS
                             : string.Format(Messages.TOOLTIP_REMOVE_NETWORK_TOOLS, BrandManager.VmTools));
-                        EditButtonContainer.SetToolTip(vm.HasNewVirtualisationStates()
+                        EditButtonContainer.SetToolTip(vm.HasNewVirtualizationStates()
                             ? Messages.TOOLTIP_EDIT_NETWORK_IO_DRIVERS
                             : string.Format(Messages.TOOLTIP_EDIT_NETWORK_TOOLS, BrandManager.VmTools));
                         toolTipContainerActivateToggle.SetToolTip(vif.currently_attached

--- a/XenAdmin/Controls/XenSearch/GroupingControl.cs
+++ b/XenAdmin/Controls/XenSearch/GroupingControl.cs
@@ -71,14 +71,14 @@ namespace XenAdmin.Controls.XenSearch
             potentialGroups.Add(hostGroup);
             potentialGroups.Add(new PropertyGroupingType<String>(ObjectTypes.VM, PropertyNames.os_name));
             potentialGroups.Add(new PropertyGroupingType<vm_power_state>(ObjectTypes.VM, PropertyNames.power_state));
-            potentialGroups.Add(new PropertyGroupingType<VM.VirtualisationStatus>(ObjectTypes.VM, PropertyNames.virtualisation_status));
+            potentialGroups.Add(new PropertyGroupingType<VM.VirtualizationStatus>(ObjectTypes.VM, PropertyNames.virtualisation_status));
             potentialGroups.Add(new PropertyGroupingType<ObjectTypes>(ObjectTypes.AllExcFolders, PropertyNames.type));
             potentialGroups.Add(new XenModelObjectPropertyGroupingType<XenAPI.Network>(ObjectTypes.VM, PropertyNames.networks, poolGroup));
             XenModelObjectPropertyGroupingType<SR> srGroup =
                 new XenModelObjectPropertyGroupingType<SR>(ObjectTypes.VM | ObjectTypes.VDI, PropertyNames.storage, poolGroup);
             potentialGroups.Add(srGroup);
             potentialGroups.Add(new XenModelObjectPropertyGroupingType<VDI>(ObjectTypes.VM, PropertyNames.disks, srGroup));
-            potentialGroups.Add(new PropertyGroupingType<VM.HA_Restart_Priority>(ObjectTypes.VM, PropertyNames.ha_restart_priority));
+            potentialGroups.Add(new PropertyGroupingType<VM.HaRestartPriority>(ObjectTypes.VM, PropertyNames.ha_restart_priority));
             potentialGroups.Add(new BoolGroupingType(ObjectTypes.VM, PropertyNames.read_caching_enabled));
             potentialGroups.Add(new BoolGroupingType(ObjectTypes.VM, PropertyNames.vendor_device_state));
 			potentialGroups.Add(applianceGroup);

--- a/XenAdmin/Controls/XenSearch/QueryElement.cs
+++ b/XenAdmin/Controls/XenSearch/QueryElement.cs
@@ -74,9 +74,9 @@ namespace XenAdmin.Controls.XenSearch
             queryTypes.Add(new IPAddressQueryType(3, ObjectTypes.VM | ObjectTypes.Server | ObjectTypes.LocalSR | ObjectTypes.RemoteSR, PropertyNames.ip_address));
             queryTypes.Add(new DatePropertyQueryType(3, ObjectTypes.VM, PropertyNames.start_time));
             queryTypes.Add(new EnumPropertyQueryType<vm_power_state>(3, ObjectTypes.VM, PropertyNames.power_state));
-            queryTypes.Add(new EnumPropertyQueryType<VM.VirtualisationStatus>(3, ObjectTypes.VM, PropertyNames.virtualisation_status));
+            queryTypes.Add(new EnumPropertyQueryType<VM.VirtualizationStatus>(3, ObjectTypes.VM, PropertyNames.virtualisation_status));
             queryTypes.Add(new ValuePropertyQueryType(3, ObjectTypes.VM, PropertyNames.os_name));
-            queryTypes.Add(new EnumPropertyQueryType<VM.HA_Restart_Priority>(3, ObjectTypes.VM, PropertyNames.ha_restart_priority));
+            queryTypes.Add(new EnumPropertyQueryType<VM.HaRestartPriority>(3, ObjectTypes.VM, PropertyNames.ha_restart_priority));
             queryTypes.Add(new BooleanQueryType(3, ObjectTypes.VM, PropertyNames.read_caching_enabled));
             queryTypes.Add(new BooleanQueryType(3, ObjectTypes.VM, PropertyNames.vendor_device_state));
             queryTypes.Add(new EnumPropertyQueryType<SR.SRTypes>(3, /*ObjectTypes.LocalSR | ObjectTypes.RemoteSR*/ ObjectTypes.None, PropertyNames.sr_type));

--- a/XenAdmin/Diagnostics/Checks/AssertCanEvacuateCheck.cs
+++ b/XenAdmin/Diagnostics/Checks/AssertCanEvacuateCheck.cs
@@ -235,7 +235,7 @@ namespace XenAdmin.Diagnostics.Checks
         private static CannotMigrateVM.CannotMigrateVMReason GetMoreSpecificReasonForCannotMigrateVm(VM vm, CannotMigrateVM.CannotMigrateVMReason reason)
         {
             var gm = vm.Connection.Resolve(vm.guest_metrics);
-            var status = vm.GetVirtualisationStatus(out _);
+            var status = vm.GetVirtualizationStatus(out _);
 
             if (vm.IsWindows())
             {
@@ -244,7 +244,7 @@ namespace XenAdmin.Diagnostics.Checks
                     reason = CannotMigrateVM.CannotMigrateVMReason.CannotMigrateVmNoTools;
                 }
             }
-            else if (status == VM.VirtualisationStatus.NOT_INSTALLED || status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
+            else if (status == VM.VirtualizationStatus.NotInstalled || status.HasFlag(VM.VirtualizationStatus.PvDriversOutOfDate))
             {
                 reason = CannotMigrateVM.CannotMigrateVMReason.CannotMigrateVmNoTools;
             }

--- a/XenAdmin/Dialogs/EvacuateHostDialog.cs
+++ b/XenAdmin/Dialogs/EvacuateHostDialog.cs
@@ -831,7 +831,7 @@ namespace XenAdmin.Dialogs
                         break;
 
                     case Solution.InstallPVDrivers:
-                        error = vm.HasNewVirtualisationStates()
+                        error = vm.HasNewVirtualizationStates()
                             ? string.Format(Messages.EVACUATE_HOST_INSTALL_MGMNT_PROMPT, message)
                             : string.Format(Messages.EVACUATE_HOST_INSTALL_TOOLS_PROMPT, message, BrandManager.VmTools);
                         break;
@@ -839,8 +839,8 @@ namespace XenAdmin.Dialogs
                     case Solution.InstallPVDriversNoSolution:
                         // if the state is not unknown we have metrics and can show a detailed message.
                         // Otherwise go with the server and just say they aren't installed
-                        error = !vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.UNKNOWN)
-                            ? vm.GetVirtualisationWarningMessages()
+                        error = !vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.Unknown)
+                            ? vm.GetVirtualizationWarningMessages()
                             : string.Format(Messages.PV_DRIVERS_NOT_INSTALLED, BrandManager.VmTools);
                         break;
                 }

--- a/XenAdmin/Dialogs/VmSnapshotDialog.cs
+++ b/XenAdmin/Dialogs/VmSnapshotDialog.cs
@@ -138,8 +138,8 @@ namespace XenAdmin.Dialogs
                 labelQuiesceInfo.Text = Messages.FIELD_DISABLED;
             else if (_VM.power_state != vm_power_state.Running)
                 labelQuiesceInfo.Text = Messages.INFO_QUIESCE_MODE_POWER_STATE;
-            else if (!_VM.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED))
-                labelQuiesceInfo.Text = _VM.HasNewVirtualisationStates()
+            else if (!_VM.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.ManagementInstalled))
+                labelQuiesceInfo.Text = _VM.HasNewVirtualizationStates()
                     ? Messages.INFO_QUIESCE_MODE_NO_MGMNT
                     : string.Format(Messages.INFO_QUIESCE_MODE_NO_TOOLS, BrandManager.VmTools);
             else
@@ -149,8 +149,8 @@ namespace XenAdmin.Dialogs
                 labelCheckpointInfo.Text = Messages.FIELD_DISABLED;
             else if (_VM.power_state != vm_power_state.Running)
                 labelCheckpointInfo.Text = Messages.INFO_DISKMEMORY_MODE_POWER_STATE;
-            else if (!_VM.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
-                labelCheckpointInfo.Text = _VM.HasNewVirtualisationStates()
+            else if (!_VM.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
+                labelCheckpointInfo.Text = _VM.HasNewVirtualizationStates()
                     ? Messages.INFO_DISKMEMORY_MODE_NO_IO_DRIVERS
                     : string.Format(Messages.INFO_DISKMEMORY_MODE_NO_TOOLS, BrandManager.VmTools);
             else

--- a/XenAdmin/SettingsPanels/EditNetworkPage.cs
+++ b/XenAdmin/SettingsPanels/EditNetworkPage.cs
@@ -366,7 +366,7 @@ namespace XenAdmin.SettingsPanels
             foreach (VIF v in network.Connection.ResolveAll<VIF>(network.VIFs))
             {
                 VM vm = network.Connection.Resolve<VM>(v.VM);
-                if (vm.power_state != vm_power_state.Running || vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+                if (vm.power_state != vm_power_state.Running || vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
                     continue;
 
                 runningVMsWithoutTools = true;

--- a/XenAdmin/SettingsPanels/GpuEditPage.cs
+++ b/XenAdmin/SettingsPanels/GpuEditPage.cs
@@ -69,7 +69,7 @@ namespace XenAdmin.SettingsPanels
             }
         }
 
-        public VM.HA_Restart_Priority SelectedPriority { private get; set; }
+        public VM.HaRestartPriority SelectedPriority { private get; set; }
 
         #region IEditPage Members
 

--- a/XenAdmin/SettingsPanels/USBEditPage.cs
+++ b/XenAdmin/SettingsPanels/USBEditPage.cs
@@ -46,7 +46,7 @@ namespace XenAdmin.SettingsPanels
     public partial class USBEditPage : XenTabPage, IEditPage
     {
         private VM _vm;
-        public VM.HA_Restart_Priority SelectedPriority { private get; set; }
+        public VM.HaRestartPriority SelectedPriority { private get; set; }
 
         public USBEditPage()
         {

--- a/XenAdmin/SettingsPanels/VMHAEditPage.cs
+++ b/XenAdmin/SettingsPanels/VMHAEditPage.cs
@@ -51,7 +51,7 @@ namespace XenAdmin.SettingsPanels
 
         private VM vm;
         private bool vmIsAgile;
-        private VM.HA_Restart_Priority origRestartPriority;
+        private VM.HaRestartPriority origRestartPriority;
         private long origNtol;
         private long origOrder;
         private long origStartDelay;
@@ -263,7 +263,7 @@ namespace XenAdmin.SettingsPanels
             m_comboBoxProtectionLevel.Items.Clear();
             ToggleScanningVmAgile(false);
 
-            List<VM.HA_Restart_Priority> restartPriorities = VM.GetAvailableRestartPriorities(vm.Connection);
+            List<VM.HaRestartPriority> restartPriorities = VM.GetAvailableRestartPriorities(vm.Connection);
             foreach (var restartPriority in restartPriorities)
             {
                 // add "restart" priorities only is vm is agile
@@ -392,7 +392,7 @@ namespace XenAdmin.SettingsPanels
             return nudOrder.Value != origOrder || nudStartDelay.Value != origStartDelay;
         }
 
-        public VM.HA_Restart_Priority SelectedPriority { get; private set; }
+        public VM.HaRestartPriority SelectedPriority { get; private set; }
 
         public List<VGPU> VGpus { private get; set; }
 
@@ -586,9 +586,9 @@ namespace XenAdmin.SettingsPanels
 
         private class PriorityWrapper
         {
-            public readonly VM.HA_Restart_Priority Priority;
+            public readonly VM.HaRestartPriority Priority;
 
-            public PriorityWrapper(VM.HA_Restart_Priority priority)
+            public PriorityWrapper(VM.HaRestartPriority priority)
             {
                 this.Priority = priority;
             }

--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1641,27 +1641,27 @@ namespace XenAdmin.TabPages
             if (vm != null && vm.Connection != null)
             {
                 //For Dundee or higher Windows VMs
-                if (vm.HasNewVirtualisationStates())
+                if (vm.HasNewVirtualizationStates())
                 {
-                    var status = vm.GetVirtualisationStatus(out var statusString);
+                    var status = vm.GetVirtualizationStatus(out var statusString);
 
                     var sb = new StringBuilder();
 
                     if (vm.power_state == vm_power_state.Running)
                     {
-                        if (status.HasFlag(VM.VirtualisationStatus.UNKNOWN))
+                        if (status.HasFlag(VM.VirtualizationStatus.Unknown))
                         {
                             sb.AppendLine(statusString);
                         }
                         else
                         {
                             //Row 1 : I/O Drivers
-                            sb.AppendLine(status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED)
+                            sb.AppendLine(status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled)
                                 ? Messages.VIRTUALIZATION_STATE_VM_IO_OPTIMIZED
                                 : Messages.VIRTUALIZATION_STATE_VM_IO_NOT_OPTIMIZED);
 
                             //Row 2: Management Agent
-                            sb.AppendLine(status.HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED)
+                            sb.AppendLine(status.HasFlag(VM.VirtualizationStatus.ManagementInstalled)
                                 ? Messages.VIRTUALIZATION_STATE_VM_MANAGEMENT_AGENT_INSTALLED
                                 : Messages.VIRTUALIZATION_STATE_VM_MANAGEMENT_AGENT_NOT_INSTALLED);
                         }
@@ -1680,12 +1680,12 @@ namespace XenAdmin.TabPages
                         string installMessage = string.Empty;
                         var canInstall = InstallToolsCommand.CanRun(vm);
 
-                        if (canInstall && !status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+                        if (canInstall && !status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
                         {
                             installMessage = Messages.VIRTUALIZATION_STATE_VM_INSTALL_IO_DRIVERS_AND_MANAGEMENT_AGENT;
                         }
-                        else if (canInstall && status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED) &&
-                                 !status.HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED))
+                        else if (canInstall && status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled) &&
+                                 !status.HasFlag(VM.VirtualizationStatus.ManagementInstalled))
                         {
                             installMessage = Messages.VIRTUALIZATION_STATE_VM_INSTALL_MANAGEMENT_AGENT;
                         }
@@ -1716,9 +1716,9 @@ namespace XenAdmin.TabPages
                 //for everything else (All VMs on pre-Dundee hosts & All non-Windows VMs on any host)
                 else if (vm.power_state == vm_power_state.Running)
                 {
-                    var status = vm.GetVirtualisationStatus(out var statusString);
+                    var status = vm.GetVirtualizationStatus(out var statusString);
 
-                    if (status == VM.VirtualisationStatus.NOT_INSTALLED || status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
+                    if (status == VM.VirtualizationStatus.NotInstalled || status.HasFlag(VM.VirtualizationStatus.PvDriversOutOfDate))
                     {
                         if (InstallToolsCommand.CanRun(vm))
                         {

--- a/XenAdmin/Wizards/HAWizard.cs
+++ b/XenAdmin/Wizards/HAWizard.cs
@@ -124,21 +124,21 @@ namespace XenAdmin.Wizards
                 xenTabPageHaFinish.Ntol = xenTabPageAssignPriorities.Ntol;
 
                 int alwaysRestartHighPriority = 0, alwaysRestart = 0, bestEffort = 0, doNotRestart = 0;
-                foreach (VM.HA_Restart_Priority priority in xenTabPageAssignPriorities.CurrentSettings.Values)
+                foreach (VM.HaRestartPriority priority in xenTabPageAssignPriorities.CurrentSettings.Values)
                 {
                     switch (priority)
                     {
-                        case VM.HA_Restart_Priority.AlwaysRestartHighPriority:
+                        case VM.HaRestartPriority.AlwaysRestartHighPriority:
                             alwaysRestartHighPriority++;
                             break;
-                        case VM.HA_Restart_Priority.AlwaysRestart:
-                        case VM.HA_Restart_Priority.Restart:
+                        case VM.HaRestartPriority.AlwaysRestart:
+                        case VM.HaRestartPriority.Restart:
                             alwaysRestart++;
                             break;
-                        case VM.HA_Restart_Priority.BestEffort:
+                        case VM.HaRestartPriority.BestEffort:
                             bestEffort++;
                             break;
-                        case VM.HA_Restart_Priority.DoNotRestart:
+                        case VM.HaRestartPriority.DoNotRestart:
                             doNotRestart++;
                             break;
                     }

--- a/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
+++ b/XenAdmin/Wizards/HAWizard_Pages/AssignPriorities.cs
@@ -83,7 +83,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
 
         private void UpdateMenuItems()
         {
-            List<VM.HA_Restart_Priority> restartPriorities = VM.GetAvailableRestartPriorities(connection);
+            List<VM.HaRestartPriority> restartPriorities = VM.GetAvailableRestartPriorities(connection);
 
             //When this line: m_dropDownButtonRestartPriority.ContextMenuStrip = this.contextMenuStrip
             //was called in the designer a "dummy" item was added to the contextMenuStrip by the m_dropDownButtonRestartPriority,
@@ -126,7 +126,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
         /// <summary>
         /// The current (uncommitted) VM restart priorities.
         /// </summary>
-        public Dictionary<VM, VM.HA_Restart_Priority> CurrentSettings
+        public Dictionary<VM, VM.HaRestartPriority> CurrentSettings
         {
             get { return haNtolIndicator.Settings; }
         }
@@ -246,7 +246,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
                     // The first case is for the HA wizard when priorities are being configured for the first time,
                     // the second is for the edit dialog, when HA is already enabled.
                     
-                    VM.HA_Restart_Priority? priority = firstTime ? (VM.HA_Restart_Priority?)null : vm.HARestartPriority();
+                    VM.HaRestartPriority? priority = firstTime ? (VM.HaRestartPriority?)null : vm.HARestartPriority();
                     var row = new VmWithSettingsRow(vm, priority);
                     newRows.Add(row);
                 }
@@ -335,16 +335,16 @@ namespace XenAdmin.Wizards.HAWizard_Pages
                 {
                     Debug.Assert(ProtectVmsByDefault);
 
-                    var priority = isNowAgile ? VM.HaHighestProtectionAvailable(connection) : VM.HA_Restart_Priority.BestEffort;
+                    var priority = isNowAgile ? VM.HaHighestProtectionAvailable(connection) : VM.HaRestartPriority.BestEffort;
 
                     row.UpdateRestartPriority(priority);
                     haNtolIndicator.Settings = getCurrentSettings();
                 }
                 else if (!isNowAgile
-                        && row.RestartPriority != VM.HA_Restart_Priority.BestEffort
-                        && row.RestartPriority != VM.HA_Restart_Priority.DoNotRestart)
+                        && row.RestartPriority != VM.HaRestartPriority.BestEffort
+                        && row.RestartPriority != VM.HaRestartPriority.DoNotRestart)
                 {
-                    row.UpdateRestartPriority(VM.HA_Restart_Priority.BestEffort);
+                    row.UpdateRestartPriority(VM.HaRestartPriority.BestEffort);
                     haNtolIndicator.Settings = getCurrentSettings();
                 }
 
@@ -377,7 +377,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
             var vms = connection.Cache.VMs.Where(v => v.HaCanProtect(Properties.Settings.Default.ShowHiddenVMs));
             bool firstTime = IsHaActivatedFirstTime(vms);
 
-            VM.HA_Restart_Priority? priority = firstTime ? (VM.HA_Restart_Priority?)null : vm.HARestartPriority();
+            VM.HaRestartPriority? priority = firstTime ? (VM.HaRestartPriority?)null : vm.HARestartPriority();
             var row = new VmWithSettingsRow(vm, priority);
             dataGridViewVms.Rows.Add(row);
             UpdateVMsAgility(new List<VM> {vm});
@@ -485,7 +485,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
         private void priority_Click(object sender, EventArgs e)
         {
             var menuitem = (ToolStripMenuItem)sender;
-            VM.HA_Restart_Priority pri = (VM.HA_Restart_Priority)menuitem.Tag;
+            VM.HaRestartPriority pri = (VM.HaRestartPriority)menuitem.Tag;
 
             bool changesMade = false;
             foreach (var row in dataGridViewVms.SelectedRows.Cast<VmWithSettingsRow>())
@@ -509,16 +509,16 @@ namespace XenAdmin.Wizards.HAWizard_Pages
         /// <summary>
         /// Gets the current (uncommitted) VM restart priorities. Must be called on the GUI thread.
         /// </summary>
-        private Dictionary<VM, VM.HA_Restart_Priority> getCurrentSettings()
+        private Dictionary<VM, VM.HaRestartPriority> getCurrentSettings()
         {
             Program.AssertOnEventThread();
-            Dictionary<VM, VM.HA_Restart_Priority> result = new Dictionary<VM, VM.HA_Restart_Priority>();
+            Dictionary<VM, VM.HaRestartPriority> result = new Dictionary<VM, VM.HaRestartPriority>();
 
             foreach (var row in dataGridViewVms.Rows.Cast<VmWithSettingsRow>())
             {
                 // If the restart priority is null, it means we don't know if the VM is agile yet, and we have
                 // protectVmsByDefault == true.
-                result[row.Vm] = row.RestartPriority ?? VM.HA_Restart_Priority.BestEffort;
+                result[row.Vm] = row.RestartPriority ?? VM.HaRestartPriority.BestEffort;
             }
             return result;
         }
@@ -534,7 +534,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
 
             foreach (ToolStripMenuItem item in contextMenuStrip.Items)
             {
-                var itemRestartPriority = ((VM.HA_Restart_Priority)item.Tag);
+                var itemRestartPriority = ((VM.HaRestartPriority)item.Tag);
                 item.Checked = selectedRows.Count > 0 && selectedRows.All(s => s.RestartPriority == itemRestartPriority);
             }
         }
@@ -573,7 +573,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
 
             foreach (ToolStripMenuItem item in contextMenuStrip.Items)
             {
-                VM.HA_Restart_Priority itemRestartPriority = (VM.HA_Restart_Priority)item.Tag;
+                VM.HaRestartPriority itemRestartPriority = (VM.HaRestartPriority)item.Tag;
 
                 if (selectedRows.All(r => r.RestartPriority == itemRestartPriority))
                 {
@@ -603,7 +603,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
             // Now set the buttons and tooltips)
             foreach (ToolStripMenuItem menuItem in contextMenuStrip.Items)
             {
-                var priority = (VM.HA_Restart_Priority)menuItem.Tag;
+                var priority = (VM.HaRestartPriority)menuItem.Tag;
 
                 if (VM.HaPriorityIsRestart(connection, priority))
                 {
@@ -675,7 +675,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
                 if (curRow.HasChanged())
                     result[curRow.Vm] = new VMStartupOptions(curRow.StartOrder,
                                                              curRow.StartDelay,
-                                                             curRow.RestartPriority ?? VM.HA_Restart_Priority.BestEffort);
+                                                             curRow.RestartPriority ?? VM.HaRestartPriority.BestEffort);
             }
             return result;
         }
@@ -737,7 +737,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
             public VM Vm { get; private set; }
             public long StartDelay { get; private set; }
             public long StartOrder { get; private set; }
-            public VM.HA_Restart_Priority? RestartPriority { get; private set; }
+            public VM.HaRestartPriority? RestartPriority { get; private set; }
             public bool IsAgile { get; private set; }
 
             /// <summary>
@@ -781,7 +781,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
                 }
             }
 
-            public VmWithSettingsRow(VM vm, VM.HA_Restart_Priority? priority)
+            public VmWithSettingsRow(VM vm, VM.HaRestartPriority? priority)
             {
                 cellImage = new DataGridViewImageCell {ValueType = typeof(Image)};
                 cellVm = new DataGridViewTextBoxCell();
@@ -817,7 +817,7 @@ namespace XenAdmin.Wizards.HAWizard_Pages
                 cellStartOrder.Value = startOrder.ToString();
             }
 
-            public void UpdateRestartPriority(VM.HA_Restart_Priority? restartPriority)
+            public void UpdateRestartPriority(VM.HaRestartPriority? restartPriority)
             {
                 RestartPriority = restartPriority;
                 cellRestartPriority.Value = Helpers.RestartPriorityI18n(restartPriority);

--- a/XenAdmin/XenSearch/Columns.cs
+++ b/XenAdmin/XenSearch/Columns.cs
@@ -99,31 +99,31 @@ namespace XenAdmin.XenSearch
             VM vm = o as VM;
             if (vm != null)
             {
-                VM.VirtualisationStatus status = vm.GetVirtualisationStatus(out _);
+                VM.VirtualizationStatus status = vm.GetVirtualizationStatus(out _);
                 if (vm.power_state != vm_power_state.Running ||
-                    status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED | VM.VirtualisationStatus.MANAGEMENT_INSTALLED) ||
-                    status.HasFlag(VM.VirtualisationStatus.UNKNOWN))
+                    status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled | VM.VirtualizationStatus.ManagementInstalled) ||
+                    status.HasFlag(VM.VirtualizationStatus.Unknown))
                     return false;
 
-                if (property == PropertyNames.memoryValue && status.HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED))
+                if (property == PropertyNames.memoryValue && status.HasFlag(VM.VirtualizationStatus.ManagementInstalled))
                     return false;
 
-                if ((property == PropertyNames.diskText || property == PropertyNames.networkText) && status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+                if ((property == PropertyNames.diskText || property == PropertyNames.networkText) && status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
                     return false;
 
                 string warningMessage;
                 int colSpan;                
 
-                if (property == PropertyNames.memoryValue && !status.HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED))
+                if (property == PropertyNames.memoryValue && !status.HasFlag(VM.VirtualizationStatus.ManagementInstalled))
                 {
-                    if (vm.HasNewVirtualisationStates())
+                    if (vm.HasNewVirtualizationStates())
                     {
                         warningMessage = Messages.VIRTUALIZATION_STATE_VM_MANAGEMENT_AGENT_NOT_INSTALLED;
                         colSpan = 1;
                     }
                     else
                     {
-                        warningMessage = vm.GetVirtualisationWarningMessages();
+                        warningMessage = vm.GetVirtualizationWarningMessages();
                         colSpan = 3;
                     }
 
@@ -160,7 +160,7 @@ namespace XenAdmin.XenSearch
                     }
                 }
 
-                if (property == PropertyNames.diskText && vm.HasNewVirtualisationStates() && !status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED))
+                if (property == PropertyNames.diskText && vm.HasNewVirtualizationStates() && !status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled))
                 {
                     warningMessage = Messages.VIRTUALIZATION_STATE_VM_IO_NOT_OPTIMIZED;
                     colSpan = 2;

--- a/XenAdminTests/SearchTests/VirtualisationStatePropertyQueryTests.cs
+++ b/XenAdminTests/SearchTests/VirtualisationStatePropertyQueryTests.cs
@@ -222,12 +222,12 @@ namespace XenAdminTests.SearchTests
         [TestCase("Fully optimized", new[] {"vm1", "vm5"})]
         public void TestVirtStatusIs(string filter, string[] expectedVmNames)
         {
-            var dict = PropertyAccessors.Geti18nFor(PropertyNames.virtualisation_status) as Dictionary<string, VM.VirtualisationStatus>;
+            var dict = PropertyAccessors.Geti18nFor(PropertyNames.virtualisation_status) as Dictionary<string, VM.VirtualizationStatus>;
 
             Assert.NotNull(dict, "Did not find i18n for VM.VirtualisationStatus");
             Assert.IsTrue(dict.TryGetValue(filter, out var status), $"Did not find i18n for {filter}");
 
-            var query = new EnumPropertyQuery<VM.VirtualisationStatus>(PropertyNames.virtualisation_status, status, true);
+            var query = new EnumPropertyQuery<VM.VirtualizationStatus>(PropertyNames.virtualisation_status, status, true);
             CheckMatch(query, expectedVmNames);
         }
 
@@ -240,21 +240,21 @@ namespace XenAdminTests.SearchTests
         [TestCase("Fully optimized", new[] {"vm0", "vm2", "vm3", "vm4", "vm6"})]
         public void TestVirtStatusIsNot(string filter, string[] expectedVmNames)
         {
-            var dict = PropertyAccessors.Geti18nFor(PropertyNames.virtualisation_status) as Dictionary<string, VM.VirtualisationStatus>;
+            var dict = PropertyAccessors.Geti18nFor(PropertyNames.virtualisation_status) as Dictionary<string, VM.VirtualizationStatus>;
 
             Assert.NotNull(dict, "Did not find i18n for VM.VirtualisationStatus");
             Assert.IsTrue(dict.TryGetValue(filter, out var status), $"Did not find i18n for {filter}");
 
-            var query = new EnumPropertyQuery<VM.VirtualisationStatus>(PropertyNames.virtualisation_status, status, false);
+            var query = new EnumPropertyQuery<VM.VirtualizationStatus>(PropertyNames.virtualisation_status, status, false);
             CheckMatch(query, expectedVmNames);
         }
 
-        private void CheckMatch(EnumPropertyQuery<VM.VirtualisationStatus> query, string[] expectedVmNames)
+        private void CheckMatch(EnumPropertyQuery<VM.VirtualizationStatus> query, string[] expectedVmNames)
         {
             foreach (var moqVm in _allVms)
             {
                 var vm = moqVm.Object;
-                bool? match = query.MatchProperty(vm.GetVirtualisationStatus(out _));
+                bool? match = query.MatchProperty(vm.GetVirtualizationStatus(out _));
                 Assert.True(match.HasValue);
 
                 var name = vm.Name();

--- a/XenModel/Actions/OvfActions/Export.cs
+++ b/XenModel/Actions/OvfActions/Export.cs
@@ -292,6 +292,11 @@ namespace XenAdmin.Actions.OvfActions
                 OVF.AddOtherSystemSettingData(ovfEnv, vsId, "recommendations", vm.recommendations, hypervisorInfo);
             }
 
+            if (!string.IsNullOrEmpty(vm.reference_label))
+            {
+                OVF.AddOtherSystemSettingData(ovfEnv, vsId, "reference_label", vm.reference_label, hypervisorInfo);
+            }
+
             if (vm.has_vendor_device)
             {
                 //serialise it with a different name to avoid it being deserialised automatically and getting the wrong type

--- a/XenModel/Actions/Pool/EnableHAAction.cs
+++ b/XenModel/Actions/Pool/EnableHAAction.cs
@@ -84,7 +84,7 @@ namespace XenAdmin.Actions
                 foreach (VM vm in startupOptions.Keys)
                 {
                     log.DebugFormat("Setting HA priority on {0} to {1}", vm.Name(), startupOptions[vm].HaRestartPriority);
-                    VM.SetHaRestartPriority(Session, vm, (VM.HA_Restart_Priority)startupOptions[vm].HaRestartPriority);
+                    VM.SetHaRestartPriority(Session, vm, (VM.HaRestartPriority)startupOptions[vm].HaRestartPriority);
 
                     log.DebugFormat("Setting start order on {0} to {1}", vm.Name(), startupOptions[vm].Order);
                     VM.set_order(Session, vm.opaque_ref, startupOptions[vm].Order);

--- a/XenModel/Actions/VM/HAUnprotectVMAction.cs
+++ b/XenModel/Actions/VM/HAUnprotectVMAction.cs
@@ -39,7 +39,7 @@ namespace XenAdmin.Actions
 
         public HAUnprotectVMAction(VM vm)
             : base(vm.Connection, string.Format(Messages.ACTION_HA_UNPROTECT_VM_TITLE, Helpers.GetName(vm),
-            Helpers.RestartPriorityI18n(VM.HA_Restart_Priority.DoNotRestart)), Messages.ACTION_HA_UNPROTECT_VM_DESCRIPTION)
+            Helpers.RestartPriorityI18n(VM.HaRestartPriority.DoNotRestart)), Messages.ACTION_HA_UNPROTECT_VM_DESCRIPTION)
         {
             VM = vm;
             ApiMethodsToRoleCheck.Add("VM.set_ha_restart_priority");

--- a/XenModel/Actions/VM/InstallPVToolsAction.cs
+++ b/XenModel/Actions/VM/InstallPVToolsAction.cs
@@ -86,7 +86,7 @@ namespace XenAdmin.Actions
 
             // Check the version (if any) of the PV tools already on this host...
             VM_guest_metrics guestMetrics = Connection.Resolve(VM.guest_metrics);
-            if (guestMetrics != null && !VM.HasNewVirtualisationStates() && guestMetrics.PV_drivers_installed() && guestMetrics.PV_drivers_up_to_date)
+            if (guestMetrics != null && !VM.HasNewVirtualizationStates() && guestMetrics.PV_drivers_installed() && guestMetrics.PV_drivers_up_to_date)
             {
                 this.Description = string.Format(Messages.INSTALLTOOLS_EXIST, BrandManager.VmTools);
                 return;

--- a/XenModel/Actions/VM/SetHaPrioritiesAction.cs
+++ b/XenModel/Actions/VM/SetHaPrioritiesAction.cs
@@ -71,12 +71,12 @@ namespace XenAdmin.Actions
             int i = 0;
             foreach (VM vm in settings.Keys)
             {
-                if (VM.HaPriorityIsRestart(vm.Connection, (VM.HA_Restart_Priority)settings[vm].HaRestartPriority))
+                if (VM.HaPriorityIsRestart(vm.Connection, (VM.HaRestartPriority)settings[vm].HaRestartPriority))
                     continue;
 
                 Description = string.Format(Messages.HA_SETTING_PRIORITY_ON_X, Helpers.GetName(vm));
 
-                VM.SetHaRestartPriority(Session, vm, (VM.HA_Restart_Priority)settings[vm].HaRestartPriority);
+                VM.SetHaRestartPriority(Session, vm, (VM.HaRestartPriority)settings[vm].HaRestartPriority);
                 VM.set_order(Session, vm.opaque_ref, settings[vm].Order);
                 VM.set_start_delay(Session, vm.opaque_ref, settings[vm].StartDelay);
 
@@ -90,12 +90,12 @@ namespace XenAdmin.Actions
             // Then move any VMs from unprotected -> protected
             foreach (VM vm in settings.Keys)
             {
-                if (!VM.HaPriorityIsRestart(vm.Connection, (VM.HA_Restart_Priority)settings[vm].HaRestartPriority))
+                if (!VM.HaPriorityIsRestart(vm.Connection, (VM.HaRestartPriority)settings[vm].HaRestartPriority))
                     continue;
 
                 Description = string.Format(Messages.HA_SETTING_PRIORITY_ON_X, Helpers.GetName(vm));
 
-                VM.SetHaRestartPriority(Session, vm, (VM.HA_Restart_Priority)settings[vm].HaRestartPriority);
+                VM.SetHaRestartPriority(Session, vm, (VM.HaRestartPriority)settings[vm].HaRestartPriority);
                 VM.set_order(Session, vm.opaque_ref, settings[vm].Order);
                 VM.set_start_delay(Session, vm.opaque_ref, settings[vm].StartDelay);
 

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1066,7 +1066,7 @@ namespace XenAdmin.Core
         /// </summary>
         /// <param name="priority"></param>
         /// <returns></returns>
-        public static string RestartPriorityI18n(VM.HA_Restart_Priority? priority)
+        public static string RestartPriorityI18n(VM.HaRestartPriority? priority)
         {
             if (priority == null)
             {
@@ -1078,7 +1078,7 @@ namespace XenAdmin.Core
             }
         }
 
-        public static string RestartPriorityDescription(VM.HA_Restart_Priority? priority)
+        public static string RestartPriorityDescription(VM.HaRestartPriority? priority)
         {
             if (priority == null)
             {
@@ -1096,9 +1096,9 @@ namespace XenAdmin.Core
         /// </summary>
         /// <param name="connection">Must not be null.</param>
         /// <returns></returns>
-        public static Dictionary<VM, VM.HA_Restart_Priority> GetVmHaRestartPriorities(IXenConnection connection, bool showHiddenVMs)
+        public static Dictionary<VM, VM.HaRestartPriority> GetVmHaRestartPriorities(IXenConnection connection, bool showHiddenVMs)
         {
-            Dictionary<VM, VM.HA_Restart_Priority> result = new Dictionary<VM, VM.HA_Restart_Priority>();
+            Dictionary<VM, VM.HaRestartPriority> result = new Dictionary<VM, VM.HaRestartPriority>();
             foreach (VM vm in connection.Cache.VMs)
             {
                 if (vm.HaCanProtect(showHiddenVMs))
@@ -1115,12 +1115,12 @@ namespace XenAdmin.Core
         /// </summary>
         /// <param name="settings">Must not be null.</param>
         /// <returns></returns>
-        public static Dictionary<XenRef<VM>, string> GetVmHaRestartPrioritiesForApi(Dictionary<VM, VM.HA_Restart_Priority> settings)
+        public static Dictionary<XenRef<VM>, string> GetVmHaRestartPrioritiesForApi(Dictionary<VM, VM.HaRestartPriority> settings)
         {
             Dictionary<XenRef<VM>, string> result = new Dictionary<XenRef<VM>, string>();
             foreach (VM vm in settings.Keys)
             {
-                if (settings[vm] == VM.HA_Restart_Priority.BestEffort || settings[vm] == VM.HA_Restart_Priority.DoNotRestart)
+                if (settings[vm] == VM.HaRestartPriority.BestEffort || settings[vm] == VM.HaRestartPriority.DoNotRestart)
                 {
                     // The server doesn't want to know about best-effort/do not restart VMs.
                     // (They don't influence the plan, and sending in the dictionary gives an error).

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -468,7 +468,7 @@ namespace XenAPI
 
         // AutoPowerOn is supposed to be unsupported. However, we advise customers how to
         // enable it (http://support.citrix.com/article/CTX133910), so XenCenter has to be
-        // able to recognise it, and turn it off during Rolling Pool Upgrade.
+        // able to recognize it, and turn it off during Rolling Pool Upgrade.
         public bool GetAutoPowerOn()
         {
             return BoolKey(other_config, "auto_poweron");
@@ -483,13 +483,13 @@ namespace XenAPI
         {
             foreach (var vbdRef in VBDs)
             {
-                var vbd = Connection.Resolve<VBD>(vbdRef);
+                var vbd = Connection.Resolve(vbdRef);
                 if (vbd != null)
                 {
-                    var vdi = Connection.Resolve<VDI>(vbd.VDI);
+                    var vdi = Connection.Resolve(vbd.VDI);
                     if (vdi != null)
                     {
-                        var sr = Connection.Resolve<SR>(vdi.SR);
+                        var sr = Connection.Resolve(vdi.SR);
                         if (sr != null && !sr.shared)
                         {
                             if (sr.content_type == SR.Content_Type_ISO)
@@ -515,7 +515,7 @@ namespace XenAPI
             {
                 if (!vbd.IsCDROM())
                 {
-                    var VDI = Connection.Resolve<VDI>(vbd.VDI);
+                    var VDI = Connection.Resolve(vbd.VDI);
                     if (VDI != null && VDI.Show(showHiddenVMs))
                     {
                         var TheSR = Connection.Resolve(VDI.SR);
@@ -780,7 +780,7 @@ namespace XenAPI
         {
             if (Connection == null)
                 return false;
-            foreach (var vbd in Connection.ResolveAll<VBD>(VBDs))
+            foreach (var vbd in Connection.ResolveAll(VBDs))
             {
                 if (vbd.type == vbd_type.Disk)
                 {
@@ -788,10 +788,10 @@ namespace XenAPI
                 }
                 else
                 {
-                    var vdi = Connection.Resolve<VDI>(vbd.VDI);
+                    var vdi = Connection.Resolve(vbd.VDI);
                     if (vdi == null)
                         continue;
-                    var sr = Connection.Resolve<SR>(vdi.SR);
+                    var sr = Connection.Resolve(vdi.SR);
                     if (sr == null || sr.shared)
                         continue;
                     return false; // we have a shared cd
@@ -1400,7 +1400,7 @@ namespace XenAPI
 
         public bool HasCD()
         {
-            foreach (var vbd in Connection.ResolveAll<VBD>(VBDs))
+            foreach (var vbd in Connection.ResolveAll(VBDs))
             {
                 if (vbd.IsCDROM())
                 {

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -147,10 +147,8 @@ namespace XenAPI
                 vbds.Sort();
                 return vbds[0];
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
         public SR FindVMCDROMSR()
@@ -286,11 +284,10 @@ namespace XenAPI
                 int weight;
                 if (int.TryParse(VCPUs_params["weight"], out weight)) // if we cant parse it we assume its because it is too large, obviously if it isnt a number (ie a string) then we will still go to the else
                     return weight > 0 ? weight : 1; // because we perform a log on what is returned from this the weight must always be greater than 0
-                else
-                    return 65536; // could not parse number, assume max
+                return 65536; // could not parse number, assume max
             }
-            else
-                return 256;
+
+            return 256;
         }
 
         public void SetVcpuWeight(int value)
@@ -496,10 +493,8 @@ namespace XenAPI
                             {
                                 return Messages.EJECT_YOUR_CD;
                             }
-                            else
-                            {
-                                return Messages.VM_USES_LOCAL_STORAGE;
-                            }
+
+                            return Messages.VM_USES_LOCAL_STORAGE;
                         }
                     }
                 }
@@ -560,9 +555,8 @@ namespace XenAPI
                 otherClass = 2;
 
             if (myClass != otherClass)
-                return (myClass - otherClass);
-            else
-                return base.CompareTo(other);
+                return myClass - otherClass;
+            return base.CompareTo(other);
         }
 
         /// <summary>
@@ -786,16 +780,14 @@ namespace XenAPI
                 {
                     return false; // we have a disk :(
                 }
-                else
-                {
-                    var vdi = Connection.Resolve(vbd.VDI);
-                    if (vdi == null)
-                        continue;
-                    var sr = Connection.Resolve(vdi.SR);
-                    if (sr == null || sr.shared)
-                        continue;
-                    return false; // we have a shared cd
-                }
+
+                var vdi = Connection.Resolve(vbd.VDI);
+                if (vdi == null)
+                    continue;
+                var sr = Connection.Resolve(vdi.SR);
+                if (sr == null || sr.shared)
+                    continue;
+                return false; // we have a shared cd
             }
             return true; // we have no disks hooray!!
         }
@@ -1023,8 +1015,7 @@ namespace XenAPI
 
             if (os_name == "")
                 return Messages.UNKNOWN;
-            else
-                return os_name;
+            return os_name;
         }
 
         /// <summary>
@@ -1089,7 +1080,8 @@ namespace XenAPI
                 {
                     return base.NameWithLocation();
                 }
-                else if (is_a_snapshot)
+
+                if (is_a_snapshot)
                 {
                     var snapshotOf = Connection.Resolve(snapshot_of);
                     if (snapshotOf == null)
@@ -1097,7 +1089,7 @@ namespace XenAPI
 
                     return string.Format(Messages.SNAPSHOT_OF_TITLE, Name(), snapshotOf.Name(), LocationString());
                 }
-                else if (is_a_template)
+                if (is_a_template)
                 {
                     if (Helpers.IsPool(Connection))
                         return string.Format(Messages.OBJECT_IN_POOL, Name(), Connection.Name);
@@ -1606,8 +1598,7 @@ namespace XenAPI
                 case VDI.ReadCachingDisabledReasonCode.LICENSE_RESTRICTION:
                     if (Helpers.FeatureForbidden(Connection, Host.RestrictReadCaching))
                         return Messages.VM_READ_CACHING_DISABLED_REASON_LICENSE;
-                    else
-                        return Messages.VM_READ_CACHING_DISABLED_REASON_PREV_LICENSE;
+                    return Messages.VM_READ_CACHING_DISABLED_REASON_PREV_LICENSE;
                 case VDI.ReadCachingDisabledReasonCode.SR_NOT_SUPPORTED:
                     return Messages.VM_READ_CACHING_DISABLED_REASON_SR_TYPE;
                 case VDI.ReadCachingDisabledReasonCode.NO_RO_IMAGE:
@@ -1766,7 +1757,7 @@ namespace XenAPI
 
         public bool UsingUpstreamQemu()
         {
-            return (platform != null) &&
+            return platform != null &&
                 platform.ContainsKey("device-model") &&
                 platform["device-model"] == "qemu-upstream-compat";
         }

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -216,14 +216,14 @@ namespace XenAPI
             if (xdRecommendations != null)
                 return xdRecommendations;
 
-            if (string.IsNullOrEmpty(this.recommendations))
+            if (string.IsNullOrEmpty(recommendations))
                 return null;
 
             xdRecommendations = new XmlDocument();
 
             try
             {
-                xdRecommendations.LoadXml(this.recommendations);
+                xdRecommendations.LoadXml(recommendations);
             }
             catch
             {
@@ -263,8 +263,8 @@ namespace XenAPI
         /// </remarks>
         public string GetBootOrder()
         {
-            if (this.HVM_boot_params.ContainsKey("order"))
-                return this.HVM_boot_params["order"].ToUpper();
+            if (HVM_boot_params.ContainsKey("order"))
+                return HVM_boot_params["order"].ToUpper();
 
             return "CD";
         }
@@ -330,7 +330,7 @@ namespace XenAPI
 
         public bool HasRDP()
         {
-            var metrics = Connection.Resolve(this.guest_metrics);
+            var metrics = Connection.Resolve(guest_metrics);
             if (metrics == null)
                 return false;
             // feature-ts is the feature flag indicating the toolstack
@@ -340,7 +340,7 @@ namespace XenAPI
 
         public bool RDPEnabled()
         {
-            var vmMetrics = Connection.Resolve(this.guest_metrics);
+            var vmMetrics = Connection.Resolve(guest_metrics);
             if (vmMetrics == null)
                 return false;
             // data/ts indicates the VM has RDP enabled
@@ -349,7 +349,7 @@ namespace XenAPI
 
         public bool RDPControlEnabled()
         {
-            var metrics = Connection.Resolve(this.guest_metrics);
+            var metrics = Connection.Resolve(guest_metrics);
             if (metrics == null)
                 return false;
             // feature-ts2 is the feature flag indicating that data/ts is valid
@@ -616,11 +616,11 @@ namespace XenAPI
             var status = GetVirtualisationStatus(out _);
 
             if (status.HasFlag(VirtualisationStatus.IO_DRIVERS_INSTALLED) && status.HasFlag(VirtualisationStatus.MANAGEMENT_INSTALLED)
-                || status.HasFlag(VM.VirtualisationStatus.UNKNOWN))
+                || status.HasFlag(VirtualisationStatus.UNKNOWN))
                     // calling function shouldn't send us here if tools are, or might be, present: used to assert here but it can sometimes happen (CA-51460)
                     return "";
 
-            if (status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
+            if (status.HasFlag(VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
             {
                     var guestMetrics = Connection.Resolve(guest_metrics);
                     if (guestMetrics != null
@@ -1078,26 +1078,26 @@ namespace XenAPI
         /// </summary>
         public HA_Restart_Priority HARestartPriority()
         {
-            return StringToPriority(this.ha_restart_priority);
+            return StringToPriority(ha_restart_priority);
         }
 
          public override string NameWithLocation()
         {
-            if (this.Connection != null)
+            if (Connection != null)
             {
-                if (this.IsRealVm())
+                if (IsRealVm())
                 {
                     return base.NameWithLocation();
                 }
-                else if (this.is_a_snapshot)
+                else if (is_a_snapshot)
                 {
-                    var snapshotOf = this.Connection.Resolve(this.snapshot_of);
+                    var snapshotOf = Connection.Resolve(snapshot_of);
                     if (snapshotOf == null)
                         return base.NameWithLocation();
 
                     return string.Format(Messages.SNAPSHOT_OF_TITLE, Name(), snapshotOf.Name(), LocationString());
                 }
-                else if (this.is_a_template)
+                else if (is_a_template)
                 {
                     if (Helpers.IsPool(Connection))
                         return string.Format(Messages.OBJECT_IN_POOL, Name(), Connection.Name);
@@ -1111,11 +1111,11 @@ namespace XenAPI
 
         internal override string LocationString()
         {
-            var server = this.Home();
+            var server = Home();
             if (server != null)
                 return string.Format(Messages.ON_SERVER, server);
 
-            var pool = Helpers.GetPool(this.Connection);
+            var pool = Helpers.GetPool(Connection);
             if (pool != null)
                 return string.Format(Messages.IN_POOL, pool);
 
@@ -1225,7 +1225,7 @@ namespace XenAPI
         /// <param name="priority"></param>
         public static void SetHaRestartPriority(Session session, VM vm, HA_Restart_Priority priority)
         {
-            VM.set_ha_restart_priority(session, vm.opaque_ref, PriorityToString(priority));
+            set_ha_restart_priority(session, vm.opaque_ref, PriorityToString(priority));
         }
 
         public bool AnyDiskFastClonable()
@@ -1400,7 +1400,7 @@ namespace XenAPI
 
         public bool HasCD()
         {
-            foreach (var vbd in this.Connection.ResolveAll<VBD>(this.VBDs))
+            foreach (var vbd in Connection.ResolveAll<VBD>(VBDs))
             {
                 if (vbd.IsCDROM())
                 {
@@ -1471,7 +1471,7 @@ namespace XenAPI
                 return homeServer.CoresPerSocket();
 
             var maxCoresPerSocket = 0;
-            foreach (var host in this.Connection.Cache.Hosts)
+            foreach (var host in Connection.Cache.Hosts)
             {
                 var coresPerSocket = host.CoresPerSocket();
                 if (coresPerSocket > maxCoresPerSocket)
@@ -1691,7 +1691,7 @@ namespace XenAPI
 
         public bool WindowsUpdateCapable()
         {
-            return this.has_vendor_device && this.IsWindows();
+            return has_vendor_device && IsWindows();
         }
 
         /// <summary>
@@ -1701,9 +1701,9 @@ namespace XenAPI
         {
             var ipAddresses = new List<string>();
 
-            if (!this.is_control_domain) //vm
+            if (!is_control_domain) //vm
             {
-                var vifs = this.Connection.ResolveAll(this.VIFs);
+                var vifs = Connection.ResolveAll(VIFs);
                 vifs.Sort();
 
                 foreach (var vif in vifs)
@@ -1720,12 +1720,12 @@ namespace XenAPI
             }
             else //control domain
             {
-                var pifList = new List<PIF>(this.Connection.Cache.PIFs);
+                var pifList = new List<PIF>(Connection.Cache.PIFs);
                 pifList.Sort(); // This sort ensures that the primary PIF comes before other management PIFs
 
                 foreach (var pif in pifList)
                 {
-                    if (pif.host.opaque_ref != this.resident_on.opaque_ref || !pif.currently_attached)
+                    if (pif.host.opaque_ref != resident_on.opaque_ref || !pif.currently_attached)
                         continue;
 
                     if (pif.IsManagementInterface(false))

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -151,15 +151,8 @@ namespace XenAPI
         public SR FindVMCDROMSR()
         {
             var vbd = FindVMCDROM();
-            if (vbd != null)
-            {
-                var vdi = vbd.Connection.Resolve(vbd.VDI);
-                if (vdi != null)
-                {
-                    return vdi.Connection.Resolve(vdi.SR);
-                }
-            }
-            return null;
+            var vdi = vbd?.Connection.Resolve(vbd.VDI);
+            return vdi?.Connection.Resolve(vdi.SR);
         }
 
         public override string Name()
@@ -240,9 +233,7 @@ namespace XenAPI
                 if (theVDI == null || !theVDI.Show(true))
                     continue;
                 var theSr = Connection.Resolve(theVDI.SR);
-                if (theSr == null)
-                    continue;
-                var host = theSr.GetStorageHost();
+                var host = theSr?.GetStorageHost();
                 if (host != null)
                 {
                     return host;
@@ -576,8 +567,7 @@ namespace XenAPI
             _startupTime = value;
             // This has an impact on the virt state of the VM as we allow a set amount of time for tools to show up before assuming unvirt
             NotifyPropertyChanged("virtualisation_status");
-            if (_virtualizationTimer != null)
-                _virtualizationTimer.Stop();
+            _virtualizationTimer?.Stop();
             // 2 minutes before we give up plus some breathing space
             _virtualizationTimer = new Timer(182000) {AutoReset = false};
             _virtualizationTimer.Elapsed += VirtualizationTimer_Elapsed;
@@ -981,10 +971,8 @@ namespace XenAPI
         public string GetOSName()
         {
             var guestMetrics = Connection.Resolve(guest_metrics);
-            if (guestMetrics == null)
-                return Messages.UNKNOWN;
 
-            if (guestMetrics.os_version == null)
+            if (guestMetrics?.os_version == null)
                 return Messages.UNKNOWN;
 
             if (!guestMetrics.os_version.ContainsKey("name"))
@@ -1418,13 +1406,10 @@ namespace XenAPI
             var vbds = Connection.ResolveAll(VBDs);
             foreach (var vbd in vbds)
             {
-                if (vbd != null)
+                var vdi = vbd?.Connection.Resolve(vbd.VDI);
+                if (vdi != null)
                 {
-                    var vdi = vbd.Connection.Resolve(vbd.VDI);
-                    if (vdi != null)
-                    {
-                        yield return vdi.Connection.Resolve(vdi.SR);
-                    }
+                    yield return vdi.Connection.Resolve(vdi.SR);
                 }
             }
         }

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -102,7 +102,7 @@ namespace XenAPI
         public bool HasSavedRestartPriority()
         {
             var pool = Helpers.GetPoolOfOne(Connection);
-            return pool != null && pool.ha_enabled && !String.IsNullOrEmpty(ha_restart_priority);
+            return pool != null && pool.ha_enabled && !string.IsNullOrEmpty(ha_restart_priority);
         }
 
         /// <summary>
@@ -990,7 +990,7 @@ namespace XenAPI
             return Util.TryParseIso8601DateTime(importDate, out var result) ? result : DateTime.MinValue;
         }
 
-        public String GetOSName()
+        public string GetOSName()
         {
             var guestMetrics = Connection.Resolve(guest_metrics);
             if (guestMetrics == null)

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -62,7 +62,7 @@ namespace XenAPI
         // CP-41825: > 32 vCPUs is only supported for trusted VMs
         public const long MAX_VCPUS_FOR_NON_TRUSTED_VMS = 32; 
 
-        private XmlDocument xdRecommendations = null;
+        private XmlDocument xdRecommendations;
         public const int MAX_ALLOWED_VTPMS = 1;
 
         public int MaxVCPUsAllowed()
@@ -599,7 +599,7 @@ namespace XenAPI
             NotifyPropertyChanged("virtualisation_status");
         }
 
-        private Timer VirtualizationTimer = null;
+        private Timer VirtualizationTimer;
 
         [Flags]
         public enum VirtualisationStatus

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -115,7 +115,7 @@ namespace XenAPI
             if (is_a_snapshot)  // Snapshots have the same "home" as their VM. This is necessary to make a pool-server-VM-snapshot tree (CA-76273).
             {
                 var from = Connection.Resolve(snapshot_of);
-                return (from == null ? null : from.Home()); // "from" can be null if VM has been deleted
+                return from?.Home(); // "from" can be null if VM has been deleted
             }
 
             if (is_a_template)  // Templates (apart from snapshots) don't have a "home", even if their affinity is set CA-36286

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -60,7 +60,7 @@ namespace XenAPI
         public const int DEFAULT_CORES_PER_SOCKET = 1;
         public const long MAX_SOCKETS = 16;  // current hard limit in Xen: CA-198276
         // CP-41825: > 32 vCPUs is only supported for trusted VMs
-        public const long MAX_VCPUS_FOR_NON_TRUSTED_VMS = 32; 
+        public const long MAX_VCPUS_FOR_NON_TRUSTED_VMS = 32;
 
         private XmlDocument _xdRecommendations;
         public const int MAX_ALLOWED_VTPMS = 1;
@@ -294,7 +294,7 @@ namespace XenAPI
 
         public string InstallRepository()
         {
-           return Get(other_config, "install-repository");
+            return Get(other_config, "install-repository");
         }
 
         public string InstallDistro()
@@ -569,7 +569,7 @@ namespace XenAPI
             NotifyPropertyChanged("virtualisation_status");
             _virtualizationTimer?.Stop();
             // 2 minutes before we give up plus some breathing space
-            _virtualizationTimer = new Timer(182000) {AutoReset = false};
+            _virtualizationTimer = new Timer(182000) { AutoReset = false };
             _virtualizationTimer.Elapsed += VirtualizationTimer_Elapsed;
             _virtualizationTimer.Start();
         }
@@ -584,11 +584,11 @@ namespace XenAPI
         [Flags]
         public enum VirtualizationStatus
         {
-            NotInstalled               = 0,
-            Unknown                     = 1,
-            PvDriversOutOfDate      = 2,
-            IoDriversInstalled        = 4,
-            ManagementInstalled        = 8,
+            NotInstalled = 0,
+            Unknown = 1,
+            PvDriversOutOfDate = 2,
+            IoDriversInstalled = 4,
+            ManagementInstalled = 8,
         };
 
         public string GetVirtualizationWarningMessages()
@@ -597,21 +597,21 @@ namespace XenAPI
 
             if (status.HasFlag(VirtualizationStatus.IoDriversInstalled) && status.HasFlag(VirtualizationStatus.ManagementInstalled)
                 || status.HasFlag(VirtualizationStatus.Unknown))
-                    // calling function shouldn't send us here if tools are, or might be, present: used to assert here but it can sometimes happen (CA-51460)
-                    return "";
+                // calling function shouldn't send us here if tools are, or might be, present: used to assert here but it can sometimes happen (CA-51460)
+                return "";
 
             if (status.HasFlag(VirtualizationStatus.PvDriversOutOfDate))
             {
-                    var guestMetrics = Connection.Resolve(guest_metrics);
-                    if (guestMetrics != null
-                        && guestMetrics.PV_drivers_version.ContainsKey("major")
-                        && guestMetrics.PV_drivers_version.ContainsKey("minor"))
-                    {
-                        return string.Format(Messages.PV_DRIVERS_OUT_OF_DATE, BrandManager.VmTools,
-                            guestMetrics.PV_drivers_version["major"], guestMetrics.PV_drivers_version["minor"]);
-                    }
-                    
-                    return string.Format(Messages.PV_DRIVERS_OUT_OF_DATE_UNKNOWN_VERSION, BrandManager.VmTools);
+                var guestMetrics = Connection.Resolve(guest_metrics);
+                if (guestMetrics != null
+                    && guestMetrics.PV_drivers_version.ContainsKey("major")
+                    && guestMetrics.PV_drivers_version.ContainsKey("minor"))
+                {
+                    return string.Format(Messages.PV_DRIVERS_OUT_OF_DATE, BrandManager.VmTools,
+                        guestMetrics.PV_drivers_version["major"], guestMetrics.PV_drivers_version["minor"]);
+                }
+
+                return string.Format(Messages.PV_DRIVERS_OUT_OF_DATE_UNKNOWN_VERSION, BrandManager.VmTools);
             }
 
             return HasNewVirtualizationStates()
@@ -814,7 +814,7 @@ namespace XenAPI
             Windows = 2,
             WindowsServer = 3,
             LegacyWindows = 4,
-            Asianux  = 5,
+            Asianux = 5,
             Centos = 6,
             CoreOS = 7,
             Debian = 8,
@@ -1056,7 +1056,7 @@ namespace XenAPI
             return StringToPriority(ha_restart_priority);
         }
 
-         public override string NameWithLocation()
+        public override string NameWithLocation()
         {
             if (Connection != null)
             {
@@ -1473,7 +1473,7 @@ namespace XenAPI
         public string Topology()
         {
             var cores = GetCoresPerSocket();
-            var sockets = ValidVCPUConfiguration(VCPUs_max, cores) == "" ? VCPUs_max/cores : 0;
+            var sockets = ValidVCPUConfiguration(VCPUs_max, cores) == "" ? VCPUs_max / cores : 0;
             return GetTopology(sockets, cores);
         }
 
@@ -1768,7 +1768,7 @@ namespace XenAPI
                 cannotReason = string.Format(Messages.VTPM_MAX_REACHED, MAX_ALLOWED_VTPMS);
                 return false;
             }
-            
+
             if (power_state != vm_power_state.Halted)
             {
                 cannotReason = Messages.VTPM_POWER_STATE_WRONG_ATTACH;

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -67,9 +67,9 @@ namespace XenAPI
 
         public int MaxVCPUsAllowed()
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='vcpus-max']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='vcpus-max']");
             if (int.TryParse(xn?.Attributes?["max"]?.Value, out var result))
                 return result;
 
@@ -78,9 +78,9 @@ namespace XenAPI
 
         public int MinVCPUs()
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='vcpus-min']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='vcpus-min']");
             if (int.TryParse(xn?.Attributes?["min"]?.Value, out var result))
                 return result;
 
@@ -101,7 +101,7 @@ namespace XenAPI
         /// <returns></returns>
         public bool HasSavedRestartPriority()
         {
-            Pool pool = Helpers.GetPoolOfOne(Connection);
+            var pool = Helpers.GetPoolOfOne(Connection);
             return pool != null && pool.ha_enabled && !String.IsNullOrEmpty(ha_restart_priority);
         }
 
@@ -114,7 +114,7 @@ namespace XenAPI
         {
             if (is_a_snapshot)  // Snapshots have the same "home" as their VM. This is necessary to make a pool-server-VM-snapshot tree (CA-76273).
             {
-                VM from = Connection.Resolve(snapshot_of);
+                var from = Connection.Resolve(snapshot_of);
                 return (from == null ? null : from.Home()); // "from" can be null if VM has been deleted
             }
 
@@ -124,11 +124,11 @@ namespace XenAPI
             if (power_state == vm_power_state.Running)
                 return Connection.Resolve(resident_on);
 
-            Host storage_host = GetStorageHost(false);
+            var storage_host = GetStorageHost(false);
             if (storage_host != null)
                 return storage_host;
 
-            Host affinityHost = Connection.Resolve(affinity);
+            var affinityHost = Connection.Resolve(affinity);
             if (affinityHost != null && affinityHost.IsLive())
                 return affinityHost;
 
@@ -140,7 +140,7 @@ namespace XenAPI
             if (Connection == null)
                 return null;
 
-            List<VBD> vbds = Connection.ResolveAll(VBDs).FindAll(vbd => vbd.IsCDROM());
+            var vbds = Connection.ResolveAll(VBDs).FindAll(vbd => vbd.IsCDROM());
 
             if (vbds.Count > 0)
             {
@@ -155,10 +155,10 @@ namespace XenAPI
 
         public SR FindVMCDROMSR()
         {
-            VBD vbd = FindVMCDROM();
+            var vbd = FindVMCDROM();
             if (vbd != null)
             {
-                VDI vdi = vbd.Connection.Resolve(vbd.VDI);
+                var vdi = vbd.Connection.Resolve(vbd.VDI);
                 if (vdi != null)
                 {
                     return vdi.Connection.Resolve(vdi.SR);
@@ -180,9 +180,9 @@ namespace XenAPI
 
         public long MaxMemAllowed()
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='memory-static-max']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='memory-static-max']");
             if (long.TryParse(xn?.Attributes?["max"]?.Value, out var result))
                 return result;
 
@@ -191,9 +191,9 @@ namespace XenAPI
 
         public int MaxVIFsAllowed()
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@property='number-of-vifs']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@property='number-of-vifs']");
             if (int.TryParse(xn?.Attributes?["max"]?.Value, out var result))
                 return result;
 
@@ -202,9 +202,9 @@ namespace XenAPI
 
         public int MaxVBDsAllowed()
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@property='number-of-vbds']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@property='number-of-vbds']");
             if (int.TryParse(xn?.Attributes?["max"]?.Value, out var result))
                 return result;
 
@@ -236,19 +236,19 @@ namespace XenAPI
         public Host GetStorageHost(bool ignoreCDs)
         {
 
-            foreach (VBD TheVBD in Connection.ResolveAll(VBDs))
+            foreach (var TheVBD in Connection.ResolveAll(VBDs))
             {
 
                 if (ignoreCDs && TheVBD.type == vbd_type.CD)
                     continue;
-                VDI TheVDI = Connection.Resolve(TheVBD.VDI);
+                var TheVDI = Connection.Resolve(TheVBD.VDI);
 
                 if (TheVDI == null || !TheVDI.Show(true))
                     continue;
-                SR TheSR = Connection.Resolve(TheVDI.SR);
+                var TheSR = Connection.Resolve(TheVDI.SR);
                 if (TheSR == null)
                     continue;
-                Host host = TheSR.GetStorageHost();
+                var host = TheSR.GetStorageHost();
                 if (host != null)
                 {
                     return host;
@@ -381,9 +381,9 @@ namespace XenAPI
             if (!IsHVM())
                 return false;
 
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='allow-gpu-passthrough']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='allow-gpu-passthrough']");
             if (int.TryParse(xn?.Attributes?["value"]?.Value, out var result))
                 return result != 0;
 
@@ -392,9 +392,9 @@ namespace XenAPI
 
         public bool HasSriovRecommendation()
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='allow-network-sriov']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='allow-network-sriov']");
             if (int.TryParse(xn?.Attributes?["value"]?.Value, out var result))
                 return result != 0;
 
@@ -403,9 +403,9 @@ namespace XenAPI
 
         public bool HasVendorDeviceRecommendation()
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='has-vendor-device']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='has-vendor-device']");
             if (bool.TryParse(xn?.Attributes?["value"]?.Value, out var result))
                 return result;
 
@@ -423,9 +423,9 @@ namespace XenAPI
             if (!IsHVM() || !CanHaveGpu())
                 return false;
 
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='allow-vgpu']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='allow-vgpu']");
             if (int.TryParse(xn?.Attributes?["value"]?.Value, out var result))
                 return result != 0;
 
@@ -457,9 +457,9 @@ namespace XenAPI
 
         private string GetRecommendationByField(string fieldName)
         {
-            XmlDocument xd = GetRecommendations();
+            var xd = GetRecommendations();
 
-            XmlNode xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='" + fieldName + "']");
+            var xn = xd?.SelectSingleNode(@"restrictions/restriction[@field='" + fieldName + "']");
 
             return xn?.Attributes?["value"]?.Value ?? string.Empty;
         }
@@ -481,15 +481,15 @@ namespace XenAPI
 
         public string IsOnSharedStorage()
         {
-            foreach (XenRef<VBD> vbdRef in VBDs)
+            foreach (var vbdRef in VBDs)
             {
-                VBD vbd = Connection.Resolve<VBD>(vbdRef);
+                var vbd = Connection.Resolve<VBD>(vbdRef);
                 if (vbd != null)
                 {
-                    VDI vdi = Connection.Resolve<VDI>(vbd.VDI);
+                    var vdi = Connection.Resolve<VDI>(vbd.VDI);
                     if (vdi != null)
                     {
-                        SR sr = Connection.Resolve<SR>(vdi.SR);
+                        var sr = Connection.Resolve<SR>(vdi.SR);
                         if (sr != null && !sr.shared)
                         {
                             if (sr.content_type == SR.Content_Type_ISO)
@@ -511,14 +511,14 @@ namespace XenAPI
         {
             decimal totalSpace = 0;
 
-            foreach (VBD vbd in Connection.ResolveAll(VBDs))
+            foreach (var vbd in Connection.ResolveAll(VBDs))
             {
                 if (!vbd.IsCDROM())
                 {
-                    VDI VDI = Connection.Resolve<VDI>(vbd.VDI);
+                    var VDI = Connection.Resolve<VDI>(vbd.VDI);
                     if (VDI != null && VDI.Show(showHiddenVMs))
                     {
-                        SR TheSR = Connection.Resolve(VDI.SR);
+                        var TheSR = Connection.Resolve(VDI.SR);
                         if (TheSR != null && !TheSR.IsToolsSR())
                         {
                             totalSpace += VDI.virtual_size;
@@ -613,7 +613,7 @@ namespace XenAPI
 
         public string GetVirtualisationWarningMessages()
         {
-            VirtualisationStatus status = GetVirtualisationStatus(out _);
+            var status = GetVirtualisationStatus(out _);
 
             if (status.HasFlag(VirtualisationStatus.IO_DRIVERS_INSTALLED) && status.HasFlag(VirtualisationStatus.MANAGEMENT_INSTALLED)
                 || status.HasFlag(VM.VirtualisationStatus.UNKNOWN))
@@ -622,7 +622,7 @@ namespace XenAPI
 
             if (status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
             {
-                    VM_guest_metrics guestMetrics = Connection.Resolve(guest_metrics);
+                    var guestMetrics = Connection.Resolve(guest_metrics);
                     if (guestMetrics != null
                         && guestMetrics.PV_drivers_version.ContainsKey("major")
                         && guestMetrics.PV_drivers_version.ContainsKey("minor"))
@@ -780,7 +780,7 @@ namespace XenAPI
         {
             if (Connection == null)
                 return false;
-            foreach (VBD vbd in Connection.ResolveAll<VBD>(VBDs))
+            foreach (var vbd in Connection.ResolveAll<VBD>(VBDs))
             {
                 if (vbd.type == vbd_type.Disk)
                 {
@@ -788,10 +788,10 @@ namespace XenAPI
                 }
                 else
                 {
-                    VDI vdi = Connection.Resolve<VDI>(vbd.VDI);
+                    var vdi = Connection.Resolve<VDI>(vbd.VDI);
                     if (vdi == null)
                         continue;
-                    SR sr = Connection.Resolve<SR>(vdi.SR);
+                    var sr = Connection.Resolve<SR>(vdi.SR);
                     if (sr == null || sr.shared)
                         continue;
                     return false; // we have a shared cd
@@ -873,7 +873,7 @@ namespace XenAPI
             if (!DefaultTemplate())
                 return VmTemplateType.Custom;
 
-            string os = name_label.ToLowerInvariant();
+            var os = name_label.ToLowerInvariant();
 
             if (os.Contains("citrix"))
                 return VmTemplateType.Citrix;
@@ -986,13 +986,13 @@ namespace XenAPI
             if (other_config == null || !other_config.ContainsKey(P2V_IMPORT_DATE))
                 return DateTime.MinValue;
 
-            string importDate = other_config[P2V_IMPORT_DATE];
+            var importDate = other_config[P2V_IMPORT_DATE];
             return Util.TryParseIso8601DateTime(importDate, out var result) ? result : DateTime.MinValue;
         }
 
         public String GetOSName()
         {
-            VM_guest_metrics guestMetrics = Connection.Resolve(guest_metrics);
+            var guestMetrics = Connection.Resolve(guest_metrics);
             if (guestMetrics == null)
                 return Messages.UNKNOWN;
 
@@ -1002,10 +1002,10 @@ namespace XenAPI
             if (!guestMetrics.os_version.ContainsKey("name"))
                 return Messages.UNKNOWN;
 
-            String os_name = guestMetrics.os_version["name"];
+            var os_name = guestMetrics.os_version["name"];
 
             // This hack is to make the windows names look nicer
-            int index = os_name.IndexOf("|");
+            var index = os_name.IndexOf("|");
             if (index >= 1)
                 os_name = os_name.Substring(0, index);
 
@@ -1033,7 +1033,7 @@ namespace XenAPI
         /// </summary>
         public DateTime GetStartTime()
         {
-            VM_metrics metrics = Connection.Resolve(this.metrics);
+            var metrics = Connection.Resolve(this.metrics);
             if (metrics == null)
                 return DateTime.MinValue;
 
@@ -1050,7 +1050,7 @@ namespace XenAPI
                 return null;
             }
 
-            DateTime startTime = GetStartTime();
+            var startTime = GetStartTime();
             if (startTime == Epoch || startTime == DateTime.MinValue)
                 return null;
             return new PrettyTimeSpan(DateTime.UtcNow - startTime - Connection.ServerTimeOffset);
@@ -1111,11 +1111,11 @@ namespace XenAPI
 
         internal override string LocationString()
         {
-            Host server = this.Home();
+            var server = this.Home();
             if (server != null)
                 return string.Format(Messages.ON_SERVER, server);
 
-            Pool pool = Helpers.GetPool(this.Connection);
+            var pool = Helpers.GetPool(this.Connection);
             if (pool != null)
                 return string.Format(Messages.IN_POOL, pool);
 
@@ -1213,7 +1213,7 @@ namespace XenAPI
         {
             if (Connection == null)
                 return false;
-            Pool myPool = Helpers.GetPoolOfOne(Connection);
+            var myPool = Helpers.GetPoolOfOne(Connection);
             if (myPool == null)
                 return false;
             return myPool.ha_enabled && HARestartPriority() != HA_Restart_Priority.DoNotRestart;
@@ -1232,20 +1232,20 @@ namespace XenAPI
         {
             if (Connection == null)
                 return false;
-            foreach (VBD vbd in Connection.ResolveAll(VBDs))
+            foreach (var vbd in Connection.ResolveAll(VBDs))
             {
                 if (vbd.type != vbd_type.Disk)
                     continue;
 
-                VDI vdi = Connection.Resolve(vbd.VDI);
+                var vdi = Connection.Resolve(vbd.VDI);
                 if (vdi == null)
                     continue;
 
-                SR sr = Connection.Resolve(vdi.SR);
+                var sr = Connection.Resolve(vdi.SR);
                 if (sr == null)
                     continue;
 
-                SM sm = SM.GetByType(Connection, sr.type);
+                var sm = SM.GetByType(Connection, sr.type);
                 if (sm == null)
                     continue;
 
@@ -1259,7 +1259,7 @@ namespace XenAPI
         {
             if (Connection == null)
                 return false;
-            foreach (VBD vbd in Connection.ResolveAll(VBDs))
+            foreach (var vbd in Connection.ResolveAll(VBDs))
             {
                 if (vbd.type != vbd_type.Disk)
                     continue;
@@ -1300,7 +1300,7 @@ namespace XenAPI
             foreach (var pbd in Connection.Cache.PBDs)
             {
                 if (pbd != null &&
-                    pbd.other_config.TryGetValue("storage_driver_domain", out string vmRef) &&
+                    pbd.other_config.TryGetValue("storage_driver_domain", out var vmRef) &&
                     vmRef == opaque_ref)
                 {
                     sr = Connection.Resolve(pbd.SR);
@@ -1333,11 +1333,11 @@ namespace XenAPI
         {
             try
             {
-                string xml = Get(other_config, "disks");
+                var xml = Get(other_config, "disks");
                 if (string.IsNullOrEmpty(xml))
                     return null;
 
-                XmlDocument doc = new XmlDocument();
+                var doc = new XmlDocument();
                 doc.LoadXml(xml);
                 return doc.FirstChild;
             }
@@ -1368,7 +1368,7 @@ namespace XenAPI
         /// </summary>
         public string AffinityServerString()
         {
-            Host host = Connection.Resolve(affinity);
+            var host = Connection.Resolve(affinity);
             if (host == null)
                 return Messages.NONE;
 
@@ -1392,8 +1392,8 @@ namespace XenAPI
                 return false;
             }
 
-            bool value = bios_strings.ContainsKey("bios-vendor") && bios_strings["bios-vendor"] == "Xen"
-                         && bios_strings.ContainsKey("system-manufacturer") && bios_strings["system-manufacturer"] == "Xen";
+            var value = bios_strings.ContainsKey("bios-vendor") && bios_strings["bios-vendor"] == "Xen"
+                                                                && bios_strings.ContainsKey("system-manufacturer") && bios_strings["system-manufacturer"] == "Xen";
 
             return !value;
         }
@@ -1427,12 +1427,12 @@ namespace XenAPI
 
         public virtual IEnumerable<SR> SRs()
         {
-            List<VBD> vbds = Connection.ResolveAll(VBDs);
+            var vbds = Connection.ResolveAll(VBDs);
             foreach (var vbd in vbds)
             {
                 if (vbd != null)
                 {
-                    VDI vdi = vbd.Connection.Resolve(vbd.VDI);
+                    var vdi = vbd.Connection.Resolve(vbd.VDI);
                     if (vdi != null)
                     {
                         yield return vdi.Connection.Resolve(vdi.SR);
@@ -1544,19 +1544,19 @@ namespace XenAPI
 
         public VM_Docker_Info DockerInfo()
         {
-            string xml = Get(other_config, "docker_info");
+            var xml = Get(other_config, "docker_info");
             if (string.IsNullOrEmpty(xml))
                 return null;
-            VM_Docker_Info info = new VM_Docker_Info(xml);
+            var info = new VM_Docker_Info(xml);
             return info;
         }
 
         public VM_Docker_Version DockerVersion()
         {
-            string xml = Get(other_config, "docker_version");
+            var xml = Get(other_config, "docker_version");
             if (string.IsNullOrEmpty(xml))
                 return null;
-            VM_Docker_Version info = new VM_Docker_Version(xml);
+            var info = new VM_Docker_Version(xml);
             return info;
         }
 
@@ -1676,12 +1676,12 @@ namespace XenAPI
         {
             if (!string.IsNullOrEmpty(last_booted_record))
             {
-                Regex regex = new Regex("'guest_metrics' +'(OpaqueRef:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})'");
+                var regex = new Regex("'guest_metrics' +'(OpaqueRef:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})'");
 
                 var v = regex.Match(last_booted_record);
                 if (v.Success)
                 {
-                    string s = v.Groups[1].ToString();
+                    var s = v.Groups[1].ToString();
                     return Connection.Resolve(new XenRef<VM_guest_metrics>(s));
                 }
             }
@@ -1699,11 +1699,11 @@ namespace XenAPI
         /// </summary>
         public string IPAddressForSSH()
         {
-            List<string> ipAddresses = new List<string>();
+            var ipAddresses = new List<string>();
 
             if (!this.is_control_domain) //vm
             {
-                List<VIF> vifs = this.Connection.ResolveAll(this.VIFs);
+                var vifs = this.Connection.ResolveAll(this.VIFs);
                 vifs.Sort();
 
                 foreach (var vif in vifs)
@@ -1720,10 +1720,10 @@ namespace XenAPI
             }
             else //control domain
             {
-                List<PIF> pifList = new List<PIF>(this.Connection.Cache.PIFs);
+                var pifList = new List<PIF>(this.Connection.Cache.PIFs);
                 pifList.Sort(); // This sort ensures that the primary PIF comes before other management PIFs
 
-                foreach (PIF pif in pifList)
+                foreach (var pif in pifList)
                 {
                     if (pif.host.opaque_ref != this.resident_on.opaque_ref || !pif.currently_attached)
                         continue;
@@ -1737,7 +1737,7 @@ namespace XenAPI
 
             //find first IPv4 address and return it - we would use it if there is one
             IPAddress addr;
-            foreach (string addrString in ipAddresses)
+            foreach (var addrString in ipAddresses)
                 if (IPAddress.TryParse(addrString, out addr) && addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
                     return addrString;
 

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -158,7 +158,7 @@ namespace XenAPI
         ///     List of distros that we treat as Linux/Non-Windows (written in the VM.guest_metrics
         ///     by the Linux Guest Agent after evaluating xe-linux-distribution)
         /// </summary>
-        private static readonly string[] _linuxDistros =
+        private static readonly string[] LinuxDistros =
         {
             "debian", "rhel", "fedora", "centos", "scientific", "oracle", "sles",
             "lsb", "boot2docker", "freebsd", "ubuntu", "neokylin", "gooroom", "rocky"
@@ -1613,7 +1613,7 @@ namespace XenAPI
                 return false;
 
             if (guestMetrics.os_version.TryGetValue("distro", out var distro) &&
-                !string.IsNullOrEmpty(distro) && _linuxDistros.Contains(distro.ToLowerInvariant()))
+                !string.IsNullOrEmpty(distro) && LinuxDistros.Contains(distro.ToLowerInvariant()))
                 return true;
 
             if (guestMetrics.os_version.TryGetValue("uname", out var uname) &&

--- a/XenModel/XenAPI-Extensions/VM.cs
+++ b/XenModel/XenAPI-Extensions/VM.cs
@@ -44,9 +44,9 @@ using Newtonsoft.Json;
 
 namespace XenAPI
 {
-    public partial class VM : IComparable<VM>
+    public partial class VM
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
         // The following variables are only used when the corresponding variable is missing from
         // the recommendations field of the VM (which is inherited from the recommendations field
         // of the template it was created from). This should not normally happen, so we just use
@@ -96,9 +96,6 @@ namespace XenAPI
         /// Returns true if the VM's pool has HA enabled and the VM has a saved restart priority other than DoNotRestart.
         /// Does not take account of ha-always-run.
         /// </summary>
-        /// <param name="session"></param>
-        /// <param name="vm"></param>
-        /// <returns></returns>
         public bool HasSavedRestartPriority()
         {
             var pool = Helpers.GetPoolOfOne(Connection);
@@ -587,7 +584,7 @@ namespace XenAPI
             _virtualizationTimer.Start();
         }
 
-        void VirtualizationTimer_Elapsed(object sender, ElapsedEventArgs e)
+        private void VirtualizationTimer_Elapsed(object sender, ElapsedEventArgs e)
         {
             NotifyPropertyChanged("virtualisation_status");
         }

--- a/XenModel/XenSearch/Common.cs
+++ b/XenModel/XenSearch/Common.cs
@@ -178,9 +178,9 @@ namespace XenAdmin.XenSearch
         private static Dictionary<PropertyNames, Func<IXenObject, IComparable>> properties = new Dictionary<PropertyNames, Func<IXenObject, IComparable>>();
 
         public static readonly Dictionary<String, vm_power_state> VM_power_state_i18n = new Dictionary<string, vm_power_state>();
-        public static readonly Dictionary<String, VM.VirtualisationStatus> VirtualisationStatus_i18n = new Dictionary<string, VM.VirtualisationStatus>();
+        public static readonly Dictionary<String, VM.VirtualizationStatus> VirtualisationStatus_i18n = new Dictionary<string, VM.VirtualizationStatus>();
         public static readonly Dictionary<String, ObjectTypes> ObjectTypes_i18n = new Dictionary<string, ObjectTypes>();
-        public static readonly Dictionary<String, VM.HA_Restart_Priority> HARestartPriority_i18n = new Dictionary<string, VM.HA_Restart_Priority>();
+        public static readonly Dictionary<String, VM.HaRestartPriority> HARestartPriority_i18n = new Dictionary<string, VM.HaRestartPriority>();
         public static readonly Dictionary<String, SR.SRTypes> SRType_i18n = new Dictionary<string, SR.SRTypes>();
 
         public static readonly Dictionary<PropertyNames, String> PropertyNames_i18n = new Dictionary<PropertyNames, string>();
@@ -198,12 +198,12 @@ namespace XenAdmin.XenSearch
             foreach (SR.SRTypes type in Enum.GetValues(typeof(SR.SRTypes)))
                 SRType_i18n[SR.GetFriendlyTypeName(type)] = type;
 
-            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_NOT_OPTIMIZED] = VM.VirtualisationStatus.NOT_INSTALLED;
-            VirtualisationStatus_i18n[Messages.OUT_OF_DATE] = VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE;
-            VirtualisationStatus_i18n[Messages.UNKNOWN] = VM.VirtualisationStatus.UNKNOWN;
-            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_IO_OPTIMIZED_ONLY] = VM.VirtualisationStatus.IO_DRIVERS_INSTALLED;
-            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_MANAGEMENT_AGENT_INSTALLED_ONLY] = VM.VirtualisationStatus.MANAGEMENT_INSTALLED;
-            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_OPTIMIZED] = VM.VirtualisationStatus.IO_DRIVERS_INSTALLED | VM.VirtualisationStatus.MANAGEMENT_INSTALLED;
+            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_NOT_OPTIMIZED] = VM.VirtualizationStatus.NotInstalled;
+            VirtualisationStatus_i18n[Messages.OUT_OF_DATE] = VM.VirtualizationStatus.PvDriversOutOfDate;
+            VirtualisationStatus_i18n[Messages.UNKNOWN] = VM.VirtualizationStatus.Unknown;
+            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_IO_OPTIMIZED_ONLY] = VM.VirtualizationStatus.IoDriversInstalled;
+            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_MANAGEMENT_AGENT_INSTALLED_ONLY] = VM.VirtualizationStatus.ManagementInstalled;
+            VirtualisationStatus_i18n[Messages.VIRTUALIZATION_STATE_VM_OPTIMIZED] = VM.VirtualizationStatus.IoDriversInstalled | VM.VirtualizationStatus.ManagementInstalled;
 
             ObjectTypes_i18n[Messages.VMS] = ObjectTypes.VM;
             ObjectTypes_i18n[string.Format(Messages.XENSERVER_TEMPLATES, BrandManager.ProductBrand)] = ObjectTypes.DefaultTemplate;
@@ -220,7 +220,7 @@ namespace XenAdmin.XenSearch
         	ObjectTypes_i18n[Messages.VM_APPLIANCE] = ObjectTypes.Appliance;
 
 
-            foreach (VM.HA_Restart_Priority p in VM.GetAvailableRestartPriorities(null)) //CA-57600 - From Boston onwards, the HA restart priorities list contains Restart instead of AlwaysRestartHighPriority and AlwaysRestart
+            foreach (VM.HaRestartPriority p in VM.GetAvailableRestartPriorities(null)) //CA-57600 - From Boston onwards, the HA restart priorities list contains Restart instead of AlwaysRestartHighPriority and AlwaysRestart
             {
                 HARestartPriority_i18n[Helpers.RestartPriorityI18n(p)] = p;
             }
@@ -284,11 +284,11 @@ namespace XenAdmin.XenSearch
             property_types.Add(PropertyNames.host, typeof(Host));
             property_types.Add(PropertyNames.os_name, typeof(string));
             property_types.Add(PropertyNames.power_state, typeof(vm_power_state));
-            property_types.Add(PropertyNames.virtualisation_status, typeof(VM.VirtualisationStatus));
+            property_types.Add(PropertyNames.virtualisation_status, typeof(VM.VirtualizationStatus));
             property_types.Add(PropertyNames.type, typeof(ObjectTypes));
             property_types.Add(PropertyNames.networks, typeof(XenAPI.Network));
             property_types.Add(PropertyNames.storage, typeof(SR));
-            property_types.Add(PropertyNames.ha_restart_priority, typeof(VM.HA_Restart_Priority));
+            property_types.Add(PropertyNames.ha_restart_priority, typeof(VM.HaRestartPriority));
             property_types.Add(PropertyNames.read_caching_enabled, typeof(bool));
 			property_types.Add(PropertyNames.appliance, typeof(VM_appliance));
             property_types.Add(PropertyNames.tags, typeof(string));
@@ -304,7 +304,7 @@ namespace XenAdmin.XenSearch
             properties[PropertyNames.os_name] = o => o is VM vm && vm.IsRealVm() ? vm.GetOSName() : null;
             properties[PropertyNames.power_state] = o => o is VM vm && vm.IsRealVm() ? (IComparable)vm.power_state : null;
             properties[PropertyNames.vendor_device_state] = o => o is VM vm && vm.IsRealVm() ? (bool?)vm.WindowsUpdateCapable() : null;
-            properties[PropertyNames.virtualisation_status] = o => o is VM vm && vm.IsRealVm() ? (IComparable)vm.GetVirtualisationStatus(out _) : null;
+            properties[PropertyNames.virtualisation_status] = o => o is VM vm && vm.IsRealVm() ? (IComparable)vm.GetVirtualizationStatus(out _) : null;
             properties[PropertyNames.start_time] = o => o is VM vm && vm.IsRealVm() ? (DateTime?)vm.GetStartTime() : null;
             properties[PropertyNames.read_caching_enabled] = o => o is VM vm && vm.IsRealVm() ? (bool?)vm.ReadCachingEnabled() : null;
 
@@ -343,7 +343,7 @@ namespace XenAdmin.XenSearch
                 {
                     Pool pool = Helpers.GetPool(vm.Connection);
                     if (pool != null && pool.ha_enabled)
-                        return vm.HaPriorityIsRestart() ? VM.HA_Restart_Priority.Restart : vm.HARestartPriority();
+                        return vm.HaPriorityIsRestart() ? VM.HaRestartPriority.Restart : vm.HARestartPriority();
 
                     // CA-57600 - From Boston onwards, the HA_restart_priority enum contains Restart instead of
                     // AlwaysRestartHighPriority and AlwaysRestart. When searching in a pre-Boston pool for VMs
@@ -465,7 +465,7 @@ namespace XenAdmin.XenSearch
             {
                 return vm.IsRealVm() &&
                        vm.power_state == vm_power_state.Running &&
-                       vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED)
+                       vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.ManagementInstalled)
                     ? PropertyAccessorHelper.vmMemoryUsageString(vm)
                     : null;
             }
@@ -487,7 +487,7 @@ namespace XenAdmin.XenSearch
             {
                 return vm.IsRealVm() &&
                        vm.power_state == vm_power_state.Running &&
-                       vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED)
+                       vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.ManagementInstalled)
                     ? (IComparable)PropertyAccessorHelper.vmMemoryUsageRank(vm)
                     : null;
             }
@@ -509,7 +509,7 @@ namespace XenAdmin.XenSearch
                 {
                     return vm.IsRealVm() &&
                            vm.power_state == vm_power_state.Running &&
-                           vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.MANAGEMENT_INSTALLED)
+                           vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.ManagementInstalled)
                         ? (IComparable)PropertyAccessorHelper.vmMemoryUsageValue(vm)
                         : null;
                 }
@@ -531,7 +531,7 @@ namespace XenAdmin.XenSearch
             {
                 return vm.IsRealVm() &&
                        vm.power_state == vm_power_state.Running &&
-                       vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED)
+                       vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.IoDriversInstalled)
                     ? PropertyAccessorHelper.vmNetworkUsageString(vm)
                     : null;
             }
@@ -549,7 +549,7 @@ namespace XenAdmin.XenSearch
             return o is VM vm &&
                    vm.IsRealVm() &&
                    vm.power_state == vm_power_state.Running &&
-                   vm.GetVirtualisationStatus(out _).HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED)
+                   vm.GetVirtualizationStatus(out _).HasFlag(VM.VirtualizationStatus.IoDriversInstalled)
                 ? PropertyAccessorHelper.vmDiskUsageString(vm)
                 : null;
         }
@@ -1007,12 +1007,12 @@ namespace XenAdmin.XenSearch
                     });
 
                 case PropertyNames.virtualisation_status:
-                    return (Func<VM.VirtualisationStatus, Icons>)(status =>
+                    return (Func<VM.VirtualizationStatus, Icons>)(status =>
                     {
-                        if (status.HasFlag(VM.VirtualisationStatus.IO_DRIVERS_INSTALLED | VM.VirtualisationStatus.MANAGEMENT_INSTALLED))
+                        if (status.HasFlag(VM.VirtualizationStatus.IoDriversInstalled | VM.VirtualizationStatus.ManagementInstalled))
                             return Icons.ToolInstalled;
 
-                        if (status.HasFlag(VM.VirtualisationStatus.PV_DRIVERS_OUT_OF_DATE))
+                        if (status.HasFlag(VM.VirtualizationStatus.PvDriversOutOfDate))
                             return Icons.ToolsOutOfDate;
 
                         return Icons.ToolsNotInstalled;
@@ -1025,7 +1025,7 @@ namespace XenAdmin.XenSearch
                     return (Func<string, Icons>)(_ => Icons.Tag);
 
                 case PropertyNames.ha_restart_priority:
-                    return (Func<VM.HA_Restart_Priority, Icons>)(_ => Icons.HA);
+                    return (Func<VM.HaRestartPriority, Icons>)(_ => Icons.HA);
 
                 case PropertyNames.read_caching_enabled:
                     return (Func<bool, Icons>)(_ => Icons.VDI);

--- a/XenModel/XenSearch/Search.cs
+++ b/XenModel/XenSearch/Search.cs
@@ -785,9 +785,9 @@ namespace XenAdmin.XenSearch
                     new GroupQuery(
                         new QueryFilter[] {
                             new EnumPropertyQuery<vm_power_state>(PropertyNames.power_state, vm_power_state.Running, true),
-                            new EnumPropertyQuery<VM.VirtualisationStatus>(PropertyNames.virtualisation_status, VM.VirtualisationStatus.IO_DRIVERS_INSTALLED | VM.VirtualisationStatus.MANAGEMENT_INSTALLED, false)
+                            new EnumPropertyQuery<VM.VirtualizationStatus>(PropertyNames.virtualisation_status, VM.VirtualizationStatus.IoDriversInstalled | VM.VirtualizationStatus.ManagementInstalled, false)
                         }, GroupQuery.GroupQueryType.And)),
-                new PropertyGrouping<VM.VirtualisationStatus>(PropertyNames.virtualisation_status, null),
+                new PropertyGrouping<VM.VirtualizationStatus>(PropertyNames.virtualisation_status, null),
                 string.Format(Messages.DEFAULT_SEARCH_VMS_WO_XS_TOOLS, BrandManager.VmTools),
                 "dead-beef-1234-vmswotools", true
             );


### PR DESCRIPTION
Please read the following before reviewing 👇 

I suggest you review this PR this way:

1. Tidy up commits, one at a time. They should be fairly straightforward.
2. For the others, still one at a time but please hold comments until the last one, since I refactored quite a few things then. You could review them together but I moved methods a bit in e9d3c9555d7c28e9f023cc478e9ba8d72c5ad3b4 so it won't be super easy I'm afraid.

What this PR is effectively doing is ignoring the VM's `restrictions` in its `recommendations` parameter. It is switching to checking the value in the VM templates for the host we're connected to. 

If possible, it returns the value of the template that matched the VM (using `reference_label`). If that cannot be done, it will either return a default value or fetch the max/min one from the list of all templates.

> Why from all templates?

We need to set a default fall-back value for these fields. We could just update the constants in `VM.cs`. However, it was pointed out to me that the max or min values across all templates are usually what we would define as the fall-back values, anyway.

Also, this means that these defaults will change according to which host the VM is residing on, which is an extra added benefit of doing it this way. 