### PR TITLE
(master) Removed erroneously added backslashes. Generate the xml files without the BOM.

### DIFF
--- a/scripts/xenadmin-build.ps1
+++ b/scripts/xenadmin-build.ps1
@@ -299,7 +299,7 @@ $source_checksum | Out-File -LiteralPath "$OUTPUT_DIR\$appName-source.zip.checks
 Write-Host "INFO: Calculated checksum source checksum: $source_checksum"
 
 $xmlFormat=@"
-<?xml version=\"1.0\" ?>
+<?xml version="1.0" ?>
 <patchdata>
     <versions>
         <version
@@ -317,15 +317,21 @@ $xmlFormat=@"
 
 $msi_url = $XC_UPDATES_URL -replace "XCUpdates.xml","$appName.msi"
 $date=(Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-$productVersion =  "$BRANDING_XC_PRODUCT_VERSION.$buildNumber"
-$productFullName =  "$appName $productVersion"
+$productVersion = "$BRANDING_XC_PRODUCT_VERSION.$buildNumber"
+$productFullName = "$appName $productVersion"
+
+$prodXml = [string]::Format($xmlFormat, $productFullName, $date, $msi_url, $msi_checksum, $productVersion)
+$testXml = [string]::Format($xmlFormat, $productFullName, $date, "@DEV_MSI_URL_PLACEHOLDER@", $msi_checksum, $productVersion)
+
+Write-Host $prodXml
+Write-Host $testXml
+
+# generate the xmls without the byte order mark because sometimes it is
+# written out as a ? character in the file causing the xml to be invalid
+$bomLessEncoding = New-Object System.Text.UTF8Encoding $false
 
 Write-Host "INFO: Generating XCUpdates.xml"
-
-[string]::Format($xmlFormat, $productFullName, $date, $msi_url, $msi_checksum, $productVersion) |`
-    Out-File -FilePath $OUTPUT_DIR\XCUpdates.xml -Encoding utf8
+[System.IO.File]::WriteAllLines("$OUTPUT_DIR\XCUpdates.xml", $prodXml, $bomLessEncoding)
 
 Write-Host "INFO: Generating stage-test-XCUpdates.xml. URL is a placeholder value"
-
-[string]::Format($xmlFormat, $productFullName, $date, "@DEV_MSI_URL_PLACEHOLDER@", $msi_checksum, $productVersion) |`
-    Out-File -FilePath $OUTPUT_DIR\stage-test-XCUpdates.xml -Encoding utf8
+[System.IO.File]::WriteAllLines("$OUTPUT_DIR\stage-test-XCUpdates.xml", $testXml, $bomLessEncoding)


### PR DESCRIPTION
This ports to master the corrections committed on release/2023/e via PRs #3231, #3232, #3233.