### PR TITLE
CA-384579: Call previous NRPE plugin xapi to resolve certs permission issue

### DIFF
--- a/XenModel/Actions/NRPE/NRPEHostConfiguration.cs
+++ b/XenModel/Actions/NRPE/NRPEHostConfiguration.cs
@@ -44,6 +44,7 @@ namespace XenAdmin.Actions.NRPE
         public const string XAPI_NRPE_SET_CONFIG = "set-config";
         public const string XAPI_NRPE_SET_THRESHOLD = "set-threshold";
         public const string XAPI_NRPE_RESTART = "restart";
+        public const string XAPI_NRPE_CONTROL = "control";
 
         public const string DEBUG_ENABLE = "1";
         public const string DEBUG_DISABLE = "0";


### PR DESCRIPTION
There is a bug caused by [CA-384572](https://issues.citrite.net/browse/CA-384572). NRPE service can't start after RPU from Yangtze to XS 8 Stream.
The certificate used by NRPE which is generated in Yangtze has no permission. This leads the NRPE operation command (start, restart, etc) failed.
A workaround is that XenCenter sends 'control' command before NRPE enabled. ('control' will modify the permission of certificate)