### PR TITLE
CA-385151 & CP-45516: Fix skipped patch + Bump pipeline to v4.12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@
 
 def XENADMIN_BRANDING_TAG = 'v5.3'
 
-@Library(['PacmanSharedLibrary', "xencenter-pipeline@v4.11"])
+@Library(['PacmanSharedLibrary', "xencenter-pipeline@v4.12"])
 import com.xenserver.pipeline.xencenter.*
 
 properties([

--- a/WixInstaller/wix_src.patch
+++ b/WixInstaller/wix_src.patch
@@ -1007,7 +1007,7 @@ diff -ru wixlib/ExitDialog.wxl wixlib/ExitDialog.wxl
 +                <Control Id="OptionalCheckBox" Type="CheckBox" X="135" Y="200" Width="220" Height="10" Hidden="yes" Property="WIXUI_EXITDIALOGOPTIONALCHECKBOX" CheckBoxValue="1" Text="[WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT]">
 +                    <Condition Action="show">WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT AND NOT (WixUI_InstallMode="Remove") AND XS_WixUIRMPressedOk="0"</Condition>
                  </Control>
-diff --git wixlib/MsiRMFilesInUse.wxs wixlib/MsiRMFilesInUse.wxs
+diff -ru wixlib/MsiRMFilesInUse.wxs wixlib/MsiRMFilesInUse.wxs
 --- wixlib/MsiRMFilesInUse.wxs
 +++ wixlib/MsiRMFilesInUse.wxs
 @@ -6,10 +6,13 @@
@@ -1024,4 +1024,3 @@ diff --git wixlib/MsiRMFilesInUse.wxs wixlib/MsiRMFilesInUse.wxs
                  </Control>
                  <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
                      <Publish Event="EndDialog" Value="Exit">1</Publish>
- 


### PR DESCRIPTION
The patch was skipped, and the "Launch XenCenter" button did not show anymore. This was because the custom property `XS_WixUIRMPressedOk` is defined within the patch.

Regressed after dd98fe67 because the way we're applying patches with the PowerShell script doesn't like the `diff --git` format.

I suspect it's got something to do with defining proper directories using `git apply --directory` but an easy solution (this one) is to just use `git -ru`